### PR TITLE
Fix for #1401: parser_parse() now skips trailing token when parsing chara

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -278,7 +278,7 @@ enum parser_error parser_parse(struct parser *p, const char *line) {
 		} else if (t == T_CHAR) {
 			tok = strtok(sp, "");
 			if (tok)
-				sp = tok + 1;
+				sp = tok + 2;
 		} else {
 			tok = strtok(sp, "");
 			sp = NULL;

--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -20,12 +20,13 @@ run : build
 %.o : %.c
 	@$(CC) $(CFLAGS) -c -o $@ $^
 
-bin/% : %.o
+bin/% : %.o ../angband.o
 	@mkdir -p $(shell echo "$$(dirname $@)")
-	@$(CC) $(CFLAGS) -o $@ $^ ../angband.o $(LDFLAGS)
+	@$(CC) $(CFLAGS) -o $@ $< ../angband.o $(LDFLAGS)
 	@echo "  CC $@"
 
 clean :
 	$(RM) $(TESTPROGS)
 
 .PHONY : all clean
+.PRECIOUS : %.o

--- a/src/tests/parse/r-info.c
+++ b/src/tests/parse/r-info.c
@@ -1,10 +1,12 @@
 /* parse/r-info */
 
 #include "unit-test.h"
+#include "unit-test-data.h"
 #include "init.h"
 #include "monster/constants.h"
 #include "monster/monster.h"
 #include "types.h"
+#include "externs.h"
 
 static int setup(void **state) {
 	*state = init_parse_r();
@@ -29,9 +31,11 @@ static int test_n0(void *state) {
 }
 
 static int test_t0(void *state) {
-	enum parser_error r = parser_parse(state, "T:townsfolk");
+	enum parser_error r;
 	struct monster_race *mr;
 
+	rb_info = &test_rb_info;
+	r = parser_parse(state, "T:townsfolk");
 	eq(r, PARSE_ERROR_NONE);
 	mr = parser_priv(state);
 	require(mr);

--- a/src/tests/unit-test-data.h
+++ b/src/tests/unit-test-data.h
@@ -234,4 +234,15 @@ static struct player_class test_class = {
 	.start_items = &start_longsword,
 };
 
+static struct monster_base test_rb_info = {
+	.next = NULL,
+	.name = "townsfolk",
+	.text = "Townsfolk",
+	.flags = "\0\0\0\0\0\0\0\0\0\0\0\0",
+	.spell_flags = "\0\0\0\0\0\0\0\0\0\0\0\0",
+	.d_char = 116,
+	.pain = NULL,
+	
+};
+
 #endif /* !UNIT_TEST_DATA */


### PR DESCRIPTION
Fix for #1401: parser_parse() now skips trailing token when parsing characters.
Modified tests Makefile to make test binaries depend on angband.o and to avoid
removing secondary object files.
Added dummy rb_info struct to unit-test-data.h for parse/r-info/t0 test.

Sorry about the previous pull request. It was not supposed to go into master...anyway, I expect all current unit tests to pass after this pull.
