### PR TITLE
Fixed broken link to compilation instructions

### DIFF
--- a/fix/readme-compile-url
+++ b/fix/readme-compile-url
@@ -9,7 +9,7 @@ press '?'.
 For more information, somewhere to upload your characters and screenshots,
 and discuss the game, try http://angband.oook.cz/.
 
-If you're compiling the game yourself, read http://rephial.org/wiki/Compiling.
+If you're compiling the game yourself, read http://trac.rephial.org/wiki/Compiling.
 
 Enjoy!
 


### PR DESCRIPTION
The url to the compilation instructions in the Readme.txt file is broken. I believe it's been moved to http://trac.rephial.org/wiki/Compiling.