### PR TITLE
Fix gcu knowledge menu crash

### DIFF
--- a/src/ui-knowledge.c
+++ b/src/ui-knowledge.c
@@ -852,7 +852,9 @@ static bool visual_mode_command(ui_event ke, bool *visual_list_ptr,
 		case 'v':
 		{
 		        /* No visual mode without graphics, for now - NRM */
-		        if (current_graphics_mode->grafID == 0) break;
+		       if (current_graphics_mode != NULL)
+			       if (current_graphics_mode->grafID == 0)
+				       break;
 
 			if (!*visual_list_ptr)
 			{


### PR DESCRIPTION
Turns out current_graphics_mode is not always defined.  After this (well-formed) pull request is pulled, that will no longer be a problem.
