### PR TITLE
Documentation for the wizard command Wipe recall

### DIFF
--- a/lib/help/debug.txt
+++ b/lib/help/debug.txt
@@ -52,6 +52,9 @@ Learn about objects (``l``)
 
 Monster recall (``r``)
   Gives you full monster recall on all monsters or on a chosen monster.
+
+Wipe recall (``W``)
+  Resets monster recall on all monsters or on a chosen monster.
 		
 Unhide monsters (``u``)
   Reveals all monsters whose distance to the character is at most 255. If


### PR DESCRIPTION
The help file debug.txt now contains documentation
for the wizard command 'W', which resets monster
recall information.

Changes in:
debug.txt
