### PR TITLE
Dynamically allocated item_list must use correct length in item_is_available()

### DIFF
--- a/src/obj-util.c
+++ b/src/obj-util.c
@@ -2120,7 +2120,7 @@ bool item_is_available(int item, bool (*tester)(const object_type *), int mode)
 	int item_num;
 	int i;
 
-	item_num = scan_items(item_list, N_ELEMENTS(item_list), mode, tester);
+	item_num = scan_items(item_list, item_max, mode, tester);
 
 	for (i = 0; i < item_num; i++)
 		if (item_list[i] == item) {


### PR DESCRIPTION
It's not an array any more, so N_ELEMENTS() can't work.
