### PR TITLE
Fix more object list stuff.

### DIFF
--- a/src/obj-list.c
+++ b/src/obj-list.c
@@ -376,6 +376,10 @@ void object_list_format_name(const object_list_entry_t *entry,
 	struct object *base_obj;
 	int iy;
 	int ix;
+	bool object_is_artifact;
+	bool object_name_visible;
+	bool object_known;
+	bool object_is_recognized_artifact;
 
 	if (entry == NULL || entry->object == NULL || entry->object->kind == NULL)
 		return;
@@ -383,20 +387,28 @@ void object_list_format_name(const object_list_entry_t *entry,
 	base_obj = cave->objects[entry->object->oidx];
 	iy = entry->object->iy;
 	ix = entry->object->ix;
+	object_is_artifact = (base_obj->artifact != NULL);
+	object_name_visible = object_name_is_visible(base_obj);
+	object_known = object_is_known(base_obj);
+	object_is_recognized_artifact = (object_is_artifact && (object_name_visible || object_known));
 
 	/* Hack - these don't have a prefix when there is only one, so just pad
 	 * with a space. */
 	switch (entry->object->kind->tval) {
 		case TV_SOFT_ARMOR:
-			has_singular_prefix = (entry->object->kind->sval == lookup_sval(TV_SOFT_ARMOR, "Robe"));
+			if (object_is_recognized_artifact)
+				has_singular_prefix = true;
+			else if (base_obj->kind->sval == lookup_sval(TV_SOFT_ARMOR, "Robe"))
+				has_singular_prefix = true;
+			else
+				has_singular_prefix = false;
 			break;
 		case TV_HARD_ARMOR:
 		case TV_DRAG_ARMOR:
-			if ((object_name_is_visible(base_obj) || object_is_known(base_obj))
-				&& entry->object->artifact)
+			if (object_is_recognized_artifact)
 				has_singular_prefix = true;
 			else
-				has_singular_prefix = false;				
+				has_singular_prefix = false;
 			break;
 		default:
 			has_singular_prefix = true;

--- a/src/obj-list.c
+++ b/src/obj-list.c
@@ -205,15 +205,6 @@ void object_list_collect(object_list_t *list)
 				list->entries[entry_index].dx = x - player->px;
 				entry = &list->entries[entry_index];
 				break;
-			} else if (!is_unknown(obj)) {
-				/* Use a matching object if we find one. */
-				struct object *obj1 = cave->objects[obj->oidx];
-				struct object *obj2 = cave->objects[list_obj->oidx];
- 
-				if (object_similar(obj1, obj2, OSTACK_LIST)) {
-					entry = &list->entries[entry_index];
-					break;
-				}
 			}
 		}
 


### PR DESCRIPTION
This fixes additional issues in 1611 relating to prefixes for soft armors in two parts:
- The first part of the fix prevents the object list from trying to unique the list by object type. `?..@.?` would only show one book with the coordinates of the eastern one (since it's the closest). Now, that same situation would show both books separately with correct coordinates. This also handles stacks correctly. If the left `?` was a stack of books, the stack will be shown on its own line, and the singular book to the right will be on its own line. This new behavior seems to me more consistent and clear than the old.
- The second part just fixes some implementation errors with the specific checks for soft armors and such. Some data isn't being cleared somewhere, which was triggering incorrect situations.
I think I've gotten all situations tested in 1611 except for the fuzzy detection.

Also, this adds a debug feature to the C/c menus to drop all objects or artifacts, or just all from a particular tval.