### PR TITLE
Fixed minor problems with parser tests for e_x and k_f.

### DIFF
--- a/src/tests/parse/e-info.c
+++ b/src/tests/parse/e-info.c
@@ -46,7 +46,7 @@ int test_x0(void *state) {
 	eq(e->rarity, 4);
 	eq(e->cost, 6);
 	eq(e->rating, 8);
-	return PARSE_ERROR_NONE;
+	ok;
 }
 
 int test_t0(void *state) {

--- a/src/tests/parse/k-info.c
+++ b/src/tests/parse/k-info.c
@@ -147,13 +147,18 @@ int test_m0(void *state) {
 }
 
 int test_f0(void *state) {
-	errr r = parser_parse(state, "F:STR");
+	errr r = parser_parse(state, "F:EASY_KNOW | FEATHER");
 	struct object_kind *k;
 
 	eq(r, 0);
 	k = parser_priv(state);
 	require(k);
 	require(k->flags);
+	require(k->kind_flags);
+	eq(of_has(k->flags, OF_FEATHER), 1);
+	eq(of_has(k->flags, OF_SLOW_DIGEST), 0);
+	eq(kf_has(k->kind_flags, KF_EASY_KNOW), 1);
+	eq(kf_has(k->kind_flags, KF_INSTA_ART), 0);
 	ok;
 }
 


### PR DESCRIPTION
e_x is just a display cleanup. k_f was necessary because of the removal of STR from flags; I also beefed up the test a bit.
