### PR TITLE
Add null and notnull test functions

### DIFF
--- a/src/tests/game/basic.c
+++ b/src/tests/game/basic.c
@@ -66,7 +66,7 @@ int test_newgame(void *state) {
 	eq(player->is_dead, FALSE);
 	cave_generate(&cave, player);
 	on_new_level();
-	noteq(cave, NULL);
+	notnull(cave);
 	eq(player->chp, player->mhp);
 	eq(player->food, PY_FOOD_FULL - 1);
 
@@ -85,7 +85,7 @@ int test_loadgame(void *state) {
 	eq(savefile_load("Test1", FALSE), TRUE);
 
 	eq(player->is_dead, FALSE);
-	noteq(cave, NULL);
+	notnull(cave);
 	eq(player->chp, player->mhp);
 	eq(player->food, PY_FOOD_FULL - 1);
 
@@ -139,7 +139,7 @@ int test_drop_pickup(void *state) {
 		cmdq_push(CMD_AUTOPICKUP);
 		run_game_loop();
 	}
-	eq(square_object(cave, player->py, player->px), NULL);
+	null(square_object(cave, player->py, player->px));
 
 	ok;
 }
@@ -167,7 +167,7 @@ int test_drop_eat(void *state) {
 	if (num > 1) {
 		eq(square_object(cave, player->py, player->px)->number, num - 1);
 	} else {
-		eq(square_object(cave, player->py, player->px), NULL);
+		null(square_object(cave, player->py, player->px));
 	}
 
 	ok;

--- a/src/tests/unit-test.h
+++ b/src/tests/unit-test.h
@@ -47,6 +47,28 @@ const char *suite_name;
 		return 1; \
 	}
 
+#define null(x) \
+	if ((x) != 0) { \
+		if (verbose) { \
+			showfail(); \
+			printf("    %s:%d: requirement '%s' == NULL failed\n", suite_name, \
+		           __LINE__, #x); \
+			printf("      %s: 0x%016lld\n", #x, (long long)x); \
+		} \
+		return 1; \
+	}
+
+#define notnull(x) \
+	if ((x) == 0) { \
+		if (verbose) { \
+			showfail(); \
+			printf("    %s:%d: requirement '%s' != NULL failed\n", suite_name, \
+		           __LINE__, #x); \
+			printf("      %s: 0x%016lld\n", #x, (long long)x); \
+		} \
+		return 1; \
+	}
+
 #define require(x) \
 	do { \
 		if (!(x)) { \


### PR DESCRIPTION
This should fix warning in test reporting caused by trying to use the eq() and noteq() macros for NULL values