### PR TITLE
Offset cursor for sval squelch menu. [1785]

### DIFF
--- a/src/ui-menu.c
+++ b/src/ui-menu.c
@@ -182,7 +182,7 @@ static void display_scrolling(menu_type *menu, int cursor, int *top, region *loc
 	}
 
 	if (menu->cursor >= 0)
-		Term_gotoxy(col, row + cursor - *top);
+		Term_gotoxy(col + menu->cursor_x_offset, row + cursor - *top);
 }
 
 static char scroll_get_tag(menu_type *menu, int pos)
@@ -276,7 +276,7 @@ static void display_columns(menu_type *menu, int cursor, int *top, region *loc)
 	}
 
 	if (menu->cursor >= 0)
-		Term_gotoxy(col + (cursor / rows_per_page) * colw,
+		Term_gotoxy(col + (cursor / rows_per_page) * colw + menu->cursor_x_offset,
 				row + (cursor % rows_per_page) - *top);
 }
 
@@ -849,6 +849,7 @@ void menu_init(menu_type *menu, skin_id skin_id, const menu_iter *iter)
 	menu->row_funcs = iter;
 	menu->skin = skin;
 	menu->cursor = 0;
+	menu->cursor_x_offset = 0;
 }
 
 menu_type *menu_new(skin_id skin_id, const menu_iter *iter)
@@ -865,6 +866,11 @@ menu_type *menu_new_action(menu_action *acts, size_t n)
 	return m;
 }
 
+void menu_set_cursor_x_offset(menu_type *m, int offset)
+{
+	/* This value is used in the menu skin's display_list() function. */
+	m->cursor_x_offset = offset;
+}
 
 /*** Dynamic menu handling ***/
 

--- a/src/ui-menu.h
+++ b/src/ui-menu.h
@@ -217,7 +217,7 @@ struct menu_type
 	int cursor;             /* Currently selected row */
 	int top;                /* Position in list for partial display */
 	region active;          /* Subregion actually active for selection */
-
+	int cursor_x_offset;    /* Adjustment to the default position of the cursor on a line. */
 };
 
 
@@ -328,6 +328,10 @@ void menu_ensure_cursor_valid(menu_type *m);
 bool menu_handle_mouse(menu_type *menu, const ui_event *in, ui_event *out);
 bool menu_handle_keypress(menu_type *menu, const ui_event *in, ui_event *out);
 
+/**
+ * Allow adjustment of the cursor's default x offset.
+ */
+void menu_set_cursor_x_offset(menu_type *m, int offset);
 
 /*** Dynamic menu handling ***/
 

--- a/src/ui-options.c
+++ b/src/ui-options.c
@@ -1375,6 +1375,7 @@ static bool sval_menu(int tval, const char *desc)
 	menu_setpriv(menu, n_choices, choices);
 	menu->cmd_keys = "Tt";
 	menu_layout(menu, &area);
+	menu_set_cursor_x_offset(menu, 1); /* Place cursor in brackets. */
 	menu_select(menu, 0, FALSE);
 
 	/* Free memory */


### PR DESCRIPTION
This allows a horizontal offset to be added to the cursor. I wasn't seeing the same cursor behavior as described in the issue; on OS X, the cursor was just at the beginning of the line. At the very least, this places the cursor in between the brackets on OS X.
