### PR TITLE
Unbreak quickstart births.

### DIFF
--- a/src/ui-birth.c
+++ b/src/ui-birth.c
@@ -983,6 +983,8 @@ int textui_do_birth(void)
 			{
 				display_player(0);
 				next = textui_birth_quickstart();
+				if (next == BIRTH_COMPLETE)
+					done = TRUE;
 				break;
 			}
 


### PR DESCRIPTION
If we never set done to true, we sit in this loop forever, and since
the state is set to BIRTH_COMPLETE already, the game spins using
100% CPU. Oops.
