### PR TITLE
#1447 Help on birth options not available during gameplay

### DIFF
--- a/src/ui-options.c
+++ b/src/ui-options.c
@@ -98,7 +98,11 @@ static bool option_toggle_handle(menu_type *m, const ui_event *event,
 	bool next = FALSE;
 
 	if (event->type == EVT_SELECT) {
-		option_set(option_name(oid), !op_ptr->opt[oid]);
+		/* Hack -- birth options can not be toggled after birth */
+		/* At birth, m->flags == MN_DBL_TAP. After birth, m->flags == MN_NO_TAGS */
+		if (!(OPT_BIRTH <= oid && oid <= OPT_BIRTH + N_OPTS_BIRTH - 1 && m->flags == MN_NO_TAGS)) {
+			option_set(option_name(oid), !op_ptr->opt[oid]);
+		}
 	} else if (event->type == EVT_KBRD) {
 		if (event->key.code == 'y' || event->key.code == 'Y') {
 			option_set(option_name(oid), TRUE);
@@ -152,8 +156,9 @@ static void option_toggle_menu(const char *name, int page)
 
 	/* We add 10 onto the page amount to indicate we're at birth */
 	if (page == OPT_PAGE_BIRTH) {
-		m->prompt = "You can only modify these options at character birth.";
-		m->flags |= MN_NO_ACTION;
+		m->prompt = "You can only modify these options at character birth. '?' for information";
+		m->cmd_keys = "?";
+		m->flags = MN_NO_TAGS;
 	} else if (page == OPT_PAGE_BIRTH + 10) {
 		page -= 10;
 	}


### PR DESCRIPTION
#1447 Help on birth options not available during gameplay

Help file can now be displayed for birth options during gameplay.
Changes in ui-options.c in the functions:
option_toggle_handle
option_toggle_menu

Note: Birth options can not be changed during gameplay.
