### PR TITLE
Make sure quiver slots are rounded correctly, and report the correct number of missiles

### DIFF
--- a/src/ui-object.c
+++ b/src/ui-object.c
@@ -457,7 +457,7 @@ static void show_obj_list(olist_detail_t mode)
 	/* For the inventory: print the quiver count */
 	if (mode & OLIST_QUIVER) {
 		int count, j;
-		int quiver_slots = 1 + player->upkeep->quiver_cnt / z_info->stack_size;
+		int quiver_slots = (player->upkeep->quiver_cnt + z_info->stack_size - 1) / z_info->stack_size;
 
 		/* Quiver may take multiple lines */
 		for (j = 0; j < quiver_slots; j++, i++) {
@@ -466,7 +466,7 @@ static void show_obj_list(olist_detail_t mode)
 
 			/* Number of missiles in this "slot" */
 			if (j == quiver_slots - 1)
-				count = player->upkeep->quiver_cnt % (z_info->stack_size);
+				count = player->upkeep->quiver_cnt - (z_info->stack_size * (quiver_slots - 1));
 			else
 				count = z_info->stack_size;
 


### PR DESCRIPTION
Fix the corner cases of exactly stack_size missles in the quiver.
Can't use quiver_cnt % stack_size, as that will show 0 rather than 40, so I just subtracted the rest of the quiver from the count for the last slot.
Likewise the number of slots isn't simply 1 +, as that will give 2 slots if there are exactly 40. It has to be a formal rounding up.