### PR TITLE
Parser arg to state err or quit on file not found.

### DIFF
--- a/src/generate.c
+++ b/src/generate.c
@@ -197,7 +197,7 @@ static struct parser *init_parse_profile(void) {
 }
 
 static errr run_parse_profile(struct parser *p) {
-	return parse_file(p, "dungeon_profile");
+	return parse_file_quit_not_found(p, "dungeon_profile");
 }
 
 static errr finish_parse_profile(struct parser *p) {
@@ -416,7 +416,7 @@ static struct parser *init_parse_room(void) {
 }
 
 static errr run_parse_room(struct parser *p) {
-	return parse_file(p, "room_template");
+	return parse_file_quit_not_found(p, "room_template");
 }
 
 static errr finish_parse_room(struct parser *p) {
@@ -563,7 +563,7 @@ struct parser *init_parse_vault(void) {
 }
 
 static errr run_parse_vault(struct parser *p) {
-	return parse_file(p, "vault");
+	return parse_file_quit_not_found(p, "vault");
 }
 
 static errr finish_parse_vault(struct parser *p) {

--- a/src/init.c
+++ b/src/init.c
@@ -732,7 +732,7 @@ struct parser *init_parse_constants(void) {
 }
 
 static errr run_parse_constants(struct parser *p) {
-	return parse_file(p, "constants");
+	return parse_file_quit_not_found(p, "constants");
 }
 
 static errr finish_parse_constants(struct parser *p) {
@@ -899,7 +899,7 @@ struct parser *init_parse_object_base(void) {
 }
 
 static errr run_parse_object_base(struct parser *p) {
-	return parse_file(p, "object_base");
+	return parse_file_quit_not_found(p, "object_base");
 }
 
 static errr finish_parse_object_base(struct parser *p) {
@@ -1321,7 +1321,7 @@ struct parser *init_parse_object(void) {
 }
 
 static errr run_parse_object(struct parser *p) {
-	return parse_file(p, "object");
+	return parse_file_quit_not_found(p, "object");
 }
 
 static errr finish_parse_object(struct parser *p) {
@@ -1561,7 +1561,7 @@ struct parser *init_parse_act(void) {
 }
 
 static errr run_parse_act(struct parser *p) {
-	return parse_file(p, "activation");
+	return parse_file_quit_not_found(p, "activation");
 }
 
 static errr finish_parse_act(struct parser *p) {
@@ -1858,7 +1858,7 @@ struct parser *init_parse_artifact(void) {
 }
 
 static errr run_parse_artifact(struct parser *p) {
-	return parse_file(p, "artifact");
+	return parse_file_quit_not_found(p, "artifact");
 }
 
 static errr finish_parse_artifact(struct parser *p) {
@@ -1966,7 +1966,7 @@ struct parser *init_parse_names(void) {
 }
 
 static errr run_parse_names(struct parser *p) {
-	return parse_file(p, "names");
+	return parse_file_quit_not_found(p, "names");
 }
 
 static errr finish_parse_names(struct parser *p) {
@@ -2207,7 +2207,7 @@ struct parser *init_parse_trap(void) {
 }
 
 static errr run_parse_trap(struct parser *p) {
-    return parse_file(p, "trap");
+    return parse_file_quit_not_found(p, "trap");
 }
 
 static errr finish_parse_trap(struct parser *p) {
@@ -2375,7 +2375,7 @@ struct parser *init_parse_feat(void) {
 }
 
 static errr run_parse_feat(struct parser *p) {
-	return parse_file(p, "terrain");
+	return parse_file_quit_not_found(p, "terrain");
 }
 
 static errr finish_parse_feat(struct parser *p) {
@@ -2778,7 +2778,7 @@ struct parser *init_parse_ego(void) {
 }
 
 static errr run_parse_ego(struct parser *p) {
-	return parse_file(p, "ego_item");
+	return parse_file_quit_not_found(p, "ego_item");
 }
 
 static errr finish_parse_ego(struct parser *p) {
@@ -2894,7 +2894,7 @@ struct parser *init_parse_body(void) {
 }
 
 static errr run_parse_body(struct parser *p) {
-	return parse_file(p, "body");
+	return parse_file_quit_not_found(p, "body");
 }
 
 static errr finish_parse_body(struct parser *p) {
@@ -3209,7 +3209,7 @@ struct parser *init_parse_p_race(void) {
 }
 
 static errr run_parse_p_race(struct parser *p) {
-	return parse_file(p, "p_race");
+	return parse_file_quit_not_found(p, "p_race");
 }
 
 static errr finish_parse_p_race(struct parser *p) {
@@ -3679,7 +3679,7 @@ struct parser *init_parse_class(void) {
 }
 
 static errr run_parse_class(struct parser *p) {
-	return parse_file(p, "class");
+	return parse_file_quit_not_found(p, "class");
 }
 
 static errr finish_parse_class(struct parser *p) {
@@ -3776,7 +3776,7 @@ struct parser *init_parse_history(void) {
 }
 
 static errr run_parse_history(struct parser *p) {
-	return parse_file(p, "history");
+	return parse_file_quit_not_found(p, "history");
 }
 
 static errr finish_parse_history(struct parser *p) {
@@ -3904,7 +3904,7 @@ struct parser *init_parse_flavor(void) {
 }
 
 static errr run_parse_flavor(struct parser *p) {
-	return parse_file(p, "flavor");
+	return parse_file_quit_not_found(p, "flavor");
 }
 
 static errr finish_parse_flavor(struct parser *p) {
@@ -3958,7 +3958,7 @@ struct parser *init_parse_hints(void) {
 }
 
 static errr run_parse_hints(struct parser *p) {
-	return parse_file(p, "hints");
+	return parse_file_quit_not_found(p, "hints");
 }
 
 static errr finish_parse_hints(struct parser *p) {
@@ -4025,7 +4025,7 @@ struct parser *init_parse_pain(void) {
 }
 
 static errr run_parse_pain(struct parser *p) {
-	return parse_file(p, "pain");
+	return parse_file_quit_not_found(p, "pain");
 }
 
 static errr finish_parse_pain(struct parser *p) {
@@ -4288,7 +4288,7 @@ struct parser *init_parse_pit(void) {
 }
 
 static errr run_parse_pit(struct parser *p) {
-	return parse_file(p, "pit");
+	return parse_file_quit_not_found(p, "pit");
 }
  
 static errr finish_parse_pit(struct parser *p) {

--- a/src/mon-init.c
+++ b/src/mon-init.c
@@ -1351,7 +1351,7 @@ struct parser *init_parse_lore(void) {
 
 static errr run_parse_lore(struct parser *p) {
 	/* Failure is always an option */
-	if (parse_file(p, "lore")) {
+	if (parse_file_quit_not_found(p, "lore", false)) {
 		event_signal_message(EVENT_INITSTATUS, 0, "No monster lore file found");
 	}
 	return PARSE_ERROR_NONE;

--- a/src/mon-init.c
+++ b/src/mon-init.c
@@ -1351,7 +1351,7 @@ struct parser *init_parse_lore(void) {
 
 static errr run_parse_lore(struct parser *p) {
 	/* Failure is always an option */
-	if (parse_file(p, "lore", false)) {
+	if (parse_file(p, "lore")) {
 		event_signal_message(EVENT_INITSTATUS, 0, "No monster lore file found");
 	}
 	return PARSE_ERROR_NONE;

--- a/src/mon-init.c
+++ b/src/mon-init.c
@@ -359,7 +359,7 @@ struct parser *init_parse_mon_spell(void) {
 }
 
 static errr run_parse_mon_spell(struct parser *p) {
-	return parse_file(p, "monster_spell");
+	return parse_file_quit_not_found(p, "monster_spell");
 }
 
 static errr finish_parse_mon_spell(struct parser *p) {
@@ -507,7 +507,7 @@ static struct parser *init_parse_mon_base(void) {
 }
 
 static errr run_parse_mon_base(struct parser *p) {
-	return parse_file(p, "monster_base");
+	return parse_file_quit_not_found(p, "monster_base");
 }
 
 static errr finish_parse_mon_base(struct parser *p) {
@@ -919,7 +919,7 @@ struct parser *init_parse_monster(void) {
 }
 
 static errr run_parse_monster(struct parser *p) {
-	return parse_file(p, "monster");
+	return parse_file_quit_not_found(p, "monster");
 }
 
 static errr finish_parse_monster(struct parser *p) {
@@ -1351,7 +1351,7 @@ struct parser *init_parse_lore(void) {
 
 static errr run_parse_lore(struct parser *p) {
 	/* Failure is always an option */
-	if (parse_file_quit_not_found(p, "lore", false)) {
+	if (parse_file(p, "lore", false)) {
 		event_signal_message(EVENT_INITSTATUS, 0, "No monster lore file found");
 	}
 	return PARSE_ERROR_NONE;

--- a/src/parser.c
+++ b/src/parser.c
@@ -638,12 +638,11 @@ errr run_parser(struct file_parser *fp) {
 }
 
 /**
- * The basic file parsing function
+ * The basic file parsing function.  Attempt to load filename through
+ * parser and perform a quit if the file is not found.
  */
-errr parse_file(struct parser *p, const char *filename) {
-	/* Default behaviour for file parsing is to issue a quit if
-	 * the file isn't found. */
-	return parse_file_quit_not_found(p, filename, true);
+errr parse_file_quit_not_found(struct parser *p, const char *filename) {
+	return parse_file(p, filename, true);
 }
 
 /**
@@ -651,7 +650,7 @@ errr parse_file(struct parser *p, const char *filename) {
  * parser.  If quit_not_found is true and the file is not found,
  * perform a quit.
  */
-errr parse_file_quit_not_found(struct parser *p, const char *filename, bool quit_not_found) {
+errr parse_file(struct parser *p, const char *filename, bool quit_not_found) {
 	char path[1024];
 	char buf[1024];
 	ang_file *fh;

--- a/src/parser.c
+++ b/src/parser.c
@@ -641,6 +641,17 @@ errr run_parser(struct file_parser *fp) {
  * The basic file parsing function
  */
 errr parse_file(struct parser *p, const char *filename) {
+	/* Default behaviour for file parsing is to issue a quit if
+	 * the file isn't found. */
+	return parse_file_quit_not_found(p, filename, true);
+}
+
+/**
+ * The basic file parsing function.  Attempt to load filename through
+ * parser.  If quit_not_found is true and the file is not found,
+ * perform a quit.
+ */
+errr parse_file_quit_not_found(struct parser *p, const char *filename, bool quit_not_found) {
 	char path[1024];
 	char buf[1024];
 	ang_file *fh;
@@ -658,12 +669,12 @@ errr parse_file(struct parser *p, const char *filename) {
 		fh = file_open(path, MODE_READ, FTYPE_TEXT);
 	}
 
-	/* The lore file is optional, lack of others is terminal */
+	/* Some files are optional, lack of others is terminal */
 	if (!fh) {
-		if (streq(filename, "lore"))
-			return PARSE_ERROR_NO_FILE_FOUND;
-		else
+		if (quit_not_found)
 			quit(format("Cannot open '%s.txt'", filename));
+		else
+			return PARSE_ERROR_NO_FILE_FOUND;
 	}
 
 	/* Parse it */

--- a/src/parser.h
+++ b/src/parser.h
@@ -76,8 +76,8 @@ extern int parser_getstate(struct parser *p, struct parser_state *s);
 extern void parser_setstate(struct parser *p, unsigned int col, const char *msg);
 
 errr run_parser(struct file_parser *fp);
-errr parse_file(struct parser *p, const char *filename);
-errr parse_file_quit_not_found(struct parser *p, const char *filename, bool quit_not_found);
+errr parse_file_quit_not_found(struct parser *p, const char *filename);
+errr parse_file(struct parser *p, const char *filename, bool quit_not_found);
 void cleanup_parser(struct file_parser *fp);
 int lookup_flag(const char **flag_table, const char *flag_name);
 errr grab_rand_value(random_value *value, const char **value_type,

--- a/src/parser.h
+++ b/src/parser.h
@@ -77,7 +77,7 @@ extern void parser_setstate(struct parser *p, unsigned int col, const char *msg)
 
 errr run_parser(struct file_parser *fp);
 errr parse_file_quit_not_found(struct parser *p, const char *filename);
-errr parse_file(struct parser *p, const char *filename, bool quit_not_found);
+errr parse_file(struct parser *p, const char *filename);
 void cleanup_parser(struct file_parser *fp);
 int lookup_flag(const char **flag_table, const char *flag_name);
 errr grab_rand_value(random_value *value, const char **value_type,

--- a/src/parser.h
+++ b/src/parser.h
@@ -77,6 +77,7 @@ extern void parser_setstate(struct parser *p, unsigned int col, const char *msg)
 
 errr run_parser(struct file_parser *fp);
 errr parse_file(struct parser *p, const char *filename);
+errr parse_file_quit_not_found(struct parser *p, const char *filename, bool quit_not_found);
 void cleanup_parser(struct file_parser *fp);
 int lookup_flag(const char **flag_table, const char *flag_name);
 errr grab_rand_value(random_value *value, const char **value_type,

--- a/src/player-quest.c
+++ b/src/player-quest.c
@@ -84,7 +84,7 @@ struct parser *init_parse_quest(void) {
 }
 
 static errr run_parse_quest(struct parser *p) {
-	return parse_file(p, "quest");
+	return parse_file_quit_not_found(p, "quest");
 }
 
 static errr finish_parse_quest(struct parser *p) {

--- a/src/store.c
+++ b/src/store.c
@@ -285,7 +285,7 @@ struct parser *init_parse_stores(void) {
 }
 
 static errr run_parse_stores(struct parser *p) {
-	return parse_file(p, "store");
+	return parse_file_quit_not_found(p, "store");
 }
 
 static errr finish_parse_stores(struct parser *p) {


### PR DESCRIPTION
Removed call to `quit` from `parse_file`.  Quitting is now performed by new wrapper function, `parse_file_quit_not_found`.  This creates two entry points, a one for optional config files like _lore_ (`parse_file`) and a one for mandatory config files (`parse_file_quit_not_found`).

This removes checking for "lore" filename within `parse_file`, makes the function more generic, and makes it clear in the calling code if a failure to locate the file will result in a `quit`.