### PR TITLE
#851 Drain EXP should drain XP in proportion to total XP

### DIFF
--- a/src/dungeon.c
+++ b/src/dungeon.c
@@ -761,8 +761,10 @@ static void process_world(struct cave *c)
 	/* Handle experience draining */
 	if (check_state(p_ptr, OF_DRAIN_EXP, p_ptr->state.flags))
 	{
-		if ((p_ptr->exp > 0) && one_in_(10))
-			player_exp_lose(p_ptr, 1, FALSE);
+		if ((p_ptr->exp > 0) && one_in_(10)) {
+			s32b d = damroll(10, 6) + (p_ptr->exp/100) * MON_DRAIN_LIFE;
+			player_exp_lose(p_ptr, d / 10, FALSE);
+		}
 
 		wieldeds_notice_flag(p_ptr, OF_DRAIN_EXP);
 	}


### PR DESCRIPTION
An object with the flag OF_DRAIN_EXP now drains proportionally to
player exp.

Changes in:
dungeon.c (process_world)

Note: The formula is taken from the lowest possible monster melee drain
in melee2.c. It should drain about 0.2%. It needs to be low because the drain
happens often, about one in ten turns.

Note: No message is displayed, because it would be too much spam with
a message about every 10 turns.

Note: previous behaviour was draining 1 point of exp.
