### PR TITLE
New, different, fix for #1490 Stat coloring / message bugs

### DIFF
--- a/src/spells2.c
+++ b/src/spells2.c
@@ -218,6 +218,17 @@ bool do_dec_stat(int stat, bool perma)
 		return (TRUE);
 	}
 
+	/* If the stat is at minimum it can't be reduced */
+	if (p_ptr->state.stat_use[stat] <= 3)
+	{
+		/* Message */
+		msg("You feel very %s for a moment, but the feeling passes.",
+		           desc_stat_neg[stat]);
+
+		/* Notice effect */
+		return (TRUE);
+	}
+
 	/* Attempt to reduce the stat */
 	if (player_stat_dec(p_ptr, stat, perma))
 	{


### PR DESCRIPTION
This fix eliminates both the unwanted stat colouring and the unwanted messages.

Instead there will be another message, e.g.:
"You feel very ugly for a moment, but the feeling passes."

The fix has been tested with a half-troll warrior, a Rot jelly (reduces chr), and a Yellow worm mass (reduces dex).

If this fix is pushed, my earlier suggested fix is not needed.
