### PR TITLE
Avoiding conditional directives that break statements.

### DIFF
--- a/src/z-file.c
+++ b/src/z-file.c
@@ -169,6 +169,7 @@ size_t path_build(char *buf, size_t len, const char *base, const char *leaf)
 {
 	size_t cur_len = 0;
 	buf[0] = '\0';
+	int starts_with_separator;
 
 	if (!leaf || !leaf[0]) {
 		if (base && base[0])
@@ -184,12 +185,11 @@ size_t path_build(char *buf, size_t len, const char *base, const char *leaf)
 	 *   or there's no base path,
 	 * We use the leafname only.
 	 */
+	starts_with_separator = (!base || !base[0]) || prefix(leaf, PATH_SEP);
 #if defined(UNIX)
-	if ((!base || !base[0]) || prefix(leaf, PATH_SEP) || leaf[0] == '~')
-#else
-	if ((!base || !base[0]) || prefix(leaf, PATH_SEP))
+	starts_with_separator = starts_with_separator || leaf[0] == ‘~’;
 #endif
-	{
+	if (starts_with_separator) {
 		path_process(buf, len, &cur_len, leaf);
 		return cur_len;
 	}


### PR DESCRIPTION
A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

- https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
- https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness.