### PR TITLE
Add m4 directory to configure.ac.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -46,7 +46,7 @@ run_or_die ()
 
 cd $TOP_DIR
 
-run_or_die $ACLOCAL -I m4
+run_or_die $ACLOCAL
 run_or_die $AUTOHEADER
 run_or_die $AUTOCONF
 

--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,8 @@ AC_SUBST(PACKAGE, angband)
 
 AC_CONFIG_HEADERS(src/autoconf.h)
 
+AC_CONFIG_MACRO_DIR([m4])
+
 AC_DEFINE_UNQUOTED(PACKAGE, "$PACKAGE", [Name of package])
 AC_DEFINE_UNQUOTED(VERSION, "$VERSION", [Version number of package])
 


### PR DESCRIPTION
This patch includes the m4 directory through configure.ac rather than aclocal arguments in autogen.sh. It should be functionally equivalent, but this will make the build system easier to use on platforms that don't use autogen.sh to create the files, as is the case for the FreeBSD port.