### PR TITLE
Update object list on pickup. [1970]

### DIFF
--- a/src/cmd-pickup.c
+++ b/src/cmd-pickup.c
@@ -375,6 +375,10 @@ void do_cmd_pickup(struct command *cmd)
 
 	/* Charge this amount of energy. */
 	player->upkeep->energy_use = energy_cost;
+
+	/* Redraw the object list using the upkeep flag so that the update can be
+	 * somewhat coalesced. Use event_signal(EVENT_ITEMLIST to force update. */
+	player->upkeep->redraw = (PR_ITEMLIST);
 }
 
 /**
@@ -389,4 +393,8 @@ void do_cmd_autopickup(struct command *cmd)
 
 	/* Look at or feel what's left */
 	event_signal(EVENT_SEEFLOOR);
+
+	/* Redraw the object list using the upkeep flag so that the update can be
+	 * somewhat coalesced. Use event_signal(EVENT_ITEMLIST to force update. */
+	player->upkeep->redraw = (PR_ITEMLIST);
 }


### PR DESCRIPTION
Sets `PR_ITEMLIST` on pickup and auto pickup. There didn't seem to be any issues with the object list updating when dropping from equipment or inventory, wielding from the floor, or when monsters drop. This should fix the first part of 1970.