### PR TITLE
Warning Cleanup

### DIFF
--- a/src/buildid.c
+++ b/src/buildid.c
@@ -24,7 +24,7 @@ const char *buildver = VERSION_STRING;
 /**
  * Hack -- Link a copyright message into the executable
  */
-const char *copyright =
+static const char *copyright =
 	"Copyright (c) 1987-2015 Angband contributors.\n"
 	"\n"
 	"This work is free software; you can redistribute it and/or modify it\n"

--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -364,14 +364,14 @@ void do_cmd_open(struct command *cmd)
 	/* Get arguments */
 	err = cmd_get_arg_direction(cmd, "direction", &dir);
 	if (err || dir == DIR_UNKNOWN) {
-		int y, x;
+		int y2, x2;
 		int n_closed_doors, n_locked_chests;
 
-		n_closed_doors = count_feats(&y, &x, square_iscloseddoor, false);
-		n_locked_chests = count_chests(&y, &x, CHEST_OPENABLE);
+		n_closed_doors = count_feats(&y2, &x2, square_iscloseddoor, false);
+		n_locked_chests = count_chests(&y2, &x2, CHEST_OPENABLE);
 
 		if (n_closed_doors + n_locked_chests == 1) {
-			dir = coords_to_dir(y, x);
+			dir = coords_to_dir(y2, x2);
 			cmd_set_arg_direction(cmd, "direction", dir);
 		} else if (cmd_get_direction(cmd, "direction", &dir, false)) {
 			return;
@@ -507,11 +507,11 @@ void do_cmd_close(struct command *cmd)
 	/* Get arguments */
 	err = cmd_get_arg_direction(cmd, "direction", &dir);
 	if (err || dir == DIR_UNKNOWN) {
-		int y, x;
+		int y2, x2;
 
 		/* Count open doors */
-		if (count_feats(&y, &x, square_isopendoor, false) == 1) {
-			dir = coords_to_dir(y, x);
+		if (count_feats(&y2, &x2, square_isopendoor, false) == 1) {
+			dir = coords_to_dir(y2, x2);
 			cmd_set_arg_direction(cmd, "direction", dir);
 		} else if (cmd_get_direction(cmd, "direction", &dir, false)) {
 			return;
@@ -903,14 +903,14 @@ void do_cmd_disarm(struct command *cmd)
 	/* Get arguments */
 	err = cmd_get_arg_direction(cmd, "direction", &dir);
 	if (err || dir == DIR_UNKNOWN) {
-		int y, x;
+		int y2, x2;
 		int n_traps, n_chests;
 
-		n_traps = count_feats(&y, &x, square_isknowntrap, true);
-		n_chests = count_chests(&y, &x, CHEST_TRAPPED);
+		n_traps = count_feats(&y2, &x2, square_isknowntrap, true);
+		n_chests = count_chests(&y2, &x2, CHEST_TRAPPED);
 
 		if (n_traps + n_chests == 1) {
-			dir = coords_to_dir(y, x);
+			dir = coords_to_dir(y2, x2);
 			cmd_set_arg_direction(cmd, "direction", dir);
 		} else if (cmd_get_direction(cmd, "direction", &dir, n_chests > 0)) {
 			/* If there are chests to disarm, 5 is allowed as a direction */

--- a/src/cmd-core.c
+++ b/src/cmd-core.c
@@ -259,7 +259,12 @@ bool cmdq_pop(cmd_context c)
  */
 errr cmdq_push_repeat(cmd_code c, int nrepeats)
 {
-	struct command cmd = { 0 };
+	struct command cmd = {
+		.context = CMD_INIT,
+		.code = CMD_NULL,
+		.nrepeats = 0,
+		.arg = { { 0 } }
+	};
 
 	if (cmd_idx(c) == -1)
 		return 1;

--- a/src/cmd-obj.c
+++ b/src/cmd-obj.c
@@ -456,7 +456,6 @@ static void use_aux(struct command *cmd, struct object *obj, enum use use,
 	bool none_left = false;
 	int dir = 5;
 	int px = player->px, py = player->py;
-	enum use;
 	struct trap_kind *rune = lookup_trap("glyph of warding");
 
 	/* Get arguments */

--- a/src/cmd-obj.c
+++ b/src/cmd-obj.c
@@ -851,7 +851,7 @@ void do_cmd_refill(struct command *cmd)
  */
 void do_cmd_cast(struct command *cmd)
 {
-	int spell_index, dir;
+	int spell_index, dir = 0;
 
 	const char *verb = player->class->magic.spell_realm->verb;
 	const char *noun = player->class->magic.spell_realm->spell_noun;

--- a/src/cmd-pickup.c
+++ b/src/cmd-pickup.c
@@ -266,17 +266,17 @@ static byte player_pickup_item(struct object *obj, bool menu)
 	/* Display a list if requested. */
 	if (menu && !current) {
 		const char *q, *s;
-		struct object *obj = NULL;
+		struct object *obj_local = NULL;
 
 		/* Get an object or exit. */
 		q = "Get which item?";
 		s = "You see nothing there.";
-		if (!get_item(&obj, q, s, CMD_PICKUP, inven_carry_okay, USE_FLOOR)) {
+		if (!get_item(&obj_local, q, s, CMD_PICKUP, inven_carry_okay, USE_FLOOR)) {
 			mem_free(floor_list);
 			return (objs_picked_up);
 		}
 
-		current = obj;
+		current = obj_local;
 		call_function_again = true;
 
 		/* With a list, we do not need explicit pickup messages */

--- a/src/game-input.c
+++ b/src/game-input.c
@@ -18,6 +18,7 @@
 
 #include "angband.h"
 #include "cmd-core.h"
+#include "game-input.h"
 
 bool (*get_string_hook)(const char *prompt, char *buf, size_t len);
 int (*get_quantity_hook)(const char *prompt, int max);

--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -741,8 +741,8 @@ struct chunk *labyrinth_chunk(int depth, int h, int w, bool lit, bool soft)
     /* Cut out a grid of 1x1 rooms which we will call "cells" */
     for (y = 0; y < h; y += 2) {
 		for (x = 0; x < w; x += 2) {
-			int k = yx_to_i(y, x, w);
-			sets[k] = k;
+			int k_local = yx_to_i(y, x, w);
+			sets[k_local] = k_local;
 			square_set_feat(c, y + 1, x + 1, FEAT_FLOOR);
 			if (lit) sqinfo_on(c->squares[y + 1][x + 1].info, SQUARE_GLOW);
 		}
@@ -756,14 +756,14 @@ struct chunk *labyrinth_chunk(int depth, int h, int w, bool lit, bool soft)
      *
      * This is a randomized version of Kruskal's algorithm. */
     for (i = 0; i < n; i++) {
-		int a, b, x, y;
+		int a, b, x_local, y_local;
 
 		j = walls[i];
 
 		/* If this cell isn't an adjoining wall, skip it */
-		i_to_yx(j, w, &y, &x);
-		if ((x < 1 && y < 1) || (x > w - 2 && y > h - 2)) continue;
-		if (x % 2 == y % 2) continue;
+		i_to_yx(j, w, &y_local, &x_local);
+		if ((x_local < 1 && y_local < 1) || (x_local > w - 2 && y_local > h - 2)) continue;
+		if (x_local % 2 == y_local % 2) continue;
 
 		/* Figure out which cells are separated by this wall */
 		lab_get_adjoin(j, w, &a, &b);
@@ -772,8 +772,8 @@ struct chunk *labyrinth_chunk(int depth, int h, int w, bool lit, bool soft)
 		if (sets[a] != sets[b]) {
 			int sa = sets[a];
 			int sb = sets[b];
-			square_set_feat(c, y + 1, x + 1, FEAT_FLOOR);
-			if (lit) sqinfo_on(c->squares[y + 1][x + 1].info, SQUARE_GLOW);
+			square_set_feat(c, y_local + 1, x_local + 1, FEAT_FLOOR);
+			if (lit) sqinfo_on(c->squares[y_local + 1][x_local + 1].info, SQUARE_GLOW);
 
 			for (k = 0; k < n; k++) {
 				if (sets[k] == sb) sets[k] = sa;

--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -700,7 +700,7 @@ static bool lab_is_tunnel(struct chunk *c, int y, int x) {
  */
 struct chunk *labyrinth_chunk(int depth, int h, int w, bool lit, bool soft)
 {
-    int i, j, k, y, x;
+    int i, j, k, y, x = 0;
     /* This is the number of squares in the labyrinth */
     int n = h * w;
 
@@ -1454,7 +1454,7 @@ static void build_store(struct chunk *c, int n, int yy, int xx)
  */
 static void town_gen_layout(struct chunk *c, struct player *p)
 {
-	int y, x, n, num_lava = 3 + randint0(3), num_rubble = 3 + randint0(3);
+	int y, x = 0, n, num_lava = 3 + randint0(3), num_rubble = 3 + randint0(3);
 
 	/* Create walls */
 	draw_rectangle(c, 0, 0, c->height - 1, c->width - 1, FEAT_PERM,

--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -77,7 +77,7 @@
 /**
  * Check whether a square has one of the tunnelling helper flags
  * \param c is the current chunk
- * \param y
+ * \param y are the co-ordinates
  * \param x are the co-ordinates
  * \param flag is the relevant flag
  */
@@ -146,9 +146,9 @@ static void build_streamer(struct chunk *c, int feat, int chance)
  * Constructs a tunnel between two points
  *
  * \param c is the current chunk
- * \param row1 
+ * \param row1 are the co-ordinates of the first point
  * \param col1 are the co-ordinates of the first point
- * \param row2
+ * \param row2 are the co-ordinates of the second point
  * \param col2 are the co-ordinates of the second point
  *
  * This function must be called BEFORE any streamers are created, since we use
@@ -357,7 +357,7 @@ static void build_tunnel(struct chunk *c, int row1, int col1, int row2, int col2
  * This routine currently only counts actual "empty floor" grids which are not
  * in rooms.
  * \param c is the current chunk
- * \param y1
+ * \param y1 are the co-ordinates
  * \param x1 are the co-ordinates
  *
  * TODO: count stairs, open doors, closed doors?
@@ -384,7 +384,7 @@ static int next_to_corr(struct chunk *c, int y1, int x1)
 /**
  * Returns whether a doorway can be built in a space.
  * \param c is the current chunk
- * \param y
+ * \param y are the co-ordinates
  * \param x are the co-ordinates
  *
  * To have a doorway, a space must be adjacent to at least two corridors and be
@@ -407,7 +407,7 @@ static bool possible_doorway(struct chunk *c, int y, int x)
 /**
  * Places door at y, x position if at least 2 walls found
  * \param c is the current chunk
- * \param y
+ * \param y are the co-ordinates
  * \param x are the co-ordinates
  */
 static void try_door(struct chunk *c, int y, int x)
@@ -648,7 +648,7 @@ struct chunk *classic_gen(struct player *p) {
  * labyrinth_gen().
  * \param i is the wall index
  * \param w is the width of the labyrinth
- * \param a
+ * \param a are the two cell indices
  * \param b are the two cell indices
  */
 static void lab_get_adjoin(int i, int w, int *a, int *b) {
@@ -667,7 +667,7 @@ static void lab_get_adjoin(int i, int w, int *a, int *b) {
  * Return whether (x, y) is in a tunnel.
  *
  * \param c is the current chunk
- * \param y
+ * \param y are the co-ordinates
  * \param x are the co-ordinates
  *
  * For our purposes a tunnel is a horizontal or vertical path, not an
@@ -692,7 +692,7 @@ static bool lab_is_tunnel(struct chunk *c, int y, int x) {
  * Build a labyrinth chunk of a given height and width
  *
  * \param depth is the native depth 
- * \param h
+ * \param h are the dimensions of the chunk
  * \param w are the dimensions of the chunk
  * \param lit is whether the labyrinth is lit
  * \param soft is true if we use regular walls, false if permanent walls
@@ -915,7 +915,7 @@ static void init_cavern(struct chunk *c, int density) {
 /**
  * Return the number of walls (0-8) adjacent to this square.
  * \param c is the current chunk
- * \param y
+ * \param y are the co-ordinates
  * \param x are the co-ordinates
  */
 static int count_adj_walls(struct chunk *c, int y, int x) {
@@ -983,7 +983,7 @@ static void array_filler(int data[], int value, int size) {
  * Determine if we need to worry about coloring a point, or can ignore it.
  * \param c is the current chunk
  * \param colors is the array of current point colors
- * \param y
+ * \param y are the co-ordinates
  * \param x are the co-ordinates
  */
 static int ignore_point(struct chunk *c, int colors[], int y, int x) {
@@ -1016,7 +1016,7 @@ static void glow_point(struct chunk *c, int y, int x) {
  * \param c is the current chunk
  * \param colors is the array of current point colors
  * \param counts is the array of current color counts
- * \param y
+ * \param y are the co-ordinates
  * \param x are the co-ordinates
  * \param color is the color we are coloring
  * \param diagonal controls whether we can progress diagonally
@@ -1300,7 +1300,7 @@ void ensure_connectedness(struct chunk *c) {
 /**
  * The cavern generator's main function.
  * \param depth the chunk's native depth
- * \param h
+ * \param h the chunk's dimensions
  * \param w the chunk's dimensions
  * \return a pointer to the generated chunk
  */
@@ -1423,7 +1423,7 @@ struct chunk *cavern_gen(struct player *p) {
  * Builds a store at a given pseudo-location
  * \param c is the current chunk
  * \param n is which shop it is
- * \param yy
+ * \param yy the row and column of this store in the store layout
  * \param xx the row and column of this store in the store layout
  *
  * Currently, there is a main street horizontally through the middle of town,
@@ -1605,7 +1605,7 @@ struct chunk *town_gen(struct player *p)
 /**
  * The main modified generation algorithm
  * \param depth is the chunk's native depth
- * \param height
+ * \param height are the chunk's dimensions
  * \param width are the chunk's dimensions
  * \return a pointer to the generated chunk
  */
@@ -1836,7 +1836,7 @@ struct chunk *modified_gen(struct player *p) {
 /**
  * The main moria generation algorithm
  * \param depth is the chunk's native depth
- * \param height
+ * \param height are the chunk's dimensions
  * \param width are the chunk's dimensions
  * \return a pointer to the generated chunk
  */

--- a/src/gen-chunk.c
+++ b/src/gen-chunk.c
@@ -39,9 +39,9 @@ u16b chunk_list_max = 0;      /**< current max actual chunk index */
  * Write a chunk to memory and return a pointer to it.  Optionally write
  * monsters, objects and/or traps, and in those cases delete those things from
  * the source chunk
- * \param y0
+ * \param y0 coordinates of the top left corner of the chunk being written
  * \param x0 coordinates of the top left corner of the chunk being written
- * \param height
+ * \param height dimensions of the chunk being written
  * \param width dimensions of the chunk being written
  * \param monsters whether monsters get written
  * \param objects whether objects get written
@@ -207,9 +207,9 @@ bool chunk_find(struct chunk *c)
 /**
  * Transform y, x coordinates by rotation, reflection and translation
  * Stolen from PosChengband
- * \param y
+ * \param y the coordinates being transformed
  * \param x the coordinates being transformed
- * \param y0
+ * \param y0 how much the coordinates are being translated
  * \param x0 how much the coordinates are being translated
  * \param height height of the chunk
  * \param width width of the chunk
@@ -242,9 +242,9 @@ void symmetry_transform(int *y, int *x, int y0, int x0, int height, int width,
  * objects are copied from the old chunk and not retained there
  * \param dest the chunk where the copy is going
  * \param source the chunk being copied
- * \param y0
- * \param x0 
- * \param rotate 
+ * \param y0 transformation parameters  - see symmetry_transform()
+ * \param x0 transformation parameters  - see symmetry_transform()
+ * \param rotate transformation parameters  - see symmetry_transform()
  * \param reflect transformation parameters  - see symmetry_transform()
  * \return success - fails if the copy would not fit in the destination chunk
  */

--- a/src/gen-monster.c
+++ b/src/gen-monster.c
@@ -114,7 +114,7 @@ static bool mon_select(struct monster_race *race)
  */
 bool mon_restrict(const char *monster_type, int depth, bool unique_ok)
 {
-    int i, j;
+    int i, j = 0;
 
     /* Clear global monster restriction variables. */
     allow_unique = unique_ok;

--- a/src/gen-monster.c
+++ b/src/gen-monster.c
@@ -187,9 +187,9 @@ bool mon_restrict(const char *monster_type, int depth, bool unique_ok)
  * \param type the type of monster (see comments to mon_restrict())
  * \param depth selection depth
  * \param num the number of monsters to try and place - inexact due to groups
- * \param y0
+ * \param y0 the centre of the rectangle for monster placement
  * \param x0 the centre of the rectangle for monster placement
- * \param dy
+ * \param dy the dimensions of the rectangle
  * \param dx the dimensions of the rectangle
  * \param origin the origin for monster drops
  *
@@ -263,9 +263,9 @@ void spread_monsters(struct chunk *c, const char *type, int depth, int num,
  * \param racial_symbol the allowable monster_base symbols
  * \param vault_type the type of vault, which affects monster selection depth
  * \param data the vault text description, which contains the racial symbol
- * \param y1
- * \param y2
- * \param x1
+ * \param y1 the limits of the vault
+ * \param y2 the limits of the vault
+ * \param x1 the limits of the vault
  * \param x2 the limits of the vault
  */
 void get_vault_monsters(struct chunk *c, char racial_symbol[], char *vault_type,
@@ -318,9 +318,9 @@ void get_vault_monsters(struct chunk *c, char racial_symbol[], char *vault_type,
  * Funtion for placing appropriate monsters in a room of chambers
  *
  * \param c the current chunk being generated
- * \param y1
- * \param x1
- * \param y2
+ * \param y1 the limits of the vault
+ * \param x1 the limits of the vault
+ * \param y2 the limits of the vault
  * \param x2 the limits of the vault
  * \param name the name of the monster type for use in mon_select()
  * \param area the total room area, used for scaling monster quantity

--- a/src/gen-room.c
+++ b/src/gen-room.c
@@ -1983,7 +1983,7 @@ bool build_vault(struct chunk *c, int y0, int x0, struct vault *v)
 {
 	const char *data = v->text;
 	int y1, x1, y2, x2;
-	int x, y, races = 0;
+	int x, y, races_local = 0;
 	const char *t;
 	char racial_symbol[30] = "";
 	bool icky;
@@ -2089,8 +2089,8 @@ bool build_vault(struct chunk *c, int y0, int x0, struct vault *v)
 				/* If the symbol is not yet stored, ... */
 				if (!strchr(racial_symbol, *t)) {
 					/* ... store it for later processing. */
-					if (races < 30)
-						racial_symbol[races++] = *t;
+					if (races_local < 30)
+						racial_symbol[races_local++] = *t;
 				}
 			}
 
@@ -2619,22 +2619,22 @@ bool build_room_of_chambers(struct chunk *c, int y0, int x0)
 	/* Build the chambers. */
 	for (i = 0; i < num_chambers; i++) {
 		int c_y1, c_x1, c_y2, c_x2;
-		int size, width, height;
+		int size, width_local, height_local;
 
 		/* Determine size of chamber. */
 		size = 3 + randint0(4);
-		width = size + randint0(10);
-		height = size + randint0(4);
+		width_local = size + randint0(10);
+		height_local = size + randint0(4);
 
 		/* Pick an upper-left corner at random. */
-		c_y1 = y1 + randint0(1 + y2 - y1 - height);
-		c_x1 = x1 + randint0(1 + x2 - x1 - width);
+		c_y1 = y1 + randint0(1 + y2 - y1 - height_local);
+		c_x1 = x1 + randint0(1 + x2 - x1 - width_local);
 
 		/* Determine lower-right corner of chamber. */
-		c_y2 = c_y1 + height;
+		c_y2 = c_y1 + height_local;
 		if (c_y2 > y2) c_y2 = y2;
 
-		c_x2 = c_x1 + width;
+		c_x2 = c_x1 + width_local;
 		if (c_x2 > x2) c_x2 = x2;
 
 		/* Make me a (magma filled) chamber. */

--- a/src/gen-room.c
+++ b/src/gen-room.c
@@ -88,9 +88,9 @@ struct vault *random_vault(int depth, const char *typ)
 /**
  * Mark squares as being in a room, and optionally light them.
  * \param c the current chunk
- * \param y1
- * \param x1
- * \param y2
+ * \param y1 inclusive room boundaries
+ * \param x1 inclusive room boundaries
+ * \param y2 inclusive room boundaries
  * \param x2 inclusive room boundaries
  * \param light whether or not to light the room
  */
@@ -109,9 +109,9 @@ static void generate_room(struct chunk *c, int y1, int x1, int y2, int x2, int l
 /**
  * Mark a rectangle with a sqinfo flag
  * \param c the current chunk
- * \param y1
- * \param x1
- * \param y2
+ * \param y1 inclusive room boundaries
+ * \param x1 inclusive room boundaries
+ * \param y2 inclusive room boundaries
  * \param x2 inclusive room boundaries
  * \param flag the SQUARE_* flag we are marking with
  */
@@ -130,9 +130,9 @@ void generate_mark(struct chunk *c, int y1, int x1, int y2, int x2, int flag)
 /**
  * Fill a rectangle with a feature.
  * \param c the current chunk
- * \param y1
- * \param x1
- * \param y2
+ * \param y1 inclusive room boundaries
+ * \param x1 inclusive room boundaries
+ * \param y2 inclusive room boundaries
  * \param x2 inclusive room boundaries
  * \param feat the terrain feature
  * \param flag the SQUARE_* flag we are marking with
@@ -151,9 +151,9 @@ void fill_rectangle(struct chunk *c, int y1, int x1, int y2, int x2, int feat,
 /**
  * Fill the edges of a rectangle with a feature.
  * \param c the current chunk
- * \param y1
- * \param x1
- * \param y2
+ * \param y1 inclusive room boundaries
+ * \param x1 inclusive room boundaries
+ * \param y2 inclusive room boundaries
  * \param x2 inclusive room boundaries
  * \param feat the terrain feature
  * \param flag the SQUARE_* flag we are marking with
@@ -185,8 +185,8 @@ void draw_rectangle(struct chunk *c, int y1, int x1, int y2, int x2, int feat,
 /**
  * Fill a horizontal range with the given feature/info.
  * \param c the current chunk
- * \param y
- * \param x1
+ * \param y inclusive room boundaries
+ * \param x1 inclusive room boundaries
  * \param x2 inclusive range boundaries
  * \param feat the terrain feature
  * \param flag the SQUARE_* flag we are marking with
@@ -209,8 +209,8 @@ static void fill_xrange(struct chunk *c, int y, int x1, int x2, int feat,
 /**
  * Fill a vertical range with the given feature/info.
  * \param c the current chunk
- * \param x
- * \param y1
+ * \param x inclusive room boundaries
+ * \param y1 inclusive room boundaries
  * \param y2 inclusive range boundaries
  * \param feat the terrain feature
  * \param flag the SQUARE_* flag we are marking with
@@ -233,7 +233,7 @@ static void fill_yrange(struct chunk *c, int x, int y1, int y2, int feat,
 /**
  * Fill a circle with the given feature/info.
  * \param c the current chunk
- * \param y0
+ * \param y0 the circle centre
  * \param x0 the circle centre
  * \param radius the circle radius
  * \param border the width of the circle border
@@ -266,9 +266,9 @@ static void fill_circle(struct chunk *c, int y0, int x0, int radius, int border,
  * Fill the lines of a cross/plus with a feature.
  *
  * \param c the current chunk
- * \param y1
- * \param x1
- * \param y2
+ * \param y1 inclusive room boundaries
+ * \param x1 inclusive room boundaries
+ * \param y2 inclusive room boundaries
  * \param x2 inclusive room boundaries
  * \param feat the terrain feature
  * \param flag the SQUARE_* flag we are marking with
@@ -296,9 +296,9 @@ static void generate_plus(struct chunk *c, int y1, int x1, int y2, int x2,
 /**
  * Generate helper -- open all sides of a rectangle with a feature
  * \param c the current chunk
- * \param y1
- * \param x1
- * \param y2
+ * \param y1 inclusive room boundaries
+ * \param x1 inclusive room boundaries
+ * \param y2 inclusive room boundaries
  * \param x2 inclusive room boundaries
  * \param feat the terrain feature
  */
@@ -321,9 +321,9 @@ static void generate_open(struct chunk *c, int y1, int x1, int y2, int x2, int f
 /**
  * Generate helper -- open one side of a rectangle with a feature
  * \param c the current chunk
- * \param y1
- * \param x1
- * \param y2
+ * \param y1 inclusive room boundaries
+ * \param x1 inclusive room boundaries
+ * \param y2 inclusive room boundaries
  * \param x2 inclusive room boundaries
  * \param feat the terrain feature
  */
@@ -348,7 +348,7 @@ static void generate_hole(struct chunk *c, int y1, int x1, int y2, int x2, int f
 /**
  * Place a square of granite with a flag
  * \param c the current chunk
- * \param y
+ * \param y the square co-ordinates
  * \param x the square co-ordinates
  * \param flag the SQUARE_* flag we are marking with
  */
@@ -362,9 +362,9 @@ void set_marked_granite(struct chunk *c, int y, int x, int flag)
  * Make a starburst room. -LM-
  *
  * \param c the current chunk
- * \param y1
- * \param x1
- * \param y2
+ * \param y1 boundaries which will contain the starburst
+ * \param x1 boundaries which will contain the starburst
+ * \param y2 boundaries which will contain the starburst
  * \param x2 boundaries which will contain the starburst
  * \param light lit or not
  * \param feat the terrain feature to make the starburst of
@@ -737,9 +737,9 @@ extern bool generate_starburst_room(struct chunk *c, int y1, int x1, int y2,
 /**
  * Find a good spot for the next room.
  *
- * \param y
+ * \param y centre of the room
  * \param x centre of the room
- * \param height
+ * \param height dimensions of the room
  * \param width dimensions of the room
  * \return success
  *
@@ -820,7 +820,7 @@ static bool find_space(int *y, int *x, int height, int width)
 /**
  * Build a circular room (interior radius 4-7).
  * \param c the chunk the room is being built in
- * \param y0
+ * \param y0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \param x0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \return success
  */
@@ -868,7 +868,7 @@ bool build_circular(struct chunk *c, int y0, int x0)
 /**
  * Builds a normal rectangular room.
  * \param c the chunk the room is being built in
- * \param y0
+ * \param y0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \param x0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \return success
  */
@@ -928,7 +928,7 @@ bool build_simple(struct chunk *c, int y0, int x0)
 /**
  * Builds an overlapping rectangular room.
  * \param c the chunk the room is being built in
- * \param y0
+ * \param y0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \param x0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \return success
  */
@@ -1004,7 +1004,7 @@ bool build_overlap(struct chunk *c, int y0, int x0)
 /**
  * Builds a cross-shaped room.
  * \param c the chunk the room is being built in
- * \param y0
+ * \param y0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \param x0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \return success
  *
@@ -1167,7 +1167,7 @@ bool build_crossed(struct chunk *c, int y0, int x0)
 /**
  * Build a large room with an inner room.
  * \param c the chunk the room is being built in
- * \param y0
+ * \param y0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \param x0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \return success
  *
@@ -1475,7 +1475,7 @@ void set_pit_type(int depth, int type)
 /**
  * Build a monster nest
  * \param c the chunk the room is being built in
- * \param y0
+ * \param y0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \param x0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \return success
  *
@@ -1591,7 +1591,7 @@ bool build_nest(struct chunk *c, int y0, int x0)
 /**
  * Build a monster pit
  * \param c the chunk the room is being built in
- * \param y0
+ * \param y0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \param x0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \return success
  *
@@ -1782,9 +1782,9 @@ bool build_pit(struct chunk *c, int y0, int x0)
 /**
  * Build a room template from its string representation.
  * \param c the chunk the room is being built in
- * \param y0
+ * \param y0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \param x0 co-ordinates of the centre; out of chunk bounds invoke find_space()
- * \param ymax 
+ * \param ymax the room dimensions
  * \param xmax the room dimensions
  * \param doors the door position
  * \param data the room template text description
@@ -1933,7 +1933,7 @@ static bool build_room_template(struct chunk *c, int y0, int x0, int ymax, int x
 /**
  * Helper function for building room templates.
  * \param c the chunk the room is being built in
- * \param y0
+ * \param y0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \param x0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \param typ the room template type (currently unused)
  * \return success
@@ -1958,7 +1958,7 @@ static bool build_room_template_type(struct chunk *c, int y0, int x0, int typ)
 /**
  * Build a template room
  * \param c the chunk the room is being built in
- * \param y0
+ * \param y0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \param x0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \return success
 */
@@ -1974,7 +1974,7 @@ bool build_template(struct chunk *c, int y0, int x0)
 /**
  * Build a vault from its string representation.
  * \param c the chunk the room is being built in
- * \param y0
+ * \param y0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \param x0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \param v pointer to the vault template
  * \return success
@@ -2221,7 +2221,7 @@ bool build_vault(struct chunk *c, int y0, int x0, struct vault *v)
 /**
  * Helper function for building vaults.
  * \param c the chunk the room is being built in
- * \param y0
+ * \param y0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \param x0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \param typ the vault type
  * \param label name of the vault type (eg "Greater vault")
@@ -2251,7 +2251,7 @@ static bool build_vault_type(struct chunk *c, int y0, int x0, const char *typ)
 /**
  * Build an interesting room.
  * \param c the chunk the room is being built in
- * \param y0
+ * \param y0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \param x0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \return success
  */
@@ -2264,7 +2264,7 @@ bool build_interesting(struct chunk *c, int y0, int x0)
 /**
  * Build a lesser vault.
  * \param c the chunk the room is being built in
- * \param y0
+ * \param y0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \param x0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \return success
  */
@@ -2279,7 +2279,7 @@ bool build_lesser_vault(struct chunk *c, int y0, int x0)
 /**
  * Build a medium vault.
  * \param c the chunk the room is being built in
- * \param y0
+ * \param y0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \param x0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \return success
  */
@@ -2294,7 +2294,7 @@ bool build_medium_vault(struct chunk *c, int y0, int x0)
 /**
  * Build a greater vaults.
  * \param c the chunk the room is being built in
- * \param y0
+ * \param y0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \param x0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \return success
  *
@@ -2341,7 +2341,7 @@ bool build_greater_vault(struct chunk *c, int y0, int x0)
 /**
  * Moria room (from Oangband).  Uses the "starburst room" code.
  * \param c the chunk the room is being built in
- * \param y0
+ * \param y0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \param x0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \return success
  */
@@ -2410,8 +2410,8 @@ bool build_moria(struct chunk *c, int y0, int x0)
 /**
  * Helper for rooms of chambers; builds a marked wall grid if appropriate
  * \param c the chunk the room is being built in
- * \param y
- * \param x co-ordinates 
+ * \param y co-ordinates
+ * \param x co-ordinates
  */
 static void make_inner_chamber_wall(struct chunk *c, int y, int x)
 {
@@ -2429,9 +2429,9 @@ static void make_inner_chamber_wall(struct chunk *c, int y, int x)
  * Create a door in a random inner wall grid along the border of the
  * rectangle.
  * \param c the chunk the room is being built in
- * \param y1
- * \param x1
- * \param y2
+ * \param y1 chamber dimensions
+ * \param x1 chamber dimensions
+ * \param y2 chamber dimensions
  * \param x2 chamber dimensions
  */
 static void make_chamber(struct chunk *c, int y1, int x1, int y2, int x2)
@@ -2519,7 +2519,7 @@ static void make_chamber(struct chunk *c, int y1, int x1, int y2, int x2)
  * Expand in every direction from a start point, turning magma into rooms.
  * Stop only when the magma and the open doors totally run out.
  * \param c the chunk the room is being built in
- * \param y
+ * \param y co-ordinates to start hollowing
  * \param x co-ordinates to start hollowing
  */
 static void hollow_out_room(struct chunk *c, int y, int x)
@@ -2553,7 +2553,7 @@ static void hollow_out_room(struct chunk *c, int y, int x)
 /**
  * Rooms of chambers
  * \param c the chunk the room is being built in
- * \param y0
+ * \param y0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \param x0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \return success
  *
@@ -2865,7 +2865,7 @@ bool build_room_of_chambers(struct chunk *c, int y0, int x0)
  * even divided with irregularly-shaped fields of rubble. No special
  * monsters.  Appears deeper than level 40.
  * \param c the chunk the room is being built in
- * \param y0
+ * \param y0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \param x0 co-ordinates of the centre; out of chunk bounds invoke find_space()
  * \return success
  *
@@ -2945,7 +2945,7 @@ bool build_huge(struct chunk *c, int y0, int x0)
  * Attempt to build a room of the given type at the given block
  *
  * \param c the chunk the room is being built in
- * \param by0
+ * \param by0 block co-ordinates of the top left block
  * \param bx0 block co-ordinates of the top left block
  * \param profile the profile of the rooom we're trying to build
  * \param finds_own_space whether we are allowing the room to place itself

--- a/src/gen-room.c
+++ b/src/gen-room.c
@@ -2581,7 +2581,7 @@ bool build_room_of_chambers(struct chunk *c, int y0, int x0)
 {
 	int i, d;
 	int area, num_chambers;
-	int y, x, y1, x1, y2, x2;
+	int y, x = 0, y1, x1, y2, x2;
 
 	int height, width, count;
 

--- a/src/gen-util.c
+++ b/src/gen-util.c
@@ -109,7 +109,7 @@ byte get_angle_to_grid[41][41] =
 
 /**
  * Used to convert (x, y) into an array index (i) in a chunk of width w.
- * \param y
+ * \param y co-ordinates
  * \param x co-ordinates
  * \param w area width
  * \return grid index
@@ -122,7 +122,7 @@ int yx_to_i(int y, int x, int w) {
  * Used to convert an array index (i) into (x, y) in a chunk of width w.
  * \param i grid index
  * \param w area width
- * \param y
+ * \param y co-ordinates
  * \param x co-ordinates
  */
 void i_to_yx(int i, int w, int *y, int *x) {
@@ -152,10 +152,10 @@ void shuffle(int *arr, int n)
  * predicate.
  * \param c current chunk
  * \param y found y co-ordinate
- * \param y1
+ * \param y1 y-range
  * \param y2 y-range
  * \param x found x co-ordinate
- * \param x1
+ * \param x1 x-range
  * \param x2 x-range
  * \param pred square_predicate specifying what we're looking for
  * \return success
@@ -210,10 +210,10 @@ bool cave_find(struct chunk *c, int *y, int *x, square_predicate pred)
  * predicate.
  * \param c current chunk
  * \param y found y co-ordinate
- * \param y1
+ * \param y1 y-range
  * \param y2 y-range
  * \param x found x co-ordinate
- * \param x1
+ * \param x1 x-range
  * \param x2 x-range
  * \param pred square_predicate specifying what we're looking for
  * \return success
@@ -242,10 +242,10 @@ bool find_empty(struct chunk *c, int *y, int *x)
  * Locate an empty square for y1 <= y < y2, x1 <= x < x2.
  * \param c current chunk
  * \param y found y co-ordinate
- * \param y1
+ * \param y1 y-range
  * \param y2 y-range
  * \param x found x co-ordinate
- * \param x1
+ * \param x1 x-range
  * \param x2 x-range
  * \return success
  */
@@ -280,9 +280,9 @@ bool find_nearby_grid(struct chunk *c, int *y, int y0, int yd, int *x, int x0, i
  * Given two points, pick a valid cardinal direction from one to the other.
  * \param rdir found row change (up or down)
  * \param cdir found column change (left or right)
- * \param y1
+ * \param y1 starting co-ordinates
  * \param x1 starting co-ordinates
- * \param y2
+ * \param y2 target co-ordinates
  * \param x2 target co-ordinates
  */
 void correct_dir(int *rdir, int *cdir, int y1, int x1, int y2, int x2)
@@ -304,7 +304,7 @@ void correct_dir(int *rdir, int *cdir, int y1, int x1, int y2, int x2)
 
 /**
  * Pick a random cardinal direction.
- * \param rdir
+ * \param rdir direction co-ordinates
  * \param cdir direction co-ordinates
  */
 void rand_dir(int *rdir, int *cdir)
@@ -319,7 +319,7 @@ void rand_dir(int *rdir, int *cdir)
 /**
  * Determine whether the given coordinate is a valid starting location.
  * \param c current chunk
- * \param y
+ * \param y co-ordinates
  * \param x co-ordinates
  * \return success
  */
@@ -358,7 +358,7 @@ void new_player_spot(struct chunk *c, struct player *p)
 /**
  * Return how many cardinal directions around (x, y) contain walls.
  * \param c current chunk
- * \param y
+ * \param y co-ordinates
  * \param x co-ordinates
  * \return the number of walls 
  */
@@ -379,7 +379,7 @@ static int next_to_walls(struct chunk *c, int y, int x)
 /**
  * Place rubble at (x, y).
  * \param c current chunk
- * \param y
+ * \param y co-ordinates
  * \param x co-ordinates
  */
 static void place_rubble(struct chunk *c, int y, int x)
@@ -391,7 +391,7 @@ static void place_rubble(struct chunk *c, int y, int x)
 /**
  * Place stairs (of the requested type 'feat' if allowed) at (x, y).
  * \param c current chunk
- * \param y
+ * \param y co-ordinates
  * \param x co-ordinates
  * \param feat stair terrain type
  *
@@ -411,7 +411,7 @@ static void place_stairs(struct chunk *c, int y, int x, int feat)
 /**
  * Place random stairs at (x, y).
  * \param c current chunk
- * \param y
+ * \param y co-ordinates
  * \param x co-ordinates
  */
 void place_random_stairs(struct chunk *c, int y, int x)
@@ -425,7 +425,7 @@ void place_random_stairs(struct chunk *c, int y, int x)
 /**
  * Place a random object at (x, y).
  * \param c current chunk
- * \param y
+ * \param y co-ordinates
  * \param x co-ordinates
  * \param level generation depth
  * \param good is it a good object?
@@ -468,7 +468,7 @@ void place_object(struct chunk *c, int y, int x, int level, bool good, bool grea
 /**
  * Place a random amount of gold at (x, y).
  * \param c current chunk
- * \param y
+ * \param y co-ordinates
  * \param x co-ordinates
  * \param level generation depth
  * \param origin item origin
@@ -496,7 +496,7 @@ void place_gold(struct chunk *c, int y, int x, int level, byte origin)
 /**
  * Place a secret door at (x, y).
  * \param c current chunk
- * \param y
+ * \param y co-ordinates
  * \param x co-ordinates
  */
 void place_secret_door(struct chunk *c, int y, int x)
@@ -508,7 +508,7 @@ void place_secret_door(struct chunk *c, int y, int x)
 /**
  * Place a closed door at (x, y).
  * \param c current chunk
- * \param y
+ * \param y co-ordinates
  * \param x co-ordinates
  */
 void place_closed_door(struct chunk *c, int y, int x)
@@ -522,7 +522,7 @@ void place_closed_door(struct chunk *c, int y, int x)
 /**
  * Place a random door at (x, y).
  * \param c current chunk
- * \param y
+ * \param y co-ordinates
  * \param x co-ordinates
  *
  * The door generated could be closed, open, broken, or secret.
@@ -640,7 +640,7 @@ bool alloc_object(struct chunk *c, int set, int typ, int depth, byte origin)
 /**
  * Create up to 'num' objects near the given coordinates in a vault.
  * \param c the current chunk
- * \param y
+ * \param y co-ordinates
  * \param x co-ordinates
  * \param depth geneeration depth
  * \param num number of objects
@@ -674,9 +674,9 @@ void vault_objects(struct chunk *c, int y, int x, int depth, int num)
 /**
  * Place a trap near (x, y), with a given displacement.
  * \param c the current chunk
- * \param y
+ * \param y co-ordinates to place the trap near
  * \param x co-ordinates to place the trap near
- * \param yd
+ * \param yd how far afield to look for a place
  * \param xd how far afield to look for a place
  */
 static void vault_trap_aux(struct chunk *c, int y, int x, int yd, int xd)
@@ -697,9 +697,9 @@ static void vault_trap_aux(struct chunk *c, int y, int x, int yd, int xd)
 /**
  * Place 'num' traps near (x, y), with a given displacement.
  * \param c the current chunk
- * \param y
+ * \param y co-ordinates to place the trap near
  * \param x co-ordinates to place the trap near
- * \param yd
+ * \param yd how far afield to look for a place
  * \param xd how far afield to look for a place
  * \param num number of traps to place
  */
@@ -714,7 +714,7 @@ void vault_traps(struct chunk *c, int y, int x, int yd, int xd, int num)
 /**
  * Place 'num' sleeping monsters near (x, y).
  * \param c the current chunk
- * \param y1
+ * \param y1 co-ordinates to place the monsters near
  * \param x1 co-ordinates to place the monsters near
  * \param depth generation depth
  * \param num number of monsters to place

--- a/src/generate.c
+++ b/src/generate.c
@@ -854,7 +854,7 @@ void cave_generate(struct chunk **c, struct player *p)
 {
 	const char *error = "no generation";
 	int i, y, x, tries = 0;
-	struct chunk *chunk;
+	struct chunk *chunk = NULL;
 
 	assert(c);
 

--- a/src/generate.c
+++ b/src/generate.c
@@ -52,7 +52,7 @@
  */
 struct pit_profile *pit_info;
 struct vault *vaults;
-struct cave_profile *cave_profiles;
+static struct cave_profile *cave_profiles;
 struct dun_data *dun;
 struct room_template *room_templates;
 

--- a/src/generate.c
+++ b/src/generate.c
@@ -888,19 +888,19 @@ void cave_generate(struct chunk **c, struct player *p)
 
 		/* Ensure quest monsters */
 		if (is_quest(chunk->depth)) {
-			int i;
-			for (i = 1; i < z_info->r_max; i++) {
-				struct monster_race *race = &r_info[i];
-				int y, x;
-				
+			int i2;
+			for (i2 = 1; i2 < z_info->r_max; i2++) {
+				struct monster_race *race = &r_info[i2];
+				int y2, x2;
+
 				/* The monster must be an unseen quest monster of this depth. */
 				if (race->cur_num > 0) continue;
 				if (!rf_has(race->flags, RF_QUESTOR)) continue;
 				if (race->level != chunk->depth) continue;
 	
 				/* Pick a location and place the monster */
-				find_empty(chunk, &y, &x);
-				place_new_monster(chunk, y, x, race, true, true, ORIGIN_DROP);
+				find_empty(chunk, &y2, &x2);
+				place_new_monster(chunk, y2, x2, race, true, true, ORIGIN_DROP);
 			}
 		}
 

--- a/src/init.c
+++ b/src/init.c
@@ -1337,24 +1337,24 @@ static enum parser_error parse_object_values(struct parser *p) {
 			add_game_brand(b);
 		}
 		if (!grab_index_and_int(&value, &index, slays, "SLAY_", t)) {
-			struct slay *s;
+			struct slay *slay;
 			found = true;
-			s = mem_zalloc(sizeof *s);
-			s->name = string_make(slay_names[index]);
-			s->race_flag = index;
-			s->multiplier = value;
-			s->next = k->slays;
-			k->slays = s;
-			add_game_slay(s);
+			slay = mem_zalloc(sizeof *slay);
+			slay->name = string_make(slay_names[index]);
+			slay->race_flag = index;
+			slay->multiplier = value;
+			slay->next = k->slays;
+			k->slays = slay;
+			add_game_slay(slay);
 		} else if (!grab_base_and_int(&value, &name, t)) {
-			struct slay *s;
+			struct slay *slay;
 			found = true;
-			s = mem_zalloc(sizeof *s);
-			s->name = string_make(name);
-			s->multiplier = value;
-			s->next = k->slays;
-			k->slays = s;
-			add_game_slay(s);
+			slay = mem_zalloc(sizeof *slay);
+			slay->name = string_make(name);
+			slay->multiplier = value;
+			slay->next = k->slays;
+			k->slays = slay;
+			add_game_slay(slay);
 		}
 		if (!grab_index_and_int(&value, &index, elements, "RES_", t)) {
 			found = true;
@@ -1876,24 +1876,24 @@ static enum parser_error parse_artifact_values(struct parser *p) {
 			add_game_brand(b);
 		}
 		if (!grab_index_and_int(&value, &index, slays, "SLAY_", t)) {
-			struct slay *s;
+			struct slay *slay;
 			found = true;
-			s = mem_zalloc(sizeof *s);
-			s->name = string_make(slay_names[index]);
-			s->race_flag = index;
-			s->multiplier = value;
-			s->next = a->slays;
-			a->slays = s;
-			add_game_slay(s);
+			slay = mem_zalloc(sizeof *slay);
+			slay->name = string_make(slay_names[index]);
+			slay->race_flag = index;
+			slay->multiplier = value;
+			slay->next = a->slays;
+			a->slays = slay;
+			add_game_slay(slay);
 		} else if (!grab_base_and_int(&value, &name, t)) {
-			struct slay *s;
+			struct slay *slay;
 			found = true;
-			s = mem_zalloc(sizeof *s);
-			s->name = string_make(name);
-			s->multiplier = value;
-			s->next = a->slays;
-			a->slays = s;
-			add_game_slay(s);
+			slay = mem_zalloc(sizeof *slay);
+			slay->name = string_make(name);
+			slay->multiplier = value;
+			slay->next = a->slays;
+			a->slays = slay;
+			add_game_slay(slay);
 		}
 		if (!grab_index_and_int(&value, &index, elements, "RES_", t)) {
 			found = true;
@@ -2769,24 +2769,24 @@ static enum parser_error parse_ego_values(struct parser *p) {
 			add_game_brand(b);
 		}
 		if (!grab_index_and_int(&value, &index, slays, "SLAY_", t)) {
-			struct slay *s;
+			struct slay *slay;
 			found = true;
-			s = mem_zalloc(sizeof *s);
-			s->name = string_make(slay_names[index]);
-			s->race_flag = index;
-			s->multiplier = value;
-			s->next = e->slays;
-			e->slays = s;
-			add_game_slay(s);
+			slay = mem_zalloc(sizeof *slay);
+			slay->name = string_make(slay_names[index]);
+			slay->race_flag = index;
+			slay->multiplier = value;
+			slay->next = e->slays;
+			e->slays = slay;
+			add_game_slay(slay);
 		} else if (!grab_base_and_int(&value, &name, t)) {
-			struct slay *s;
+			struct slay *slay;
 			found = true;
-			s = mem_zalloc(sizeof *s);
-			s->name = string_make(name);
-			s->multiplier = value;
-			s->next = e->slays;
-			e->slays = s;
-			add_game_slay(s);
+			slay = mem_zalloc(sizeof *slay);
+			slay->name = string_make(name);
+			slay->multiplier = value;
+			slay->next = e->slays;
+			e->slays = slay;
+			add_game_slay(slay);
 		}
 		if (!grab_index_and_int(&value, &index, elements, "RES_", t)) {
 			found = true;

--- a/src/init.c
+++ b/src/init.c
@@ -2332,7 +2332,7 @@ static void cleanup_trap(void)
 	mem_free(trap_info);
 }
 
-struct file_parser trap_parser = {
+static struct file_parser trap_parser = {
     "trap",
     init_parse_trap,
     run_parse_trap,

--- a/src/list-mon-spells.h
+++ b/src/list-mon-spells.h
@@ -11,7 +11,7 @@
  * type - spell type
  */
 /* 	name		type*/
-RSF(NONE,		)
+RSF(NONE,		0)
 RSF(SHRIEK,		RST_ANNOY | RST_INNATE)
 RSF(ARROW_1,	RST_BOLT | RST_INNATE)
 RSF(ARROW_2,	RST_BOLT | RST_INNATE)

--- a/src/load.c
+++ b/src/load.c
@@ -49,32 +49,32 @@
 /**
  * Dungeon constants
  */
-byte square_size = 0;
+static byte square_size = 0;
 
 /**
  * Player constants
  */
-byte hist_size = 0;
+static byte hist_size = 0;
 
 /**
  * Object constants
  */
-byte obj_mod_max = 0;
-byte of_size = 0;
-byte elem_max = 0;
+static byte obj_mod_max = 0;
+static byte of_size = 0;
+static byte elem_max = 0;
 
 /**
  * Monster constants
  */
-byte monster_blow_max = 0;
-byte rf_size = 0;
-byte rsf_size = 0;
-byte mflag_size = 0;
+static byte monster_blow_max = 0;
+static byte rf_size = 0;
+static byte rsf_size = 0;
+static byte mflag_size = 0;
 
 /**
  * Trap constants
  */
-byte trf_size = 0;
+static byte trf_size = 0;
 
 /**
  * Shorthand function pointer for rd_item version

--- a/src/load.c
+++ b/src/load.c
@@ -159,10 +159,10 @@ static struct object *rd_item(void)
 	/* Read brands */
 	rd_byte(&tmp8u);
 	while (tmp8u) {
-		char buf[40];
+		char buf_local[40];
 		struct brand *b = mem_zalloc(sizeof *b);
-		rd_string(buf, sizeof(buf));
-		b->name = string_make(buf);
+		rd_string(buf_local, sizeof(buf_local));
+		b->name = string_make(buf_local);
 		rd_s16b(&tmp16s);
 		b->element = tmp16s;
 		rd_s16b(&tmp16s);
@@ -175,10 +175,10 @@ static struct object *rd_item(void)
 	/* Read slays */
 	rd_byte(&tmp8u);
 	while (tmp8u) {
-		char buf[40];
+		char buf_local[40];
 		struct slay *s = mem_zalloc(sizeof *s);
-		rd_string(buf, sizeof(buf));
-		s->name = string_make(buf);
+		rd_string(buf_local, sizeof(buf_local));
+		s->name = string_make(buf_local);
 		rd_s16b(&tmp16s);
 		s->race_flag = tmp16s;
 		rd_s16b(&tmp16s);

--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -1148,10 +1148,10 @@ static size_t Term_mbcs_cocoa(wchar_t *dest, const char *src, int n)
     [pool drain];
     
     while (!game_in_progress) {
-        NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+        NSAutoreleasePool *splashScreenPool = [[NSAutoreleasePool alloc] init];
         NSEvent *event = [NSApp nextEventMatchingMask:NSAnyEventMask untilDate:[NSDate distantFuture] inMode:NSDefaultRunLoopMode dequeue:YES];
         if (event) [NSApp sendEvent:event];
-        [pool drain];
+        [splashScreenPool drain];
     }
 
     Term_fresh();
@@ -3633,8 +3633,8 @@ static bool cocoa_get_file(const char *suggested_name, char *path, size_t len)
     SEL action = @selector(setGraphicsMode:);
     
     /* Add an initial Classic ASCII menu item */
-    NSMenuItem *item = [menu addItemWithTitle:@"Classic ASCII" action:action keyEquivalent:@""];
-    [item setTag:GRAPHICS_NONE];
+    NSMenuItem *classicItem = [menu addItemWithTitle:@"Classic ASCII" action:action keyEquivalent:@""];
+    [classicItem setTag:GRAPHICS_NONE];
     
     /* Walk through the list of graphics modes */
     NSInteger i;

--- a/src/mon-attack.c
+++ b/src/mon-attack.c
@@ -24,6 +24,7 @@
 #include "cave.h"
 #include "effects.h"
 #include "init.h"
+#include "mon-attack.h"
 #include "mon-blow-methods.h"
 #include "mon-blow-effects.h"
 #include "mon-desc.h"

--- a/src/mon-blow-effects.c
+++ b/src/mon-blow-effects.c
@@ -263,7 +263,7 @@ static void melee_effect_handler_DRAIN_CHARGES(melee_effect_handler_context_t *c
 {
 	struct object *obj;
 	struct monster *monster = context->mon;
-	struct player *player = context->p;
+	struct player *current_player = context->p;
 	int tries;
 	int unpower = 0, newcharge;
 
@@ -271,7 +271,7 @@ static void melee_effect_handler_DRAIN_CHARGES(melee_effect_handler_context_t *c
 	take_hit(context->p, context->damage, context->ddesc);
 
 	/* Player is dead */
-	if (player->is_dead)
+	if (current_player->is_dead)
 		return;
 
 	/* Find an item */
@@ -311,14 +311,14 @@ static void melee_effect_handler_DRAIN_CHARGES(melee_effect_handler_context_t *c
 			monster->hp += heal;
 
 			/* Redraw (later) if needed */
-			if (player->upkeep->health_who == monster)
-				player->upkeep->redraw |= (PR_HEALTH);
+			if (current_player->upkeep->health_who == monster)
+				current_player->upkeep->redraw |= (PR_HEALTH);
 
 			/* Combine the pack */
-			player->upkeep->notice |= (PN_COMBINE);
+			current_player->upkeep->notice |= (PN_COMBINE);
 
 			/* Redraw stuff */
-			player->upkeep->redraw |= (PR_INVEN);
+			current_player->upkeep->redraw |= (PR_INVEN);
 
 			/* Affect only a single inventory slot */
 			break;
@@ -331,33 +331,33 @@ static void melee_effect_handler_DRAIN_CHARGES(melee_effect_handler_context_t *c
  */
 static void melee_effect_handler_EAT_GOLD(melee_effect_handler_context_t *context)
 {
-	struct player *player = context->p;
+	struct player *current_player = context->p;
 
     /* Take damage */
-    take_hit(player, context->damage, context->ddesc);
+    take_hit(current_player, context->damage, context->ddesc);
 
 	/* Player is dead */
-	if (player->is_dead)
+	if (current_player->is_dead)
 		return;
 
     /* Obvious */
     context->obvious = true;
 
     /* Attempt saving throw (unless paralyzed) based on dex and level */
-    if (!player->timed[TMD_PARALYZED] &&
-        (randint0(100) < (adj_dex_safe[player->state.stat_ind[STAT_DEX]]
-						  + player->lev))) {
+    if (!current_player->timed[TMD_PARALYZED] &&
+        (randint0(100) < (adj_dex_safe[current_player->state.stat_ind[STAT_DEX]]
+						  + current_player->lev))) {
         /* Saving throw message */
         msg("You quickly protect your money pouch!");
 
         /* Occasional blink anyway */
         if (randint0(3)) context->blinked = true;
     } else {
-        s32b gold = (player->au / 10) + randint1(25);
+        s32b gold = (current_player->au / 10) + randint1(25);
         if (gold < 2) gold = 2;
-        if (gold > 5000) gold = (player->au / 20) + randint1(3000);
-        if (gold > player->au) gold = player->au;
-        player->au -= gold;
+        if (gold > 5000) gold = (current_player->au / 20) + randint1(3000);
+        if (gold > current_player->au) gold = current_player->au;
+        current_player->au -= gold;
         if (gold <= 0) {
             msg("Nothing was stolen.");
             return;
@@ -365,7 +365,7 @@ static void melee_effect_handler_EAT_GOLD(melee_effect_handler_context_t *contex
 
         /* Let the player know they were robbed */
         msg("Your purse feels lighter.");
-        if (player->au)
+        if (current_player->au)
             msg("%d coins were stolen!", gold);
         else
             msg("All of your coins were stolen!");
@@ -386,14 +386,14 @@ static void melee_effect_handler_EAT_GOLD(melee_effect_handler_context_t *contex
             /* Set origin to stolen, so it is not confused with
              * dropped treasure in monster_death */
             obj->origin = ORIGIN_STOLEN;
-			obj->origin_depth = player->depth;
+			obj->origin_depth = current_player->depth;
 
             /* Give the gold to the monster */
             monster_carry(cave, context->mon, obj);
         }
 
         /* Redraw gold */
-        player->upkeep->redraw |= (PR_GOLD);
+        current_player->upkeep->redraw |= (PR_GOLD);
 
         /* Blink away */
         context->blinked = true;

--- a/src/mon-init.c
+++ b/src/mon-init.c
@@ -991,17 +991,17 @@ static errr finish_parse_monster(struct parser *p) {
 
 	/* Convert friend names into race pointers */
 	for (i = 0; i < z_info->r_max; i++) {
-		struct monster_race *r = &r_info[i];
+		struct monster_race *race = &r_info[i];
 		struct monster_friends *f;
-		for (f = r->friends; f; f = f->next) {
+		for (f = race->friends; f; f = f->next) {
 			if (!my_stricmp(f->name, "same"))
-				f->race = r;
+				f->race = race;
 			else
 				f->race = lookup_monster(f->name);
 
 			if (!f->race)
 				quit_fmt("Couldn't find friend named '%s' for monster '%s'",
-						 f->name, r->name);
+						 f->name, race->name);
 
 			string_free(f->name);
 		}

--- a/src/mon-init.c
+++ b/src/mon-init.c
@@ -1121,7 +1121,7 @@ static enum parser_error parse_lore_counts(struct parser *p) {
 static enum parser_error parse_lore_blow(struct parser *p) {
 	struct monster_lore *l = parser_priv(p);
 	int method, effect = 0, seen = 0, index = 0;
-	struct random dam;
+	struct random dam = { 0, 0, 0, 0 };
 
 	if (!l)
 		return PARSE_ERROR_MISSING_RECORD_HEADER;

--- a/src/mon-make.c
+++ b/src/mon-make.c
@@ -1112,7 +1112,7 @@ static bool place_monster_base_okay(struct monster_race *race)
 					struct monster_race *friends_race, int total, bool sleep,
 					byte origin)
  {
-	int level_difference, extra_chance, nx, ny;
+	int level_difference, extra_chance, nx = 0, ny = 0;
 	int j;
 	bool is_unique, success = true;
 	

--- a/src/mon-power.c
+++ b/src/mon-power.c
@@ -38,17 +38,17 @@ s32b tot_mon_power;
 static long eval_blow_effect(int effect, random_value atk_dam, int rlev)
 {
 	int adjustment = monster_blow_effect_eval(effect);
-	int power = randcalc(atk_dam, rlev, MAXIMISE);
+	int blow_power = randcalc(atk_dam, rlev, MAXIMISE);
 
 	if (effect == RBE_POISON) {
-		power *= 5;
-		power /= 4;
-		power += rlev;
+		blow_power *= 5;
+		blow_power /= 4;
+		blow_power += rlev;
 	} else {
-		power += adjustment;
+		blow_power += adjustment;
 	}
 
-	return power;
+	return blow_power;
 }
 
 static byte adj_energy(struct monster_race *race)

--- a/src/mon-power.c
+++ b/src/mon-power.c
@@ -31,9 +31,9 @@
 bool arg_power;				/* Command arg -- Generate monster power */
 bool arg_rebalance;			/* Command arg -- Rebalance monsters */
 
-long *power, *scaled_power, *final_hp, *final_melee_dam, *final_spell_dam;
-int *highest_threat;
-s32b tot_mon_power;
+static long *power, *scaled_power, *final_hp, *final_melee_dam, *final_spell_dam;
+static int *highest_threat;
+static s32b tot_mon_power;
 
 static long eval_blow_effect(int effect, random_value atk_dam, int rlev)
 {

--- a/src/obj-ignore.c
+++ b/src/obj-ignore.c
@@ -108,7 +108,7 @@ byte ignore_level[ITYPE_MAX];
 const size_t ignore_size = ITYPE_MAX;
 bool **ego_ignore_types;
 /* Hackish - ego_ignore_types should be initialised with arrays */
-int num_ego_types;
+static int num_ego_types;
 
 
 /**

--- a/src/obj-info.c
+++ b/src/obj-info.c
@@ -1801,7 +1801,7 @@ textblock *object_info(const struct object *obj, oinfo_detail_t mode)
 textblock *object_info_ego(struct ego_item *ego)
 {
 	struct object_kind *kind = NULL;
-	struct object obj = { 0 }, known_obj = { 0 };
+	struct object obj = OBJECT_NULL, known_obj = OBJECT_NULL;
 	size_t i;
 
 	for (i = 0; i < z_info->k_max; i++) {

--- a/src/obj-power.c
+++ b/src/obj-power.c
@@ -387,26 +387,26 @@ static s32b slay_power(const struct object *obj, int p, int verbose,
 		 * total number of monsters.
 		 */
 		if (verbose) {
-			struct brand *b, *brands = NULL;
-			struct slay *s, *slays = NULL;
+			struct brand *b, *verbose_brands = NULL;
+			struct slay *s, *verbose_slays = NULL;
 
 			/* Write info about the slay combination and multiplier */
 			log_obj("Slay multiplier for: ");
 
-			brands = brand_collect(obj->brands, NULL);
-			slays = slay_collect(obj->slays, NULL);
+			verbose_brands = brand_collect(obj->brands, NULL);
+			verbose_slays = slay_collect(obj->slays, NULL);
 
-			for (b = brands; b; b = b->next) {
+			for (b = verbose_brands; b; b = b->next) {
 				log_obj(format("%sx%d ", b->name, b->multiplier));
 			}
-			for (s = slays; s; s = s->next) {
+			for (s = verbose_slays; s; s = s->next) {
 				log_obj(format("%sx%d ", s->name, s->multiplier));
 			}
 			log_obj(format("\nsv is: %d\n", sv));
 			log_obj(format(" and t_m_p is: %d \n", tot_mon_power));
 			log_obj(format("times 1000 is: %d\n", (1000 * sv) / tot_mon_power));
-			free_brand(brands);
-			free_slay(slays);
+			free_brand(verbose_brands);
+			free_slay(verbose_slays);
 		}
 
 		/* Add to the cache */

--- a/src/obj-power.c
+++ b/src/obj-power.c
@@ -133,7 +133,7 @@ static s16b ability_power[25] =
 	74, 84, 96, 110};
 
 /* Log file declared here for simplicity */
-ang_file *object_log;
+static ang_file *object_log;
 
 /**
  * Log progress info to the object log

--- a/src/obj-randart.c
+++ b/src/obj-randart.c
@@ -2718,7 +2718,7 @@ static void scramble_artifact(int a_idx)
 static bool artifacts_acceptable(void)
 {
 	int swords = 5, polearms = 5, blunts = 5, bows = 4;
-	int bodies = 5, shields = 4, cloaks = 4, hats = 4;
+	int bodies_local = 5, shields = 4, cloaks = 4, hats = 4;
 	int gloves = 4, boots = 4;
 	int i;
 
@@ -2737,7 +2737,7 @@ static bool artifacts_acceptable(void)
 			case TV_SOFT_ARMOR:
 			case TV_HARD_ARMOR:
 			case TV_DRAG_ARMOR:
-				bodies--; break;
+				bodies_local--; break;
 			case TV_SHIELD:
 				shields--; break;
 			case TV_CLOAK:
@@ -2756,7 +2756,7 @@ static bool artifacts_acceptable(void)
 	file_putf(log_file, "Deficit amount for polearms is %d\n", polearms);
 	file_putf(log_file, "Deficit amount for blunts is %d\n", blunts);
 	file_putf(log_file, "Deficit amount for bows is %d\n", bows);
-	file_putf(log_file, "Deficit amount for bodies is %d\n", bodies);
+	file_putf(log_file, "Deficit amount for bodies is %d\n", bodies_local);
 	file_putf(log_file, "Deficit amount for shields is %d\n", shields);
 	file_putf(log_file, "Deficit amount for cloaks is %d\n", cloaks);
 	file_putf(log_file, "Deficit amount for hats is %d\n", hats);
@@ -2764,7 +2764,7 @@ static bool artifacts_acceptable(void)
 	file_putf(log_file, "Deficit amount for boots is %d\n", boots);
 
 	if (swords > 0 || polearms > 0 || blunts > 0 || bows > 0 ||
-	    bodies > 0 || shields > 0 || cloaks > 0 || hats > 0 ||
+	    bodies_local > 0 || shields > 0 || cloaks > 0 || hats > 0 ||
 	    gloves > 0 || boots > 0) {
 		if (verbose) {
 			char types[256];
@@ -2773,7 +2773,7 @@ static bool artifacts_acceptable(void)
 					polearms > 0 ? " polearms" : "",
 					blunts > 0 ? " blunts" : "",
 					bows > 0 ? " bows" : "",
-					bodies > 0 ? " body-armors" : "",
+					bodies_local > 0 ? " body-armors" : "",
 					shields > 0 ? " shields" : "",
 					cloaks > 0 ? " cloaks" : "",
 					hats > 0 ? " hats" : "",

--- a/src/obj-randart.c
+++ b/src/obj-randart.c
@@ -221,7 +221,7 @@ struct activation *activations;
 static int verbose = 1;
 
 /* Fake pvals array for maintaining current behaviour NRM */
-int fake_pval[3] = {0, 0, 0};
+static int fake_pval[3] = {0, 0, 0};
 
 /**
  * Include the elements and names

--- a/src/obj-slays.c
+++ b/src/obj-slays.c
@@ -286,7 +286,7 @@ bool append_random_slay(struct slay **current, char **name)
 
 /**
  * Count the brands in a struct brand
- * \param brands 
+ * \param brands The brands to count.
  */
 int brand_count(struct brand *brands)
 {
@@ -302,7 +302,7 @@ int brand_count(struct brand *brands)
 
 /**
  * Count the slays in a struct slay
- * \param slays 
+ * \param slays The slays to count.
  */
 int slay_count(struct slay *slays)
 {
@@ -451,8 +451,6 @@ bool react_to_specific_slay(struct slay *slay, const struct monster *mon)
  * \param verb is the verb used in the attack ("smite", etc)
  * \param real is whether this is a real attack (where we update lore) or a
  *  simulation (where we don't)
- * \param known_only is whether we are using all the brands and slays, or only
- * the ones we *already* know about
  */
 void improve_attack_modifier(struct object *obj, const struct monster *mon,
 							 const struct brand **brand_used, 
@@ -554,7 +552,7 @@ bool react_to_slay(struct object *obj, const struct monster *mon)
 /**
  * Determine whether two lists of brands are the same
  *
- * \param brand1
+ * \param brand1 the lists being compared
  * \param brand2 the lists being compared
  */
 bool brands_are_equal(struct brand *brand1, struct brand *brand2)
@@ -594,7 +592,7 @@ bool brands_are_equal(struct brand *brand1, struct brand *brand2)
 /**
  * Determine whether two lists of slays are the same
  *
- * \param slay1
+ * \param slay1 the lists being compared
  * \param slay2 the lists being compared
  */
 bool slays_are_equal(struct slay *slay1, struct slay *slay2)

--- a/src/obj-slays.c
+++ b/src/obj-slays.c
@@ -44,7 +44,7 @@ struct brand_info {
  * sorted properly, and there will also need to be a list of possibilities
  * in obj-randart.c
  */
-const struct brand_info brand_names[] = {
+static const struct brand_info brand_names[] = {
 	{ "acid", "dissolve", "corrode", RF_IM_ACID },
 	{ "lightning", "shock", "zap", RF_IM_ELEC },
 	{ "fire", "burn", "singe", RF_IM_FIRE },
@@ -63,7 +63,7 @@ struct slay_info {
  * These should go into obj-randart.c, but can wait for brands to be done
  * (because they're more complicated) - NRM
  */
-const struct slay_info slay_names[] = {
+static const struct slay_info slay_names[] = {
 	{ "evil creatures", RF_EVIL, 2 },
 	{ "animals", RF_ANIMAL, 2 },
 	{ "orcs", RF_ORC, 3 },

--- a/src/obj-util.c
+++ b/src/obj-util.c
@@ -274,7 +274,20 @@ bool object_test(item_tester tester, const struct object *obj)
  */
 bool is_unknown(const struct object *obj)
 {
-	struct grid_data gd = { 0 };
+	struct grid_data gd = {
+		.m_idx = 0,
+		.f_idx = 0,
+		.first_kind = NULL,
+		.trap = NULL,
+		.multiple_objects = false,
+		.unseen_object = false,
+		.unseen_money = false,
+		.lighting = LIGHTING_LOS,
+		.in_view = false,
+		.is_player = false,
+		.hallucinate = false,
+		.trapborder = false
+	};
 	map_info(obj->iy, obj->ix, &gd);
 	return gd.unseen_object;
 }	

--- a/src/object.h
+++ b/src/object.h
@@ -413,6 +413,49 @@ struct object {
 	quark_t note; 		/* Inscription index */
 };
 
+/**
+ * Null object constant, for safe initialization.
+ */
+static struct object const OBJECT_NULL = {
+	.kind = NULL,
+	.ego = NULL,
+	.artifact = NULL,
+	.prev = NULL,
+	.next = NULL,
+	.known = NULL,
+	.oidx = 0,
+	.iy = 0,
+	.ix = 0,
+	.tval = 0,
+	.sval = 0,
+	.pval = 0,
+	.weight = 0,
+	.flags = { 0 },
+	.modifiers = { 0 },
+	.el_info = { { 0, 0 } },
+	.brands = NULL,
+	.slays = NULL,
+	.ac = 0,
+	.to_a = 0,
+	.to_h = 0,
+	.to_d = 0,
+	.dd = 0,
+	.ds = 0,
+	.effect = NULL,
+	.effect_msg = NULL,
+	.activation = NULL,
+	.time = { 0, 0, 0, 0 },
+	.timeout = 0,
+	.number = 0,
+	.notice = 0,
+	.held_m_idx = 0,
+	.mimicking_m_idx = 0,
+	.origin = 0,
+	.origin_depth = 0,
+	.origin_xtra = 0,
+	.note = 0,
+};
+
 struct flavor
 {
 	char *text;

--- a/src/player-attack.c
+++ b/src/player-attack.c
@@ -349,9 +349,9 @@ static bool py_attack_real(int y, int x, bool *fear)
 		/* Get the best attack from all slays or
 		 * brands on all non-launcher equipment */
 		for (j = 2; j < player->body.count; j++) {
-			struct object *obj = slot_object(player, j);
-			if (obj)
-				improve_attack_modifier(obj, mon, &b, &s, verb, false, true);
+			struct object *obj_local = slot_object(player, j);
+			if (obj_local)
+				improve_attack_modifier(obj_local, mon, &b, &s, verb, false, true);
 		}
 
 		improve_attack_modifier(obj, mon, &b, &s, verb, false, true);

--- a/src/player-calcs.c
+++ b/src/player-calcs.c
@@ -40,7 +40,7 @@
 /**
  * Stat Table (INT) -- Magic devices
  */
-const byte adj_int_dev[STAT_RANGE] =
+static const byte adj_int_dev[STAT_RANGE] =
 {
 	0	/* 3 */,
 	0	/* 4 */,
@@ -85,7 +85,7 @@ const byte adj_int_dev[STAT_RANGE] =
 /**
  * Stat Table (WIS) -- Saving throw
  */
-const byte adj_wis_sav[STAT_RANGE] =
+static const byte adj_wis_sav[STAT_RANGE] =
 {
 	0	/* 3 */,
 	0	/* 4 */,
@@ -131,7 +131,7 @@ const byte adj_wis_sav[STAT_RANGE] =
 /**
  * Stat Table (DEX) -- disarming
  */
-const byte adj_dex_dis[STAT_RANGE] =
+static const byte adj_dex_dis[STAT_RANGE] =
 {
 	0	/* 3 */,
 	0	/* 4 */,
@@ -177,7 +177,7 @@ const byte adj_dex_dis[STAT_RANGE] =
 /**
  * Stat Table (INT) -- disarming
  */
-const byte adj_int_dis[STAT_RANGE] =
+static const byte adj_int_dis[STAT_RANGE] =
 {
 	0	/* 3 */,
 	0	/* 4 */,
@@ -222,7 +222,7 @@ const byte adj_int_dis[STAT_RANGE] =
 /**
  * Stat Table (DEX) -- bonus to ac (plus 128)
  */
-const byte adj_dex_ta[STAT_RANGE] =
+static const byte adj_dex_ta[STAT_RANGE] =
 {
 	128 + -4	/* 3 */,
 	128 + -3	/* 4 */,
@@ -267,7 +267,7 @@ const byte adj_dex_ta[STAT_RANGE] =
 /**
  * Stat Table (STR) -- bonus to dam (plus 128)
  */
-const byte adj_str_td[STAT_RANGE] =
+static const byte adj_str_td[STAT_RANGE] =
 {
 	128 + -2	/* 3 */,
 	128 + -2	/* 4 */,
@@ -313,7 +313,7 @@ const byte adj_str_td[STAT_RANGE] =
 /**
  * Stat Table (DEX) -- bonus to hit (plus 128)
  */
-const byte adj_dex_th[STAT_RANGE] =
+static const byte adj_dex_th[STAT_RANGE] =
 {
 	128 + -3	/* 3 */,
 	128 + -2	/* 4 */,
@@ -359,7 +359,7 @@ const byte adj_dex_th[STAT_RANGE] =
 /**
  * Stat Table (STR) -- bonus to hit (plus 128)
  */
-const byte adj_str_th[STAT_RANGE] =
+static const byte adj_str_th[STAT_RANGE] =
 {
 	128 + -3	/* 3 */,
 	128 + -2	/* 4 */,
@@ -405,7 +405,7 @@ const byte adj_str_th[STAT_RANGE] =
 /**
  * Stat Table (STR) -- weight limit in deca-pounds
  */
-const byte adj_str_wgt[STAT_RANGE] =
+static const byte adj_str_wgt[STAT_RANGE] =
 {
 	5	/* 3 */,
 	6	/* 4 */,
@@ -497,7 +497,7 @@ const byte adj_str_hold[STAT_RANGE] =
 /**
  * Stat Table (STR) -- digging value
  */
-const byte adj_str_dig[STAT_RANGE] =
+static const byte adj_str_dig[STAT_RANGE] =
 {
 	0	/* 3 */,
 	0	/* 4 */,
@@ -589,7 +589,7 @@ const byte adj_str_blow[STAT_RANGE] =
 /**
  * Stat Table (DEX) -- index into the "blow" table
  */
-const byte adj_dex_blow[STAT_RANGE] =
+static const byte adj_dex_blow[STAT_RANGE] =
 {
 	0	/* 3 */,
 	0	/* 4 */,
@@ -727,7 +727,7 @@ const byte adj_con_fix[STAT_RANGE] =
 /**
  * Stat Table (CON) -- extra 1/100th hitpoints per level
  */
-const int adj_con_mhp[STAT_RANGE] =
+static const int adj_con_mhp[STAT_RANGE] =
 {
 	-250	/* 3 */,
 	-150	/* 4 */,
@@ -769,7 +769,7 @@ const int adj_con_mhp[STAT_RANGE] =
 	1250	/* 18/220+ */
 };
 
-const int adj_mag_study[STAT_RANGE] =
+static const int adj_mag_study[STAT_RANGE] =
 {
 	  0	/* 3 */,
 	  0	/* 4 */,
@@ -814,7 +814,7 @@ const int adj_mag_study[STAT_RANGE] =
 /**
  * Stat Table (INT/WIS) -- extra 1/100 mana-points per level
  */
-const int adj_mag_mana[STAT_RANGE] =
+static const int adj_mag_mana[STAT_RANGE] =
 {
 	  0	/* 3 */,
 	 10	/* 4 */,
@@ -884,7 +884,7 @@ const int adj_mag_mana[STAT_RANGE] =
  * The player gets blows/round equal to 100/this number, up to a maximum of
  * "num" blows/round, plus any "bonus" blows/round.
  */
-const byte blows_table[12][12] =
+static const byte blows_table[12][12] =
 {
 	/* P */
    /* D:   0,   1,   2,   3,   4,   5,   6,   7,   8,   9,   10,  11+ */

--- a/src/player-calcs.c
+++ b/src/player-calcs.c
@@ -1428,7 +1428,7 @@ static void calc_mana(struct player *p, struct player_state *state, bool update)
 	/* Weigh the armor */
 	cur_wgt = 0;
 	for (i = 0; i < p->body.count; i++) {
-		struct object *obj = slot_object(p, i);
+		struct object *obj_local = slot_object(p, i);
 
 		/* Ignore non-armor */
 		if (slot_type_is(i, EQUIP_WEAPON)) continue;
@@ -1438,8 +1438,8 @@ static void calc_mana(struct player *p, struct player_state *state, bool update)
 		if (slot_type_is(i, EQUIP_LIGHT)) continue;
 
 		/* Add weight */
-		if (obj)
-			cur_wgt += obj->weight;
+		if (obj_local)
+			cur_wgt += obj_local->weight;
 	}
 
 	/* Determine the weight allowance */

--- a/src/player-history.c
+++ b/src/player-history.c
@@ -242,7 +242,7 @@ static bool history_is_artifact_logged(struct artifact *artifact)
  */
 bool history_add_artifact(struct artifact *artifact, bool known, bool found)
 {
-	struct object body = { 0 }, known_body = { 0 };
+	struct object body = OBJECT_NULL, known_body = OBJECT_NULL;
 	struct object *fake = &body, *known_obj = &known_body;
 
 	char o_name[80];

--- a/src/player-path.c
+++ b/src/player-path.c
@@ -371,12 +371,12 @@ int pathfind_direction_to(struct loc from, struct loc to)
 
 
 
-int run_cur_dir;		/* Direction we are running */
-int run_old_dir;		/* Direction we came from */
-bool run_unused;		/* Unused (padding field) */
-bool run_open_area;		/* Looking for an open area */
-bool run_break_right;	/* Looking for a break (right) */
-bool run_break_left;	/* Looking for a break (left) */
+static int run_cur_dir;		/* Direction we are running */
+static int run_old_dir;		/* Direction we came from */
+static bool run_unused;		/* Unused (padding field) */
+static bool run_open_area;		/* Looking for an open area */
+static bool run_break_right;	/* Looking for a break (right) */
+static bool run_break_left;	/* Looking for a break (left) */
 
 /**
  * Hack -- allow quick "cycling" through the legal directions

--- a/src/player-spell.c
+++ b/src/player-spell.c
@@ -34,7 +34,7 @@
 /**
  * Stat Table (INT/WIS) -- Minimum failure rate (percentage)
  */
-const byte adj_mag_fail[STAT_RANGE] =
+static const byte adj_mag_fail[STAT_RANGE] =
 {
 	99	/* 3 */,
 	99	/* 4 */,
@@ -79,7 +79,7 @@ const byte adj_mag_fail[STAT_RANGE] =
 /**
  * Stat Table (INT/WIS) -- failure rate adjustment
  */
-const int adj_mag_stat[STAT_RANGE] =
+static const int adj_mag_stat[STAT_RANGE] =
 {
 	-5	/* 3 */,
 	-4	/* 4 */,

--- a/src/player-util.c
+++ b/src/player-util.c
@@ -808,7 +808,7 @@ static int player_resting_repeat_count = 0;
 /**
  * Get the number of resting turns to repeat.
  *
- * \param count is the number of turns requested for rest most recently.
+ * \param p The current player.
  */
 int player_get_resting_repeat_count(struct player *p)
 {

--- a/src/project-feat.c
+++ b/src/project-feat.c
@@ -552,7 +552,7 @@ static const project_feature_handler_f feature_handlers[] = {
  *
  * \param who is the monster list index of the caster
  * \param r is the distance from the centre of the effect
- * \param y
+ * \param y the coordinates of the grid being handled
  * \param x the coordinates of the grid being handled
  * \param dam is the "damage" from the effect at distance r from the centre
  * \param typ is the projection (GF_) type

--- a/src/project-mon.c
+++ b/src/project-mon.c
@@ -997,7 +997,7 @@ static void project_m_apply_side_effects(project_monster_handler_context_t *cont
  *
  * \param who is the monster list index of the caster
  * \param r is the distance from the centre of the effect
- * \param y
+ * \param y the coordinates of the grid being handled
  * \param x the coordinates of the grid being handled
  * \param dam is the "damage" from the effect at distance r from the centre
  * \param typ is the projection (GF_) type

--- a/src/project-obj.c
+++ b/src/project-obj.c
@@ -409,7 +409,7 @@ static const project_object_handler_f object_handlers[] = {
  *
  * \param who is the monster list index of the caster
  * \param r is the distance from the centre of the effect
- * \param y
+ * \param y the coordinates of the grid being handled
  * \param x the coordinates of the grid being handled
  * \param dam is the "damage" from the effect at distance r from the centre
  * \param typ is the projection (GF_) type

--- a/src/project-player.c
+++ b/src/project-player.c
@@ -494,7 +494,7 @@ static const project_player_handler_f player_handlers[] = {
  *
  * \param who is the monster list index of the caster
  * \param r is the distance from the centre of the effect
- * \param y
+ * \param y the coordinates of the grid being handled
  * \param x the coordinates of the grid being handled
  * \param dam is the "damage" from the effect at distance r from the centre
  * \param typ is the projection (GF_) type

--- a/src/project.c
+++ b/src/project.c
@@ -437,17 +437,17 @@ const char *gf_idx_to_name(int type)
  * Generic "beam"/"bolt"/"ball" projection routine.  
  *   -BEN-, some changes by -LM-
  *
- *   \param who: Index of "source" monster (negative for the character)
- *   \param rad: Radius of explosion (0 = beam/bolt, 1 to 20 = ball), or maximum
+ *   \param who Index of "source" monster (negative for the character)
+ *   \param rad Radius of explosion (0 = beam/bolt, 1 to 20 = ball), or maximum
  *	  length of arc from the source.
- *   \param y
- *   \param x: Target location (or location to travel towards)
- *   \param dam: Base damage to apply to monsters, terrain, objects, or player
- *   \param typ: Type of projection (fire, frost, dispel demons etc.)
- *   \param flg: Extra bit flags that control projection behavior
- *   \param degrees_of_arc: How wide an arc spell is (in degrees).
- *   \param diameter_of_source: how wide the source diameter is.
- *   \param obj: An object that the projection ignores
+ *   \param y Target location (or location to travel towards)
+ *   \param x Target location (or location to travel towards)
+ *   \param dam Base damage to apply to monsters, terrain, objects, or player
+ *   \param typ Type of projection (fire, frost, dispel demons etc.)
+ *   \param flg Extra bit flags that control projection behavior
+ *   \param degrees_of_arc How wide an arc spell is (in degrees).
+ *   \param diameter_of_source how wide the source diameter is.
+ *   \param obj An object that the projection ignores
  *
  *   \return true if any effects of the projection were observed, else false
  *

--- a/src/savefile.c
+++ b/src/savefile.c
@@ -496,16 +496,16 @@ static errr next_blockheader(ang_file *f, struct blockheader *b) {
  * Find the right loader for this block, return it
  */
 static loader_t find_loader(struct blockheader *b,
-							const struct blockinfo *loaders)
+							const struct blockinfo *local_loaders)
 {
 	size_t i = 0;
 
 	/* Find the right loader */
-	for (i = 0; loaders[i].name[0]; i++) {
-		if (!streq(b->name, loaders[i].name)) continue;
-		if (b->version != loaders[i].version) continue;
+	for (i = 0; local_loaders[i].name[0]; i++) {
+		if (!streq(b->name, local_loaders[i].name)) continue;
+		if (b->version != local_loaders[i].version) continue;
 
-		return loaders[i].loader;
+		return local_loaders[i].loader;
 	} 
 
 	return NULL;
@@ -543,7 +543,7 @@ static void skip_block(ang_file *f, struct blockheader *b)
 /**
  * Try to load a savefile
  */
-static bool try_load(ang_file *f, const struct blockinfo *loaders)
+static bool try_load(ang_file *f, const struct blockinfo *local_loaders)
 {
 	struct blockheader b;
 	errr err;
@@ -555,7 +555,7 @@ static bool try_load(ang_file *f, const struct blockinfo *loaders)
 
 	/* Get the next block header */
 	while ((err = next_blockheader(f, &b)) == 0) {
-		loader_t loader = find_loader(&b, loaders);
+		loader_t loader = find_loader(&b, local_loaders);
 		if (!loader) {
 			note("Savefile block can't be read.");
 			note("Maybe try and load the savefile in an earlier version of Angband.");

--- a/src/sound-core.c
+++ b/src/sound-core.c
@@ -167,7 +167,7 @@ void message_sound_define(u16b message_id, const char *sounds_str)
 	char *cur_token;
 	char *next_token;
 
-	u16b sound_id;
+	u16b sound_id = 0;
 
 	u32b hash;
 	int i;

--- a/src/sound-core.c
+++ b/src/sound-core.c
@@ -82,7 +82,7 @@ static struct sound_hooks hooks;
  * If preload_sounds is true, sounds are loaded immediately when assigned to
  * a message. Otherwise, each sound is only loaded when first played.
  */
-bool preload_sounds = false;
+static bool preload_sounds = false;
 
 static struct sound_data *grow_sound_list(void)
 {

--- a/src/sound-core.c
+++ b/src/sound-core.c
@@ -254,21 +254,21 @@ enum parser_error parse_prefs_sound(struct parser *p)
 {
 	int msg_index;
 	const char *type;
-	const char *sounds;
+	const char *sounds_local;
 
 	struct prefs_data *d = parser_priv(p);
 	assert(d != NULL);
 	if (d->bypass) return PARSE_ERROR_NONE;
 
 	type = parser_getsym(p, "type");
-	sounds = parser_getstr(p, "sounds");
+	sounds_local = parser_getstr(p, "sounds");
 
 	msg_index = message_lookup_by_name(type);
 
 	if (msg_index < 0)
 		return PARSE_ERROR_INVALID_MESSAGE;
 
-	message_sound_define(msg_index, sounds);
+	message_sound_define(msg_index, sounds_local);
 
 	return PARSE_ERROR_NONE;
 }

--- a/src/store.c
+++ b/src/store.c
@@ -311,11 +311,11 @@ static struct file_parser store_parser = {
 
 static struct store *flatten_stores(struct store *store_list) {
 	struct store *s;
-	struct store *stores = mem_zalloc(MAX_STORES * sizeof(*stores));
+	struct store *stores_local = mem_zalloc(MAX_STORES * sizeof(*stores_local));
 
 	for (s = store_list; s; s = s->next) {
 		if (s->sidx < MAX_STORES)
-			memcpy(&stores[s->sidx], s, sizeof(*s));
+			memcpy(&stores_local[s->sidx], s, sizeof(*s));
 	}
 
 	while (store_list) {
@@ -326,7 +326,7 @@ static struct store *flatten_stores(struct store *store_list) {
 		store_list = s;
 	}
 
-	return stores;
+	return stores_local;
 }
 
 void store_init(void)

--- a/src/ui-context.c
+++ b/src/ui-context.c
@@ -1133,7 +1133,7 @@ static void cmd_sub_entry(struct menu *menu, int oid, bool cursor, int row,
 	const struct cmd_info *commands = menu_priv(menu);
 
 	int mode = OPT(rogue_like_commands) ? KEYMAP_MODE_ROGUE : KEYMAP_MODE_ORIG;
-	struct keypress kp = { EVT_KBRD, commands[oid].key[mode] };
+	struct keypress kp = { EVT_KBRD, commands[oid].key[mode], 0 };
 	char buf[16];
 
 	/* Write the description */

--- a/src/ui-display.c
+++ b/src/ui-display.c
@@ -41,6 +41,7 @@
 #include "savefile.h"
 #include "target.h"
 #include "ui-birth.h"
+#include "ui-display.h"
 #include "ui-game.h"
 #include "ui-input.h"
 #include "ui-map.h"

--- a/src/ui-event.h
+++ b/src/ui-event.h
@@ -166,6 +166,15 @@ struct keypress {
 };
 
 /**
+ * Null keypress constant, for safe initializtion.
+ */
+static struct keypress const KEYPRESS_NULL = {
+	.type = EVT_NONE,
+	.code = 0,
+	.mods = 0
+};
+
+/**
  * Struct holding all relevant info for mouse clicks.
  */
 struct mouseclick {

--- a/src/ui-game.c
+++ b/src/ui-game.c
@@ -73,22 +73,22 @@ char savefile[1024];
  */
 struct cmd_info cmd_item[] =
 {
-	{ "Inscribe an object", { '{' }, CMD_INSCRIBE },
-	{ "Uninscribe an object", { '}' }, CMD_UNINSCRIBE },
-	{ "Wear/wield an item", { 'w' }, CMD_WIELD },
-	{ "Take off/unwield an item", { 't', 'T'}, CMD_TAKEOFF },
-	{ "Examine an item", { 'I' }, CMD_NULL, textui_obj_examine },
-	{ "Drop an item", { 'd' }, CMD_DROP },
+	{ "Inscribe an object", { '{' }, CMD_INSCRIBE, NULL, NULL },
+	{ "Uninscribe an object", { '}' }, CMD_UNINSCRIBE, NULL, NULL },
+	{ "Wear/wield an item", { 'w' }, CMD_WIELD, NULL, NULL },
+	{ "Take off/unwield an item", { 't', 'T'}, CMD_TAKEOFF, NULL, NULL },
+	{ "Examine an item", { 'I' }, CMD_NULL, textui_obj_examine, NULL },
+	{ "Drop an item", { 'd' }, CMD_DROP, NULL, NULL },
 	{ "Fire your missile weapon", { 'f', 't' }, CMD_FIRE, NULL, player_can_fire_prereq },
-	{ "Use a staff", { 'u', 'Z' }, CMD_USE_STAFF },
-	{ "Aim a wand", {'a', 'z'}, CMD_USE_WAND },
-	{ "Zap a rod", {'z', 'a'}, CMD_USE_ROD },
-	{ "Activate an object", {'A' }, CMD_ACTIVATE },
-	{ "Eat some food", { 'E' }, CMD_EAT },
-	{ "Quaff a potion", { 'q' }, CMD_QUAFF },
+	{ "Use a staff", { 'u', 'Z' }, CMD_USE_STAFF, NULL, NULL },
+	{ "Aim a wand", {'a', 'z'}, CMD_USE_WAND, NULL, NULL },
+	{ "Zap a rod", {'z', 'a'}, CMD_USE_ROD, NULL, NULL },
+	{ "Activate an object", {'A' }, CMD_ACTIVATE, NULL, NULL },
+	{ "Eat some food", { 'E' }, CMD_EAT, NULL, NULL },
+	{ "Quaff a potion", { 'q' }, CMD_QUAFF, NULL, NULL },
 	{ "Read a scroll", { 'r' }, CMD_READ_SCROLL, NULL, player_can_read_prereq },
 	{ "Fuel your light source", { 'F' }, CMD_REFILL, NULL, player_can_refuel_prereq },
-	{ "Use an item", { 'U', 'X' }, CMD_USE }
+	{ "Use an item", { 'U', 'X' }, CMD_USE, NULL, NULL }
 };
 
 /**
@@ -96,21 +96,21 @@ struct cmd_info cmd_item[] =
  */
 struct cmd_info cmd_action[] =
 {
-	{ "Search for traps/doors", { 's' }, CMD_SEARCH },
-	{ "Disarm a trap or chest", { 'D' }, CMD_DISARM },
-	{ "Rest for a while", { 'R' }, CMD_NULL, textui_cmd_rest },
-	{ "Look around", { 'l', 'x' }, CMD_NULL, do_cmd_look },
-	{ "Target monster or location", { '*' }, CMD_NULL, textui_target },
-	{ "Target closest monster", { '\'' }, CMD_NULL, textui_target_closest },
-	{ "Dig a tunnel", { 'T', KTRL('T') }, CMD_TUNNEL },
-	{ "Go up staircase", {'<' }, CMD_GO_UP },
-	{ "Go down staircase", { '>' }, CMD_GO_DOWN },
-	{ "Toggle search mode", { 'S', '#' }, CMD_TOGGLE_SEARCH },
-	{ "Open a door or a chest", { 'o' }, CMD_OPEN },
-	{ "Close a door", { 'c' }, CMD_CLOSE },
-	{ "Fire at nearest target", { 'h', KC_TAB }, CMD_NULL, do_cmd_fire_at_nearest },
-	{ "Throw an item", { 'v' }, CMD_THROW },
-	{ "Walk into a trap", { 'W', '-' }, CMD_JUMP, NULL },
+	{ "Search for traps/doors", { 's' }, CMD_SEARCH, NULL, NULL },
+	{ "Disarm a trap or chest", { 'D' }, CMD_DISARM, NULL, NULL },
+	{ "Rest for a while", { 'R' }, CMD_NULL, textui_cmd_rest, NULL },
+	{ "Look around", { 'l', 'x' }, CMD_NULL, do_cmd_look, NULL },
+	{ "Target monster or location", { '*' }, CMD_NULL, textui_target, NULL },
+	{ "Target closest monster", { '\'' }, CMD_NULL, textui_target_closest, NULL },
+	{ "Dig a tunnel", { 'T', KTRL('T') }, CMD_TUNNEL, NULL, NULL },
+	{ "Go up staircase", {'<' }, CMD_GO_UP, NULL, NULL },
+	{ "Go down staircase", { '>' }, CMD_GO_DOWN, NULL, NULL },
+	{ "Toggle search mode", { 'S', '#' }, CMD_TOGGLE_SEARCH, NULL, NULL },
+	{ "Open a door or a chest", { 'o' }, CMD_OPEN, NULL, NULL },
+	{ "Close a door", { 'c' }, CMD_CLOSE, NULL, NULL },
+	{ "Fire at nearest target", { 'h', KC_TAB }, CMD_NULL, do_cmd_fire_at_nearest, NULL },
+	{ "Throw an item", { 'v' }, CMD_THROW, NULL, NULL },
+	{ "Walk into a trap", { 'W', '-' }, CMD_JUMP, NULL, NULL },
 };
 
 /**
@@ -118,11 +118,11 @@ struct cmd_info cmd_action[] =
  */
 struct cmd_info cmd_item_manage[] =
 {
-	{ "Display equipment listing", { 'e' }, CMD_NULL, do_cmd_equip },
-	{ "Display inventory listing", { 'i' }, CMD_NULL, do_cmd_inven },
-	{ "Display quiver listing", { '|' }, CMD_NULL, do_cmd_quiver },
-	{ "Pick up objects", { 'g' }, CMD_PICKUP, NULL },
-	{ "Ignore an item", { 'k', KTRL('D') }, CMD_IGNORE, textui_cmd_ignore },	
+	{ "Display equipment listing", { 'e' }, CMD_NULL, do_cmd_equip, NULL },
+	{ "Display inventory listing", { 'i' }, CMD_NULL, do_cmd_inven, NULL },
+	{ "Display quiver listing", { '|' }, CMD_NULL, do_cmd_quiver, NULL },
+	{ "Pick up objects", { 'g' }, CMD_PICKUP, NULL, NULL },
+	{ "Ignore an item", { 'k', KTRL('D') }, CMD_IGNORE, textui_cmd_ignore, NULL },
 };
 
 /**
@@ -130,22 +130,22 @@ struct cmd_info cmd_item_manage[] =
  */
 struct cmd_info cmd_info[] =
 {
-	{ "Browse a book", { 'b', 'P' }, CMD_BROWSE_SPELL, textui_spell_browse },
+	{ "Browse a book", { 'b', 'P' }, CMD_BROWSE_SPELL, textui_spell_browse, NULL },
 	{ "Gain new spells", { 'G' }, CMD_STUDY, NULL, player_can_study_prereq },
 	{ "Cast a spell", { 'm' }, CMD_CAST, NULL, player_can_cast_prereq },
 	{ "Cast a spell", { 'p' }, CMD_CAST, NULL, player_can_cast_prereq },
-	{ "Full dungeon map", { 'M' }, CMD_NULL, do_cmd_view_map },
-	{ "Toggle ignoring of items", { 'K', 'O' }, CMD_NULL, textui_cmd_toggle_ignore },
-	{ "Display visible item list", { ']' }, CMD_NULL, do_cmd_itemlist },
-	{ "Display visible monster list", { '[' }, CMD_NULL, do_cmd_monlist },
-	{ "Locate player on map", { 'L', 'W' }, CMD_NULL, do_cmd_locate },
-	{ "Help", { '?' }, CMD_NULL, do_cmd_help },
-	{ "Identify symbol", { '/' }, CMD_NULL, do_cmd_query_symbol },
-	{ "Character description", { 'C' }, CMD_NULL, do_cmd_change_name },
-	{ "Check knowledge", { '~' }, CMD_NULL, textui_browse_knowledge },
-	{ "Repeat level feeling", { KTRL('F') }, CMD_NULL, do_cmd_feeling },
-	{ "Show previous message", { KTRL('O') }, CMD_NULL, do_cmd_message_one },
-	{ "Show previous messages", { KTRL('P') }, CMD_NULL, do_cmd_messages }
+	{ "Full dungeon map", { 'M' }, CMD_NULL, do_cmd_view_map, NULL },
+	{ "Toggle ignoring of items", { 'K', 'O' }, CMD_NULL, textui_cmd_toggle_ignore, NULL },
+	{ "Display visible item list", { ']' }, CMD_NULL, do_cmd_itemlist, NULL },
+	{ "Display visible monster list", { '[' }, CMD_NULL, do_cmd_monlist, NULL },
+	{ "Locate player on map", { 'L', 'W' }, CMD_NULL, do_cmd_locate, NULL },
+	{ "Help", { '?' }, CMD_NULL, do_cmd_help, NULL },
+	{ "Identify symbol", { '/' }, CMD_NULL, do_cmd_query_symbol, NULL },
+	{ "Character description", { 'C' }, CMD_NULL, do_cmd_change_name, NULL },
+	{ "Check knowledge", { '~' }, CMD_NULL, textui_browse_knowledge, NULL },
+	{ "Repeat level feeling", { KTRL('F') }, CMD_NULL, do_cmd_feeling, NULL },
+	{ "Show previous message", { KTRL('O') }, CMD_NULL, do_cmd_message_one, NULL },
+	{ "Show previous messages", { KTRL('P') }, CMD_NULL, do_cmd_messages, NULL }
 };
 
 /**
@@ -153,15 +153,15 @@ struct cmd_info cmd_info[] =
  */
 struct cmd_info cmd_util[] =
 {
-	{ "Interact with options", { '=' }, CMD_NULL, do_cmd_xxx_options },
+	{ "Interact with options", { '=' }, CMD_NULL, do_cmd_xxx_options, NULL },
 
-	{ "Save and don't quit", { KTRL('S') }, CMD_NULL, save_game },
-	{ "Save and quit", { KTRL('X') }, CMD_NULL, textui_quit },
-	{ "Quit (commit suicide)", { 'Q' }, CMD_NULL, textui_cmd_suicide },
-	{ "Redraw the screen", { KTRL('R') }, CMD_NULL, do_cmd_redraw },
+	{ "Save and don't quit", { KTRL('S') }, CMD_NULL, save_game, NULL },
+	{ "Save and quit", { KTRL('X') }, CMD_NULL, textui_quit, NULL },
+	{ "Quit (commit suicide)", { 'Q' }, CMD_NULL, textui_cmd_suicide, NULL },
+	{ "Redraw the screen", { KTRL('R') }, CMD_NULL, do_cmd_redraw, NULL },
 
-	{ "Load \"screen dump\"", { '(' }, CMD_NULL, do_cmd_load_screen },
-	{ "Save \"screen dump\"", { ')' }, CMD_NULL, do_cmd_save_screen }
+	{ "Load \"screen dump\"", { '(' }, CMD_NULL, do_cmd_load_screen, NULL },
+	{ "Save \"screen dump\"", { ')' }, CMD_NULL, do_cmd_save_screen, NULL }
 };
 
 /**
@@ -169,19 +169,19 @@ struct cmd_info cmd_util[] =
  */
 struct cmd_info cmd_hidden[] =
 {
-	{ "Take notes", { ':' }, CMD_NULL, do_cmd_note },
-	{ "Version info", { 'V' }, CMD_NULL, do_cmd_version },
-	{ "Load a single pref line", { '"' }, CMD_NULL, do_cmd_pref },
-	{ "Toggle windows", { KTRL('E') }, CMD_NULL, toggle_inven_equip }, /* XXX */
-	{ "Alter a grid", { '+' }, CMD_ALTER, NULL },
-	{ "Walk", { ';' }, CMD_WALK, NULL },
-	{ "Start running", { '.', ',' }, CMD_RUN, NULL },
-	{ "Stand still", { ',', '.' }, CMD_HOLD, NULL },
-	{ "Center map", { KTRL('L'), '@' }, CMD_NULL, do_cmd_center_map },
-	{ "Toggle wizard mode", { KTRL('W') }, CMD_NULL, do_cmd_wizard },
-	{ "Repeat previous command", { 'n', KTRL('V') }, CMD_REPEAT, NULL },
-	{ "Do autopickup", { KTRL('G') }, CMD_AUTOPICKUP, NULL },
-	{ "Debug mode commands", { KTRL('A') }, CMD_NULL, textui_cmd_debug },
+	{ "Take notes", { ':' }, CMD_NULL, do_cmd_note, NULL },
+	{ "Version info", { 'V' }, CMD_NULL, do_cmd_version, NULL },
+	{ "Load a single pref line", { '"' }, CMD_NULL, do_cmd_pref, NULL },
+	{ "Toggle windows", { KTRL('E') }, CMD_NULL, toggle_inven_equip, NULL }, /* XXX */
+	{ "Alter a grid", { '+' }, CMD_ALTER, NULL, NULL },
+	{ "Walk", { ';' }, CMD_WALK, NULL, NULL },
+	{ "Start running", { '.', ',' }, CMD_RUN, NULL, NULL },
+	{ "Stand still", { ',', '.' }, CMD_HOLD, NULL, NULL },
+	{ "Center map", { KTRL('L'), '@' }, CMD_NULL, do_cmd_center_map, NULL },
+	{ "Toggle wizard mode", { KTRL('W') }, CMD_NULL, do_cmd_wizard, NULL },
+	{ "Repeat previous command", { 'n', KTRL('V') }, CMD_REPEAT, NULL, NULL },
+	{ "Do autopickup", { KTRL('G') }, CMD_AUTOPICKUP, NULL, NULL },
+	{ "Debug mode commands", { KTRL('A') }, CMD_NULL, textui_cmd_debug, NULL },
 };
 
 /**
@@ -194,7 +194,7 @@ struct command_list cmds_all[] =
 	{ "Information",     cmd_info,        N_ELEMENTS(cmd_info) },
 	{ "Utility",         cmd_util,        N_ELEMENTS(cmd_util) },
 	{ "Hidden",          cmd_hidden,      N_ELEMENTS(cmd_hidden) },
-	{ 0 }
+	{ NULL,              NULL,            0 }
 };
 
 

--- a/src/ui-history.c
+++ b/src/ui-history.c
@@ -36,8 +36,8 @@ static void print_history_header(void)
  */
 void history_display(void)
 {
-	struct history_info *history_list = NULL;
-	size_t max_item = history_get_list(&history_list);
+	struct history_info *history_list_local = NULL;
+	size_t max_item = history_get_list(&history_list_local);
 	int row, wid, hgt, page_size;
 	char buf[120];
 	static size_t first_item = 0;
@@ -64,11 +64,11 @@ void history_display(void)
 		for (i = first_item; row <= page_size && i < max_item; i++)
 		{
 			strnfmt(buf, sizeof(buf), "%10d%7d\'  %s",
-				history_list[i].turn,
-				history_list[i].dlev * 50,
-				history_list[i].event);
+				history_list_local[i].turn,
+				history_list_local[i].dlev * 50,
+				history_list_local[i].event);
 
-			if (hist_has(history_list[i].type, HIST_ARTIFACT_LOST))
+			if (hist_has(history_list_local[i].type, HIST_ARTIFACT_LOST))
 				my_strcat(buf, " (LOST)", sizeof(buf));
 
 			/* Size of header = 3 lines */
@@ -124,8 +124,8 @@ void history_display(void)
  */
 void dump_history(ang_file *file)
 {
-	struct history_info *history_list = NULL;
-	size_t max_item = history_get_list(&history_list);
+	struct history_info *history_list_local = NULL;
+	size_t max_item = history_get_list(&history_list_local);
 	size_t i;
 	char buf[120];
 
@@ -134,11 +134,11 @@ void dump_history(ang_file *file)
 
 	for (i = 0; i < max_item; i++) {
 		strnfmt(buf, sizeof(buf), "%10d%7d\'  %s",
-				history_list[i].turn,
-				history_list[i].dlev * 50,
-				history_list[i].event);
+				history_list_local[i].turn,
+				history_list_local[i].dlev * 50,
+				history_list_local[i].event);
 
-		if (hist_has(history_list[i].type, HIST_ARTIFACT_LOST))
+		if (hist_has(history_list_local[i].type, HIST_ARTIFACT_LOST))
 			my_strcat(buf, " (LOST)", sizeof(buf));
 
 		file_putf(file, "%s", buf);

--- a/src/ui-input.c
+++ b/src/ui-input.c
@@ -692,7 +692,7 @@ bool askfor_aux(char *buf, size_t len, bool (*keypress_h)(char *, size_t, size_t
 	size_t k = 0;		/* Cursor position */
 	size_t nul = 0;		/* Position of the null byte in the string */
 
-	struct keypress ch = { 0 };
+	struct keypress ch = KEYPRESS_NULL;
 
 	bool done = false;
 	bool firsttime = true;
@@ -1383,7 +1383,7 @@ ui_event textui_get_command(int *count)
 {
 	int mode = OPT(rogue_like_commands) ? KEYMAP_MODE_ROGUE : KEYMAP_MODE_ORIG;
 
-	struct keypress tmp[2] = { { 0 }, { 0 } };
+	struct keypress tmp[2] = { KEYPRESS_NULL, KEYPRESS_NULL };
 
 	ui_event ke = EVENT_EMPTY;
 

--- a/src/ui-keymap.c
+++ b/src/ui-keymap.c
@@ -175,7 +175,7 @@ void keymap_dump(ang_file *fff)
 
 	for (k = keymaps[mode]; k; k = k->next) {
 		char buf[1024];
-		struct keypress key[2] = { { 0 }, { 0 } };
+		struct keypress key[2] = { KEYPRESS_NULL, KEYPRESS_NULL };
 
 		if (!k->user) continue;
 

--- a/src/ui-knowledge.c
+++ b/src/ui-knowledge.c
@@ -1445,7 +1445,7 @@ static struct object *find_artifact(struct artifact *artifact)
  */
 static void desc_art_fake(int a_idx)
 {
-	struct object *obj, *known_obj;
+	struct object *obj, *known_obj = NULL;
 	struct object object_body = OBJECT_NULL, known_object_body = OBJECT_NULL;
 	bool fake = false;
 

--- a/src/ui-knowledge.c
+++ b/src/ui-knowledge.c
@@ -1372,7 +1372,7 @@ static int *obj_group_order = NULL;
 
 static void get_artifact_display_name(char *o_name, size_t namelen, int a_idx)
 {
-	struct object body = { 0 }, known_body = { 0 };
+	struct object body = OBJECT_NULL, known_body = OBJECT_NULL;
 	struct object *obj = &body, *known_obj = &known_body;
 
 	make_fake_artifact(obj, &a_info[a_idx]);
@@ -1446,7 +1446,7 @@ static struct object *find_artifact(struct artifact *artifact)
 static void desc_art_fake(int a_idx)
 {
 	struct object *obj, *known_obj;
-	struct object object_body = { 0 }, known_object_body = { 0 };
+	struct object object_body = OBJECT_NULL, known_object_body = OBJECT_NULL;
 	bool fake = false;
 
 	char header[120];
@@ -3054,7 +3054,7 @@ void do_cmd_locate(void)
 
 		/* Get a direction */
 		while (!dir) {
-			struct keypress command = { 0 };
+			struct keypress command = KEYPRESS_NULL;
 
 			/* Get a command (or Cancel) */
 			if (!get_com(out_val, (char *)&command.code)) break;

--- a/src/ui-object.c
+++ b/src/ui-object.c
@@ -1453,7 +1453,7 @@ void display_object_recall(struct object *obj)
  */
 void display_object_kind_recall(struct object_kind *kind)
 {
-	struct object object = { 0 }, known_obj = { 0 };
+	struct object object = OBJECT_NULL, known_obj = OBJECT_NULL;
 	object_prep(&object, kind, 0, EXTREMIFY);
 	object.known = &known_obj;
 

--- a/src/ui-object.c
+++ b/src/ui-object.c
@@ -68,12 +68,12 @@ struct object_menu_data {
 	char key;
 };
 
-struct object_menu_data items[MAX_ITEMS];
-int num_obj;
-int num_head;
-size_t max_len;
-int ex_width;
-int ex_offset;
+static struct object_menu_data items[MAX_ITEMS];
+static int num_obj;
+static int num_head;
+static size_t max_len;
+static int ex_width;
+static int ex_offset;
 
 /**
  * ------------------------------------------------------------------------
@@ -570,21 +570,21 @@ void show_floor(struct object **floor_list, int floor_num, int mode,
  * Variables for object selection
  * ------------------------------------------------------------------------ */
 
-item_tester tester_m;
+static item_tester tester_m;
 static region area = { 20, 1, -1, -2 };
 static struct object *selection;
-const char *prompt;
-char header[80];
-int i1, i2;
-int e1, e2;
-int q1, q2;
-int f1, f2;
-struct object **floor_list;
+static const char *prompt;
+static char header[80];
+static int i1, i2;
+static int e1, e2;
+static int q1, q2;
+static int f1, f2;
+static struct object **floor_list;
 static olist_detail_t olist_mode = 0;
-int item_mode;
-cmd_code item_cmd;
-bool newmenu = false;
-bool allow_all = false;
+static int item_mode;
+static cmd_code item_cmd;
+static bool newmenu = false;
+static bool allow_all = false;
 
 /**
  * ------------------------------------------------------------------------

--- a/src/ui-options.c
+++ b/src/ui-options.c
@@ -388,7 +388,7 @@ static struct keypress keymap_buffer[KEYMAP_ACTION_MAX];
 static struct keypress keymap_get_trigger(void)
 {
 	char tmp[80];
-	struct keypress buf[2] = { { 0 }, { 0 } };
+	struct keypress buf[2] = { KEYPRESS_NULL, KEYPRESS_NULL };
 
 	/* Flush */
 	event_signal(EVENT_INPUT_FLUSH);
@@ -1788,14 +1788,14 @@ static menu_action option_actions[] =
 	{ 0, 'w', "Subwindow setup", do_cmd_options_win },
 	{ 0, 'i', "Item ignoring setup", do_cmd_options_item },
 	{ 0, '{', "Auto-inscription setup", textui_browse_object_knowledge },
-	{ 0 },
+	{ 0, 0, NULL, NULL },
 	{ 0, 'd', "Set base delay factor", do_cmd_delay },
 	{ 0, 'h', "Set hitpoint warning", do_cmd_hp_warn },
 	{ 0, 'm', "Set movement delay", do_cmd_lazymove_delay },
-	{ 0 },
+	{ 0, 0, NULL, NULL },
 	{ 0, 's', "Save subwindow setup to pref file", do_dump_options },
 	{ 0, 't', "Save autoinscriptions to pref file", do_dump_autoinsc },
-	{ 0 },
+	{ 0, 0, NULL, NULL },
 	{ 0, 'l', "Load a user pref file", options_load_pref_file },
 	{ 0, 'k', "Edit keymaps (advanced)", do_cmd_keymaps },
 	{ 0, 'c', "Edit colours (advanced)", do_cmd_colors },

--- a/src/ui-prefs.c
+++ b/src/ui-prefs.c
@@ -596,10 +596,10 @@ static enum parser_error parse_prefs_object(struct parser *p)
 			return PARSE_ERROR_UNRECOGNISED_SVAL;
 
 		for (i = 0; i < z_info->k_max; i++) {
-			struct object_kind *kind = &k_info[i];
+			struct object_kind *kind_local = &k_info[i];
 
-			kind_x_attr[kind->kidx] = attr;
-			kind_x_char[kind->kidx] = chr;
+			kind_x_attr[kind_local->kidx] = attr;
+			kind_x_char[kind_local->kidx] = chr;
 		}
 
 		for (flavor = flavors; flavor; flavor = flavor->next) {
@@ -619,13 +619,13 @@ static enum parser_error parse_prefs_object(struct parser *p)
 			struct flavor *flavor;
 
 			for (i = 0; i < z_info->k_max; i++) {
-				struct object_kind *kind = &k_info[i];
+				struct object_kind *kind_local = &k_info[i];
 
-				if (kind->tval != tvi)
+				if (kind_local->tval != tvi)
 					continue;
 
-				kind_x_attr[kind->kidx] = attr;
-				kind_x_char[kind->kidx] = chr;
+				kind_x_attr[kind_local->kidx] = attr;
+				kind_x_char[kind_local->kidx] = chr;
 			}
 
 			for (flavor = flavors; flavor; flavor = flavor->next)

--- a/src/ui-prefs.c
+++ b/src/ui-prefs.c
@@ -1118,7 +1118,7 @@ static void print_error(const char *name, struct parser *p) {
 /**
  * Process the user pref file with a given path.
  *
- * \param name is the name of the pref file.
+ * \param path is the name of the pref file.
  * \param quiet means "don't complain about not finding the file".
  * \param user should be true if the pref file is user-specific and not a game
  * default.

--- a/src/ui-prefs.c
+++ b/src/ui-prefs.c
@@ -50,7 +50,7 @@ byte *trap_x_attr[LIGHTING_MAX];
 wchar_t *trap_x_char[LIGHTING_MAX];
 byte *flavor_x_attr;
 wchar_t *flavor_x_char;
-size_t flavor_max = 0;
+static size_t flavor_max = 0;
 
 /**
  * ------------------------------------------------------------------------

--- a/src/ui-store.c
+++ b/src/ui-store.c
@@ -475,7 +475,7 @@ static bool store_sell(struct store_context *ctx)
 	struct store *store = ctx->store;
 
 	struct object *obj;
-	struct object object_type_body = { 0 };
+	struct object object_type_body = OBJECT_NULL;
 	struct object *temp_obj = &object_type_body;
 
 	char o_name[120];

--- a/src/ui-target.c
+++ b/src/ui-target.c
@@ -341,17 +341,17 @@ static ui_event target_set_interactive_aux(int y, int x, int mode)
 
 		/* Hallucination messes things up */
 		if (player->timed[TMD_IMAGE]) {
-			const char *name = "something strange";
+			const char *name_strange = "something strange";
 
 			/* Display a message */
 			if (player->wizard)
 				strnfmt(out_val, sizeof(out_val),
 						"%s%s%s%s, %s (%d:%d, cost=%d, when=%d).", s1, s2, s3,
-						name, coords, y, x, (int)cave->squares[y][x].cost,
+						name_strange, coords, y, x, (int)cave->squares[y][x].cost,
 						(int)cave->squares[y][x].when);
 			else
 				strnfmt(out_val, sizeof(out_val), "%s%s%s%s, %s.",
-						s1, s2, s3, name, coords);
+						s1, s2, s3, name_strange, coords);
 
 			prt(out_val, 0, 0);
 			move_cursor_relative(y, x);
@@ -648,10 +648,10 @@ static ui_event target_set_interactive_aux(int y, int x, int mode)
 			/* Only one object to display */
 			else {
 				/* Get the single object in the list */
-				struct object *obj = floor_list[0];
+				struct object *obj_local = floor_list[0];
 
 				/* Allow user to recall an object */
-				press = target_recall_loop_object(obj, y, x, out_val, s1, s2,
+				press = target_recall_loop_object(obj_local, y, x, out_val, s1, s2,
 												  s3, coords);
 
 				/* Stop on everything but "return"/"space" */
@@ -662,7 +662,7 @@ static ui_event target_set_interactive_aux(int y, int x, int mode)
 				if ((press.key.code == ' ') && !(mode & (TARGET_LOOK))) break;
 
 				/* Plurals */
-				s1 = VERB_AGREEMENT(obj->number, "It is ", "They are ");
+				s1 = VERB_AGREEMENT(obj_local->number, "It is ", "They are ");
 
 				/* Preposition */
 				s2 = "on ";
@@ -1027,13 +1027,13 @@ bool target_set_interactive(int mode, int x, int y)
 					x = KEY_GRID_X(press);
 					if (press.mouse.mods & KC_MOD_CONTROL) {
 						/* same as keyboard target selection command below */
-						struct monster *m = square_monster(cave, y, x);
+						struct monster *m_local = square_monster(cave, y, x);
 
-						if (target_able(m)) {
+						if (target_able(m_local)) {
 							/* Set up target information */
-							monster_race_track(player->upkeep, m->race);
-							health_track(player->upkeep, m);
-							target_set_monster(m);
+							monster_race_track(player->upkeep, m_local->race);
+							health_track(player->upkeep, m_local);
+							target_set_monster(m_local);
 							done = true;
 						} else {
 							bell("Illegal target!");
@@ -1125,11 +1125,11 @@ bool target_set_interactive(int mode, int x, int y)
 					case '0':
 					case '.':
 					{
-						struct monster *m = square_monster(cave, y, x);
+						struct monster *m_local = square_monster(cave, y, x);
 
-						if (target_able(m)) {
-							health_track(player->upkeep, m);
-							target_set_monster(m);
+						if (target_able(m_local)) {
+							health_track(player->upkeep, m_local);
+							target_set_monster(m_local);
 							done = true;
 						} else {
 							bell("Illegal target!");

--- a/src/wiz-debug.c
+++ b/src/wiz-debug.c
@@ -823,8 +823,8 @@ static void wiz_create_item(bool art)
 		if (art) {
 			int j;
 			for (j = 1; j < z_info->a_max; j++) {
-				struct artifact *art = &a_info[j];
-				if (art->tval == i) break;
+				struct artifact *art_local = &a_info[j];
+				if (art_local->tval == i) break;
 			}
 			if (j == z_info->a_max) continue;
 		}

--- a/src/wiz-debug.c
+++ b/src/wiz-debug.c
@@ -204,7 +204,7 @@ static void do_cmd_keylog(void) {
 	int i;
 	char buf[50];
 	char buf2[12];
-	struct keypress keys[2] = {{EVT_NONE, 0}, {EVT_NONE, 0}};
+	struct keypress keys[2] = {KEYPRESS_NULL, KEYPRESS_NULL};
 
 	screen_save();
 

--- a/src/wiz-debug.c
+++ b/src/wiz-debug.c
@@ -452,7 +452,7 @@ static void wiz_display_item(const struct object *obj, bool all)
 
 
 /** Object creation code **/
-bool choose_artifact = false;
+static bool choose_artifact = false;
 
 static const region wiz_create_item_area = { 0, 0, 0, 0 };
 


### PR DESCRIPTION
Fixes a bunch of warnings that I found using `-Weverything`, minus some other warnings. Commits are generally done by warning type, so they can be cherry picked if needed. The goal was to do the minimum to clear the warnings, so there may be a better way, for example: variables that shadow others just had their name changed slightly as opposed to trying to figure out a better name.