### PR TITLE
Add spaces to colour names for text_out_e

### DIFF
--- a/src/ui-birth.c
+++ b/src/ui-birth.c
@@ -520,12 +520,12 @@ static void clear_question(void)
 
 
 #define BIRTH_MENU_HELPTEXT \
-	"{lightblue}Please select your character from the menu below:{/}\n\n" \
-	"Use the {lightgreen}movement keys{/} to scroll the menu, " \
-	"{lightgreen}Enter{/} to select the current menu item, '{lightgreen}*{/}' " \
-	"for a random menu item, '{lightgreen}ESC{/}' to step back through the " \
-	"birth process, '{lightgreen}={/}' for the birth options, '{lightgreen}?{/} " \
-	"for help, or '{lightgreen}Ctrl-X{/}' to quit."
+	"{light blue}Please select your character from the menu below:{/}\n\n" \
+	"Use the {light green}movement keys{/} to scroll the menu, " \
+	"{light green}Enter{/} to select the current menu item, '{light green}*{/}' " \
+	"for a random menu item, '{light green}ESC{/}' to step back through the " \
+	"birth process, '{light green}={/}' for the birth options, '{light green}?{/} " \
+	"for help, or '{light green}Ctrl-X{/}' to quit."
 
 /* Show the birth instructions on an otherwise blank screen */	
 static void print_menu_instructions(void)


### PR DESCRIPTION
Adding spaces to colour names (LightGreen -> Light Green) had broken the {lightgreen} tags for formatting for text_out_e.
