### PR TITLE
Staging fix for knowledge menu bug

### DIFF
--- a/src/object/obj-desc.c
+++ b/src/object/obj-desc.c
@@ -36,11 +36,7 @@ void object_kind_name(char *buf, size_t max, int k_idx, bool easy_know)
 	/* If not aware, use flavor */
 	if (!easy_know && !k_ptr->aware && k_ptr->flavor)
 	{
-		if (k_ptr->tval == TV_SCROLL)
-		{
-			strnfmt(buf, max, "\"%s\"", scroll_adj[k_ptr->sval]);
-		}
-		else if (k_ptr->tval == TV_FOOD && k_ptr->sval > SV_FOOD_MIN_SHROOM)
+		if (k_ptr->tval == TV_FOOD && k_ptr->sval > SV_FOOD_MIN_SHROOM)
 		{
 			strnfmt(buf, max, "%s Mushroom", flavor_info[k_ptr->flavor].text);
 		}
@@ -116,10 +112,8 @@ static const char *obj_desc_get_modstr(const object_type *o_ptr)
 		case TV_ROD:
 		case TV_POTION:
 		case TV_FOOD:
-			return flavor_info[k_ptr->flavor].text;
-
 		case TV_SCROLL:
-			return scroll_adj[o_ptr->sval];
+			return flavor_info[k_ptr->flavor].text;
 
 		case TV_MAGIC_BOOK:
 		case TV_PRAYER_BOOK:
@@ -193,7 +187,7 @@ static const char *obj_desc_get_basename(const object_type *o_ptr, bool aware)
 			return (show_flavor ? "& # Potion~" : "& Potion~");
 
 		case TV_SCROLL:
-			return (show_flavor ? "& Scroll~ titled \"#\"" : "& Scroll~");
+			return (show_flavor ? "& Scroll~ titled #" : "& Scroll~");
 
 		case TV_MAGIC_BOOK:
 			return "& Book~ of Magic Spells #";

--- a/src/object/obj-util.c
+++ b/src/object/obj-util.c
@@ -30,9 +30,9 @@
 #include "tvalsval.h"
 
 /*
- * Hold the titles of scrolls, 6 to 14 characters each.
+ * Hold the titles of scrolls, 6 to 14 characters each, plus quotes.
  */
-char scroll_adj[MAX_TITLES][16];
+char scroll_adj[MAX_TITLES][18];
 
 static void flavor_assign_fixed(void)
 {
@@ -109,6 +109,12 @@ static void flavor_assign_random(byte tval)
 				/* Mark the flavor as used */
 				flavor_info[j].sval = k_info[i].sval;
 
+				/* Hack - set the scroll name if it's a scroll */
+				if (tval == TV_SCROLL)
+				{
+					flavor_info[j].text = scroll_adj[k_info[i].sval];
+				}
+
 				/* One less flavor to choose from */
 				flavor_count--;
 
@@ -164,26 +170,26 @@ void flavor_init(void)
 	flavor_assign_random(TV_ROD);
 	flavor_assign_random(TV_FOOD);
 	flavor_assign_random(TV_POTION);
-	flavor_assign_random(TV_SCROLL);
 
 	/* Scrolls (random titles, always white) */
 	for (i = 0; i < MAX_TITLES; i++)
 	{
-		char buf[24];
-		char *end = buf;
+		char buf[26] = "\"";
+		char *end = buf + 1;
 		int titlelen = 0;
 		int wordlen;
 		bool okay = TRUE;
 
 		wordlen = randname_make(RANDNAME_SCROLL, 2, 8, end, 24, name_sections);
-		while (titlelen + wordlen < (int)(sizeof(scroll_adj[0]) - 1))
+		while (titlelen + wordlen < (int)(sizeof(scroll_adj[0]) - 3))
 		{
 			end[wordlen] = ' ';
 			titlelen += wordlen + 1;
 			end += wordlen + 1;
 			wordlen = randname_make(RANDNAME_SCROLL, 2, 8, end, 24 - titlelen, name_sections);
 		}
-		buf[titlelen - 1] = '\0';
+		buf[titlelen] = '"';
+		buf[titlelen+1] = '\0';
 
 		/* Check the scroll name hasn't already been generated */
 		for (j = 0; j < i; j++)
@@ -205,6 +211,7 @@ void flavor_init(void)
 			i--;
 		}
 	}
+	flavor_assign_random(TV_SCROLL);
 
 	/* Hack -- Use the "complex" RNG */
 	Rand_quick = FALSE;

--- a/src/object/object.h
+++ b/src/object/object.h
@@ -6,9 +6,6 @@
 /** Maximum number of scroll titles generated */
 #define MAX_TITLES     50
 
-/** The titles of scrolls, ordered by sval. */
-extern char scroll_adj[MAX_TITLES][16];
-
 struct player;
 
 /*** Constants ***/


### PR DESCRIPTION
Fixed the knowledge menu bug, rooted in the change to flavours, and not to sort as originally thought. (It showed up when the tval comparison function was called by sort.)

Has cleaned up some special case handling of scrolls and got rid of a global variable (elly will be pleased!)

Scroll text now includes quotes around the string.
