### PR TITLE
Another randart fix

### DIFF
--- a/src/obj-power.c
+++ b/src/obj-power.c
@@ -287,8 +287,8 @@ static int extra_shots_power(const object_type *obj, int p, bool known)
 			return p;
 		} else if (obj->modifiers[OBJ_MOD_SHOTS] > 0) {
 			int q = obj->modifiers[OBJ_MOD_SHOTS];
-			p += q;
-			log_obj(format("Add %d power for extra shots, total is %d\n",q, p));
+			p = p * (1 + q);
+			log_obj(format("Multiplying power by %d for extra shots, total is %d\n", 1 + q, p));
 		}
 	}
 	return p;


### PR DESCRIPTION
Restored 3.5 behavior of multiplying power by shot count when evaluating extra shots ability on randarts.
This should make for more reasonable randart launchers.