### PR TITLE
Cursor fix in bigtile mode

### DIFF
--- a/src/dungeon.c
+++ b/src/dungeon.c
@@ -1260,7 +1260,7 @@ void idle_update(void)
 {
 	if (!character_dungeon) return;
 
-	if (!OPT(animate_flicker)) return;
+	if (!OPT(animate_flicker) || (use_graphics != GRAPHICS_NONE)) return;
 
 	/* Animate and redraw if necessary */
 	do_animation();


### PR DESCRIPTION
Another wacky one - animate_flicker was making a big cursor appear near the stats on -more- prompts.  Solution - don't flicker when using tiles.
