### PR TITLE
Cherry-picked fix to sound config file, removing double and trailing spaces

### DIFF
--- a/lib/xtra/sound/sound.cfg
+++ b/lib/xtra/sound/sound.cfg
@@ -293,10 +293,10 @@ wield = plm_metal_sharpen.mp3
 cursed = pls_man_oooh.mp3
 
 # You notice something (generic notice)
-notice = id_bad_hmm.mp3 
+notice = id_bad_hmm.mp3
 
 # You notice something about your equipment or inventory.
-pseudo_id = id_good_hmm.mp3 
+pseudo_id = id_good_hmm.mp3
 
 # You successfully cast a spell.
 cast_spell = plm_spell1.mp3 plm_spell2.mp3 plm_spell3.mp3
@@ -336,7 +336,7 @@ mon_kick = mco_rubber_thud.mp3
 mon_claw = mco_ceramic_trill.mp3 mco_scurry_dry.mp3
 
 # Attack - bite
-mon_bite = mco_snarl_short.mp3 mco_bite_soft.mp3  mco_bite_munch.mp3  mco_bite_long.mp3  mco_bite_short.mp3  mco_bite_gnash.mp3  mco_bite_chomp.mp3  mco_bite_regular.mp3  mco_bite_small.mp3  mco_bite_dainty.mp3  mco_bite_hard.mp3  mco_bite_chew.mp3
+mon_bite = mco_snarl_short.mp3 mco_bite_soft.mp3 mco_bite_munch.mp3 mco_bite_long.mp3 mco_bite_short.mp3 mco_bite_gnash.mp3 mco_bite_chomp.mp3 mco_bite_regular.mp3 mco_bite_small.mp3 mco_bite_dainty.mp3 mco_bite_hard.mp3 mco_bite_chew.mp3
 
 # Attack - sting
 mon_sting = mco_castanet_trill.mp3 mco_tube_hit.mp3
@@ -443,58 +443,58 @@ summon_unique = sum_bell_tone.mp3
 breathe_frost = mco_attack_breath.mp3
 
 # Breathe electricity.
-breathe_elec = mco_attack_breath.mp3 
+breathe_elec = mco_attack_breath.mp3
 
 # Breathe acid.
-breathe_acid = mco_attack_breath.mp3  
+breathe_acid = mco_attack_breath.mp3
 
 # Breathe gas.
-breathe_gas = mco_attack_breath.mp3  
+breathe_gas = mco_attack_breath.mp3
 
 # Breathe fire.
-breathe_fire = mco_attack_breath.mp3  
+breathe_fire = mco_attack_breath.mp3
 
 # Breathe disenchantment.
-breathe_disenchant = mco_attack_breath.mp3  
+breathe_disenchant = mco_attack_breath.mp3
 
 # Breathe chaos.
-breathe_chaos = mco_attack_breath.mp3  
+breathe_chaos = mco_attack_breath.mp3
 
 # Breathe shards.
-breathe_shards = mco_attack_breath.mp3  
+breathe_shards = mco_attack_breath.mp3
 
 # Breathe sound.
-breathe_sound = mco_attack_breath.mp3  
+breathe_sound = mco_attack_breath.mp3
 
 # Breathe light.
-breathe_light = mco_attack_breath.mp3  
+breathe_light = mco_attack_breath.mp3
 
 # Breathe darkness.
-breathe_dark = mco_attack_breath.mp3  
+breathe_dark = mco_attack_breath.mp3
 
 # Breathe nether.
-breathe_nether = mco_attack_breath.mp3  
+breathe_nether = mco_attack_breath.mp3
 
 # Breathe nexus.
-breathe_nexus = mco_attack_breath.mp3  
+breathe_nexus = mco_attack_breath.mp3
 
 # Breathe time.
-breathe_time = mco_attack_breath.mp3  
+breathe_time = mco_attack_breath.mp3
 
 # Breathe inertia.
-breathe_inertia = mco_attack_breath.mp3  
+breathe_inertia = mco_attack_breath.mp3
 
 # Breathe gravity.
-breathe_gravity = mco_attack_breath.mp3  
+breathe_gravity = mco_attack_breath.mp3
 
 # Breathe plasma.
-breathe_plasma = mco_attack_breath.mp3  
+breathe_plasma = mco_attack_breath.mp3
 
 # Breathe force.
-breathe_force = mco_attack_breath.mp3  
+breathe_force = mco_attack_breath.mp3
 
 # Breathe the elements (power dragon scale mail).
-breathe_elements = mco_attack_breath.mp3  
+breathe_elements = mco_attack_breath.mp3
 
 #
 # Identifying Items


### PR DESCRIPTION
For some reason the sound config file parsing doesn't like multiple spaces, or trailing spaces on lines.

Without this, the console where the game is run gets lots of "src/angband: Couldn't read from RWops: Is a directory" warning messages