### PR TITLE
Remove breathe_confusion from sound.cfg to match z-msg-list.h.

### DIFF
--- a/lib/xtra/sound/sound.cfg
+++ b/lib/xtra/sound/sound.cfg
@@ -454,9 +454,6 @@ breathe_gas = mco_attack_breath.mp3
 # Breathe fire.
 breathe_fire = mco_attack_breath.mp3  
 
-# Breathe confusion.
-breathe_confusion = mco_attack_breath.mp3  
-
 # Breathe disenchantment.
 breathe_disenchant = mco_attack_breath.mp3  
 


### PR DESCRIPTION
Fixes a crash with sounds enabled.
