### PR TITLE
#1171 Turn off "Study" message when there are no available spells in currently carried books

### DIFF
--- a/src/player/p-util.c
+++ b/src/player/p-util.c
@@ -94,6 +94,47 @@ bool player_can_study(void)
 	return TRUE;
 }
 
+/* Does the player carry a book with a spell they can study? */
+bool player_can_study_book(void)
+{
+	int item_list[INVEN_TOTAL];
+	int item_num;
+
+	object_type *o_ptr;
+	struct spell *sp;
+
+	/* Check if the player can cast spells */
+	if (!player_can_cast())
+		return FALSE;
+
+	/* Check if the player can learn new spells */
+	if (!p_ptr->new_spells)
+		return FALSE;
+
+	/* Get the number of books in inventory */
+	item_tester_hook = obj_can_browse;
+	item_num = scan_items(item_list, N_ELEMENTS(item_list), (USE_INVEN));
+
+	/* Check through all available books */
+	for (int i = 0; i < item_num; i++)
+	{
+		o_ptr = object_from_item_idx(i);
+
+		/* Extract spells */
+		for (sp = o_ptr->kind->spells; sp; sp = sp->next)
+		{
+			/* Check if the player can study it */
+			if (spell_okay_to_study(sp->spell_index))
+			{
+				/* There is a spell the player can study */
+				return TRUE;
+			}
+		}
+	}
+
+	return FALSE;
+}
+
 /* Determine if the player can read scrolls. */
 bool player_can_read(void)
 {

--- a/src/player/player.h
+++ b/src/player/player.h
@@ -61,6 +61,7 @@ bool player_set_food(struct player *p, int v);
 s16b modify_stat_value(int value, int amount);
 bool player_can_cast(void);
 bool player_can_study(void);
+bool player_can_study_book(void);
 bool player_can_read(void);
 bool player_can_fire(void);
 bool player_confuse_dir(struct player *p, int *dir, bool too);

--- a/src/xtra3.c
+++ b/src/xtra3.c
@@ -891,22 +891,33 @@ static size_t prt_dtrap(int row, int col)
 }
 
 
-
 /*
- * Print whether a character is studying or not.
+ * Print how many spells the player can study.
  */
 static size_t prt_study(int row, int col)
 {
+	/* Can the player learn new spells? */
 	if (p_ptr->new_spells)
 	{
-		char *text = format("Study (%d)", p_ptr->new_spells);
-		put_str(text, row, col);
-		return strlen(text) + 1;
+		/* Check if the player carries a book with spells they can study */
+		if (player_can_study_book())
+		{
+			/* Print study message */
+			char *text = format("Study (%d)", p_ptr->new_spells);
+			put_str(text, row, col);
+			return strlen(text) + 1;
+		}
+		else
+		{
+			/* Print greyed-out study message */
+			char *text = format("Study (%d)", p_ptr->new_spells);
+			c_put_str(TERM_L_DARK, text, row, col);
+			return strlen(text) + 1;
+		}
 	}
 
 	return 0;
 }
-
 
 
 /*


### PR DESCRIPTION
When there are no available spells in carried books, 
the study message is now displayed in a darker grey colour.

Changes in:

xtra3.c (in prt_study)
player/p_util.h
player/p_util.c (New function: player_can_study_book)

Related functions for reference:

cmd-obj.c (do_cmd_study_spell, do_cmd_study_book)
ui-spell.c (textui_obj_study)
obj-ui.c (get_item)
calc.c (calc_spells)
z-term.h (text colours)

Note: When the player has learned all possible spells, 
the number of spells to learn will be 0, so the study
message will not be displayed at all. This was already
working and did not need to be fixed in this patch.
