### PR TITLE
Allow pickup in darkness (fixes #1665)

### DIFF
--- a/src/cmd1.c
+++ b/src/cmd1.c
@@ -479,7 +479,7 @@ byte py_pickup(int pickup)
 	if (!cave->o_idx[py][px]) return objs_picked_up;
 
 	/* Tally objects that can be picked up.*/
-	floor_num = scan_floor(floor_list, N_ELEMENTS(floor_list), py, px, 0x03);
+	floor_num = scan_floor(floor_list, N_ELEMENTS(floor_list), py, px, 0x01);
 	for (i = 0; i < floor_num; i++)
 	{
 	    can_pickup += inven_carry_okay(object_byid(floor_list[i]));


### PR DESCRIPTION
I tested this in GCU, but I don't think it is port-specific.
