### PR TITLE
Fix the worst cases of double negative options

### DIFF
--- a/lib/help/option.txt
+++ b/lib/help/option.txt
@@ -196,16 +196,18 @@ Word of Recall has no effect '[birth_no_recall]'
 Restrict the creation of artifacts '[birth_no_artifacts]'
   No artifacts will be created. Ever. Just *how* masochistic are you?
 
-.. _birth_no_stacking:
+.. _birth_stacking:
 
-Don't stack objects on the floor '[birth_no_stacking]'
-  Items dropped on the floor will spread out instead of stacking. Normal
-  items will disappear if there is no empty grid within a radius of three
-  squares.
+Stack objects on the floor '[birth_stacking]'
+  With this option turned on, multiple items can occupy one grid.
 
-.. _birth_no_preserve:
+  With this option off, items dropped on the floor will spread out instead
+  of stacking. Normal items will disappear if there is no empty grid
+  within a radius of three squares.
 
-Lose artifacts when leaving level '[birth_no_preserve]'
+.. _birth_lose_arts:
+
+Lose artifacts when leaving level '[birth_lose_arts]'
   Normally if you leave a level with an unidentified artifact on it you may
   still find it later. With this option on, if you leave a level with an
   artifact on it's gone for the rest of the game whether you knew it was
@@ -213,20 +215,23 @@ Lose artifacts when leaving level '[birth_no_preserve]'
   have already identified (i.e. picked up) - these will always be
   permanently lost if you leave a level without taking them with you.
 
-.. _birth_no_stairs:
+.. _birth_connect_stairs:
 
-Don't generate connected stairs '[birth_no_stairs]'
-  Normally, if you go down stairs, you start the new level on an up
-  staircase, and vice versa (if you go up stairs, you start the next level
-  on a down staircase).  With this option on, you will never start on a
-  staircase - but other staircases up and down elsewhere on the level will
-  still be generated.
+Generate connected stairs '[birth_connect_stairs]'
+  With this option turned on, if you go down stairs, you start the new level
+  on an up staircase, and vice versa (if you go up stairs, you start the next
+  level on a down staircase).
 
-.. _birth_no_feelings:
+  With this option off, you will never start on a staircase - but other
+  staircases up and down elsewhere on the level will still be generated.
 
-Don't show level feelings '[birth_no_feelings]'
-  The "quality" of a level is never revealed, no matter how long you spend
-  on the level.
+.. _birth_feelings:
+
+Show level feelings '[birth_feelings]'
+  With this option turned on, the game will give you hints about what a new
+  level has on it.
+
+  With this option off, these hints will not be shown.
 
 .. _birth_no_selling:
 
@@ -235,7 +240,6 @@ Increase gold drops but disable selling '[birth_no_selling]'
   identify unknown items for you, and will still sell you their wares. To
   balance out income in the game, gold found in the dungeon will be
   increased if this option is on.
-  
 .. _birth_start_kit:
 
 Start with a kit of useful gear '[birth_start_kit]'

--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -1493,7 +1493,7 @@ void display_feeling(bool obj_only)
 	const char *join;
 
 	/* Don't show feelings for cold-hearted characters */
-	if (OPT(birth_no_feelings)) return;
+	if (!OPT(birth_feelings)) return;
 
 	/* No useful feeling in town */
 	if (!player->depth) {

--- a/src/effects.c
+++ b/src/effects.c
@@ -2940,7 +2940,7 @@ bool effect_handler_DESTRUCTION(effect_handler_context_t *context)
 				struct object *obj = square_object(cave, y, x);
 				while (obj) {
 					if (obj->artifact) {
-						if (!OPT(birth_no_preserve) && !object_was_sensed(obj))
+						if (!OPT(birth_lose_arts) && !object_was_sensed(obj))
 							obj->artifact->created = false;
 						else
 							history_lose_artifact(obj->artifact);

--- a/src/gen-util.c
+++ b/src/gen-util.c
@@ -344,7 +344,7 @@ void new_player_spot(struct chunk *c, struct player *p)
     cave_find_in_range(c, &y, 0, c->height, &x, 0, c->width, square_isstart);
 
     /* Create stairs the player came down if allowed and necessary */
-	if (OPT(birth_no_stairs))
+    if (!OPT(birth_connect_stairs))
 		;
 	else if (p->upkeep->create_down_stair)
 		square_set_feat(c, y, x, FEAT_MORE);

--- a/src/generate.c
+++ b/src/generate.c
@@ -670,8 +670,8 @@ static int calc_obj_feeling(struct chunk *c)
 	/* Town gets no feeling */
 	if (c->depth == 0) return 0;
 
-	/* Artifacts trigger a special feeling when preserve=no */
-	if (c->good_item && OPT(birth_no_preserve)) return 10;
+	/* Artifacts trigger a special feeling when they can be easily lost */
+	if (c->good_item && OPT(birth_lose_arts)) return 10;
 
 	/* Check the loot adjusted for depth */
 	x = c->obj_rating / c->depth;
@@ -829,7 +829,7 @@ static void cave_clear(struct chunk *c, struct player *p)
 			struct object *obj = square_object(c, y, x);
 			while (obj) {
 				if (obj->artifact) {
-					if (!OPT(birth_no_preserve) && !object_was_sensed(obj))
+					if (!OPT(birth_lose_arts) && !object_was_sensed(obj))
 						obj->artifact->created = false;
 					else
 						history_lose_artifact(obj->artifact);

--- a/src/list-options.h
+++ b/src/list-options.h
@@ -71,26 +71,26 @@ OP(score_live,            "Score: Allow player to avoid death",
 SCORE, false)
 OP(birth_randarts,        "Randomise the artifacts (except a very few)",
 BIRTH, false)
+OP(birth_keep_randarts,   "Use previous set of randarts",
+BIRTH, true)
+OP(birth_connect_stairs,  "Generate connected stairs",
+BIRTH, true)
+OP(birth_force_descend,   "Force player descent (never make up stairs)",
+BIRTH, false)
 OP(birth_no_recall,       "Word of Recall has no effect",
 BIRTH, false)
 OP(birth_no_artifacts,    "Restrict creation of artifacts",
 BIRTH, false)
-OP(birth_no_stacking,     "Don't stack objects on the floor",
-BIRTH, false)
-OP(birth_no_preserve,     "Lose artifacts when leaving level",
-BIRTH, false)
-OP(birth_no_stairs,       "Don't generate connected stairs",
-BIRTH, false)
-OP(birth_no_feelings,     "Don't show level feelings",
-BIRTH, false)
-OP(birth_no_selling,      "Increase gold drops but disable selling",
+OP(birth_stacking,        "Stack objects on the floor",
 BIRTH, true)
-OP(birth_keep_randarts,   "Use previous set of randarts",
+OP(birth_lose_arts,       "Lose artifacts when leaving level",
+BIRTH, false)
+OP(birth_feelings,        "Show level feelings",
+BIRTH, true)
+OP(birth_no_selling,      "Increase gold drops but disable selling",
 BIRTH, true)
 OP(birth_start_kit,       "Start with a kit of useful gear",
 BIRTH, true)
 OP(birth_ai_learn,        "Monsters learn from their mistakes",
-BIRTH, false)
-OP(birth_force_descend,   "Force player descent",
 BIRTH, false)
 

--- a/src/main-stats.c
+++ b/src/main-stats.c
@@ -181,7 +181,7 @@ static void generate_player_for_stats()
 {
 	OPT(birth_randarts) = randarts;
 	OPT(birth_no_selling) = no_selling;
-	OPT(birth_no_stacking) = false;
+	OPT(birth_stacking) = true;
 	OPT(auto_more) = true;
 
 	player->wizard = 1; /* Set wizard mode on */

--- a/src/obj-pile.c
+++ b/src/obj-pile.c
@@ -818,7 +818,7 @@ bool floor_carry(struct chunk *c, int y, int x, struct object *drop, bool last)
 	}
 
 	/* The stack is already too large */
-	if (n >= z_info->floor_size || (OPT(birth_no_stacking) && n)) {
+	if (n >= z_info->floor_size || (!OPT(birth_stacking) && n)) {
 		/* Delete the oldest ignored object */
 		if (ignore) {
 			square_excise_object(c, y, x, ignore);
@@ -971,7 +971,7 @@ void drop_near(struct chunk *c, struct object *dropped, int chance, int y,
 			if (!comb) k++;
 
 			/* Option -- disallow stacking */
-			if (OPT(birth_no_stacking) && (k > 1)) continue;
+			if (OPT(birth_stacking) && (k > 1)) continue;
 
 			/* Paranoia? */
 			if ((k + n) > z_info->floor_size &&

--- a/src/ui-display.c
+++ b/src/ui-display.c
@@ -869,7 +869,7 @@ static const byte mon_feeling_color[] =
 /**
  * Prints level feelings at status if they are enabled.
  */
-static size_t prt_level_feeling(int row, int col) 
+static size_t prt_level_feeling(int row, int col)
 {
 	u16b obj_feeling;
 	u16b mon_feeling;
@@ -879,7 +879,7 @@ static size_t prt_level_feeling(int row, int col)
 	byte obj_feeling_color_print;
 
 	/* Don't show feelings for cold-hearted characters */
-	if (OPT(birth_no_feelings)) return 0;
+	if (!OPT(birth_feelings)) return 0;
 
 	/* No useful feeling in town */
 	if (!player->depth) return 0;
@@ -888,7 +888,7 @@ static size_t prt_level_feeling(int row, int col)
 	obj_feeling = cave->feeling / 10;
 	mon_feeling = cave->feeling - (10 * obj_feeling);
 
-	/* 
+	/*
 	 *   Convert object feeling to a symbol easier to parse
 	 * for a human.
 	 *   0 -> * "Looks like any other level."


### PR DESCRIPTION
Also rearrange the options a bit so they're more thematic - randarts,
dungen, object difficulty options are grouped together.

Silently breaks savefile compat for ongoing characters - renamed options will reset to their defaults

As suggested by Nomad http://angband.oook.cz/forum/showpost.php?p=110029&postcount=54