### PR TITLE
Fix (probably harmless) typo in recall

### DIFF
--- a/src/spells2.c
+++ b/src/spells2.c
@@ -463,7 +463,7 @@ bool set_recall(void)
 	}
 
 	/* Redraw status line */
-	p_ptr->redraw = PR_STATUS;
+	p_ptr->redraw |= PR_STATUS;
 	handle_stuff(p_ptr);
 
 	return TRUE;


### PR DESCRIPTION
This is a possible (but unlikely) candidate for causing the monster list not to update on first recalling.
