### PR TITLE
Fix tests

### DIFF
--- a/src/cmds.h
+++ b/src/cmds.h
@@ -1,6 +1,7 @@
 #ifndef INCLUDED_CMDS_H
 #define INCLUDED_CMDS_H
 
+#include "cave.h"
 #include "game-cmd.h"
 struct store;
 

--- a/src/obj-util.h
+++ b/src/obj-util.h
@@ -19,6 +19,9 @@
 #ifndef OBJECT_UTIL_H
 #define OBJECT_UTIL_H
 
+#include "cave.h"
+#include "player.h"
+
 struct object_kind *objkind_get(int tval, int sval);
 struct object_kind *objkind_byid(int kidx);
 void flavor_init(void);

--- a/src/store.h
+++ b/src/store.h
@@ -1,6 +1,7 @@
 #ifndef INCLUDED_STORE_H
 #define INCLUDED_STORE_H
 
+#include "object.h"
 #include "parser.h"
 
 extern bool store_in_store;

--- a/src/tests/parse/c-info.c
+++ b/src/tests/parse/c-info.c
@@ -6,6 +6,7 @@
 #include "obj-flag.h"
 #include "object.h"
 #include "obj-tvalsval.h"
+#include "obj-util.h"
 #include "player.h"
 
 int setup_tests(void **state) {

--- a/src/tests/parse/f-info.c
+++ b/src/tests/parse/f-info.c
@@ -63,7 +63,7 @@ int test_p0(void *state) {
 }
 
 int test_f0(void *state) {
-	enum parser_error r = parser_parse(state, "F:MWALK | LOOK");
+	enum parser_error r = parser_parse(state, "F:LOS | PERMANENT | DOWNSTAIR");
 	struct feature *f;
 
 	eq(r, PARSE_ERROR_NONE);
@@ -88,17 +88,6 @@ int test_x0(void *state) {
 	ok;
 }
 
-int test_e0(void *state) {
-	enum parser_error r = parser_parse(state, "E:TRAP_PIT");
-	struct feature *f;
-
-	eq(r, PARSE_ERROR_NONE);
-	f = parser_priv(state);
-	require(f);
-	require(f->effect);
-	ok;
-}
-
 const char *suite_name = "parse/f-info";
 struct test tests[] = {
 	{ "n0", test_n0 },
@@ -107,6 +96,5 @@ struct test tests[] = {
 	{ "p0", test_p0 },
 	{ "f0", test_f0 },
 	{ "x0", test_x0 },
-	{ "e0", test_e0 },
 	{ NULL, NULL }
 };

--- a/src/tests/parse/flavor.c
+++ b/src/tests/parse/flavor.c
@@ -6,7 +6,7 @@
 #include "obj-tvalsval.h"
 #include "obj-flag.h"
 #include "object.h"
-#include "z-term.h"
+#include "z-color.h"
 
 int setup_tests(void **state) {
 	*state = init_parse_flavor();

--- a/src/tests/unit-test-data.h
+++ b/src/tests/unit-test-data.h
@@ -591,8 +591,8 @@ static struct monster_base TEST_DATA test_rb_info = {
 	.next = NULL,
 	.name = "townsfolk",
 	.text = "Townsfolk",
-	.flags = "\0\0\0\0\0\0\0\0\0\0\0\0",
-	.spell_flags = "\0\0\0\0\0\0\0\0\0\0\0\0",
+	.flags = "\0\0\0\0\0\0\0\0\0\0",
+	.spell_flags = "\0\0\0\0\0\0\0\0\0\0\0",
 	.d_char = 116,
 	.pain = NULL,
 	

--- a/src/tests/z-textblock/textblock.c
+++ b/src/tests/z-textblock/textblock.c
@@ -1,8 +1,8 @@
 /* z-quark/quark.c */
 
 #include "unit-test.h"
+#include "z-color.h"
 #include "z-textblock.h"
-#include "z-term.h"
 
 int setup_tests(void **state) {
 	ok;


### PR DESCRIPTION
All tests except pathfind/pathfind should work now. I removed the parse/f-info e0 test, since the feature parser no longer knows about E: lines.
