### PR TITLE
Fix bug with gcu's -a option.

### DIFF
--- a/src/main-gcu.c
+++ b/src/main-gcu.c
@@ -668,7 +668,7 @@ static errr Term_xtra_gcu_react(void) {
 	if (ascii_walls) {
 		int i;
 		ascii_walls = FALSE;
-		for (i = 0; i < 3; i++) {
+		for (i = 0; i < 4; i++) {
 			// magma as %:D
 			f_info[50].x_char[i] = f_info[52].x_char[i] = 0x23;
 			f_info[50].x_attr[i] = f_info[52].x_attr[i] = 0x01;


### PR DESCRIPTION
Due to a loop bounds error, the ascii walls option was not
correctly changing the unlit wall features. The x_char
array has 4 entries, not 3.

Fixes #1826
