### PR TITLE
Add Scroll of Runes to learn a random unknown rune.

### DIFF
--- a/lib/gamedata/object.txt
+++ b/lib/gamedata/object.txt
@@ -1834,7 +1834,13 @@ alloc:50:5 to 70
 power:6
 effect:IDENTIFY
 
-### 269
+name:269:Runes
+graphics:?:w
+type:scroll
+properties:1:5:15
+alloc:50:5 to 70
+power:6
+effect:LEARN_RANDOM_RUNE
 
 ### Enchantments ###
 

--- a/src/effects.c
+++ b/src/effects.c
@@ -1509,6 +1509,14 @@ bool effect_handler_IDENTIFY(effect_handler_context_t *context)
     return true;
 }
 
+/**
+ * Identify an unknown rune
+ */
+bool effect_handler_LEARN_RANDOM_RUNE(effect_handler_context_t *context)
+{
+    player_learn_random_rune(player);
+    return true;
+}
 
 /**
  * Detect evil monsters around the player.  The height to detect above and

--- a/src/list-effects.h
+++ b/src/list-effects.h
@@ -49,6 +49,7 @@ EFFECT(DETECT_OBJECTS,				false,	NULL,		0,		EFINFO_NONE,	"detects objects nearby
 EFFECT(DETECT_VISIBLE_MONSTERS,		false,	NULL,		0,		EFINFO_NONE,	"detects visible creatures nearby")
 EFFECT(DETECT_INVISIBLE_MONSTERS,	false,	NULL,		0,		EFINFO_NONE,	"detects invisible creatures nearby")
 EFFECT(IDENTIFY,					false,	NULL,		0,		EFINFO_NONE,	"Identify a single unknown property of a selected item")
+EFFECT(LEARN_RANDOM_RUNE,			false,	NULL,		0,		EFINFO_NONE,	"Learn a single unknown rune")
 EFFECT(DETECT_EVIL,					false,	NULL,		0,		EFINFO_NONE,	"detects evil creatures nearby")
 EFFECT(CREATE_STAIRS,				false,	NULL,		0,		EFINFO_NONE,	"creates a staircase beneath your feet")
 EFFECT(DISENCHANT,					false,	NULL,		0,		EFINFO_NONE,	"disenchants one of your wielded items")

--- a/src/obj-knowledge.c
+++ b/src/obj-knowledge.c
@@ -561,41 +561,6 @@ void update_player_object_knowledge(struct player *p)
  * Object knowledge learners
  * These functions are for increasing player knowledge of object properties
  * ------------------------------------------------------------------------ */
-/**
- * Learn a single elemental brand, assuming it is unknown
- *
- * \param p is the player
- * \param b is the brand being learnt (known for any multiplier)
- */
-void player_learn_brand(struct player *p, struct brand *b)
-{
-	/* Copy the name and element */
-	struct brand *new_b = mem_zalloc(sizeof *new_b);
-	new_b->name = string_make(b->name);
-	new_b->element = b->element;
-
-	/* Attach the new brand */
-	new_b->next = p->obj_k->brands;
-	p->obj_k->brands = new_b;
-}
-
-/**
- * Learn a single slay, assuming it is unknown
- *
- * \param p is the player
- * \param s is the slay being learnt (known for any multiplier)
- */
-void player_learn_slay(struct player *p, struct slay *s)
-{
-	/* Copy the name and race flag */
-	struct slay *new_s = mem_zalloc(sizeof *new_s);
-	new_s->name = string_make(s->name);
-	new_s->race_flag = s->race_flag;
-
-	/* Attach the new slay */
-	new_s->next = p->obj_k->slays;
-	p->obj_k->slays = new_s;
-}
 
 /**
  * Return true if the rune with the specified index is known to the player.

--- a/src/obj-knowledge.c
+++ b/src/obj-knowledge.c
@@ -562,6 +562,163 @@ void update_player_object_knowledge(struct player *p)
  * These functions are for increasing player knowledge of object properties
  * ------------------------------------------------------------------------ */
 /**
+ * Learn a single elemental brand, assuming it is unknown
+ *
+ * \param p is the player
+ * \param b is the brand being learnt (known for any multiplier)
+ */
+void player_learn_brand(struct player *p, struct brand *b)
+{
+	/* Copy the name and element */
+	struct brand *new_b = mem_zalloc(sizeof *new_b);
+	new_b->name = string_make(b->name);
+	new_b->element = b->element;
+
+	/* Attach the new brand */
+	new_b->next = p->obj_k->brands;
+	p->obj_k->brands = new_b;
+}
+
+/**
+ * Learn a single slay, assuming it is unknown
+ *
+ * \param p is the player
+ * \param s is the slay being learnt (known for any multiplier)
+ */
+void player_learn_slay(struct player *p, struct slay *s)
+{
+	/* Copy the name and race flag */
+	struct slay *new_s = mem_zalloc(sizeof *new_s);
+	new_s->name = string_make(s->name);
+	new_s->race_flag = s->race_flag;
+
+	/* Attach the new slay */
+	new_s->next = p->obj_k->slays;
+	p->obj_k->slays = new_s;
+}
+
+/**
+ * Return true if the rune with the specified index is known to the player.
+ * Set it if indicated. If it is set, then it is automatically known.
+ */
+static bool player_rune_learned_set(struct player *p, size_t i, bool set)
+{
+	struct rune *r = &rune_list[i];
+	switch (r->variety) {
+		/* Combat runes */
+		case RUNE_VAR_COMBAT: {
+			if (r->index == COMBAT_RUNE_TO_A) {
+				if (!p->obj_k->to_a) {
+					if (set) {
+						p->obj_k->to_a = 1;
+						return true;
+					}
+				} else {
+					return true;
+				}
+			} else if (r->index == COMBAT_RUNE_TO_H) {
+				if (!p->obj_k->to_h) {
+					if (set) {
+						p->obj_k->to_h = 1;
+						return true;
+					}
+				} else {
+					return true;
+				}
+			} else if (r->index == COMBAT_RUNE_TO_D) {
+				if (!p->obj_k->to_d) {
+					if (set) {
+						p->obj_k->to_d = 1;
+						return true;
+					}
+				} else {
+					return true;
+				}
+			}
+			return false;
+		}
+		/* Flag runes */
+		case RUNE_VAR_FLAG: {
+			if (of_has(p->obj_k->flags, r->index)) {
+				return true;
+			} else if (set) {
+				return of_on(p->obj_k->flags, r->index);
+			}
+			return false;
+		}
+		/* Mod runes */
+		case RUNE_VAR_MOD: {
+			if (!p->obj_k->modifiers[r->index]) {
+				if (set) {
+					p->obj_k->modifiers[r->index] = 1;
+					return true;
+				}
+			} else {
+				return true;
+			}
+			return false;
+		}
+		/* Element runes */
+		case RUNE_VAR_RESIST: {
+			if (!p->obj_k->el_info[r->index].res_level) {
+				if (set) {
+					p->obj_k->el_info[r->index].res_level = 1;
+					return true;
+				}
+			} else {
+				return true;
+			}
+			return false;
+		}
+		/* Brand runes */
+		case RUNE_VAR_BRAND: {
+			int num;
+			struct brand *b;
+			for (b = game_brands, num = 0; b; b = b->next, num++)
+				if (num == r->index) break;
+			assert(b != NULL);
+
+			/* If the brand was unknown, add it to known brands */
+			if (!player_knows_brand(p, b) && set) {
+				/* Copy the name and element */
+				struct brand *new_b = mem_zalloc(sizeof *new_b);
+				new_b->name = string_make(b->name);
+				new_b->element = b->element;
+
+				/* Attach the new brand */
+				new_b->next = p->obj_k->brands;
+				p->obj_k->brands = new_b;
+			}
+			return player_knows_brand(p, b);
+		}
+		/* Slay runes */
+		case RUNE_VAR_SLAY: {
+			int num;
+			struct slay *s;
+			for (s = game_slays, num = 0; s; s = s->next, num++)
+				if (num == r->index) break;
+			assert(s != NULL);
+
+			/* If the slay was unknown, add it to known slays */
+			if (!player_knows_slay(p, s) && set) {
+				/* Copy the name and race flag */
+				struct slay *new_s = mem_zalloc(sizeof *new_s);
+				new_s->name = string_make(s->name);
+				new_s->race_flag = s->race_flag;
+
+				/* Attach the new slay */
+				new_s->next = p->obj_k->slays;
+				p->obj_k->slays = new_s;
+			}
+			return player_knows_slay(p, s);
+		}
+		default: {
+			return false;
+		}
+	}
+}
+
+/**
  * Learn a given rune
  *
  * \param p is the player
@@ -573,98 +730,7 @@ static void player_learn_rune(struct player *p, size_t i, bool message)
 	struct rune *r = &rune_list[i];
 	bool learned = false;
 
-	switch (r->variety) {
-		/* Combat runes */
-	case RUNE_VAR_COMBAT: {
-		if (r->index == COMBAT_RUNE_TO_A) {
-			if (!p->obj_k->to_a) {
-				p->obj_k->to_a = 1;
-				learned = true;
-			}
-		} else if (r->index == COMBAT_RUNE_TO_H) {
-			if (!p->obj_k->to_h) {
-				p->obj_k->to_h = 1;
-				learned = true;
-			}
-		} else if (r->index == COMBAT_RUNE_TO_D) {
-			if (!p->obj_k->to_d) {
-				p->obj_k->to_d = 1;
-				learned = true;
-			}
-		}
-		break;
-	}
-		/* Flag runes */
-	case RUNE_VAR_FLAG: {
-		if (of_on(p->obj_k->flags, r->index))
-			learned = true;
-		break;
-	}
-		/* Mod runes */
-	case RUNE_VAR_MOD: {
-		if (!p->obj_k->modifiers[r->index]) {
-			p->obj_k->modifiers[r->index] = 1;
-			learned = true;
-		}
-		break;
-	}
-		/* Element runes */
-	case RUNE_VAR_RESIST: {
-		if (!p->obj_k->el_info[r->index].res_level) {
-			p->obj_k->el_info[r->index].res_level = 1;
-			learned = true;
-		}
-		break;
-	}
-		/* Brand runes */
-	case RUNE_VAR_BRAND: {
-		int num;
-		struct brand *b;
-		for (b = game_brands, num = 0; b; b = b->next, num++)
-			if (num == r->index) break;
-		assert(b != NULL);
-
-		/* If the brand was unknown, add it to known brands */
-		if (!player_knows_brand(p, b)) {
-			/* Copy the name and element */
-			struct brand *new_b = mem_zalloc(sizeof *new_b);
-			new_b->name = string_make(b->name);
-			new_b->element = b->element;
-
-			/* Attach the new brand */
-			new_b->next = p->obj_k->brands;
-			p->obj_k->brands = new_b;
-			learned = true;
-		}
-		break;
-	}
-		/* Slay runes */
-	case RUNE_VAR_SLAY: {
-		int num;
-		struct slay *s;
-		for (s = game_slays, num = 0; s; s = s->next, num++)
-			if (num == r->index) break;
-		assert(s != NULL);
-
-		/* If the slay was unknown, add it to known slays */
-		if (!player_knows_slay(p, s)) {
-			/* Copy the name and race flag */
-			struct slay *new_s = mem_zalloc(sizeof *new_s);
-			new_s->name = string_make(s->name);
-			new_s->race_flag = s->race_flag;
-
-			/* Attach the new slay */
-			new_s->next = p->obj_k->slays;
-			p->obj_k->slays = new_s;
-			learned = true;
-		}
-		break;
-	}
-	default: {
-		learned = false;
-		break;
-	}
-	}
+    learned = player_rune_learned_set(p, i, true);
 
 	/* Nothing learned */
 	if (!learned) return;
@@ -683,6 +749,39 @@ static void player_learn_rune(struct player *p, size_t i, bool message)
 
 	/* Update knowledge */
 	update_player_object_knowledge(p);
+}
+
+/**
+ * Learn an unknown rune at random. Return true if a rune is learned.
+ */
+bool player_learn_random_rune(struct player *p)
+{
+	int numUnknown = 0;
+	size_t i;
+	size_t newRune;
+	// Count how many unknown runes there are.
+	for (i = 0; i < rune_max; i++) {
+		if (!player_rune_learned_set(player, i, false)) {
+			numUnknown++;
+		}
+	}
+	if (numUnknown == 0) {
+		msg("You already know every rune.");
+		return false;
+	}
+	// Select a random unknown rune to learn.
+	newRune = randint0(numUnknown);
+	for (i = 0; i < rune_max; i++) {
+		if (!player_rune_learned_set(player, i, false)) {
+			if (newRune == 0) {
+				player_learn_rune(player, i, true);
+				break;
+			} else {
+				newRune--;
+			}
+		}
+	}
+	return true;
 }
 
 /**

--- a/src/obj-knowledge.h
+++ b/src/obj-knowledge.h
@@ -57,8 +57,6 @@ bool object_element_is_known(const struct object *obj, int element);
 void object_set_base_known(struct object *obj);
 void player_know_object(struct player *p, struct object *obj);
 
-void player_learn_brand(struct player *p, struct brand *b);
-void player_learn_slay(struct player *p, struct slay *s);
 bool player_learn_random_rune(struct player *p);
 void player_learn_everything(struct player *p);
 

--- a/src/obj-knowledge.h
+++ b/src/obj-knowledge.h
@@ -57,6 +57,9 @@ bool object_element_is_known(const struct object *obj, int element);
 void object_set_base_known(struct object *obj);
 void player_know_object(struct player *p, struct object *obj);
 
+void player_learn_brand(struct player *p, struct brand *b);
+void player_learn_slay(struct player *p, struct slay *s);
+bool player_learn_random_rune(struct player *p);
 void player_learn_everything(struct player *p);
 
 void equip_learn_on_defend(struct player *p);


### PR DESCRIPTION
This adds a new scroll that identifies a single rune the player hasn't already learned. I chopped up obj-knowledge.c a bit to make this work; there's now a method `player_rune_learned_set()` that determines whether or not the specified rune is known, and optionally can set it; that way we have a single function to handle the nasty business of iterating over all runes and determining "knowed-ness".

I'm not clear on why this request can't be automatically merged; it's a single commit on top of the current head. But if there's anything I can do to simplify pulling, just let me know.