### PR TITLE
Add Identify scroll to identify an unknown rune on an item.

### DIFF
--- a/lib/gamedata/object.txt
+++ b/lib/gamedata/object.txt
@@ -1834,7 +1834,13 @@ alloc:50:5 to 70
 power:6
 effect:IDENTIFY
 
-### 269
+name:269:Runes
+graphics:?:w
+type:scroll
+properties:1:5:15
+alloc:50:5 to 70
+power:6
+effect:LEARN_RANDOM_RUNE
 
 ### Enchantments ###
 

--- a/src/effects.c
+++ b/src/effects.c
@@ -1509,6 +1509,14 @@ bool effect_handler_IDENTIFY(effect_handler_context_t *context)
     return true;
 }
 
+/**
+ * Identify an unknown rune
+ */
+bool effect_handler_LEARN_RANDOM_RUNE(effect_handler_context_t *context)
+{
+    player_learn_random_rune(player);
+    return true;
+}
 
 /**
  * Detect evil monsters around the player.  The height to detect above and

--- a/src/list-effects.h
+++ b/src/list-effects.h
@@ -49,6 +49,7 @@ EFFECT(DETECT_OBJECTS,				false,	NULL,		0,		EFINFO_NONE,	"detects objects nearby
 EFFECT(DETECT_VISIBLE_MONSTERS,		false,	NULL,		0,		EFINFO_NONE,	"detects visible creatures nearby")
 EFFECT(DETECT_INVISIBLE_MONSTERS,	false,	NULL,		0,		EFINFO_NONE,	"detects invisible creatures nearby")
 EFFECT(IDENTIFY,					false,	NULL,		0,		EFINFO_NONE,	"Identify a single unknown property of a selected item")
+EFFECT(LEARN_RANDOM_RUNE,			false,	NULL,		0,		EFINFO_NONE,	"Learn a single unknown rune")
 EFFECT(DETECT_EVIL,					false,	NULL,		0,		EFINFO_NONE,	"detects evil creatures nearby")
 EFFECT(CREATE_STAIRS,				false,	NULL,		0,		EFINFO_NONE,	"creates a staircase beneath your feet")
 EFFECT(DISENCHANT,					false,	NULL,		0,		EFINFO_NONE,	"disenchants one of your wielded items")

--- a/src/obj-knowledge.h
+++ b/src/obj-knowledge.h
@@ -59,6 +59,7 @@ void update_player_object_knowledge(struct player *p);
 
 void player_learn_brand(struct player *p, struct brand *b);
 void player_learn_slay(struct player *p, struct slay *s);
+bool player_learn_random_rune(struct player *p);
 void player_learn_everything(struct player *p);
 
 void equip_learn_on_defend(struct player *p);


### PR DESCRIPTION
This adds a new Identify scroll which, when read, will learn an unknown rune on an item. Scroll rarity currently is copied from the Scroll of Detect Invisible, which is almost certainly too common, but that's easily-tweaked later. Tested extremely briefly by making a black DSM in town and reading scrolls on it.