### PR TITLE
Fixed graphical tile loading in SDL.

### DIFF
--- a/src/main-sdl.c
+++ b/src/main-sdl.c
@@ -3351,7 +3351,7 @@ static void init_gfx(void)
 		
 		/* Check the graphic file */
 		if (graphics_modes[i].file[0]) {
-			path_build(path, sizeof(path), ANGBAND_DIR_TILES,
+			path_build(path, sizeof(path), graphics_modes[i].path,
 					   graphics_modes[i].file);
 
 			if (!file_exists(path)) {


### PR DESCRIPTION
When launching with `-g -msdl -u${USER}`, angband would fail to load tiles due to incorrect tileset paths.  The game would produce these warnings:

> angband: Can't find file /home/kjfletch/usr/share/angband/tiles/8x8.png - graphics mode 'Original Tiles' will be disabled.
> angband: Can't find file /home/kjfletch/usr/share/angband/tiles/16x16.png - graphics mode 'Adam Bolt's tiles' will be disabled.
> angband: Can't find file /home/kjfletch/usr/share/angband/tiles/32x32.png - graphics mode 'David Gervais' tiles' will be disabled.
> angband: Can't find file /home/kjfletch/usr/share/angband/tiles/8x16.png - graphics mode 'Nomad's tiles' will be disabled.
> angband: Can't find file /home/kjfletch/usr/share/angband/tiles/64x64.png - graphics mode 'Shockbolt's tiles' will be disabled.

By replacing the use of `ANGBAND_DIR_TILES` with the path of the tileset directory which has already been expanded in `graphics_modes[i].path`, graphical tiles are loaded as expected.

*NOTE:  I'm using a non-standard install `PREFIX` of `/home/kjfletch/usr/`*