### PR TITLE
cmd-pickup: remove cmd_get_arg_item() test in do_cmd_pickup()

### DIFF
--- a/src/cmd-pickup.c
+++ b/src/cmd-pickup.c
@@ -45,9 +45,6 @@ void do_cmd_pickup(struct command *cmd)
 	int energy_cost;
 	int item;
 
-	if (!cmd_get_arg_item(cmd, 0, &item))
-		return;
-
 	/* Autopickup first */
 	energy_cost = do_autopickup() * 10;
 


### PR DESCRIPTION
This test requires that the command have an item argument, but pickup implicitly
targets the floor and so has no argument.
