### PR TITLE
Wrap textblocks properly without forced line breaks. [1804]

### DIFF
--- a/src/ui-birth.c
+++ b/src/ui-birth.c
@@ -891,7 +891,6 @@ int edit_text(char *buffer, int buflen) {
 		/* Display on screen */
 		clear_from(HIST_INSTRUCT_ROW);
 		textblock_append(tb, buffer);
-		textblock_append(tb, "\n"); /* XXX This shouldn't be necessary */
 		textui_textblock_place(tb, area, NULL);
 
 		n_lines = textblock_calculate_lines(tb,

--- a/src/ui-knowledge.c
+++ b/src/ui-knowledge.c
@@ -3161,8 +3161,7 @@ void do_cmd_query_symbol(void)
 		tb = textblock_new();
 		lore_title(tb, race);
 
-		/* Line break is needed for proper display */
-		textblock_append(tb, " [(r)ecall, ESC]\n");
+		textblock_append(tb, " [(r)ecall, ESC]");
 		textui_textblock_place(tb, SCREEN_REGION, NULL);
 		textblock_free(tb);
 


### PR DESCRIPTION
Reworks text block wrapping so that a trailing \n isn't required to wrap properly.