### PR TITLE
Improving trap effect handling & debug mode

### DIFF
--- a/src/effects.c
+++ b/src/effects.c
@@ -3374,6 +3374,7 @@ bool effect_handler_BALL(effect_handler_context_t *context)
 		flg &= ~(PROJECT_STOP | PROJECT_THRU);
 	} else if (cave->trap_current) {
 		source = 0;
+		flg |= PROJECT_PLAY;
 		ty = cave->trap_current->fy;
 		tx = cave->trap_current->fx;
 	} else {

--- a/src/effects.c
+++ b/src/effects.c
@@ -3372,9 +3372,13 @@ bool effect_handler_BALL(effect_handler_context_t *context)
 		if (rf_has(mon->race->flags, RF_POWERFUL)) rad++;
 		flg |= PROJECT_PLAY;
 		flg &= ~(PROJECT_STOP | PROJECT_THRU);
+	} else if (cave->trap_current) {
+		source = 0;
+		ty = cave->trap_current->fy;
+		tx = cave->trap_current->fx;
 	} else {
-		if (context->p3) rad += player->lev / context->p3;
 		source = -1;
+		if (context->p3) rad += player->lev / context->p3;
 	}
 
 	/* Ask for a target if no direction given */

--- a/src/project-player.c
+++ b/src/project-player.c
@@ -535,7 +535,7 @@ bool project_p(int who, int r, int y, int x, int dam, int typ)
 	if (!square_isplayer(cave, y, x)) return (false);
 
 	/* Never affect projector */
-	if (cave->squares[y][x].mon == who) return (false);
+	if (who < 0) return (false);
 
 	/* Monster or trap */
 	if (mon) {

--- a/src/wiz-debug.c
+++ b/src/wiz-debug.c
@@ -41,6 +41,7 @@
 #include "player-util.h"
 #include "project.h"
 #include "target.h"
+#include "trap.h"
 #include "ui-command.h"
 #include "ui-event.h"
 #include "ui-display.h"
@@ -2250,12 +2251,25 @@ void get_debug_command(void)
 		/* Create a trap */
 		case 'T':
 		{
-			if (!square_isfloor(cave, player->py, player->px))
+			if (!square_isfloor(cave, player->py, player->px)) {
 				msg("You can't place a trap there!");
-			else if (player->depth == 0)
+				break;
+			} else if (player->depth == 0) {
 				msg("You can't place a trap in the town!");
-			else
-				square_add_trap(cave, player->py, player->px);
+				break;
+			}
+
+			char buf[40];
+			if (!get_string("Create which trap? ", buf, sizeof(buf)))
+				break;
+
+			struct trap_kind *trap = lookup_trap(buf);
+			if (trap) {
+				place_trap(cave, player->py, player->px, trap->tidx, 0);
+			} else {
+				msg("Trap not found.");
+			}
+
 			break;
 		}
 


### PR DESCRIPTION
* Make debug mode trap creation ask for the trap name.  This makes testing new traps a ton less frustrating
* Allow traps to use ball effects that can hurt the player