### PR TITLE
Fix missing PF_NO_MANA in get_pflag_desc()

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -189,7 +189,7 @@ static const char *terrain_flags[] =
 
 static const char *player_info_flags[] =
 {
-	#define PF(a, b) #a,
+	#define PF(a, b, c) #a,
 	#include "list-player-flags.h"
 	#undef PF
 	NULL

--- a/src/list-player-flags.h
+++ b/src/list-player-flags.h
@@ -6,17 +6,17 @@
  *
  */
 
-/* symbol            descr */
-PF(NONE,             "")
-PF(EXTRA_SHOT,       "receive extra shots with tension bows at levels 20 and 40")
-PF(BRAVERY_30,       "become immune to fear at level 30")
-PF(BLESS_WEAPON,     "may only wield blessed or hafted weapons")
-PF(CUMBER_GLOVE,     "have difficulty using magic with covered hands")
-PF(ZERO_FAIL,        "may obtain a perfect success rate with magic")
-PF(BEAM,             "frequently turn bolt spells into beams")
-PF(CHOOSE_SPELLS,    "may choose their own spells to study")
-PF(PSEUDO_ID_IMPROV, "get better at psudo id with experience")
-PF(KNOW_MUSHROOM,    "easily recognize mushrooms")
-PF(KNOW_ZAPPER,      "easily recognize magic devices")
-PF(SEE_ORE,          "can sense ore in the walls")
-PF(NO_MANA,          "cannot cast spells")
+/* symbol            descr                                                        birth-descr */
+PF(NONE,             "",                                                          NULL)
+PF(EXTRA_SHOT,       "receive extra shots with tension bows at levels 20 and 40", "Gains extra shots with bow")
+PF(BRAVERY_30,       "become immune to fear at level 30",                         "Gains immunity to fear")
+PF(BLESS_WEAPON,     "may only wield blessed or hafted weapons",                  "Prefers blunt/blessed weapons")
+PF(CUMBER_GLOVE,     "have difficulty using magic with covered hands",            NULL)
+PF(ZERO_FAIL,        "may obtain a perfect success rate with magic",              "Advanced spellcasting")
+PF(BEAM,             "frequently turn bolt spells into beams",                    NULL)
+PF(CHOOSE_SPELLS,    "may choose their own spells to study",                      NULL)
+PF(PSEUDO_ID_IMPROV, "get better at psudo id with experience",                    NULL)
+PF(KNOW_MUSHROOM,    "easily recognize mushrooms",                                "Identifies mushrooms")
+PF(KNOW_ZAPPER,      "easily recognize magic devices",                            "Identifies magic devices")
+PF(SEE_ORE,          "can sense ore in the walls",                                "Senses ore/minerals")
+PF(NO_MANA,          "cannot cast spells",                                        NULL)

--- a/src/player-calcs.h
+++ b/src/player-calcs.h
@@ -38,7 +38,7 @@ enum
  */
 enum
 {
-	#define PF(a,b) PF_##a,
+	#define PF(a,b,c) PF_##a,
 	#include "list-player-flags.h"
 	#undef PF
 	PF_MAX

--- a/src/ui-birth.c
+++ b/src/ui-birth.c
@@ -250,18 +250,11 @@ static const char *get_pflag_desc(bitflag flag)
 {
 	switch (flag)
 	{
-		case PF_EXTRA_SHOT: return "Gains extra shots with bow";
-		case PF_BRAVERY_30: return "Gains immunity to fear";
-		case PF_BLESS_WEAPON: return "Prefers blunt/blessed weapons";
-		case PF_CUMBER_GLOVE: return NULL;
-		case PF_ZERO_FAIL: return "Advanced spellcasting";
-		case PF_BEAM: return NULL;
-		case PF_CHOOSE_SPELLS: return NULL;
-		case PF_PSEUDO_ID_IMPROV: return NULL;
-		case PF_KNOW_MUSHROOM: return "Identifies mushrooms";
-		case PF_KNOW_ZAPPER: return "Identifies magic devices";
-		case PF_SEE_ORE: return "Senses ore/minerals";
-		default: return "Undocumented pflag";
+		#define PF(a,b,c) case PF_##a: return c;
+		#include "list-player-flags.h"
+		#undef PF
+	default:
+		abort(); /* compilation consistency problem */
 	}
 }
 


### PR DESCRIPTION
While I was at it, I also moved the descriptions to list-player-flags.h
to keep things DRY and to hopefully prevent similar issues in the future.
## 

A little note: The second column could actually be removed and/or merged with the new third column. (In case of merge, I'm thinking some of the level information could be added, and perhaps some further descriptions could be added where we currently have NULL...?) Let me know if you'd prefer to remove the 2nd column or to have me merge the two columns (with adjustments for grammar, etc.)
