### PR TITLE
#1094 Make all items pseudo on pickup at clev20

### DIFF
--- a/src/object/identify.c
+++ b/src/object/identify.c
@@ -1085,7 +1085,8 @@ void sense_inventory(void)
 	else
 		rate = p_ptr->class->sense_base / (p_ptr->lev + p_ptr->class->sense_div);
 
-	if (!one_in_(rate)) return;
+	/* Check if player may sense anything this time */
+	if (p_ptr->lev < 20 && !one_in_(rate)) return;
 
 
 	/* Check everything */


### PR DESCRIPTION
Players at character level 20 or more get automatical
pseudo identify.

Changes in:
identify.c    (in the function sense_inventory)

Note: The item is not sensed at pickup. Instead
it is sensed in the normal way.

Note: There is a small chance of failure, just like
with normal pseudo identify. Thus all objects are not
sensed immediately, which is good.

Note: Has been tested in wizard mode, before and after clev 20.
