### PR TITLE
Reset item_tester_hook in spell_identify_unknown_available() to avoid strange effects later

### DIFF
--- a/src/spells2.c
+++ b/src/spells2.c
@@ -1501,6 +1501,9 @@ bool spell_identify_unknown_available(void)
 		}
 	}
 
+	/* Reset the item tester to avoid bizarre behaviour of UI-only commands */
+	item_tester_hook = NULL;
+
 	return unidentified_inventory || floor_num > 0;
 }
 


### PR DESCRIPTION
All other uses of item_tester_hook are followed either by get_item(), or by
scan_items(). Both of those functions reset the hook once they've used it.
Fixes #1818
