### PR TITLE
#1499 Replace indices in function calls with pointers

### DIFF
--- a/src/cmd3.c
+++ b/src/cmd3.c
@@ -493,6 +493,9 @@ void do_cmd_query_symbol(void)
 
 	u16b *who;
 
+	const monster_race *r_ptr;
+	const monster_lore *l_ptr;
+
 	/* Get a character, or abort */
 	if (!get_com("Enter character to be identified, or control+[ANU]: ", &sym))
 		return;
@@ -609,6 +612,8 @@ void do_cmd_query_symbol(void)
 	{
 		/* Extract a race */
 		r_idx = who[i];
+		r_ptr = &r_info[r_idx];
+		l_ptr = &l_list[r_idx];
 
 		/* Hack -- Auto-recall */
 		monster_race_track(r_idx);
@@ -617,7 +622,7 @@ void do_cmd_query_symbol(void)
 		handle_stuff(p_ptr);
 
 		/* Hack -- Begin the prompt */
-		roff_top(r_idx);
+		roff_top(r_ptr);
 
 		/* Hack -- Complete the prompt */
 		Term_addstr(-1, TERM_WHITE, " [(r)ecall, ESC]");
@@ -632,7 +637,7 @@ void do_cmd_query_symbol(void)
 				screen_save();
 
 				/* Recall on screen */
-				screen_roff(who[i]);
+				screen_roff(r_ptr, l_ptr);
 
 				/* Hack -- Complete the prompt (again) */
 				Term_addstr(-1, TERM_WHITE, " [(r)ecall, ESC]");

--- a/src/monster/mon-lore.c
+++ b/src/monster/mon-lore.c
@@ -1867,15 +1867,11 @@ static void describe_monster_movement(const monster_race *r_ptr,
  * monster flag.
  * 
  */
-void cheat_monster_lore(int r_idx, monster_lore *l_ptr)
+void cheat_monster_lore(const monster_race *r_ptr, monster_lore *l_ptr)
 {
-	const monster_race *r_ptr;
-
 	int i;
 
-	assert(r_idx > 0);
-	r_ptr = &r_info[r_idx];
-
+	assert(r_ptr);
 	assert(l_ptr);
 	
 	/* Hack -- Maximal kills */
@@ -1932,15 +1928,11 @@ void cheat_monster_lore(int r_idx, monster_lore *l_ptr)
  * Sets the number of total kills, observed blows, and observed drops to 0.
  * Also wipes all knowledge of monster flags.
  */
-void wipe_monster_lore(int r_idx, monster_lore *l_ptr)
+void wipe_monster_lore(const monster_race *r_ptr, monster_lore *l_ptr)
 {
-	const monster_race *r_ptr;
-
 	int i;
 
-	assert(r_idx > 0);
-	r_ptr = &r_info[r_idx];
-
+	assert(r_ptr);
 	assert(l_ptr);
 	
 	/* Hack -- No kills */
@@ -1986,17 +1978,14 @@ void wipe_monster_lore(int r_idx, monster_lore *l_ptr)
  * saves about 60K of memory at the cost of disk access during monster
  * recall, which is optional to the user.
  */
-void describe_monster(int r_idx, bool spoilers)
+void describe_monster(const monster_race *r_ptr, const monster_lore *l_ptr, bool spoilers)
 {
-	const monster_race *r_ptr;
 	monster_lore lore;
-	const monster_lore *l_ptr;
 	bitflag f[RF_SIZE];
 	int melee_colors[RBE_MAX], spell_colors[RSF_MAX];
 
-	assert(r_idx > 0);
-	r_ptr = &r_info[r_idx];
-	l_ptr = &l_list[r_idx];
+	assert(r_ptr);
+	assert(l_ptr);
 
 	/* Determine the special attack colors */
 	get_attack_colors(melee_colors, spell_colors);
@@ -2021,7 +2010,7 @@ void describe_monster(int r_idx, bool spoilers)
 
 	/* Cheat -- know everything */
 	if (OPT(cheat_know) || spoilers)
-		cheat_monster_lore(r_idx, &lore);
+		cheat_monster_lore(r_ptr, &lore);
 
 	/* Show kills of monster vs. player(s) */
 	if (!spoilers)
@@ -2059,15 +2048,12 @@ void describe_monster(int r_idx, bool spoilers)
 /**
  * Display the "name" and "attr/chars" of a monster race.
  */
-void roff_top(int r_idx)
+void roff_top(const monster_race *r_ptr)
 {
-	const monster_race *r_ptr;
-
 	byte a1, a2;
 	wchar_t c1, c2;
 
-	assert(r_idx > 0);
-	r_ptr = &r_info[r_idx];
+	assert(r_ptr);
 
 	/* Get the chars */
 	c1 = r_ptr->d_char;
@@ -2113,9 +2099,10 @@ void roff_top(int r_idx)
 /**
  * Describes the given monster race at the top of the main term.
  */
-void screen_roff(int r_idx)
+void screen_roff(const monster_race *r_ptr, const monster_lore *l_ptr)
 {
-	assert(r_idx > 0);
+	assert(r_ptr);
+	assert(l_ptr);
 
 	/* Flush messages */
 	message_flush();
@@ -2127,21 +2114,22 @@ void screen_roff(int r_idx)
 	text_out_hook = text_out_to_screen;
 
 	/* Recall monster */
-	describe_monster(r_idx, FALSE);
+	describe_monster(r_ptr, l_ptr, FALSE);
 
 	/* Describe monster */
-	roff_top(r_idx);
+	roff_top(r_ptr);
 }
 
 
 /**
  * Describe the given monster race in the current "term" window.
  */
-void display_roff(int r_idx)
+void display_roff(const monster_race *r_ptr, const monster_lore *l_ptr)
 {
 	int y;
 
-	assert(r_idx > 0);
+	assert(r_ptr);
+	assert(l_ptr);
 
 	/* Erase the window */
 	for (y = 0; y < Term->hgt; y++) {
@@ -2156,10 +2144,10 @@ void display_roff(int r_idx)
 	text_out_hook = text_out_to_screen;
 
 	/* Recall monster */
-	describe_monster(r_idx, FALSE);
+	describe_monster(r_ptr, l_ptr, FALSE);
 
 	/* Describe monster */
-	roff_top(r_idx);
+	roff_top(r_ptr);
 }
 
 

--- a/src/monster/mon-lore.h
+++ b/src/monster/mon-lore.h
@@ -30,12 +30,12 @@
 /** Variables **/
 
 /** Functions **/
-void cheat_monster_lore(int r_idx, monster_lore *l_ptr);
-void wipe_monster_lore(int r_idx, monster_lore *l_ptr);
-void describe_monster(int r_idx, bool spoilers);
-void roff_top(int r_idx);
-void screen_roff(int r_idx);
-void display_roff(int r_idx);
+void cheat_monster_lore(const monster_race *r_ptr, monster_lore *l_ptr);
+void wipe_monster_lore(const monster_race *r_ptr, monster_lore *l_ptr);
+void describe_monster(const monster_race *r_ptr, const monster_lore *l_ptr, bool spoilers);
+void roff_top(const monster_race *r_ptr);
+void screen_roff(const monster_race *r_ptr, const monster_lore *l_ptr);
+void display_roff(const monster_race *r_ptr, const monster_lore *l_ptr);
 void lore_do_probe(int m_idx);
 void monster_flags_known(const monster_race *r_ptr, const monster_lore *l_ptr, bitflag flags[RF_SIZE]);
 void lore_treasure(int m_idx, int num_item, int num_gold);

--- a/src/target.c
+++ b/src/target.c
@@ -609,6 +609,9 @@ static struct keypress target_set_interactive_aux(int y, int x, int mode)
 
 	char coords[20];
 
+	const monster_race *r_ptr;
+	const monster_lore *l_ptr;
+
 	/* Describe the square location */
 	coords_desc(coords, sizeof(coords), y, x);
 
@@ -665,7 +668,8 @@ static struct keypress target_set_interactive_aux(int y, int x, int mode)
 		if (cave->m_idx[y][x] > 0)
 		{
 			monster_type *m_ptr = cave_monster(cave, cave->m_idx[y][x]);
-			monster_race *r_ptr = &r_info[m_ptr->r_idx];
+			r_ptr = &r_info[m_ptr->r_idx];
+			l_ptr = &l_list[m_ptr->r_idx];
 
 			/* Visible */
 			if (m_ptr->ml && !m_ptr->unaware)
@@ -699,7 +703,7 @@ static struct keypress target_set_interactive_aux(int y, int x, int mode)
 						screen_save();
 
 						/* Recall on screen */
-						screen_roff(m_ptr->r_idx);
+						screen_roff(r_ptr, l_ptr);
 
 						/* Command */
 						query = inkey();

--- a/src/ui-knowledge.c
+++ b/src/ui-knowledge.c
@@ -1036,8 +1036,14 @@ static const char *race_name(int gid) { return monster_group[gid].name; }
 
 static void mon_lore(int oid)
 {
+	int r_idx;
+	const monster_race *r_ptr;
+	const monster_lore *l_ptr;
+
+	r_idx = default_join[oid].oid;
+
 	/* Update the monster recall window */
-	monster_race_track(default_join[oid].oid);
+	monster_race_track(r_idx);
 	handle_stuff(p_ptr);
 
 	/* Save the screen */
@@ -1047,9 +1053,12 @@ static void mon_lore(int oid)
 	text_out_hook = text_out_to_screen;
 
 	/* Recall monster */
-	roff_top(default_join[oid].oid);
+	assert(r_idx);
+	r_ptr = &r_info[r_idx];
+	l_ptr = &l_list[r_idx];
+	roff_top(r_ptr);
 	Term_gotoxy(0, 2);
-	describe_monster(default_join[oid].oid, FALSE);
+	describe_monster(r_ptr, l_ptr, FALSE);
 
 	text_out_c(TERM_L_BLUE, "\n[Press any key to continue]\n");
 	(void)anykey();

--- a/src/wiz-spoil.c
+++ b/src/wiz-spoil.c
@@ -705,7 +705,8 @@ static void spoil_mon_info(const char *fname)
 	for (n = 0; n < count; n++)
 	{
 		int r_idx = who[n];
-		monster_race *r_ptr = &r_info[r_idx];
+		const monster_race *r_ptr = &r_info[r_idx];
+		const monster_lore *l_ptr = &l_list[r_idx];
 
 		/* Prefix */
 		if (rf_has(r_ptr->flags, RF_QUESTOR))
@@ -763,7 +764,7 @@ static void spoil_mon_info(const char *fname)
 		text_out("Exp:%ld\n", (long)(r_ptr->mexp));
 
 		/* Describe */
-		describe_monster(r_idx, TRUE);
+		describe_monster(r_ptr, l_ptr, TRUE);
 
 		/* Terminate the entry */
 		text_out("\n");

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -1631,6 +1631,8 @@ void do_cmd_debug(void)
 
 	struct keypress cmd;
 
+	const monster_race *r_ptr;
+
 
 	/* Get a "debug command" */
 	if (!get_com("Debug Command: ", &cmd)) return;
@@ -1906,8 +1908,11 @@ void do_cmd_debug(void)
 				if (sym.code == 'a' || sym.code == 'A')
 				{
 					int i;
-					for (i = 0; i < z_info->r_max; i++)
-						cheat_monster_lore(i, &l_list[i]);
+					for (i = 1; i < z_info->r_max; i++)
+					{
+						r_ptr = &r_info[i];
+						cheat_monster_lore(r_ptr, &l_list[i]);
+					}
 					break;
 				}
 				else if (sym.code == 's' || sym.code == 'S')
@@ -1943,7 +1948,10 @@ void do_cmd_debug(void)
 
 			/* Did we find a valid monster? */
 			if (r_idx > 0)
-				cheat_monster_lore(r_idx, &l_list[r_idx]);
+			{
+				r_ptr = &r_info[r_idx];
+				cheat_monster_lore(r_ptr, &l_list[r_idx]);
+			}
 			else
 				msg("No monster found.");
 	
@@ -2033,8 +2041,11 @@ void do_cmd_debug(void)
 				if (sym.code == 'a' || sym.code == 'A')
 				{
 					int i;
-					for (i = 0; i < z_info->r_max; i++)
-						wipe_monster_lore(i, &l_list[i]);
+					for (i = 1; i < z_info->r_max; i++)
+					{
+						r_ptr = &r_info[i];
+						wipe_monster_lore(r_ptr, &l_list[i]);
+					}
 					break;
 				}
 				else if (sym.code == 's' || sym.code == 'S')
@@ -2070,7 +2081,10 @@ void do_cmd_debug(void)
 
 			/* Did we find a valid monster? */
 			if (r_idx > 0)
-				wipe_monster_lore(r_idx, &l_list[r_idx]);
+			{
+				r_ptr = &r_info[r_idx];
+				wipe_monster_lore(r_ptr, &l_list[r_idx]);
+			}
 			else
 				msg("No monster found.");
 	

--- a/src/xtra3.c
+++ b/src/xtra3.c
@@ -1202,13 +1202,19 @@ static void update_monster_subwindow(game_event_type type, game_event_data *data
 {
 	term *old = Term;
 	term *inv_term = user;
+	const monster_race *r_ptr;
+	const monster_lore *l_ptr;
 
 	/* Activate */
 	Term_activate(inv_term);
 
 	/* Display monster race info */
 	if (p_ptr->monster_race_idx)
-		display_roff(p_ptr->monster_race_idx);
+	{
+		r_ptr = &r_info[p_ptr->monster_race_idx];
+		l_ptr = &l_list[p_ptr->monster_race_idx];
+		display_roff(r_ptr, l_ptr);
+	}
 
 	Term_fresh();
 	


### PR DESCRIPTION
#1499 Replace indices in function calls with pointers

Some instances of r_idx are now replaced with pointers.
All of these were in functions working with monster recall.

Also a bug was fixed in the function wipe_monster_lore,
that made it impossible to wipe lore for all monsters.
This wizard command 'W' does not seem to be documented
in the help file.

This is only a partial solution of the ticket. The 
remaining r_idx and other indices may still need cleanup.

Changes in:
mon-lore.h
mon-lore.c 

In the functions:
cheat_monster_lore  (Wizard command r)
wipe_monster_lore   (Wizard command W)
describe_monster    (Outputs the monster recall)
roff_top        (Display one line with the name and ch of the monster)
screen_roff     (Recall on the screen)
display_roff    (Recall in term window)

Also secondary changes in:
wizard.c            (Wizard commands r, W)
xtra3.c         (Recall in subwindow)
cmd3.c          (One line desc. at the recall command '/')
target.c            (Recall when targeting)
ui-knowledge.c      (Recall in list after player knowledge command ~)
wiz-spoil.c         (Create spoil files)

No changes in:
mon-util.c 
In the functions:
summon_specific_ok
What's the header file? The function does not seem to be in use.
I did not understand the function, so I didn't dare to change it.

No changes in:
cave.h
cave.c
In:
monster_race_track

No changes in mon-make.c, generate.c, spells1.c, wizard.c,
because r_idx is used inside the functions
