### PR TITLE
Fix for non-mingw builds on Cygwin.

### DIFF
--- a/compiling.txt
+++ b/compiling.txt
@@ -100,6 +100,9 @@ and zlib1.dll) from src/win/dll to the top-level dir
 Using Cygwin (with MinGW)
 -------------------------
 
+Use this option if you want to build a native Windows executable that
+can run with or without Cygwin.
+
 Use the Cygwin setup.exe to install the mingw-gcc-core package and any
 dependencies suggested by the installer.
 
@@ -111,6 +114,10 @@ Run these commands:
 
 As with the "Using MinGW" process, you need to copy the executable and
 DLLs to the top-level dir.
+
+If you want to build the Unix version of Angband that uses X11 or
+Curses and run it under Cygwin, then follow the native build
+instructions (./autogen.sh; ./configure; make; make install).
 
 
 Using eclipse (Indigo) on Windows (with MinGW)

--- a/configure.ac
+++ b/configure.ac
@@ -87,7 +87,18 @@ dnl needed because h-basic.h checks for this define for autoconf support.
 CFLAGS="$CFLAGS -DHAVE_CONFIG_H"
 CPPFLAGS="$CPPFLAGS -I." 
 
-test "$GCC" = "yes" && CFLAGS="$CFLAGS -fno-strength-reduce -W -Wall -Wno-unused-parameter -Wno-missing-field-initializers -pedantic"
+if test "$GCC" = "yes"; then
+	CFLAGS="$CFLAGS -fno-strength-reduce -W -Wall -Wno-unused-parameter -pedantic"
+	AC_MSG_CHECKING([if gcc supports -Wno-missing-field-initializers])
+	_gcc_cflags_save=$CFLAGS
+	CFLAGS="-Wno-missing-field-initializers"
+	AC_COMPILE_IFELSE([AC_LANG_SOURCE([])],_gcc_wopt=yes,_gcc_wopt=no)
+	AC_MSG_RESULT($_gcc_wopt)
+	CFLAGS=$_gcc_cflags_save;
+	if test x"$_gcc_wopt" = xyes ; then
+		CFLAGS="$CFLAGS -Wno-missing-field-initializers"
+	fi
+fi
 
 MY_PROG_MAKE_SYSVINC
 MY_PROG_MAKE_SINCLUDE


### PR DESCRIPTION
The Cygwin version of GCC doesn't support the -Wno-missing-field-initializers flag, so I modified configure.ac to check the usability of that option before using it.
