### PR TITLE
Fixes for monster list.

### DIFF
--- a/src/mon-list.c
+++ b/src/mon-list.c
@@ -282,7 +282,7 @@ void monster_list_sort(monster_list_t *list,
 	if (elements <= 1)
 		return;
 
-	sort(list->entries, elements, sizeof(list->entries[0]), compare);
+	sort(list->entries, MIN(elements, list->entries_size), sizeof(list->entries[0]), compare);
 	list->sorted = true;
 }
 

--- a/src/mon-list.c
+++ b/src/mon-list.c
@@ -97,16 +97,15 @@ monster_list_t *monster_list_shared_instance(void)
 }
 
 /**
- * Return true if the list needs to be updated. Usually this is each turn or if
- * the number of cave monsters changes.
+ * Return true if there is nothing preventing the list from being updated. This
+ * should be for structural sanity checks and not gameplay checks.
  */
-static bool monster_list_needs_update(const monster_list_t *list)
+static bool monster_list_can_update(const monster_list_t *list)
 {
 	if (list == NULL || list->entries == NULL)
 		return false;
 
-	return list->creation_turn != turn ||
-		(int)list->entries_size < cave_monster_max(cave);
+	return (int)list->entries_size <= cave_monster_max(cave);
 }
 
 /**
@@ -116,9 +115,6 @@ static bool monster_list_needs_update(const monster_list_t *list)
 void monster_list_reset(monster_list_t *list)
 {
 	if (list == NULL || list->entries == NULL)
-		return;
-
-	if (!monster_list_needs_update(list))
 		return;
 
 	if ((int)list->entries_size < cave_monster_max(cave)) {
@@ -145,6 +141,9 @@ void monster_list_collect(monster_list_t *list)
 	if (list == NULL || list->entries == NULL)
 		return;
 
+	if (!monster_list_can_update(list))
+		return;
+
 	/* Use cave_monster_max() here in case the monster list isn't compacted. */
 	for (i = 1; i < cave_monster_max(cave); i++) {
 		struct monster *mon = cave_monster(cave, i);
@@ -164,7 +163,6 @@ void monster_list_collect(monster_list_t *list)
 				entry = &list->entries[j];
 				memset(entry, 0, sizeof(monster_list_entry_t));
 				entry->race = mon->race;
-
 				break;
 			}
 			else if (list->entries[j].race == mon->race) {
@@ -181,10 +179,6 @@ void monster_list_collect(monster_list_t *list)
 		 * animation works. If this is 0, it needs to be replaced by 
 		 * the standard glyph in the UI */
 		entry->attr = mon->attr;
-
-		/* Skip the projection and location checks if nothing has changed. */
-		if (!monster_list_needs_update(list))
-			continue;
 
 		/*
 		 * Check for LOS
@@ -205,11 +199,6 @@ void monster_list_collect(monster_list_t *list)
 		entry->dx = mon->fx - player->px;
 		entry->dy = mon->fy - player->py;
 	}
-
-	/* Skip calculations if nothing has changed, otherwise this will yield
-	 * incorrect numbers. */
-	if (!monster_list_needs_update(list))
-		return;
 
 	/* Collect totals for easier calculations of the list. */
 	for (i = 0; i < (int)list->entries_size; i++) {

--- a/src/ui-mon-list.c
+++ b/src/ui-mon-list.c
@@ -100,6 +100,8 @@ static void monster_list_format_section(const monster_list_t *list, textblock *t
 		byte line_attr;
 		size_t full_width;
 		size_t name_width;
+		u16b count_in_section = 0;
+		u16b asleep_in_section = 0;
 
 		line_buffer[0] = '\0';
 
@@ -119,10 +121,12 @@ static void monster_list_format_section(const monster_list_t *list, textblock *t
 		 * space; location includes padding; last -1 for some reason? */
 		full_width = max_width - 2 - utf8_strlen(location) - 1;
 
-		if (list->entries[index].asleep[section] > 1)
-			strnfmt(asleep, sizeof(asleep), " (%d asleep)",
-					list->entries[index].asleep[section]);
-		else if (list->entries[index].asleep[section] == 1)
+		asleep_in_section = list->entries[index].asleep[section];
+		count_in_section = list->entries[index].count[section];
+
+		if (asleep_in_section > 0 && count_in_section > 1)
+			strnfmt(asleep, sizeof(asleep), " (%d asleep)", asleep_in_section);
+		else if (asleep_in_section == 1 && count_in_section == 1)
 			strnfmt(asleep, sizeof(asleep), " (asleep)");
 
 		/* Clip the monster name to fit, and append the sleep tag. */


### PR DESCRIPTION
This fixes a few things about the monster list:
- The second part of 1970, when the monster list isn't updated when it should be. The monster list should be much more responsive to changes. I don't think this should cause any noticeable performance problems, especially due to the next fix.
- This also fixes an issue where processing monster list could cause lots of churn, resulting in relatively long sorting and drawing times. A lot of times, this could also lead to a crash (which is also fixed below).
- An array bounds crash was fixed.
- Corrects the "asleep" string when only one member of a group is asleep:
`2 Jackals (asleep)` will now correctly render as `2 Jackals (1 asleep)`