### PR TITLE
change S_IREAD and S_IWRITE to S_IRUSR and S_IWUSR

### DIFF
--- a/src/z-file.c
+++ b/src/z-file.c
@@ -372,7 +372,7 @@ ang_file *file_open(const char *fname, file_mode mode, file_type ftype)
 			if (ftype == FTYPE_SAVE) {
 				/* open only if the file does not exist */
 				int fd;
-				fd = open(buf, O_CREAT | O_EXCL | O_WRONLY | O_BINARY, S_IREAD | S_IWRITE);
+				fd = open(buf, O_CREAT | O_EXCL | O_WRONLY | O_BINARY, S_IRUSR | S_IWUSR);
 				if (fd < 0) {
 					/* there was some error */
 					f->fh = NULL;


### PR DESCRIPTION
This is to address ticket #1512. The S_IREAD and S_IWRITE macros aren't defined on Android. S_IRUSR and S_IWUSR are the Posix equivalents. 
