### PR TITLE
#778 Objects on the floor should not stop trap creation

### DIFF
--- a/src/spells1.c
+++ b/src/spells1.c
@@ -1301,11 +1301,11 @@ static bool project_f(int who, int r, int y, int x, int dam, int typ, bool obvio
 		/* Make traps */
 		case GF_MAKE_TRAP:
 		{
-			/* Require a "naked" floor grid */
-			if (!cave_naked_bold(y, x)) break;
+			/* Require an "empty" floor grid */
+			if (!cave_empty_bold(y, x)) break;
 
-			/* Place a trap */
-			place_trap(cave, y, x);
+			/* Create a trap */
+			create_trap(cave, y, x);
 
 			break;
 		}

--- a/src/trap.c
+++ b/src/trap.c
@@ -102,6 +102,16 @@ void place_trap(struct cave *c, int y, int x)
 	cave_set_feat(c, y, x, FEAT_INVIS);
 }
 
+/* Create a trap during play. All traps are untyped until discovered. */
+void create_trap(struct cave *c, int y, int x)
+{
+	assert(cave_in_bounds(c, y, x));
+	assert(cave_empty_bold(y, x));
+
+	/* Place an invisible trap */
+	cave_set_feat(c, y, x, FEAT_INVIS);
+}
+
 /*
  * Handle player hitting a real trap
  */

--- a/src/trap.h
+++ b/src/trap.h
@@ -7,5 +7,6 @@ bool trap_check_hit(int power);
 extern void hit_trap(int y, int x);
 extern void pick_trap(int y, int x);
 extern void place_trap(struct cave *c, int y, int x);
+extern void create_trap(struct cave *c, int y, int x);
 
 #endif /* !TRAP_H */


### PR DESCRIPTION
Traps can now be created on a grid with an object,
but not on a grid with a player or monster.

Changes in:
spells1.c (project)
trap.h
trap.c (new function create_trap)

Note: Can be tested in wiz-mde with scrolls of Trap creation.
