### PR TITLE
Add HiDPI/Retina support to the OS X port

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -132,9 +132,6 @@ static NSFont *default_font;
     /* The buffered image */
     CGLayerRef angbandLayer;
 
-    /* Scaling factor for the buffered image */
-    float angbandLayerScale;
-
     /* The font of this context */
     NSFont *angbandViewFont;
     
@@ -632,7 +629,7 @@ static int compare_advances(const void *ap, const void *bp)
     /* Use the highest monitor scale factor on the system to work out what
      * scale to draw at - not the recommended method, but works where we
      * can't easily get the monitor the current draw is occurring on. */
-    angbandLayerScale = 1.0;
+    float angbandLayerScale = 1.0;
     if ([[NSScreen mainScreen] respondsToSelector:@selector(backingScaleFactor)]) {
         for (NSScreen *screen in [NSScreen screens]) {
             angbandLayerScale = fmax(angbandLayerScale, [screen backingScaleFactor]);

--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -131,7 +131,10 @@ static NSFont *default_font;
     
     /* The buffered image */
     CGLayerRef angbandLayer;
-    
+
+    /* Scaling factor for the buffered image */
+    float angbandLayerScale;
+
     /* The font of this context */
     NSFont *angbandViewFont;
     
@@ -623,18 +626,34 @@ static int compare_advances(const void *ap, const void *bp)
             size = [activeView bounds].size;
         }
     }
-    
-    size.width = fmax(1, ceil(size.width));
-    size.height = fmax(1, ceil(size.height));
-    
+
     CGLayerRelease(angbandLayer);
     
+    /* Use the highest monitor scale factor on the system to work out what
+     * scale to draw at - not the recommended method, but works where we
+     * can't easily get the monitor the current draw is occurring on. */
+    angbandLayerScale = 1.0;
+    if ([[NSScreen mainScreen] respondsToSelector:@selector(backingScaleFactor)]) {
+        for (NSScreen *screen in [NSScreen screens]) {
+            angbandLayerScale = fmax(angbandLayerScale, [screen backingScaleFactor]);
+        }
+    }
+
     /* Make a bitmap context as an example for our layer */
     CGColorSpaceRef cs = CGColorSpaceCreateDeviceRGB();
     CGContextRef exampleCtx = CGBitmapContextCreate(NULL, 1, 1, 8 /* bits per component */, 48 /* bytesPerRow */, cs, kCGImageAlphaNoneSkipFirst | kCGBitmapByteOrder32Host);
     CGColorSpaceRelease(cs);
+
+    /* Create the layer at the appropriate size */
+    size.width = fmax(1, ceil(size.width * angbandLayerScale));
+    size.height = fmax(1, ceil(size.height * angbandLayerScale));
     angbandLayer = CGLayerCreateWithContext(exampleCtx, *(CGSize *)&size, NULL);
+
     CFRelease(exampleCtx);
+
+    /* Set the new context of the layer to draw at the correct scale */
+    CGContextRef ctx = CGLayerGetContext(angbandLayer);
+    CGContextScaleCTM(ctx, angbandLayerScale, angbandLayerScale);
 
     [self lockFocus];
     [[NSColor blackColor] set];


### PR DESCRIPTION
Not exactly the recommended way of doing this - this patch just starts drawing everything at the highest dpi available on any monitor attached to the system, but I can't see a way of easily mapping back a drawing command to a window to be able to easily derive its dpi.  (On a system with multiple scale factors on different monitors this just means slightly slower drawing on all monitors, and slightly higher memory allocation for the buffers even on standard-dpi monitors - no big deal!)

This improves both ASCII rendering and graphical tile detail, which is great.