### PR TITLE
Fixes Windows DLL issue

### DIFF
--- a/src/Makefile.win
+++ b/src/Makefile.win
@@ -19,9 +19,11 @@ all: ../$(EXE)
 ifneq (,$(findstring \system32,$(PATH)))
   CP = copy
   RM = del
+  BAR = "\"
 else
   CP = -cp
   RM = -rm
+  BAR = "/"
 endif
 
 
@@ -102,8 +104,8 @@ endif
 
 ../$(EXE): $(EXE)
 	$(CP) $(EXE) ..
-	$(CP) win/dll/libpng12.dll ..
-	$(CP) win/dll/zlib1.dll ..
+	$(CP) win$(BAR)dll$(BAR)libpng12.dll ..
+	$(CP) win$(BAR)dll$(BAR)zlib1.dll ..
 
 $(EXE): $(OBJS)
 	$(CC) $(CFLAGS) -o $(EXE) $(OBJS) $(LIBS)


### PR DESCRIPTION
Fixes an issue when the libpng12 and zlib1 DLL files are not copied to
the root folder on some Windows environments.

This fixes the first of the errors shown here: http://angband.oook.cz/forum/showthread.php?t=4302&page=10
