### PR TITLE
#547 Trap detection should detect traps on chests

### DIFF
--- a/src/spells2.c
+++ b/src/spells2.c
@@ -540,6 +540,8 @@ bool detect_traps(bool aware)
 
 	bool detect = FALSE;
 
+	object_type *o_ptr;
+
 	(void)aware;
 
 	/* Pick an area to map */
@@ -574,6 +576,32 @@ bool detect_traps(bool aware)
 
 				/* We found something to detect */
 				detect = TRUE;
+			}
+
+			/* Scan all objects in the grid to look for traps on chests */
+			for (o_ptr = get_first_object(y, x); o_ptr; o_ptr = get_next_object(o_ptr))
+			{
+				/* Skip non-chests */
+				if (o_ptr->tval != TV_CHEST) continue;
+
+				/* Skip disarmed chests */
+				if (o_ptr->pval[DEFAULT_PVAL] <= 0) continue;
+
+				/* Skip non-trapped chests */
+				if (!chest_traps[o_ptr->pval[DEFAULT_PVAL]]) continue;
+
+				/* Identify once */
+				if (!object_is_known(o_ptr))
+				{
+					/* Know the trap */
+					object_notice_everything(o_ptr);
+
+					/* Notice it */
+					disturb(p_ptr, 0, 0);
+
+					/* We found something to detect */
+					detect = TRUE;
+				}
 			}
 
 			/* Mark as trap-detected */


### PR DESCRIPTION
#547 Trap detection should detect traps on chests

The spell "Find Traps, Doors & Stairs", and the prayer with
the same name, now also detects traps on chests that are seen by the player.
It also works with the prayer Detection.

Changes in:
spells2.c (in the function detect_traps)

Note: This pull request was accidentally deleted by me and I had to redo it,
including rewriting the patch. I hope I don't forget something from the original 
patch.

Note: The change has also been tested with a Rod of Trap Location, 
a Rod of Detection, and a Scroll of Trap Detection.

Note: The following was found through testing:
A chest that has not yet been seen by the player is not detected by the spell,
but a trap on the chest will be detected by the spell, if the chest
is within range. When the player later sees the chest, he will see that it is trapped.

Note: If trap detection of chests is allowed to work on chests that are not seen
by the player, there is a minor issue. If there are no traps on the floor, but there
is a trap on a chest and the player gets a message "You sense the presence of traps!",
then the player can logically conclude that there is a chest close by. Since chests
are not very valuable, this is probably not a big problem.

If you want me to do something about this issue it can be solved e.g. by restricting the
range, by removing the message "You sense the presence of traps!" for traps on chests,
or by making chests with detected traps visible, as if they were detected by a chest detection spell.
