### PR TITLE
Sure you can read books

### DIFF
--- a/src/ui-spell.c
+++ b/src/ui-spell.c
@@ -303,7 +303,7 @@ void textui_obj_study(void)
 
 	item_tester_hook = obj_can_study;
 	if (!get_item(&item, "Study which book? ",
-			"You have no books that you can read.",
+			"You have no books that you learn new spells from.",
 			CMD_STUDY_BOOK, (USE_INVEN | USE_FLOOR)))
 		return;
 


### PR DESCRIPTION
If you have can gain new spells but none of them match anything in your books you get the message: "You have no books that you can read." which is a wrong description. You can't learn any spells from the books you have is better, or this one. So if you know an even better description please use that one.
