### PR TITLE
Make the command line option -d actually work;

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -196,7 +196,6 @@ static void change_path(const char *info)
   for(i=0;i<N_ELEMENTS(change_path_map_keys);i++) {
     if(my_stricmp(path, change_path_map_keys[i]) == 0) {
       string_free(*change_path_map_values[i]);
-      printf("DIR: %s", dir);
       *change_path_map_values[i] = string_make(dir);
 
       /* the directory may not exist and may need to be created. */


### PR DESCRIPTION
That is, allow command lines to override the locations of any of angband's directories.

Today, the -d option doesn't actually work - it updates ANGBAND_DIR_USER, but that change is clobbered by init_stuff (which calls init_file_paths).

Digging into this, I noticed that the comments for change_path, which is called when -d is parsed, do not line up with the --help text. 

This pull request implements -d to match the original comments. In other words, any angband directory, e.g. save/pref/xtra/apex can be overriden to point to an arbitrary directory. -d now also works irregardless of whether PRIVATE_USER_PATH is set (which it is by default, when SET_UID is set, which is set on unix-like OSes).
