### PR TITLE
cave.c: fix vinfo knight's move crash

### DIFF
--- a/src/cave.h
+++ b/src/cave.h
@@ -60,9 +60,6 @@ extern void disturb(struct player *p, int stop_search, int unused_flag);
 extern bool is_quest(int level);
 extern bool dtrap_edge(int y, int x);
 
-#define CAVE_INFO_Y	DUNGEON_HGT
-#define CAVE_INFO_X	256
-
 /* XXX: temporary while I refactor */
 extern struct cave *cave;
 


### PR DESCRIPTION
This crash was caused by me forgetting that dx/dy were the targeted spot minus
the player's position, not vice versa, and hence adding sx/sy when I should've
subtracted. While adding asserts to trap this error, I found a slew of other
out-of-bounds reads and writes in update_view(), so those are also now fixed.

Signed-off-by: Elly Fong-Jones elly@leptoquark.net
