### PR TITLE
Force map refresh if player is disturbed while running

### DIFF
--- a/src/player-util.c
+++ b/src/player-util.c
@@ -908,6 +908,9 @@ void disturb(struct player *p, int stop_search)
 		if (OPT(center_player))
 			event_signal(EVENT_PLAYERMOVED);
 		p->upkeep->update |= PU_TORCH;
+
+		/* Mark the whole map to be redrawn */
+		event_signal_point(EVENT_MAP, -1, -1);
 	}
 
 	/* Cancel searching if requested */


### PR DESCRIPTION
If the map panel changes when the player is running, the map is not refreshed. The player stops running when 'disturbed', which is an ideal time to refresh the players view of the world