### PR TITLE
Fixes Windows 8 compilation

### DIFF
--- a/src/Makefile.win
+++ b/src/Makefile.win
@@ -16,7 +16,14 @@
 EXE = angband.exe
 all: ../$(EXE)
 
+ifneq (,$(findstring \SYSTEM32,$(PATH)))
+  dos = TRUE
+endif
 ifneq (,$(findstring \system32,$(PATH)))
+  dos = TRUE
+endif
+
+ifdef dos
   CP = copy
   RM = del
   BAR = "\"


### PR DESCRIPTION
Windows 8 changes system32 to SYSTEM32, causing the copy commands to fail.
This corrects it to search for both versions.
