### PR TITLE
Fix crash when reading a scroll of light.

### DIFF
--- a/src/effects.c
+++ b/src/effects.c
@@ -2682,7 +2682,7 @@ bool effect_handler_LIGHT_AREA(effect_handler_context_t *context)
 	int py = player->py;
 	int px = player->px;
 	int dam = effect_calculate_value(context, FALSE);
-	int rad = context->p2 + context->p3 ? player->lev / context->p3 : 0;
+	int rad = context->p2 + (context->p3 ? player->lev / context->p3 : 0);
 
 	int flg = PROJECT_GRID | PROJECT_KILL;
 


### PR DESCRIPTION
Prevent a divide-by-zero crash in effect_handler_LIGHT_AREA() due to operator precedence (thanks to shadowsun for bug report via IRC).
