### PR TITLE
Small hack to for server play, enforces usernames with -f

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -419,6 +419,10 @@ int main(int argc, char *argv[])
 				continue;
 			}
 
+			case 'f':
+				arg_force_name = TRUE;
+				break;
+
 			case 'm':
 				if (!*arg) goto usage;
 				mstr = arg;

--- a/src/main.h
+++ b/src/main.h
@@ -62,6 +62,9 @@ extern const char help_sdl[];
 extern const char help_test[];
 extern const char help_stats[];
 
+//phantom server play
+extern bool arg_force_name;
+
 
 struct module
 {

--- a/src/ui-birth.c
+++ b/src/ui-birth.c
@@ -97,6 +97,7 @@ static bool quickstart_allowed = FALSE;
  * Quickstart? screen.
  * ------------------------------------------------------------------------ */
 static enum birth_stage textui_birth_quickstart(void)
+//phantom name change changes
 {
 	const char *prompt = "['Y' to use this character, 'N' to start afresh, 'C' to change name or history]";
 
@@ -115,7 +116,7 @@ static enum birth_stage textui_birth_quickstart(void)
 			next = BIRTH_RACE_CHOICE;
 		} else if (ke.code == KTRL('X')) {
 			quit(NULL);
-		} else if (ke.code == 'C' || ke.code == 'c') {
+		} else if ( !arg_force_name && (ke.code == 'C' || ke.code == 'c')) {
 			next = BIRTH_NAME_CHOICE;
 		} else if (ke.code == 'Y' || ke.code == 'y') {
 			cmdq_push(CMD_ACCEPT_CHARACTER);
@@ -832,12 +833,18 @@ static enum birth_stage point_based_command(void)
  * ------------------------------------------------------------------------
  * Asking for the player's chosen name.
  * ------------------------------------------------------------------------ */
+//phantom changes for server
 static enum birth_stage get_name_command(void)
 {
 	enum birth_stage next;
 	char name[32];
+	
+	if ( arg_force_name ) {
+		next = BIRTH_HISTORY_CHOICE;
+	}
 
-	if (get_character_name(name, sizeof(name))) {
+	
+	else if (get_character_name(name, sizeof(name))) {
 		cmdq_push(CMD_NAME_CHOICE);
 		cmd_set_arg_string(cmdq_peek(), "name", name);
 		next = BIRTH_HISTORY_CHOICE;
@@ -845,6 +852,7 @@ static enum birth_stage get_name_command(void)
 		next = BIRTH_BACK;
 	}
 
+	
 	return next;
 }
 

--- a/src/ui-birth.h
+++ b/src/ui-birth.h
@@ -22,4 +22,7 @@
 void ui_init_birthstate_handlers(void);
 int textui_do_birth(void);
 
+//phantom
+bool arg_force_name;
+
 #endif


### PR DESCRIPTION
Useful for programs like dgamelaunch to play with others, standardizing highscores and configuration files.

Useage: Add -f to the commandline arguments. This enforces *nix username
or username invoked by -u.