### PR TITLE
Extern globals to prevent link issues in some configurations.

### DIFF
--- a/src/cave.c
+++ b/src/cave.c
@@ -36,6 +36,26 @@ struct feature *f_info;
 struct chunk *cave = NULL;
 struct chunk *cave_k = NULL;
 
+int FEAT_NONE;
+int FEAT_FLOOR;
+int FEAT_CLOSED;
+int FEAT_OPEN;
+int FEAT_BROKEN;
+int FEAT_LESS;
+int FEAT_MORE;
+int FEAT_SECRET;
+int FEAT_RUBBLE;
+int FEAT_PASS_RUBBLE;
+int FEAT_MAGMA;
+int FEAT_QUARTZ;
+int FEAT_MAGMA_K;
+int FEAT_QUARTZ_K;
+int FEAT_GRANITE;
+int FEAT_PERM;
+int FEAT_LAVA;
+int FEAT_DTRAP_FLOOR;
+int FEAT_DTRAP_WALL;
+
 /**
  * Global array for looping through the "keypad directions".
  */

--- a/src/cave.h
+++ b/src/cave.h
@@ -25,11 +25,11 @@
 struct player;
 struct monster;
 
-const s16b ddd[9];
-const s16b ddx[10];
-const s16b ddy[10];
-const s16b ddx_ddd[9];
-const s16b ddy_ddd[9];
+extern const s16b ddd[9];
+extern const s16b ddx[10];
+extern const s16b ddy[10];
+extern const s16b ddx_ddd[9];
+extern const s16b ddy_ddd[9];
 
 /**
  * Square flags
@@ -171,45 +171,45 @@ struct chunk {
 /*** Feature Indexes (see "lib/gamedata/terrain.txt") ***/
 
 /* Nothing */
-int FEAT_NONE;
+extern int FEAT_NONE;
 
 /* Various */
-int FEAT_FLOOR;
-int FEAT_CLOSED;
-int FEAT_OPEN;
-int FEAT_BROKEN;
-int FEAT_LESS;
-int FEAT_MORE;
+extern int FEAT_FLOOR;
+extern int FEAT_CLOSED;
+extern int FEAT_OPEN;
+extern int FEAT_BROKEN;
+extern int FEAT_LESS;
+extern int FEAT_MORE;
 
 /* Secret door */
-int FEAT_SECRET;
+extern int FEAT_SECRET;
 
 /* Rubble */
-int FEAT_RUBBLE;
-int FEAT_PASS_RUBBLE;
+extern int FEAT_RUBBLE;
+extern int FEAT_PASS_RUBBLE;
 
 /* Mineral seams */
-int FEAT_MAGMA;
-int FEAT_QUARTZ;
-int FEAT_MAGMA_K;
-int FEAT_QUARTZ_K;
+extern int FEAT_MAGMA;
+extern int FEAT_QUARTZ;
+extern int FEAT_MAGMA_K;
+extern int FEAT_QUARTZ_K;
 
 /* Walls */
-int FEAT_GRANITE;
-int FEAT_PERM;
-int FEAT_LAVA;
+extern int FEAT_GRANITE;
+extern int FEAT_PERM;
+extern int FEAT_LAVA;
 
 /* Special trap detect features  - should be replaced with square flags */
-int FEAT_DTRAP_FLOOR;
-int FEAT_DTRAP_WALL;
+extern int FEAT_DTRAP_FLOOR;
+extern int FEAT_DTRAP_WALL;
 
 
 /* Real cave */
-struct chunk *cave;
+extern struct chunk *cave;
 /* Known cave */
-struct chunk *cave_k;
-struct chunk **chunk_list;
-u16b chunk_list_max;
+extern struct chunk *cave_k;
+extern struct chunk **chunk_list;
+extern u16b chunk_list_max;
 
 /* cave-view.c */
 int distance(int y1, int x1, int y2, int x2);

--- a/src/game-input.h
+++ b/src/game-input.h
@@ -36,22 +36,22 @@
 #define QUIVER_TAGS   0x0200	/* 0-9 are quiver slots when selecting */
 
 
-bool (*get_string_hook)(const char *prompt, char *buf, size_t len);
-int (*get_quantity_hook)(const char *prompt, int max);
-bool (*get_check_hook)(const char *prompt);
-bool (*get_com_hook)(const char *prompt, char *command);
-bool (*get_rep_dir_hook)(int *dir, bool allow_none);
-bool (*get_aim_dir_hook)(int *dir);
-int (*get_spell_from_book_hook)(const char *verb, struct object *book,
-								const char *error,
-								bool (*spell_filter)(int spell));
-int (*get_spell_hook)(const char *verb, item_tester book_filter, cmd_code cmd,
-					  const char *error, bool (*spell_filter)(int spell));
-bool (*get_item_hook)(struct object **choice, const char *pmt, const char *str,
-					  cmd_code cmd, item_tester tester, int mode);
-void (*get_panel_hook)(int *min_y, int *min_x, int *max_y, int *max_x);
-bool (*panel_contains_hook)(unsigned int y, unsigned int x);
-bool (*map_is_visible_hook)(void);
+extern bool (*get_string_hook)(const char *prompt, char *buf, size_t len);
+extern int (*get_quantity_hook)(const char *prompt, int max);
+extern bool (*get_check_hook)(const char *prompt);
+extern bool (*get_com_hook)(const char *prompt, char *command);
+extern bool (*get_rep_dir_hook)(int *dir, bool allow_none);
+extern bool (*get_aim_dir_hook)(int *dir);
+extern int (*get_spell_from_book_hook)(const char *verb, struct object *book,
+									   const char *error,
+									   bool (*spell_filter)(int spell));
+extern int (*get_spell_hook)(const char *verb, item_tester book_filter, cmd_code cmd,
+							 const char *error, bool (*spell_filter)(int spell));
+extern bool (*get_item_hook)(struct object **choice, const char *pmt, const char *str,
+							 cmd_code cmd, item_tester tester, int mode);
+extern void (*get_panel_hook)(int *min_y, int *min_x, int *max_y, int *max_x);
+extern bool (*panel_contains_hook)(unsigned int y, unsigned int x);
+extern bool (*map_is_visible_hook)(void);
 
 bool get_string(const char *prompt, char *buf, size_t len);
 int get_quantity(const char *prompt, int max);

--- a/src/game-world.h
+++ b/src/game-world.h
@@ -21,13 +21,13 @@
 
 #include "cave.h"
 
-u16b daycount;
-u32b seed_randart;
-u32b seed_flavor;
-s32b turn;
-bool character_generated;
-bool character_dungeon;
-const byte extract_energy[200];
+extern u16b daycount;
+extern u32b seed_randart;
+extern u32b seed_flavor;
+extern s32b turn;
+extern bool character_generated;
+extern bool character_dungeon;
+extern const byte extract_energy[200];
 
 bool is_daytime(void);
 int turn_energy(int speed);

--- a/src/generate.c
+++ b/src/generate.c
@@ -54,7 +54,8 @@
 struct pit_profile *pit_info;
 struct vault *vaults;
 struct cave_profile *cave_profiles;
-
+struct dun_data *dun;
+struct room_template *room_templates;
 
 static const struct {
 	const char *name;

--- a/src/generate.h
+++ b/src/generate.h
@@ -237,9 +237,9 @@ struct room_template {
     byte tval;			/*!< tval for objects in this room */
 };
 
-struct dun_data *dun;
-struct vault *vaults;
-struct room_template *room_templates;
+extern struct dun_data *dun;
+extern struct vault *vaults;
+extern struct room_template *room_templates;
 
 /* gen-cave.c */
 struct chunk *town_gen(struct player *p);
@@ -302,7 +302,7 @@ bool room_build(struct chunk *c, int by0, int bx0, struct room_profile profile,
 
 
 /* gen-util.c */
-byte get_angle_to_grid[41][41];
+extern byte get_angle_to_grid[41][41];
 
 int yx_to_i(int y, int x, int w);
 void i_to_yx(int i, int w, int *y, int *x);

--- a/src/init.h
+++ b/src/init.h
@@ -115,7 +115,7 @@ struct init_module {
 	void (*cleanup)(void);
 };
 
-struct angband_constants *z_info;
+extern struct angband_constants *z_info;
 
 extern const char *ANGBAND_SYS;
 

--- a/src/mon-attack.h
+++ b/src/mon-attack.h
@@ -24,6 +24,6 @@ bool check_hit(struct player *p, int power, int level);
 int adjust_dam_armor(int damage, int ac);
 bool make_attack_normal(struct monster *mon, struct player *p);
 
-bool (*testfn_make_attack_normal)(struct monster *m, struct player *p);
+extern bool (*testfn_make_attack_normal)(struct monster *m, struct player *p);
 
 #endif /* !MONSTER_ATTACK_H */

--- a/src/mon-summon.h
+++ b/src/mon-summon.h
@@ -31,7 +31,7 @@ enum summon_flag {
 };
 
 /** Variables **/
-struct monster_base *kin_base;
+extern struct monster_base *kin_base;
 
 
 /** Functions **/

--- a/src/obj-ignore.h
+++ b/src/obj-ignore.h
@@ -83,7 +83,7 @@ struct ego_desc {
 
 extern quality_name_struct quality_values[IGNORE_MAX];
 extern quality_name_struct quality_choices[ITYPE_MAX];
-bool **ego_ignore_types;
+extern bool **ego_ignore_types;
 
 
 /* obj-ignore.c */

--- a/src/project.h
+++ b/src/project.h
@@ -77,8 +77,8 @@ bool project_p(int who, int r, int y, int x, int dam, int typ);
 
 
 /* project.c */
-byte gf_to_attr[GF_MAX][BOLT_MAX];
-wchar_t gf_to_char[GF_MAX][BOLT_MAX];
+extern byte gf_to_attr[GF_MAX][BOLT_MAX];
+extern wchar_t gf_to_char[GF_MAX][BOLT_MAX];
 
 int project_path(struct loc *gp, int range, int y1, int x1, int y2, int x2, int flg);
 bool projectable(struct chunk *c, int y1, int x1, int y2, int x2, int flg);

--- a/src/savefile.h
+++ b/src/savefile.h
@@ -30,7 +30,7 @@
 /**
  * Global "we've just saved" variable
  */
-bool character_saved;
+extern bool character_saved;
 
 /**
  * Save to the given location.  Returns true on success, false otherwise.

--- a/src/trap.h
+++ b/src/trap.h
@@ -61,7 +61,7 @@ struct trap_kind
 	struct effect *effect;		/**< Effect on entry to grid */
 };
 
-struct trap_kind *trap_info;
+extern struct trap_kind *trap_info;
 
 /**
  * An actual trap.

--- a/src/ui-birth.c
+++ b/src/ui-birth.c
@@ -50,7 +50,6 @@
  * with their character, we send the CMD_ACCEPT_CHARACTER command.
  */
 
-
 /**
  * A local-to-this-file global to hold the most important bit of state
  * between calls to the game proper.  Probably not strictly necessary,
@@ -91,6 +90,7 @@ enum birth_rollers
 
 static void point_based_start(void);
 static bool quickstart_allowed = false;
+bool arg_force_name;
 
 /**
  * ------------------------------------------------------------------------

--- a/src/ui-birth.h
+++ b/src/ui-birth.h
@@ -23,6 +23,6 @@ void ui_init_birthstate_handlers(void);
 int textui_do_birth(void);
 
 //phantom
-bool arg_force_name;
+extern bool arg_force_name;
 
 #endif

--- a/src/ui-game.h
+++ b/src/ui-game.h
@@ -23,7 +23,7 @@
 #include "cmd-core.h"
 #include "game-event.h"
 
-bool arg_wizard;
+extern bool arg_wizard;
 extern char savefile[1024];
 
 void cmd_init(void);

--- a/src/ui-input.h
+++ b/src/ui-input.h
@@ -80,7 +80,7 @@ bool askfor_aux(char *buf, size_t len, bool (*keypress_h)(char *, size_t, size_t
 bool get_character_name(char *buf, size_t buflen);
 char get_char(const char *prompt, const char *options, size_t len,
 			  char fallback);
-bool (*get_file)(const char *suggested_name, char *path, size_t len);
+extern bool (*get_file)(const char *suggested_name, char *path, size_t len);
 bool get_com_ex(const char *prompt, ui_event *command);
 void pause_line(struct term *term);
 void textui_input_init(void);

--- a/src/ui-output.c
+++ b/src/ui-output.c
@@ -22,6 +22,8 @@
 #include "ui-output.h"
 #include "z-textblock.h"
 
+s16b screen_save_depth;
+
 /**
  * ------------------------------------------------------------------------
  * Regions

--- a/src/ui-output.h
+++ b/src/ui-output.h
@@ -93,7 +93,7 @@ void prt(const char *str, int row, int col);
  * ------------------------------------------------------------------------
  * Screen loading/saving
  * ------------------------------------------------------------------------ */
-s16b screen_save_depth;
+extern s16b screen_save_depth;
 void screen_save(void);
 void screen_load(void);
 bool textui_map_is_visible(void);

--- a/src/ui-prefs.h
+++ b/src/ui-prefs.h
@@ -28,16 +28,16 @@ extern int use_graphics;
 extern int arg_graphics;
 extern bool arg_graphics_nice;
 
-byte *monster_x_attr;
-wchar_t *monster_x_char;
-byte *kind_x_attr;
-wchar_t *kind_x_char;
-byte *feat_x_attr[LIGHTING_MAX];
-wchar_t *feat_x_char[LIGHTING_MAX];
-byte *trap_x_attr[LIGHTING_MAX];
-wchar_t *trap_x_char[LIGHTING_MAX];
-byte *flavor_x_attr;
-wchar_t *flavor_x_char;
+extern byte *monster_x_attr;
+extern wchar_t *monster_x_char;
+extern byte *kind_x_attr;
+extern wchar_t *kind_x_char;
+extern byte *feat_x_attr[LIGHTING_MAX];
+extern wchar_t *feat_x_char[LIGHTING_MAX];
+extern byte *trap_x_attr[LIGHTING_MAX];
+extern wchar_t *trap_x_char[LIGHTING_MAX];
+extern byte *flavor_x_attr;
+extern wchar_t *flavor_x_char;
 
 void dump_monsters(ang_file *fff);
 void dump_objects(ang_file *fff);

--- a/src/ui-signals.h
+++ b/src/ui-signals.h
@@ -19,7 +19,7 @@
 #ifndef INCLUDED_UI_SIGNALS_H
 #define INCLUDED_UI_SIGNALS_H
 
-s16b signal_count;
+extern s16b signal_count;
 
 void signals_ignore_tstp(void);
 void signals_handle_tstp(void);

--- a/src/z-util.h
+++ b/src/z-util.h
@@ -37,7 +37,7 @@ extern char *argv0;
 /**
  * Aux functions
  */
-size_t (*text_mbcs_hook)(wchar_t *dest, const char *src, int n);
+extern size_t (*text_mbcs_hook)(wchar_t *dest, const char *src, int n);
 extern void (*plog_aux)(const char *);
 extern void (*quit_aux)(const char *);
 


### PR DESCRIPTION
This is a low-priority change that fixes a problem with duplicate symbols while linking. Xcode seems to pass flags (or has other configurations) that cause linker failures, whereas building with `make` from `Makefile.osx` does not have these issues. It is also a bit of cleanup for code correctness.

These changes shouldn't break building on other systems, but this has only been tested on OS X versions of `clang` and `ld` and such. There should also be no effect when running the actual built product.