### PR TITLE
Very minor typo -- cold damage

### DIFF
--- a/src/monster/mon-msg.c
+++ b/src/monster/mon-msg.c
@@ -78,7 +78,7 @@ static const char *msg_repository[MAX_MON_MSG + 1] =
 	"[is|are] no longer afraid.",/* MON_MSG_NOT_AFRAID */
 	"~You hear [a|several] scream[|s] of agony!",/* MON_MSG_MORIA_DEATH */
 	"disintegrates!",		/* MON_MSG_DISENTEGRATES */
-	"freez[es] and shatter[s]",  /* MON_MSG_FREEZE_SHATTER */
+	"freez[es] and shatter[s]!",  /* MON_MSG_FREEZE_SHATTER */
 	"lose[s] some mana!",		/* MON_MSG_MANA_DRAIN */
 	"looks briefly puzzled.",	/* MON_MSG_BRIEF_PUZZLE */
 	"maintain[s] the same shape.", /* MON_MSG_MAINTAIN_SHAPE */


### PR DESCRIPTION
Added exclamation mark:
"freez[es] and shatter[s]" -> "freez[es] and shatter[s]!"

Change in:
mon-msg.c

Note: similar messages had an exclamation mark. An alternative would be to use a dot.
