### PR TITLE
Fix Warrior birth screen showing "Learns  magic"

### DIFF
--- a/src/ui-birth.c
+++ b/src/ui-birth.c
@@ -378,7 +378,7 @@ static void class_help(int i, void *db, const region *l)
 	
 	skill_help(r->r_skills, c->c_skills, r->r_mhp + c->c_mhp, r->r_exp + c->c_exp, -1);
 
-	if (c->magic.spell_realm != REALM_NONE)
+	if (c->magic.spell_realm->index != REALM_NONE)
 		text_out_e("\nLearns %s magic", c->magic.spell_realm->adjective);
 
 	for (k = 0; k < PF_MAX; k++)


### PR DESCRIPTION
This is a fix for the Warrior birth screen showing "Learns  magic" (note double spaces). The code was comparing a pointer to an int.
