### PR TITLE
Fix randart stats runs

### DIFF
--- a/src/obj-randart.c
+++ b/src/obj-randart.c
@@ -325,8 +325,6 @@ static errr init_names(void)
 				strlen(a->name) + 8);
 		}
 
-		string_free(a->text);
-		string_free(a->name);
 		a->text = string_make(desc);
 		a->name = artifact_gen_name(a, name_sections);
 	}


### PR DESCRIPTION
init_names() and cleanup_a() were both freeing a_info name and text.
