### PR TITLE
Fixes to avoid potential problems when adding new stores

### DIFF
--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -1432,7 +1432,7 @@ static void build_store(struct chunk *c, int n, int yy, int xx)
 
 	/* Determine spacing based on town size */
 	int y_space = z_info->town_hgt / 7;
-	int x_space = z_info->town_wid / ((MAX_STORES / 2) + 1);
+	int x_space = z_info->town_wid / ((MAX_STORES / 2.0) + 1);
 
 	/* Find the "center" of the store */
 	int y0 = yy * 3 * y_space + 2 * y_space;

--- a/src/store.c
+++ b/src/store.c
@@ -147,7 +147,7 @@ static enum parser_error parse_store(struct parser *p) {
 	struct store *s;
 	unsigned int idx = parser_getuint(p, "index") - 1;
 
-	if (idx > STORE_HOME)
+	if (idx >= MAX_STORES)
 		return PARSE_ERROR_OUT_OF_BOUNDS;
 
 	s = store_new(parser_getuint(p, "index") - 1);


### PR DESCRIPTION
Don't use STORE_HOME to check for last store. In gen-cave.c, room with calculation has a problem with internal int cast. Change '2' to '2.0' there to avoid round-off bug when calculating room size.