### PR TITLE
Disable visual mode except for tiles

### DIFF
--- a/src/ui-knowledge.c
+++ b/src/ui-knowledge.c
@@ -850,6 +850,9 @@ static bool visual_mode_command(ui_event ke, bool *visual_list_ptr,
 		case 'V':
 		case 'v':
 		{
+		        /* No visual mode without graphics, for now - NRM */
+		        if (current_graphics_mode->grafID == 0) break;
+
 			if (!*visual_list_ptr)
 			{
 				*visual_list_ptr = TRUE;


### PR DESCRIPTION
Quick fix to stop the carbon port from crashing - the new unicode-handling mode still needs to be done.
