### PR TITLE
Swap directions in constants to the more-tradtional 'North is up'

### DIFF
--- a/src/game-cmd.h
+++ b/src/game-cmd.h
@@ -111,16 +111,16 @@ typedef enum cmd_context
 
 enum {
 	DIR_UNKNOWN = 0,
-	DIR_NW = 1,
-	DIR_N = 2,
-	DIR_NE = 3,
+	DIR_NW = 7,
+	DIR_N = 8,
+	DIR_NE = 9,
 	DIR_W = 4,
 	DIR_TARGET = 5,
 	DIR_NONE = 5,
 	DIR_E = 6,
-	DIR_SW = 7,
-	DIR_S = 8,
-	DIR_SE = 9,
+	DIR_SW = 1,
+	DIR_S = 2,
+	DIR_SE = 3,
 };
 
 typedef union 

--- a/src/pathfind.c
+++ b/src/pathfind.c
@@ -203,31 +203,22 @@ int pathfind_direction_to(struct loc from, struct loc to)
 	if (dx >= 0 && dy >= 0)
 	{
 		if (adx < ady * 2 && ady < adx * 2)
-			return DIR_NE;
-		else if (adx > ady)
-			return DIR_E;
-		else
-			return DIR_N;
-	}
-	else if (dx > 0 && dy < 0)
-	{
-		if (adx < ady * 2 && ady < adx * 2)
 			return DIR_SE;
 		else if (adx > ady)
 			return DIR_E;
 		else
 			return DIR_S;
 	}
-	else if (dx < 0 && dy > 0)
+	else if (dx > 0 && dy < 0)
 	{
 		if (adx < ady * 2 && ady < adx * 2)
-			return DIR_NW;
+			return DIR_NE;
 		else if (adx > ady)
-			return DIR_W;
+			return DIR_E;
 		else
 			return DIR_N;
 	}
-	else if (dx <= 0 && dy <= 0)
+	else if (dx < 0 && dy > 0)
 	{
 		if (adx < ady * 2 && ady < adx * 2)
 			return DIR_SW;
@@ -235,6 +226,15 @@ int pathfind_direction_to(struct loc from, struct loc to)
 			return DIR_W;
 		else
 			return DIR_S;
+	}
+	else if (dx <= 0 && dy <= 0)
+	{
+		if (adx < ady * 2 && ady < adx * 2)
+			return DIR_NW;
+		else if (adx > ady)
+			return DIR_W;
+		else
+			return DIR_N;
 	}
 
 	assert(0);


### PR DESCRIPTION
Just noticed that at some point north and south have got reversed here - the values returned from pathfind_direction_to are correct, but the names are mixed up.
