### PR TITLE
Make building directory paths a bit more robust.

### DIFF
--- a/src/z-file.c
+++ b/src/z-file.c
@@ -201,7 +201,12 @@ size_t path_build(char *buf, size_t len, const char *base, const char *leaf)
 	/* There is both a relative leafname and a base path from which it is
 	 * relative */
 	path_process(buf, len, &cur_len, base);
-	strnfcat(buf, len, &cur_len, "%s", PATH_SEP);
+
+	if (!suffix(base, PATH_SEP)) {
+		/* Append separator if it isn't already in the string. */
+		strnfcat(buf, len, &cur_len, "%s", PATH_SEP);
+	}
+
 	path_process(buf, len, &cur_len, leaf);
 
 	return cur_len;


### PR DESCRIPTION
This fixes the documents path issue on OS X. Note that this change will create and look for files in their correct locations. Users transitioning to this build will need to manually move their files from the incorrect location to the correct location: `~/Documents/Angbandsave/` to `~/Documents/Angband/save/`.

These changes make path building a bit more robust by handling the existence or lack thereof of a trailing path separator on the paths that are passed into `init_file_paths()`. This has not been tested on other platforms, but it has been tested with various combinations of paths with and without path separators in various positions.

