### PR TITLE
Add checks to prevent crashes in wiz-mode artifact creation. Fixes #1655

### DIFF
--- a/src/object/obj-util.c
+++ b/src/object/obj-util.c
@@ -3607,7 +3607,7 @@ int lookup_artifact_name(const char *name)
 			return i;
 		
 		/* Test for close matches */
-		if (a_ptr->name && my_stristr(a_ptr->name, name) && a_idx == -1)
+		if (strlen(name) >= 3 && a_ptr->name && my_stristr(a_ptr->name, name) && a_idx == -1)
 			a_idx = i;
 	} 
 

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -1671,7 +1671,7 @@ void do_cmd_debug(void)
 		/* Create an artifact */
 		case 'C':
 		{
-			if (p_ptr->command_arg > 0)
+			if (p_ptr->command_arg > 0 && p_ptr->command_arg < z_info->a_max)
 			{
 				wiz_create_artifact(p_ptr->command_arg);
 			}
@@ -1697,7 +1697,7 @@ void do_cmd_debug(void)
 						a_idx = lookup_artifact_name(name); 
 					
 					/* Did we find a valid artifact? */
-					if (a_idx != -1)
+					if (a_idx != -1 && a_idx < z_info->a_max)
 						wiz_create_artifact(a_idx);
 					else
 						msg("No artifact found.");


### PR DESCRIPTION
Signed-off-by: Peter Denison angband@marshadder.org
