### PR TITLE
Do not allow configure to succeed if no frontends can be compiled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -390,11 +390,13 @@ fi
 
 echo
 echo "-- Frontends --"
+have_frontend=no
 if test "$enable_curses" = "yes"; then
 	if test "$with_curses" = "no"; then
 		echo "- Curses                                  No; missing libraries"
 	else
 		echo "- Curses                                  Yes"
+		have_frontend=yes
 	fi
 else
 	echo "- Curses                                  Disabled"
@@ -404,6 +406,7 @@ if test "$enable_x11" = "yes"; then
 		echo "- X11                                     No; missing libraries"
 	else
 		echo "- X11                                     Yes"
+		have_frontend=yes
 	fi
 else
 	echo "- X11                                     Disabled"
@@ -413,6 +416,7 @@ if test "$enable_sdl" = "yes"; then
 		echo "- SDL                                     No; missing libraries"
 	else
 		echo "- SDL                                     Yes"
+		have_frontend=yes
 	fi
 else
 	echo "- SDL                                     Disabled"
@@ -423,6 +427,7 @@ if test "$enable_win" = "yes"; then
 		echo "- Windows                                 No; missing libraries"
 	else
 		echo "- Windows                                 Yes"
+		have_frontend=yes
 	fi
 else
 	echo "- Windows                                 Disabled"
@@ -430,14 +435,16 @@ fi
 
 if test "$enable_test" = "yes"; then
 	echo "- Test                                    Yes"
+	have_frontend=yes
 else
-    echo "- Test                                    No"
+	echo "- Test                                    No"
 fi
 
 if test "$enable_stats" = "yes"; then
 	echo "- Stats                                   Yes"
+	have_frontend=yes
 else
-    echo "- Stats                                   No"
+	echo "- Stats                                   No"
 fi
 
 echo
@@ -451,3 +458,9 @@ if test "$enable_sdl_mixer" = "yes"; then
 else
 	echo "- SDL sound                               Disabled"
 fi
+
+if test "$have_frontend" = "no"; then
+	AC_MSG_ERROR([No frontend defined (missing libraries?)])
+	rm mk/buildsys.mk
+fi
+


### PR DESCRIPTION
Fixes trac#1774. If no frontends are successfully configured, prints an error, and removes buildsys.mk so that make also fails.
