### PR TITLE
#1582 To-hit values not revealed by shooting

### DIFF
--- a/src/attack.c
+++ b/src/attack.c
@@ -444,6 +444,9 @@ static void ranged_helper(int item, int dir, int range, int shots, ranged_attack
 			monster_desc(m_name, sizeof(m_name), m_ptr, 0);
 		
 			object_notice_attack_plusses(o_ptr);
+
+			/* Learn by use for other equipped items */
+			wieldeds_notice_to_hit_on_attack();
 		
 			/* No negative damage; change verb if no damage done */
 			if (dmg <= 0) {

--- a/src/object/identify.c
+++ b/src/object/identify.c
@@ -952,6 +952,24 @@ void wieldeds_notice_flag(struct player *p, int flag)
 
 
 /**
+ * Notice to-hit bonus on attacking.
+ */
+void wieldeds_notice_to_hit_on_attack(void)
+/* Used e.g. for ranged attacks where the item's to_d is not involved. */
+/* Does not apply to weapon or bow which should be done separately */
+{
+	int i;
+
+	for (i = INVEN_WIELD + 2; i < INVEN_TOTAL; i++)
+		if (p_ptr->inventory[i].kind &&
+		    p_ptr->inventory[i].to_h)
+			object_notice_attack_plusses(&p_ptr->inventory[i]);
+
+	return;
+}
+
+
+/**
  * Notice things which happen on attacking.
  */
 void wieldeds_notice_on_attack(void)

--- a/src/object/object.h
+++ b/src/object/object.h
@@ -568,6 +568,7 @@ void object_notice_on_defend(struct player *p);
 void object_notice_on_wield(object_type *o_ptr);
 void object_notice_on_firing(object_type *o_ptr);
 void wieldeds_notice_flag(struct player *p, int flag);
+void wieldeds_notice_to_hit_on_attack(void);
 void wieldeds_notice_on_attack(void);
 void object_repair_knowledge(object_type *o_ptr);
 bool object_FA_would_be_obvious(const object_type *o_ptr);


### PR DESCRIPTION
#1582 To-hit values not revealed by shooting

Bonus on ring of accuracy, ring of slaying,
and similar items, is now revealed when
shooting, and also when throwing.

Changes in:
attack.c    (ranged_helper)
object.h
identify.c    (new function wieldeds_notice_to_hit_on_attack)

Note: tried to imitate behaviour in py_attack_real.

Note: the new function in identify.c was introduced 
to avoid revealing bonus on ring of damage.
