### PR TITLE
Cone

### DIFF
--- a/lib/gamedata/activation.txt
+++ b/lib/gamedata/activation.txt
@@ -1160,15 +1160,15 @@ aim:1
 power:12
 effect:RANDOM
 dice:5
-effect:BREATH:ACID:3
+effect:BREATH:ACID:30
 dice:200
-effect:BREATH:ELEC:3
+effect:BREATH:ELEC:30
 dice:160
-effect:BREATH:FIRE:3
+effect:BREATH:FIRE:30
 dice:200
-effect:BREATH:COLD:3
+effect:BREATH:COLD:30
 dice:160
-effect:BREATH:POIS:3
+effect:BREATH:POIS:30
 dice:120
 desc:shoots a large ball of one of the base elements for 120-200 damage
 
@@ -1206,9 +1206,9 @@ aim:1
 power:8
 effect:RANDOM
 dice:2
-effect:BREATH:FIRE
+effect:BREATH:FIRE:30
 dice:80
-effect:BREATH:COLD
+effect:BREATH:COLD:30
 dice:80
 desc:causes you to breathe either cold or flames for 80 damage
 
@@ -1317,21 +1317,21 @@ desc:grants electricity resistance for d20+20 turns and creates a lightning ball
 name:DRAGON_BLUE
 aim:1
 power:18
-effect:BREATH:ELEC:2
+effect:BREATH:ELEC:20
 dice:150
 desc:allows you to breathe lightning for 150 damage
 
 name:DRAGON_GREEN
 aim:1
 power:19
-effect:BREATH:POIS:2
+effect:BREATH:POIS:20
 dice:150
 desc:allows you to breathe poison gas for 150 damage
 
 name:DRAGON_RED
 aim:1
 power:20
-effect:BREATH:FIRE:2
+effect:BREATH:FIRE:20
 dice:200
 desc:allows you to breathe fire for 200 damage
 
@@ -1340,22 +1340,22 @@ aim:1
 power:20
 effect:RANDOM
 dice:5
-effect:BREATH:ACID:2
+effect:BREATH:ACID:20
 dice:250
-effect:BREATH:ELEC:2
+effect:BREATH:ELEC:20
 dice:250
-effect:BREATH:FIRE:2
+effect:BREATH:FIRE:20
 dice:250
-effect:BREATH:COLD:2
+effect:BREATH:COLD:20
 dice:250
-effect:BREATH:POIS:2
+effect:BREATH:POIS:20
 dice:250
 desc:allows you to breathe the elements for 250 damage
 
 name:DRAGON_GOLD
 aim:1
 power:19
-effect:BREATH:SOUND:2
+effect:BREATH:SOUND:20
 dice:150
 desc:allows you to breathe sound for 150 damage
 
@@ -1364,9 +1364,9 @@ aim:1
 power:23
 effect:RANDOM
 dice:2
-effect:BREATH:CHAOS:2
+effect:BREATH:CHAOS:20
 dice:220
-effect:BREATH:DISEN:2
+effect:BREATH:DISEN:20
 dice:220
 desc:allows you to breathe chaos or disenchantment for 220 damage
 
@@ -1375,9 +1375,9 @@ aim:1
 power:23
 effect:RANDOM
 dice:2
-effect:BREATH:SOUND:2
+effect:BREATH:SOUND:20
 dice:230
-effect:BREATH:SHARD:2
+effect:BREATH:SHARD:20
 dice:230
 desc:allows you to breathe sound or shards for 230 damage
 
@@ -1386,13 +1386,13 @@ aim:1
 power:24
 effect:RANDOM
 dice:4
-effect:BREATH:SOUND:2
+effect:BREATH:SOUND:20
 dice:250
-effect:BREATH:SHARD:2
+effect:BREATH:SHARD:20
 dice:250
-effect:BREATH:CHAOS:2
+effect:BREATH:CHAOS:20
 dice:250
-effect:BREATH:DISEN:2
+effect:BREATH:DISEN:20
 dice:250
 desc:allows you to breathe balance for 250 damage
 
@@ -1401,15 +1401,15 @@ aim:1
 power:21
 effect:RANDOM
 dice:2
-effect:BREATH:LIGHT:2
+effect:BREATH:LIGHT:20
 dice:200
-effect:BREATH:DARK:2
+effect:BREATH:DARK:20
 dice:200
 desc:allows you to breathe light or darkness for 200 damage
 
 name:DRAGON_POWER
 aim:1
 power:25
-effect:BREATH:MISSILE:2
+effect:BREATH:MISSILE:20
 dice:300
 desc:allows you to breathe for 300 damage

--- a/lib/gamedata/monster_spell.txt
+++ b/lib/gamedata/monster_spell.txt
@@ -75,7 +75,7 @@ message-miss:{name} fires a seeker arrow, but misses.
 name:BR_ACID
 msgt:BR_ACID
 hit:100
-effect:BREATH:ACID:2
+effect:BREATH:ACID:30
 power:20
 lore:acid
 message-vis:{name} breathes acid.
@@ -84,7 +84,7 @@ message-invis:You hear an acrid roar.
 name:BR_ELEC
 msgt:BR_ELEC
 hit:100
-effect:BREATH:ELEC:2
+effect:BREATH:ELEC:30
 power:10
 lore:lightning
 message-vis:{name} breathes lightning.
@@ -93,7 +93,7 @@ message-invis:You hear a crackling roar.
 name:BR_FIRE
 msgt:BR_FIRE
 hit:100
-effect:BREATH:FIRE:2
+effect:BREATH:FIRE:30
 power:10
 message-vis:{name} breathes fire.
 message-invis:You hear a scorching roar.
@@ -102,7 +102,7 @@ lore:fire
 name:BR_COLD
 msgt:BR_FROST
 hit:100
-effect:BREATH:COLD:2
+effect:BREATH:COLD:30
 power:10
 lore:frost
 message-vis:{name} breathes frost.
@@ -111,7 +111,7 @@ message-invis:You hear a whooshing roar.
 name:BR_POIS
 msgt:BR_GAS
 hit:100
-effect:BREATH:POIS:2
+effect:BREATH:POIS:30
 power:125d100M1
 lore:poison
 message-vis:{name} breathes poison.
@@ -120,7 +120,7 @@ message-invis:You hear a sickening roar.
 name:BR_NETH
 msgt:BR_NETHER
 hit:100
-effect:BREATH:NETHER:2
+effect:BREATH:NETHER:30
 power:d2000M2
 lore:nether
 message-vis:{name} breathes nether.
@@ -129,7 +129,7 @@ message-invis:You hear an eerie roar.
 name:BR_LIGHT
 msgt:BR_LIGHT
 hit:100
-effect:BREATH:LIGHT:2
+effect:BREATH:LIGHT:30
 power:10
 lore:light
 message-vis:{name} breathes light.
@@ -138,7 +138,7 @@ message-invis:You hear a humming roar.
 name:BR_DARK
 msgt:BR_DARK
 hit:100
-effect:BREATH:DARK:2
+effect:BREATH:DARK:30
 power:10
 lore:darkness
 message-vis:{name} breathes darkness.
@@ -147,7 +147,7 @@ message-invis:You hear a hushing roar.
 name:BR_SOUN
 msgt:BR_SOUND
 hit:100
-effect:BREATH:SOUND:2
+effect:BREATH:SOUND:30
 power:20
 lore:sound
 message-vis:{name} breathes sound.
@@ -156,7 +156,7 @@ message-invis:You hear an echoing roar.
 name:BR_CHAO
 msgt:BR_CHAOS
 hit:100
-effect:BREATH:CHAOS:2
+effect:BREATH:CHAOS:30
 power:d2000M2
 lore:chaos
 message-vis:{name} breathes chaos.
@@ -165,7 +165,7 @@ message-invis:You hear a cacophonous roar.
 name:BR_DISE
 msgt:BR_DISEN
 hit:100
-effect:BREATH:DISEN:2
+effect:BREATH:DISEN:30
 power:50
 lore:disenchantment
 message-vis:{name} breathes disenchantment.
@@ -174,7 +174,7 @@ message-invis:You hear a dissipating roar.
 name:BR_NEXU
 msgt:BR_NEXUS
 hit:100
-effect:BREATH:NEXUS:2
+effect:BREATH:NEXUS:30
 power:20
 lore:nexus
 message-vis:{name} breathes nexus.
@@ -183,7 +183,7 @@ message-invis:You hear a tearing roar.
 name:BR_TIME
 msgt:BR_TIME
 hit:100
-effect:BREATH:TIME:2
+effect:BREATH:TIME:30
 power:d2000M2
 lore:time
 message-vis:{name} breathes time.
@@ -192,7 +192,7 @@ message-invis:You remember hearing a roar.
 name:BR_INER
 msgt:BR_INERTIA
 hit:100
-effect:BREATH:INERTIA:2
+effect:BREATH:INERTIA:30
 power:30
 lore:inertia
 message-vis:{name} breathes inertia.
@@ -201,7 +201,7 @@ message-invis:You hear a thrumming roar.
 name:BR_GRAV
 msgt:BR_GRAVITY
 hit:100
-effect:BREATH:GRAVITY:2
+effect:BREATH:GRAVITY:30
 power:30
 lore:gravity
 message-vis:{name} breathes gravity
@@ -210,7 +210,7 @@ message-invis:You hear a heavy roar.
 name:BR_SHAR
 msgt:BR_SHARDS
 hit:100
-effect:BREATH:SHARD:2
+effect:BREATH:SHARD:30
 power:5+125d1
 lore:shards
 message-vis:{name} breathes shards.
@@ -219,7 +219,7 @@ message-invis:You hear a shattering roar.
 name:BR_PLAS
 msgt:BR_PLASMA
 hit:100
-effect:BREATH:PLASMA:2
+effect:BREATH:PLASMA:30
 power:30
 lore:plasma
 message-vis:{name} breathes plasma.
@@ -228,7 +228,7 @@ message-invis:You hear a hissing roar.
 name:BR_WALL
 msgt:BR_FORCE
 hit:100
-effect:BREATH:FORCE:2
+effect:BREATH:FORCE:30
 power:30
 lore:force
 message-vis:{name} breathes force.
@@ -236,7 +236,7 @@ message-invis:You hear a staccato roar.
 
 name:BR_MANA
 hit:100
-effect:BREATH:MANA:2
+effect:BREATH:MANA:30
 power:100
 lore:mana
 message-vis:{name} breathes raw magic.

--- a/lib/gamedata/object.txt
+++ b/lib/gamedata/object.txt
@@ -2706,9 +2706,9 @@ pile:70:1d3
 power:8
 effect:RANDOM
 dice:2
-effect:BREATH:FIRE:2
+effect:BREATH:FIRE:20
 dice:80
-effect:BREATH:COLD:2
+effect:BREATH:COLD:20
 dice:80
 
 
@@ -2988,7 +2988,7 @@ combat:0:1d1:0:0:0
 charges:1+d3
 flags:IGNORE_ACID | IGNORE_ELEC | IGNORE_FIRE | IGNORE_COLD
 power:13
-effect:BREATH:FIRE:3
+effect:BREATH:FIRE:30
 dice:200
 
 name:393:Dragon's Frost
@@ -3000,7 +3000,7 @@ combat:0:1d1:0:0:0
 charges:1+d3
 flags:IGNORE_ACID | IGNORE_ELEC | IGNORE_FIRE | IGNORE_COLD
 power:12
-effect:BREATH:COLD:3
+effect:BREATH:COLD:30
 dice:160
 
 name:394:Dragon's Breath
@@ -3014,15 +3014,15 @@ flags:IGNORE_ACID | IGNORE_ELEC | IGNORE_FIRE | IGNORE_COLD
 power:12
 effect:RANDOM
 dice:5
-effect:BREATH:ACID:3
+effect:BREATH:ACID:30
 dice:200
-effect:BREATH:ELEC:3
+effect:BREATH:ELEC:30
 dice:160
-effect:BREATH:FIRE:3
+effect:BREATH:FIRE:30
 dice:200
-effect:BREATH:COLD:3
+effect:BREATH:COLD:30
 dice:160
-effect:BREATH:POIS:3
+effect:BREATH:POIS:30
 dice:120
 
 
@@ -3975,7 +3975,7 @@ combat:16:2d4:-2:0:10
 flags:IGNORE_ACID | IGNORE_ELEC | IGNORE_FIRE | IGNORE_COLD
 values:RES_ACID[1]
 power:11
-effect:BREATH:ACID:2
+effect:BREATH:ACID:20
 dice:120
 time:50
 
@@ -3988,7 +3988,7 @@ combat:12:2d4:-2:0:10
 flags:IGNORE_ACID | IGNORE_ELEC | IGNORE_FIRE | IGNORE_COLD
 values:RES_ELEC[1]
 power:18
-effect:BREATH:ELEC:2
+effect:BREATH:ELEC:20
 dice:150
 time:50
 
@@ -4001,7 +4001,7 @@ combat:14:2d4:-2:0:10
 flags:IGNORE_ACID | IGNORE_ELEC | IGNORE_FIRE | IGNORE_COLD
 values:RES_COLD[1]
 power:10
-effect:BREATH:COLD:2
+effect:BREATH:COLD:20
 dice:100
 time:50
 
@@ -4014,7 +4014,7 @@ combat:24:2d4:-2:0:10
 flags:IGNORE_ACID | IGNORE_ELEC | IGNORE_FIRE | IGNORE_COLD
 values:RES_FIRE[1]
 power:20
-effect:BREATH:FIRE:2
+effect:BREATH:FIRE:20
 dice:200
 time:50
 
@@ -4027,7 +4027,7 @@ combat:20:2d4:-2:0:10
 flags:IGNORE_ACID | IGNORE_ELEC | IGNORE_FIRE | IGNORE_COLD
 values:RES_POIS[1]
 power:19
-effect:BREATH:POIS:2
+effect:BREATH:POIS:20
 dice:150
 time:50
 
@@ -4042,15 +4042,15 @@ values:RES_ACID[1] | RES_ELEC[1] | RES_FIRE[1] | RES_COLD[1] | RES_POIS[1]
 power:20
 effect:RANDOM
 dice:5
-effect:BREATH:ACID:2
+effect:BREATH:ACID:20
 dice:250
-effect:BREATH:ELEC:2
+effect:BREATH:ELEC:20
 dice:250
-effect:BREATH:FIRE:2
+effect:BREATH:FIRE:20
 dice:250
-effect:BREATH:COLD:2
+effect:BREATH:COLD:20
 dice:250
-effect:BREATH:POIS:2
+effect:BREATH:POIS:20
 dice:250
 time:50
 
@@ -4065,9 +4065,9 @@ values:RES_LIGHT[1] | RES_DARK[1]
 power:21
 effect:RANDOM
 dice:2
-effect:BREATH:LIGHT:2
+effect:BREATH:LIGHT:20
 dice:200
-effect:BREATH:DARK:2
+effect:BREATH:DARK:20
 dice:200
 time:50
 
@@ -4082,9 +4082,9 @@ values:RES_SOUND[1] | RES_SHARD[1]
 power:23
 effect:RANDOM
 dice:2
-effect:BREATH:SOUND:2
+effect:BREATH:SOUND:20
 dice:230
-effect:BREATH:SHARD:2
+effect:BREATH:SHARD:20
 dice:230
 time:50
 
@@ -4097,7 +4097,7 @@ combat:28:2d4:-2:0:10
 flags:IGNORE_ACID | IGNORE_ELEC | IGNORE_FIRE | IGNORE_COLD
 values:RES_SOUND[1]
 power:19
-effect:BREATH:SOUND:2
+effect:BREATH:SOUND:20
 dice:150
 time:50
 
@@ -4112,9 +4112,9 @@ values:RES_CHAOS[1] | RES_DISEN[1]
 power:23
 effect:RANDOM
 dice:2
-effect:BREATH:CHAOS:2
+effect:BREATH:CHAOS:20
 dice:220
-effect:BREATH:DISEN:2
+effect:BREATH:DISEN:20
 dice:220
 time:50
 
@@ -4129,13 +4129,13 @@ values:RES_SOUND[1] | RES_SHARD[1] | RES_CHAOS[1] | RES_DISEN[1]
 power:24
 effect:RANDOM
 dice:4
-effect:BREATH:SOUND:2
+effect:BREATH:SOUND:20
 dice:250
-effect:BREATH:SHARD:2
+effect:BREATH:SHARD:20
 dice:250
-effect:BREATH:CHAOS:2
+effect:BREATH:CHAOS:20
 dice:250
-effect:BREATH:DISEN:2
+effect:BREATH:DISEN:20
 dice:250
 time:50
 
@@ -4151,7 +4151,7 @@ values:RES_ACID[1] | RES_FIRE[1] | RES_COLD[1] | RES_ELEC[1] | RES_POIS[1]
 values:RES_DISEN[1] | RES_SOUND[1] | RES_SHARD[1]
 values:RES_LIGHT[1] | RES_DARK[1] | RES_CHAOS[1]
 power:25
-effect:BREATH:MISSILE:2
+effect:BREATH:MISSILE:20
 dice:300
 time:50
 

--- a/src/effects.c
+++ b/src/effects.c
@@ -3346,11 +3346,9 @@ bool effect_handler_BALL(effect_handler_context_t *context)
 
 
 /**
- * Breathe an element
- * Stop if we hit a monster or the player, act as a ball (for now)
- * Allow target mode to pass over monsters
+ * Breathe an element, in a cone from the breather
  * Affect grids, objects, and monsters
- * context->p1 is element, context->p2 radius
+ * context->p1 is element, context->p2 degrees of arc
  */
 bool effect_handler_BREATH(effect_handler_context_t *context)
 {
@@ -3358,20 +3356,27 @@ bool effect_handler_BREATH(effect_handler_context_t *context)
 	int px = player->px;
 	int dam = effect_calculate_value(context, TRUE);
 	int type = context->p1;
-	int rad = context->p2;
+	int rad = 0;
 	int source;
 
 	int ty = py + 99 * ddy[context->dir];
 	int tx = px + 99 * ddx[context->dir];
 
-	int flg = PROJECT_STOP | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL;
+	/* Diameter of source of energy is normally, but not always, 20. */
+	int diameter_of_source = 20;
+	int degrees_of_arc = context->p2;
+
+	int flg = PROJECT_ARC | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL;
+
+	/* Radius of zero means no fixed limit. */
+	if (rad == 0)
+		rad = z_info->max_range;
 
 	/* Player or monster? */
 	if (cave->mon_current > 0) {
 		struct monster *mon = cave_monster(cave, cave->mon_current);
 		source = cave->mon_current;
 		flg |= PROJECT_PLAY;
-		flg &= ~(PROJECT_STOP);
 
 		/* Breath parameters for monsters are monster-dependent */
 		dam = breath_dam(type, mon->hp); 
@@ -3382,14 +3387,24 @@ bool effect_handler_BREATH(effect_handler_context_t *context)
 	}
 
 	/* Ask for a target if no direction given */
-	if ((context->dir == 5) && target_okay() && source == -1) {
-		flg &= ~(PROJECT_STOP);
-
+	if ((context->dir == 5) && target_okay() && source == -1)
 		target_get(&tx, &ty);
+
+	/* Calculate the effective diameter of the energy source, if necessary. */
+	if (degrees_of_arc < 60) {
+		if (degrees_of_arc == 0)
+			diameter_of_source = rad * 10;
+		else
+			diameter_of_source = diameter_of_source * 60 / degrees_of_arc;
 	}
 
+	/* Max */
+	if (diameter_of_source > 250)
+		diameter_of_source = 250;
+
 	/* Aim at the target, explode */
-	(void) project(source, rad, ty, tx, dam, type, flg, 0, 0);
+	(void) project(source, rad, ty, tx, dam, type, flg, degrees_of_arc,
+				   diameter_of_source);
 	context->ident = TRUE;
 
 	return TRUE;

--- a/src/effects.c
+++ b/src/effects.c
@@ -3348,7 +3348,7 @@ bool effect_handler_BALL(effect_handler_context_t *context)
 /**
  * Breathe an element, in a cone from the breather
  * Affect grids, objects, and monsters
- * context->p1 is element, context->p2 degrees of arc
+ * context->p1 is element, context->p2 degrees of arc, context->p3 radius
  */
 bool effect_handler_BREATH(effect_handler_context_t *context)
 {
@@ -3356,13 +3356,14 @@ bool effect_handler_BREATH(effect_handler_context_t *context)
 	int px = player->px;
 	int dam = effect_calculate_value(context, TRUE);
 	int type = context->p1;
-	int rad = 0;
+	int rad = context->p3;
 	int source;
 
 	int ty = py + 99 * ddy[context->dir];
 	int tx = px + 99 * ddx[context->dir];
 
-	/* Diameter of source of energy is normally, but not always, 20. */
+	/* Diameter of source starts at 20, so full strength only adjacent to
+	 * the breather. */
 	int diameter_of_source = 20;
 	int degrees_of_arc = context->p2;
 
@@ -3378,9 +3379,13 @@ bool effect_handler_BREATH(effect_handler_context_t *context)
 		source = cave->mon_current;
 		flg |= PROJECT_PLAY;
 
-		/* Breath parameters for monsters are monster-dependent */
-		dam = breath_dam(type, mon->hp); 
-		if (rf_has(mon->race->flags, RF_POWERFUL)) rad++;
+		dam = breath_dam(type, mon->hp);
+
+		/* Powerful monsters breathe wider arcs */
+		if (rf_has(mon->race->flags, RF_POWERFUL)) {
+			diameter_of_source *= 2;
+			degrees_of_arc *= 2;
+		}
 	} else {
 		msgt(elements[type].msgt, "You breathe %s.", elements[type].desc);
 		source = -1;
@@ -3390,11 +3395,15 @@ bool effect_handler_BREATH(effect_handler_context_t *context)
 	if ((context->dir == 5) && target_okay() && source == -1)
 		target_get(&tx, &ty);
 
-	/* Calculate the effective diameter of the energy source, if necessary. */
+	/* Diameter of the energy source. */
 	if (degrees_of_arc < 60) {
 		if (degrees_of_arc == 0)
+			/* This handles finite length beams */
 			diameter_of_source = rad * 10;
 		else
+			/* Narrower cone means energy drops off less quickly. 30 degree
+			 * breaths are still full strength 3 grids from the breather,
+			 * and 20 degree breaths are still full strength at 5 grids. */
 			diameter_of_source = diameter_of_source * 60 / degrees_of_arc;
 	}
 
@@ -3402,7 +3411,7 @@ bool effect_handler_BREATH(effect_handler_context_t *context)
 	if (diameter_of_source > 250)
 		diameter_of_source = 250;
 
-	/* Aim at the target, explode */
+	/* Breathe at the target */
 	(void) project(source, rad, ty, tx, dam, type, flg, degrees_of_arc,
 				   diameter_of_source);
 	context->ident = TRUE;

--- a/src/project-mon.c
+++ b/src/project-mon.c
@@ -518,7 +518,7 @@ static void project_monster_handler_FORCE(project_monster_handler_context_t *con
 	project_monster_breath(context, RSF_BR_WALL, 3);
 
 	/* Prevent thursting force breathers. */
-	if (rsf_has(context->m_ptr->race->spell_flags, RSF_BR_WALL))
+	if (rsf_has(context->mon->race->spell_flags, RSF_BR_WALL))
 		return;
 
 	/* Thrust monster away. */

--- a/src/project-mon.c
+++ b/src/project-mon.c
@@ -513,8 +513,17 @@ static void project_monster_handler_FORCE(project_monster_handler_context_t *con
 {
 	int player_amount = (randint1(15) + context->r + player->lev / 5) / (context->r + 1);
 	int monster_amount = (randint1(15) + context->r) / (context->r + 1);
+	char grids_away[5];
 	project_monster_timed_damage(context, MON_TMD_STUN, player_amount, monster_amount);
 	project_monster_breath(context, RSF_BR_WALL, 3);
+
+	/* Prevent thursting force breathers. */
+	if (rsf_has(context->m_ptr->race->spell_flags, RSF_BR_WALL))
+		return;
+
+	/* Thrust monster away. */
+	strnfmt(grids_away, sizeof(grids_away), "%d", 3 + context->dam / 20);
+	effect_simple(EF_THRUST_AWAY, grids_away, context->y, context->x, 0, NULL);
 }
 
 /* Time -- breathers resist */

--- a/src/project-player.c
+++ b/src/project-player.c
@@ -364,8 +364,14 @@ static void project_player_handler_INERTIA(project_player_handler_context_t *con
 
 static void project_player_handler_FORCE(project_player_handler_context_t *context)
 {
+	char grids_away[5];
+
 	/* Stun */
 	(void)player_inc_timed(player, TMD_STUN, randint1(20), TRUE, TRUE);
+
+	/* Thrust player away. */
+	strnfmt(grids_away, sizeof(grids_away), "%d", 3 + context->dam / 20);
+	effect_simple(EF_THRUST_AWAY, grids_away, context->y, context->x, 0, NULL);
 }
 
 static void project_player_handler_TIME(project_player_handler_context_t *context)

--- a/src/project.c
+++ b/src/project.c
@@ -527,14 +527,12 @@ const char *gf_idx_to_name(int type)
  *   degrees_of_arc of zero, arcs act like beams of defined length.
  *
  * diameter_of_source controls how quickly explosions lose strength with dis-
- *   tance from the target.  Most ball spells have a source diameter of 10, 
- *   which means that they do 1/2 damage at range 1, 1/3 damage at range 2, 
- *   and so on.   Caster-centered balls usually have a source diameter of 20, 
- *   which allows them to do full damage to all adjacent grids.   Arcs have 
- *   source diameters ranging up to 20, which allows the spell designer to 
+ *   tance from the target.  Most ball spells have a source diameter of 10,
+ *   which means that they do 1/2 damage at range 1, 1/3 damage at range 2,
+ *   and so on.   Caster-centered balls usually have a source diameter of 20,
+ *   which allows them to do full damage to all adjacent grids.   Arcs have
+ *   source diameters ranging up from 20, which allows the spell designer to
  *   fine-tune how quickly a breath loses strength outwards from the breather.
- *   It is expected, but not required, that wide arcs lose strength more 
- *   quickly over distance.
  *
  *
  * Implementation notes:
@@ -896,7 +894,7 @@ bool project(int who, int rad, int y, int x, int dam, int typ, int flg,
 		}
 
 		/* If a particular diameter for the source of the explosion's energy is 
-		 * given, calculate an adjusted damage. */
+		 * given, it is full strength to that diameter and then reduces. */
 		else {
 			dam_temp = (diameter_of_source * dam) / ((i + 1) * 10);
 			if (dam_temp > (u32b) dam)

--- a/src/project.c
+++ b/src/project.c
@@ -581,7 +581,7 @@ const char *gf_idx_to_name(int type)
  * and "update_view()" and "update_monsters()" need to be called.
  */
 bool project(int who, int rad, int y, int x, int dam, int typ, int flg,
-			 int degrees_of_arc, byte diameter_of_source)
+			 int degrees_of_arc, int diameter_of_source)
 {
 	int i, j, k, dist_from_centre;
 

--- a/src/project.h
+++ b/src/project.h
@@ -93,6 +93,6 @@ const char *gf_blind_desc(int type);
 int gf_name_to_idx(const char *name);
 const char *gf_idx_to_name(int type);
 bool project(int who, int rad, int y, int x, int dam, int typ, int flg,
-			 int degrees_of_arc, byte diameter_of_source);
+			 int degrees_of_arc, int diameter_of_source);
 
 #endif /* !PROJECT_H */


### PR DESCRIPTION
This makes all breaths cone-shaped, whether from monsters, item activations, wands or potions.  It also gives a pushing effect to force breath, so monsters and the player are pushed away from the breather.