### PR TITLE
borg not correctly passing parameter to wcstombs()

### DIFF
--- a/src/borg/borg1.c
+++ b/src/borg/borg1.c
@@ -1502,7 +1502,7 @@ errr borg_what_text(int x, int y, int n, byte *a, char *s)
     (*a) = d_a;
 
     /* Convert back to a char string */
-    wcstombs(s, screen_str, n+1);
+    wcstombs(s, screen_str, ABS(n)+1);
     /* Too short */
     if ((n > 0) && (i != n)) return (1);
 


### PR DESCRIPTION
borg_what_text() can take a negative value of n to invoke special behavior, but it didn't check whether or not the value was negative before passing it on to wcstombs().
