### PR TITLE
#1381 Split up describe_combat() (second try)

### DIFF
--- a/src/object/obj-info.c
+++ b/src/object/obj-info.c
@@ -489,25 +489,119 @@ static void calculate_missile_crits(player_state *state, int weight,
 	*div  = 100;
 }
 
-/*
- * Describe combat advantages.
- */
-static bool describe_combat(textblock *tb, const object_type *o_ptr,
-		oinfo_detail_t mode)
-{
-	bool full = mode & OINFO_FULL;
 
+/*
+ * Describe blows.
+ */
+static bool describe_blows(textblock *tb, const object_type *o_ptr,
+		player_state state, bitflag f[OF_SIZE])
+{
+	int str_plus, dex_plus, old_blows = 0, new_blows, extra_blows;
+	int str_faster = -1, str_done = -1;
+	int dex_plus_bound;
+	int str_plus_bound;
+	int i;
+
+	bitflag tmp_f[OF_SIZE];
+
+	dex_plus_bound = STAT_RANGE - state.stat_ind[A_DEX];
+	str_plus_bound = STAT_RANGE - state.stat_ind[A_STR];
+
+	/* Write to the text block */
+	textblock_append_c(tb, TERM_L_GREEN, "%d.%d ",
+			state.num_blows / 100, (state.num_blows / 10) % 10);
+	textblock_append(tb, "blow%s/round.\n",
+			(state.num_blows > 100) ? "s" : "");
+
+	/* Check to see if extra STR or DEX would yield extra blows */
+	old_blows = state.num_blows;
+	extra_blows = 0;
+
+	/* First we need to look for extra blows on other items, as
+	 * state does not track these */
+	for (i = INVEN_BOW; i < INVEN_TOTAL; i++)
+	{
+		if (!p_ptr->inventory[i].kind)
+			continue;
+
+		object_flags_known(&p_ptr->inventory[i], tmp_f);
+
+		if (of_has(tmp_f, OF_BLOWS))
+			extra_blows += p_ptr->inventory[i].pval[which_pval(&p_ptr->inventory[i], OF_BLOWS)];
+	}
+
+	/* Then we add blows from the weapon being examined */
+	if (of_has(f, OF_BLOWS))
+		extra_blows += o_ptr->pval[which_pval(o_ptr, OF_BLOWS)];
+
+	/* Then we check for extra "real" blows */
+	for (dex_plus = 0; dex_plus < dex_plus_bound; dex_plus++)
+	{
+		for (str_plus = 0; str_plus < str_plus_bound; str_plus++)
+        {
+			state.stat_ind[A_STR] += str_plus;
+			state.stat_ind[A_DEX] += dex_plus;
+			new_blows = calc_blows(o_ptr, &state, extra_blows);
+
+			/* Test to make sure that this extra blow is a
+			 * new str/dex combination, not a repeat
+			 */
+			if ((new_blows - new_blows % 10) > (old_blows - old_blows % 10) &&
+				(str_plus < str_done ||
+				str_done == -1))
+			{
+				textblock_append(tb, "With +%d STR and +%d DEX you would get %d.%d blows\n",
+					str_plus, dex_plus, (new_blows / 100),
+					(new_blows / 10) % 10);
+				state.stat_ind[A_STR] -= str_plus;
+				state.stat_ind[A_DEX] -= dex_plus;
+				str_done = str_plus;
+				break;
+			}
+
+			/* If the combination doesn't increment
+			 * the displayed blows number, it might still
+			 * take a little less energy
+			 */
+			if (new_blows > old_blows &&
+				(str_plus < str_faster ||
+				str_faster == -1) &&
+				(str_plus < str_done ||
+				str_done == -1))
+			{
+				textblock_append(tb, "With +%d STR and +%d DEX you would attack a bit faster\n",
+					str_plus, dex_plus);
+				state.stat_ind[A_STR] -= str_plus;
+				state.stat_ind[A_DEX] -= dex_plus;
+				str_faster = str_plus;
+				continue;
+			}
+
+			state.stat_ind[A_STR] -= str_plus;
+			state.stat_ind[A_DEX] -= dex_plus;
+		}
+	}
+
+	return TRUE;
+}
+
+
+/*
+ * Describe damage.
+ */
+static bool describe_damage(textblock *tb, const object_type *o_ptr,
+		player_state state, bitflag f[OF_SIZE])
+{
 	const char *desc[SL_MAX] = { 0 };
 	int i;
 	int mult[SL_MAX];
 	int cnt, dam, total_dam, plus = 0;
 	int xtra_postcrit = 0, xtra_precrit = 0;
 	int crit_mult, crit_div, crit_add;
-	int str_plus, dex_plus, old_blows = 0, new_blows, extra_blows;
-	int str_faster = -1, str_done = -1;
+	int old_blows = 0;
 	object_type *bow = &p_ptr->inventory[INVEN_BOW];
 
-	bitflag f[OF_SIZE], tmp_f[OF_SIZE], mask[OF_SIZE];
+	bitflag tmp_f[OF_SIZE], mask[OF_SIZE];
 
 	bool weapon = (wield_slot(o_ptr) == INVEN_WIELD);
 	bool ammo   = (p_ptr->state.ammo_tval == o_ptr->tval) &&
@@ -516,6 +610,148 @@ static bool describe_combat(textblock *tb, const object_type *o_ptr,
 
 	/* Create the "all slays" mask */
 	create_mask(mask, FALSE, OFT_SLAY, OFT_KILL, OFT_BRAND, OFT_MAX);
+
+	if (weapon)
+	{
+		dam = ((o_ptr->ds + 1) * o_ptr->dd * 5);
+
+		xtra_postcrit = state.dis_to_d * 10;
+		if (object_attack_plusses_are_visible(o_ptr))
+		{
+			xtra_precrit += o_ptr->to_d * 10;
+			plus += o_ptr->to_h;
+		}
+
+		calculate_melee_crits(&state, o_ptr->weight, plus,
+				&crit_mult, &crit_add, &crit_div);
+
+		old_blows = state.num_blows;
+	}
+	else /* Ammo */
+	{
+		if (object_attack_plusses_are_visible(o_ptr))
+			plus += o_ptr->to_h;
+
+		calculate_missile_crits(&p_ptr->state, o_ptr->weight, plus,
+				&crit_mult, &crit_add, &crit_div);
+
+		/* Calculate damage */
+		dam = ((o_ptr->ds + 1) * o_ptr->dd * 5);
+
+		if (object_attack_plusses_are_visible(o_ptr))
+			dam += (o_ptr->to_d * 10);
+		if (object_attack_plusses_are_visible(bow))
+			dam += (bow->to_d * 10);
+
+		/* Apply brands/slays from the shooter to the ammo, but only if known
+		 * Note that this is not dependent on mode, so that viewing shop-held
+		 * ammo (fully known) does not leak information about launcher */
+		object_flags_known(bow, tmp_f);
+		of_union(f, tmp_f);
+	}
+
+	/* Collect slays */
+	/* Melee weapons get slays and brands from other items now */
+	if (weapon)
+	{
+		bool nonweap_slay = FALSE;
+
+		for (i = INVEN_LEFT; i < INVEN_TOTAL; i++)
+		{
+			if (!p_ptr->inventory[i].kind)
+				continue;
+
+			object_flags_known(&p_ptr->inventory[i], tmp_f);
+
+			/* Strip out non-slays */
+			of_inter(tmp_f, mask);
+
+			if (of_union(f, tmp_f))
+				nonweap_slay = TRUE;
+		}
+
+		if (nonweap_slay)
+			textblock_append(tb, "This weapon may benefit from one or more off-weapon brands or slays.\n");
+	}
+
+	textblock_append(tb, "Average damage/round: ");
+
+	if (ammo) multiplier = p_ptr->state.ammo_mult;
+
+	/* Output damage for creatures effected by the brands or slays */
+	cnt = list_slays(f, mask, desc, NULL, mult, TRUE);
+	for (i = 0; i < cnt; i++)
+	{
+		/* ammo mult adds fully, melee mult is times 1, so adds 1 less */
+		int melee_adj_mult = ammo ? 0 : 1; 
+
+		/* Include bonus damage and slay in stated average */
+		total_dam = dam * (multiplier + mult[i] - melee_adj_mult) + xtra_precrit;
+		total_dam = (total_dam * crit_mult + crit_add) / crit_div;
+		total_dam += xtra_postcrit;
+
+		if (weapon) 
+			total_dam = (total_dam * old_blows) / 100;
+		else
+			total_dam *= p_ptr->state.num_shots;
+
+		if (total_dam <= 0)
+			textblock_append_c(tb, TERM_L_RED, "%d", 0);
+		else if (total_dam % 10)
+			textblock_append_c(tb, TERM_L_GREEN, "%d.%d",
+					total_dam / 10, total_dam % 10);
+		else
+			textblock_append_c(tb, TERM_L_GREEN, "%d", total_dam / 10);
+
+		textblock_append(tb, " vs. %s, ", desc[i]);
+	}
+
+	if (cnt) textblock_append(tb, "and ");
+
+	/* Include bonus damage in stated average */
+	total_dam = dam * multiplier + xtra_precrit;
+	total_dam = (total_dam * crit_mult + crit_add) / crit_div;
+	total_dam += xtra_postcrit;
+
+	/* Normal damage, not considering brands or slays */
+	if (weapon)
+		total_dam = (total_dam * old_blows) / 100;
+	else
+		total_dam *= p_ptr->state.num_shots;
+
+	if (total_dam <= 0)
+		textblock_append_c(tb, TERM_L_RED, "%d", 0);
+	else if (total_dam % 10)
+		textblock_append_c(tb, TERM_L_GREEN, "%d.%d",
+				total_dam / 10, total_dam % 10);
+	else
+		textblock_append_c(tb, TERM_L_GREEN, "%d", total_dam / 10);
+
+	if (cnt) textblock_append(tb, " vs. others");
+	textblock_append(tb, ".\n");
+
+	return true;
+}
+
+
+/*
+ * Describe combat advantages.
+ */
+static bool describe_combat(textblock *tb, const object_type *o_ptr,
+		oinfo_detail_t mode)
+{
+	bool full = mode & OINFO_FULL;
+
+	object_type *bow = &p_ptr->inventory[INVEN_BOW];
+
+	bitflag f[OF_SIZE];
+
+	bool weapon = (wield_slot(o_ptr) == INVEN_WIELD);
+	bool ammo   = (p_ptr->state.ammo_tval == o_ptr->tval) &&
+	              (bow->kind);
+
+	/* The player's hypothetical state, were they to wield this item */
+	player_state state;
 
 	/* Abort if we've nothing to say */
 	if (mode & OINFO_DUMMY) return FALSE;
@@ -542,14 +778,6 @@ static bool describe_combat(textblock *tb, const object_type *o_ptr,
 
 	if (weapon)
 	{
-		/*
-		 * Get the player's hypothetical state, were they to be
-		 * wielding this item.
-		 */
-		player_state state;
-		int dex_plus_bound;
-		int str_plus_bound;
-
 		object_type inven[INVEN_TOTAL];
 
 		memcpy(inven, p_ptr->inventory, INVEN_TOTAL * sizeof(object_type));
@@ -557,201 +785,29 @@ static bool describe_combat(textblock *tb, const object_type *o_ptr,
 
 		if (full) object_know_all_flags(&inven[INVEN_WIELD]);
 
+		/* Calculate the player's hypothetical state */
 		calc_bonuses(inven, &state, TRUE);
-		dex_plus_bound = STAT_RANGE - state.stat_ind[A_DEX];
-		str_plus_bound = STAT_RANGE - state.stat_ind[A_STR];
-
-		dam = ((o_ptr->ds + 1) * o_ptr->dd * 5);
-
-		xtra_postcrit = state.dis_to_d * 10;
-		if (object_attack_plusses_are_visible(o_ptr))
-		{
-			xtra_precrit += o_ptr->to_d * 10;
-			plus += o_ptr->to_h;
-		}
-
-		calculate_melee_crits(&state, o_ptr->weight, plus,
-				&crit_mult, &crit_add, &crit_div);
 
 		/* Warn about heavy weapons */
 		if (adj_str_hold[state.stat_ind[A_STR]] < o_ptr->weight / 10)
 			textblock_append_c(tb, TERM_L_RED, "You are too weak to use this weapon.\n");
 
-		textblock_append_c(tb, TERM_L_GREEN, "%d.%d ",
-				state.num_blows / 100, (state.num_blows / 10) % 10);
-		textblock_append(tb, "blow%s/round.\n",
-				(state.num_blows > 100) ? "s" : "");
-
-		/* Check to see if extra STR or DEX would yield extra blows */
-		old_blows = state.num_blows;
-		extra_blows = 0;
-
-		/* First we need to look for extra blows on other items, as
-		 * state does not track these */
-		for (i = INVEN_BOW; i < INVEN_TOTAL; i++)
-		{
-			if (!p_ptr->inventory[i].kind)
-				continue;
-			object_flags_known(&p_ptr->inventory[i], tmp_f);
-
-			if (of_has(tmp_f, OF_BLOWS))
-				extra_blows += p_ptr->inventory[i].pval[which_pval(&p_ptr->inventory[i], OF_BLOWS)];
-		}
-
-		/* Then we add blows from the weapon being examined */
-		if (of_has(f, OF_BLOWS))
-			extra_blows += o_ptr->pval[which_pval(o_ptr, OF_BLOWS)];
-
-		/* Then we check for extra "real" blows */
-		for (dex_plus = 0; dex_plus < dex_plus_bound; dex_plus++)
-		{
-			for (str_plus = 0; str_plus < str_plus_bound; str_plus++)
-	        {
-				state.stat_ind[A_STR] += str_plus;
-				state.stat_ind[A_DEX] += dex_plus;
-				new_blows = calc_blows(o_ptr, &state, extra_blows);
-
-				/* Test to make sure that this extra blow is a
-				 * new str/dex combination, not a repeat
-				 */
-				if ((new_blows - new_blows % 10) > (old_blows - old_blows % 10) &&
-					(str_plus < str_done ||
-					str_done == -1))
-				{
-					textblock_append(tb, "With +%d STR and +%d DEX you would get %d.%d blows\n",
-						str_plus, dex_plus, (new_blows / 100),
-						(new_blows / 10) % 10);
-					state.stat_ind[A_STR] -= str_plus;
-					state.stat_ind[A_DEX] -= dex_plus;
-					str_done = str_plus;
-					break;
-				}
-
-				/* If the combination doesn't increment
-				 * the displayed blows number, it might still
-				 * take a little less energy
-				 */
-				if (new_blows > old_blows &&
-					(str_plus < str_faster ||
-					str_faster == -1) &&
-					(str_plus < str_done ||
-					str_done == -1))
-				{
-					textblock_append(tb, "With +%d STR and +%d DEX you would attack a bit faster\n",
-						str_plus, dex_plus);
-					state.stat_ind[A_STR] -= str_plus;
-					state.stat_ind[A_DEX] -= dex_plus;
-					str_faster = str_plus;
-					continue;
-				}
-
-				state.stat_ind[A_STR] -= str_plus;
-				state.stat_ind[A_DEX] -= dex_plus;
-			}
-		}
+		/* Describe blows */
+		describe_blows(tb, o_ptr, state, f);
 	}
-	else
+	else /* Ammo */
 	{
+		/* Range of the weapon */
 		int tdis = 6 + 2 * p_ptr->state.ammo_mult;
 
-		if (object_attack_plusses_are_visible(o_ptr))
-			plus += o_ptr->to_h;
-
-		calculate_missile_crits(&p_ptr->state, o_ptr->weight, plus,
-				&crit_mult, &crit_add, &crit_div);
-
-		/* Calculate damage */
-		dam = ((o_ptr->ds + 1) * o_ptr->dd * 5);
-
-		if (object_attack_plusses_are_visible(o_ptr))
-			dam += (o_ptr->to_d * 10);
-		if (object_attack_plusses_are_visible(bow))
-			dam += (bow->to_d * 10);
-
-		/* Apply brands/slays from the shooter to the ammo, but only if known
-		 * Note that this is not dependent on mode, so that viewing shop-held
-		 * ammo (fully known) does not leak information about launcher */
-		object_flags_known(bow, tmp_f);
-		of_union(f, tmp_f);
-
+		/* Output the range */
 		textblock_append(tb, "Hits targets up to ");
 		textblock_append_c(tb, TERM_L_GREEN, format("%d", tdis * 10));
 		textblock_append(tb, " feet away.\n");
 	}
 
-	/* Collect slays */
-	/* Melee weapons get slays and brands from other items now */
-	if (weapon)
-	{
-		bool nonweap = FALSE;
-
-		for (i = INVEN_LEFT; i < INVEN_TOTAL; i++)
-		{
-			if (!p_ptr->inventory[i].kind)
-				continue;
-			object_flags_known(&p_ptr->inventory[i], tmp_f);
-
-			of_inter(tmp_f, mask); /* strip out non-slays */
-
-			if (of_union(f, tmp_f))
-				nonweap = TRUE;
-		}
-
-		if (nonweap)
-			textblock_append(tb, "This weapon may benefit from one or more off-weapon brands or slays.\n");
-	}
-
-	textblock_append(tb, "Average damage/round: ");
-
-	if (ammo) multiplier = p_ptr->state.ammo_mult;
-
-	cnt = list_slays(f, mask, desc, NULL, mult, TRUE);
-	for (i = 0; i < cnt; i++)
-	{
-		int melee_adj_mult = ammo ? 0 : 1; /* ammo mult adds fully, melee mult is times 1, so adds 1 less */
-		/* Include bonus damage and slay in stated average */
-		total_dam = dam * (multiplier + mult[i] - melee_adj_mult) + xtra_precrit;
-		total_dam = (total_dam * crit_mult + crit_add) / crit_div;
-		total_dam += xtra_postcrit;
-		if (weapon) 
-			total_dam = (total_dam * old_blows) / 100;
-		else
-			total_dam *= p_ptr->state.num_shots;
-		
-
-		if (total_dam <= 0)
-			textblock_append_c(tb, TERM_L_RED, "%d", 0);
-		else if (total_dam % 10)
-			textblock_append_c(tb, TERM_L_GREEN, "%d.%d",
-					total_dam / 10, total_dam % 10);
-		else
-			textblock_append_c(tb, TERM_L_GREEN, "%d", total_dam / 10);
-
-
-		textblock_append(tb, " vs. %s, ", desc[i]);
-	}
-
-	if (cnt) textblock_append(tb, "and ");
-
-	/* Include bonus damage in stated average */
-	total_dam = dam * multiplier + xtra_precrit;
-	total_dam = (total_dam * crit_mult + crit_add) / crit_div;
-	total_dam += xtra_postcrit;
-	if (weapon)
-		total_dam = (total_dam * old_blows) / 100;
-	else
-		total_dam *= p_ptr->state.num_shots;
-
-	if (total_dam <= 0)
-		textblock_append_c(tb, TERM_L_RED, "%d", 0);
-	else if (total_dam % 10)
-		textblock_append_c(tb, TERM_L_GREEN, "%d.%d",
-				total_dam / 10, total_dam % 10);
-	else
-		textblock_append_c(tb, TERM_L_GREEN, "%d", total_dam / 10);
-
-	if (cnt) textblock_append(tb, " vs. others");
-	textblock_append(tb, ".\n");
+	/* Describe damage */
+	describe_damage(tb, o_ptr, state, f);
 
 	/* Note the impact flag */
 	if (of_has(f, OF_IMPACT))
@@ -765,9 +821,10 @@ static bool describe_combat(textblock *tb, const object_type *o_ptr,
 		textblock_append(tb, " chance of breaking upon contact.\n");
 	}
 
-	/* You always have something to say... */
+	/* Something has been said */
 	return TRUE;
 }
+
 
 /*
  * Describe objects that can be used for digging.


### PR DESCRIPTION
The function was split into three by creating two new functions:
describe_blows and describe_damage.

Now with int i at the top of functions.

Changes in:
obj-info.c

Note: The new functions have been tested with several
artifacts, and seem to describe them correctly when the
command 'I' for examining an item is given. Comparisons
were made by running two games at the same time, side by
side, one with the original code and one with the changed
code.
