### PR TITLE
Stop crashes when changing to ASCII in SDL

### DIFF
--- a/src/main-sdl.c
+++ b/src/main-sdl.c
@@ -3017,6 +3017,7 @@ static errr sdl_BuildTileset(term_window *win)
 	if (!GfxSurface) return (1);
 
 	info = get_graphics_mode(use_graphics);
+	if (info->grafID == 0) return (1);
 
 	/* Calculate the number of tiles across & down*/
 	ta = GfxSurface->w / info->cell_width;


### PR DESCRIPTION
Another obscure one - changing from tiles to ASCII in SDL with the monster list open was causing crashes, basically because it was trying to load tiles without checking they were really there.  This should fix it.
