### PR TITLE
Removed magic numbers from CUT timer.

### DIFF
--- a/src/game-world.c
+++ b/src/game-world.c
@@ -257,7 +257,7 @@ static void decrease_timeouts(void)
 			case TMD_CUT:
 			{
 				/* Hack -- check for truly "mortal" wound */
-				decr = (player->timed[i] > 1000) ? 0 : adjust;
+				decr = (player->timed[i] > TMD_CUT_DEEP) ? 0 : adjust;
 				break;
 			}
 
@@ -341,11 +341,11 @@ void process_world(struct chunk *c)
 	/* Take damage from cuts */
 	if (player->timed[TMD_CUT]) {
 		/* Mortal wound or Deep Gash */
-		if (player->timed[TMD_CUT] > 200)
+		if (player->timed[TMD_CUT] > TMD_CUT_SEVERE)
 			i = 3;
 
 		/* Severe cut */
-		else if (player->timed[TMD_CUT] > 100)
+		else if (player->timed[TMD_CUT] > TMD_CUT_NASTY)
 			i = 2;
 
 		/* Other cuts */

--- a/src/player-timed.c
+++ b/src/player-timed.c
@@ -370,25 +370,25 @@ static bool set_cut(struct player *p, int v)
 	v = (v > 10000) ? 10000 : (v < 0) ? 0 : v;
 
 	/* Old state */
-	if (p->timed[TMD_CUT] > 1000)
+	if (p->timed[TMD_CUT] > TMD_CUT_DEEP)
 		/* Mortal wound */
 		old_aux = 7;
-	else if (p->timed[TMD_CUT] > 200)
+	else if (p->timed[TMD_CUT] > TMD_CUT_SEVERE)
 		/* Deep gash */
 		old_aux = 6;
-	else if (p->timed[TMD_CUT] > 100)
+	else if (p->timed[TMD_CUT] > TMD_CUT_NASTY)
 		/* Severe cut */
 		old_aux = 5;
-	else if (p->timed[TMD_CUT] > 50)
+	else if (p->timed[TMD_CUT] > TMD_CUT_BAD)
 		/* Nasty cut */
 		old_aux = 4;
-	else if (p->timed[TMD_CUT] > 25)
+	else if (p->timed[TMD_CUT] > TMD_CUT_LIGHT)
 		/* Bad cut */
 		old_aux = 3;
-	else if (p->timed[TMD_CUT] > 10)
+	else if (p->timed[TMD_CUT] > TMD_CUT_GRAZE)
 		/* Light cut */
 		old_aux = 2;
-	else if (p->timed[TMD_CUT] > 0)
+	else if (p->timed[TMD_CUT] > TMD_CUT_NONE)
 		/* Graze */
 		old_aux = 1;
 	else
@@ -396,25 +396,25 @@ static bool set_cut(struct player *p, int v)
 		old_aux = 0;
 
 	/* New state */
-	if (v > 1000)
+	if (v > TMD_CUT_DEEP)
 		/* Mortal wound */
 		new_aux = 7;
-	else if (v > 200)
+	else if (v > TMD_CUT_SEVERE)
 		/* Deep gash */
 		new_aux = 6;
-	else if (v > 100)
+	else if (v > TMD_CUT_NASTY)
 		/* Severe cut */
 		new_aux = 5;
-	else if (v > 50)
+	else if (v > TMD_CUT_BAD)
 		/* Nasty cut */
 		new_aux = 4;
-	else if (v > 25)
+	else if (v > TMD_CUT_LIGHT)
 		/* Bad cut */
 		new_aux = 3;
-	else if (v > 10)
+	else if (v > TMD_CUT_GRAZE)
 		/* Light cut */
 		new_aux = 2;
-	else if (v > 0)
+	else if (v > TMD_CUT_NONE)
 		/* Graze */
 		new_aux = 1;
 	else

--- a/src/player-timed.h
+++ b/src/player-timed.h
@@ -30,6 +30,17 @@
 #define PY_FOOD_STARVE	100		/* Food value (Starving) */
 
 /**
+ * Player cut timer values
+ */
+#define TMD_CUT_NONE    0
+#define TMD_CUT_GRAZE   10
+#define TMD_CUT_LIGHT   25
+#define TMD_CUT_BAD     50
+#define TMD_CUT_NASTY   100
+#define TMD_CUT_SEVERE  200
+#define TMD_CUT_DEEP    1000
+
+/**
  * Effect failure flag types
  */
 enum {


### PR DESCRIPTION
Replaced magic numbers of CUT timer values with constants as they are used in several places.

I considered suffixing the constants with ```_MAX``` to emphasis that the timer values are the upper limit of the associated cut type:

```
#define TMD_CUT_NONE        0
#define TMD_CUT_GRAZE_MAX   10
#define TMD_CUT_LIGHT_MAX   25
#define TMD_CUT_BAD_MAX     50
#define TMD_CUT_NASTY_MAX   100
#define TMD_CUT_SEVERE_MAX  200
#define TMD_CUT_DEEP_MAX    1000
```