### PR TITLE
fixed spelling errors in help

### DIFF
--- a/lib/help/attack.txt
+++ b/lib/help/attack.txt
@@ -17,7 +17,7 @@ normally stopped by walls, nor can they be shot at with bows and arrows.
 Tunnelling into the wall (using the "tunnel" or "alter" command) will allow
 you to attack any creature in the wall with your main weapon. This applies
 to creatures which "pass through" walls: if they "bore through" walls, the
-wall is no longer there, and the creature can be targetted normally.
+wall is no longer there, and the creature can be targeted normally.
 
 If you are wielding a weapon, the damage for the weapon is used when you
 hit a creature. Otherwise you get a single punch which does minimal damage.
@@ -314,8 +314,8 @@ category, whether cast by the monster or the player.
 
 In addition items on the ground are especially vulnerable to elemental 
 effects.  Potions on the ground will always be destroyed by cold, shards,
-sound and force.  Scrolls, staves, books, and non-metal gear will always get
-destroyed by fire or plasma.  Scrolls, staves, and all non-mithril gear
+sound and force.  Scrolls, staves, books, and non-metal gear will always
+get destroyed by fire or plasma.  Scrolls, staves, and all non-mithril gear
 will be destroyed by acid.  Rings, amulets, wands and rods will be
 destroyed by lightning and plasma.  And finally nearly everything will be
 destroyed by a mana storm if left on the ground. 
@@ -340,7 +340,7 @@ It should be noted that not all of these are actually vital to completing
 the game: indeed, of the above list, only fire, cold, acid, lightning,
 poison and confusion resists are regarded as truly vital, with blindness,
 chaos and nether the next most desirable. Some attack forms are not
-resistable, but thankfully these are rare: resist shards will prevent all
+resistible, but thankfully these are rare: resist shards will prevent all
 other magical attacks which cut (namely ice bolts), and confusion resistance 
 will prevent confusion by a water bolt or ball, but there is no resistance 
 to the physical damage caused by these following attacks: inertia, force, 

--- a/lib/help/command.txt
+++ b/lib/help/command.txt
@@ -42,8 +42,8 @@ Inventory list ('i')
 Equipment list ('e')
   Use this command to display a list of the objects currently being used by
   your character. The standard body (which all races currently have) has
-  12 slots for equipment. Each equipment slot corresponds to a different
-  location on the body, and each of which may contain only a single object at
+  12 slots for equipment. Every equipment slot corresponds to a different
+  location on the body, and each of which may contain only one object at
   a time, and each of which may only contain objects of the proper "type".
   For the standard body these are WEAPON (weapon), BOW (missile launcher),
   RING (ring) (two of these), AMULET (amulet), LIGHT (light source),
@@ -53,8 +53,8 @@ Equipment list ('e')
 
 Quiver list ('\|')
   Missiles that you carry will automatically be put in your quiver.  The
-  quiver has 10 slots; it also takes up inventory space, so every 40 missiles
-  will reduce your number of inventory slots by 1.
+  quiver has 10 slots; it also takes up inventory space, so every 40 
+  missiles will reduce your number of inventory slots by 1.
 
 Drop an item ('d')
   This drops an item from your inventory or equipment onto the dungeon
@@ -94,10 +94,10 @@ Movement Commands
 =================
 
 Moving (arrow keys, number keys) or (arrow keys, number keys, 'yuhjklbn')
-  This causes you to move one step in a given direction. If the quare you
+  This causes you to move one step in a given direction. If the square you
   wish to move into is occupied by a monster, you will attack it. If the
   square is occupied by a door or a trap you may attempt to open or disarm
-  it if the appropriate option is set. Preceeding this command with CTRL
+  it if the appropriate option is set. Preceding this command with CTRL
   will cause you to attack in the appropriate direction, but will not move
   your character if no monster is there. These commands take some energy.
 
@@ -404,20 +404,20 @@ Targeting Mode ('*')
   if this is not a "compass" direction) when you are asked for a direction.
   You can set a target using this command, or you can set a new target at
   the "Direction?" prompt when appropriate. At the targeting prompt, you
-  have many options. First of all, targetting mode starts targetting nearby
+  have many options. First of all, targeting mode starts targeting nearby
   monsters which can be reached by "projectable" spells and thrown objects.
   In this mode, you can press 't' (or '5' or '.') to select the
   current monster, pace to advance to the next monster, '-' to back up to
   the previous monster, direction keys to advance to a monster more or less
   in that direction, 'r' to "recall" the current monster, 'q' to exit
-  targetting mode, and 'p' (or 'o') to stop targetting monsters and
-  enter the mode for targetting a location on the floor or in a wall. Note
+  targeting mode, and 'p' (or 'o') to stop targeting monsters and
+  enter the mode for targeting a location on the floor or in a wall. Note
   that if there are no nearby monsters, you will automatically enter this
   mode. Note that hitting 'o' is just like 'p', except that the
   location cursor starts on the last examined monster instead of on the
   player. In this mode, you use the "direction" keys to move around, and
   the 'q' key to quit, and the 't' (or '5' or '.') key to target
-  the cursor location. Note that targetting a location is slightly
+  the cursor location. Note that targeting a location is slightly
   "dangerous", as the target is maintained even if you are far away. To
   cancel an old target, simply hit '*' and then 'ESCAPE' (or 'q').
   Note that when you cast a spell or throw an object at the target

--- a/lib/help/copying.txt
+++ b/lib/help/copying.txt
@@ -6,7 +6,7 @@ exceptions:
  * The SDL runtime libraries (if provided with your copy of the game) are under
    the following licence:
 
-     The Simple DirectMedia Layer (SDL for short) is a cross-platfrom library
+     The Simple DirectMedia Layer (SDL for short) is a cross-platform library
      designed to make it easy to write multi-media software, such as games and
      emulators.
 

--- a/lib/help/customize.txt
+++ b/lib/help/customize.txt
@@ -12,18 +12,18 @@ Ignore settings
 ================
       
 Angband allows you to ignore specific items that you don't want to see
-anymore. These items are marked 'ignored' and any similar items are hidden from
-view. There are several ways to ignore an item. The easiest way is to choose
-the 's' option when destroying an object. Whenever you destroy an object you
-are forced to confirm the destruction. One of the options is 's'. If you use
-this option, the object is dropped and then hidden from view.
+anymore. These items are marked 'ignored' and any similar items are hidden
+from view. There are several ways to ignore an item. The easiest way is to
+choose the 's' option when destroying an object. Whenever you destroy an
+object you are forced to confirm the destruction. One of the options is 's'.
+If you use this option, the object is dropped and then hidden from view.
 
 Weapons and armor have quality ignore options. These allow you to specify
-what types of weapons and armor you are no longer interested in seeing. There
-is a quality setting for each weapon and armor type. Ignoring weapons and
-armor by destroying the object will prompt you with a question about whether
-you wish to ignore all of that type of armor with a certain quality setting.
-These quality settings are described below:
+what types of weapons and armor you are no longer interested in seeing. 
+There is a quality setting for each weapon and armor type. Ignoring weapons
+and armor by destroying the object will prompt you with a question about
+whether you wish to ignore all of that type of armor with a certain quality
+setting. These quality settings are described below:
 
 bad
   The weapon/armor has negative AC, to-hit or to-dam.
@@ -64,7 +64,8 @@ Inscribing an item with '=g':
 Inscribing an item with '!' followed by a command letter or '*':
 	This means "ask me before using this item".  '!w' means 'ask me before
 	wielding', '!d' means 'ask me before dropping', and so on.  If you
-	inscribe an item with '!*' then the game will confirm any use of an item.
+	inscribe an item with '!*' then the game will confirm any use of an
+	item.
 
 	Say you inscribed your potion of Speed with '!q'.  This would prompt
 	you when you try to drink it to see if you really mean to.  Multiple
@@ -91,24 +92,24 @@ Inscribing an item with '@', followed by a command latter, followed by 0-9:
 	that wand.
 
 	Spellcasters should inscribe their books, so that if they lose them they
-	do not cast the wrong spell.  If you are mage and the beginner's spellbook
-	is the first in your inventory, casting 'maa' will cast magic missile. But
-	if you lose your spellbook, casting 'maa' will cast the first spell in
-	whatever new book is in the top of your inventory. This can be a waste in
-	the best case scenario and exceedingly dangerous in the worst! By
-	inscribing your spellbooks with '@m1', '@m2', etc., if you lose your first
-	spellbook and attempt to cast magic missile by using 'm1a', you cannot
-	accidentally select the wrong spellbook.
+	do not cast the wrong spell.  If you are mage and the beginner's
+	spellbook is the first in your inventory, casting 'maa' will cast magic
+	missile. But if you lose your spellbook, casting 'maa' will cast the
+	first spell in whatever new book is in the top of your inventory. This
+	can be a waste in the best case scenario and exceedingly dangerous in
+	the worst! By inscribing your spellbooks with '@m1', '@m2', etc., if
+	you lose your first spellbook and attempt to cast magic missile by
+	using 'm1a', you cannot accidentally select the wrong spellbook.
 
 Inscribing an item with '^', followed by a command letter:
 	When you wear an item inscribed with '^', the game prompts you before 
-	doing that action.  You might inscribe '^>' on an item if you want to be
-	reminded to take it off before going down stairs.  If the item is in your
-	backpack then the game won't prompt you.
+	doing that action.  You might inscribe '^>' on an item if you want to
+	be reminded to take it off before going down stairs.  If the item is in
+	your backpack then the game won't prompt you.
 
-	Like with '!', you can use '*' for the command letter if you want to game
-	to prompt you every turn whatever you're doing.  This can get very
-	annoying!
+	Like with '!', you can use '*' for the command letter if you want to
+	game to prompt you every turn whatever you're doing.  This can get
+	very annoying!
 
 
 User Pref Files
@@ -198,7 +199,7 @@ For example::
 Special keys include [Escape].
 
 The game will run keymaps in whatever keyset you use (original or roguelike).
-So if you write keymaps for roguelike keys and swith to original keys, they 
+So if you write keymaps for roguelike keys and switch to original keys, they 
 may not work as you expect!  Keymap actions aren't recursive either, so if you
 had a keymap whose trigger was F1, including F1 inside the action wouldn't run
 the keymap action again.
@@ -231,7 +232,7 @@ You can use the "Interact with visuals" menu to change various visual
 information, currently including the choice of what attr/char values are used
 to represent various monsters, objects, or terrain features. Note that in
 combination appropriate support in 'main-xxx.c', and with the use of the
-"use_graphics" flag, you may be able to specify that "graphic bitmaps" hould
+"use_graphics" flag, you may be able to specify that "graphic bitmaps" should
 be used instead of normal "colored characters" for various things.
 
 When interactively modifying the attr/char values for monsters, objects, or

--- a/lib/help/debug.txt
+++ b/lib/help/debug.txt
@@ -76,7 +76,7 @@ Teleport ('t')
   Teleports you up to 100 spaces away.
 		
 Teleport to target ('b')
-  Teleports you to the targeted grid (or close to it, if the space is occupied).
+  Teleports you to the targeted grid (or close to it, if it is occupied).
 		
 Character Improvement
 =====================
@@ -127,17 +127,18 @@ Quit without saving ('X')
   Quits the game without saving (prompts first).
 		
 Query the dungeon ('q')
-  Light up all the grids with a given square flag (see src/list-square-flags.h).
+  Light up all the grids with a given square flag
+  (see src/list-square-flags.h).
 
 Query terrain ('F')
   Light up all the grids with a given terrain type
   (see lib/gamedata/terrain.txt).
 		
 Collect stats ('f' or 'S')
-  Collects stats on monsters and objects present on level generation.  Requests
-  number of runs, and whether diving or clearing levels, and outputs the
-  results into the file 'stats.log' in the user directory.
+  Collects stats on monsters and objects present on level generation.
+  Requests number of runs, and whether diving or clearing levels, and
+  outputs the results into the file 'stats.log' in the user directory.
 		
 Ben hack ('_')
-  Maps out the reachable grids (by the flow algorithm) in successive distances
-  from the player grid.
+  Maps out the reachable grids (by the flow algorithm) in successive
+  distances from the player grid.

--- a/lib/help/dungeon.txt
+++ b/lib/help/dungeon.txt
@@ -137,11 +137,11 @@ Town Buildings
 Your character will begin his adventure with some basic supplies, and some
 extra gold with which to purchase more supplies at the town stores.
 
-You may enter any open store to buy items of the appropriate type.  The price
-that the shopkeeper requests is dependent on the price of the item.  By
-default stores will not buy items from the player.  If you choose to play with
-selling enabled, stores have a maximum value; they will not pay more than that
-for any item, regardless of how much it is actually worth.
+You may enter any open store to buy items of the appropriate type.
+The price the shopkeeper requests is dependent on the price of the item.
+By default stores will not buy items from the player.  If you choose to play
+with selling enabled, stores have a maximum value; they will not pay more
+than that for any item, regardless of how much it is actually worth.
 
 Once inside a store, you will see the name and race of the store owner, the
 name of the store, the maximum amount of cash that the store owner will pay
@@ -469,7 +469,7 @@ This feeling also depends on your current dungeon depth. A dungeon you
 feel nervous about at 2000' is way more dangerous than a murderous one
 at 50'.
 
-Once you have explored a certain ammount of the dungeon you will also
+Once you have explored a certain amount of the dungeon you will also
 get a feeling about how good are the objects lying on the floor of the
 dungeon.
 

--- a/lib/help/general.txt
+++ b/lib/help/general.txt
@@ -80,7 +80,7 @@ confirmation.
 Note that spoiler files are not distributed with the source since they may
 spoil the game for new players (hence their name). If you want to use them,
 you can obtain them from various places as with the source and executables.
-Spoiler files may be placed into the "lib/user/info" directory, or into a user
+Spoiler files may be placed into the "lib/user/info" directory, or a user
 specified external directory, to allow access via the "online help" system.
 
 Remember to tell all your friends about how much you like Angband...
@@ -128,7 +128,7 @@ given symbol represents. Press "/" then '@' now to verify the meaning of
 the '@' symbol.
 
 The solid blocks (which may be '#' symbols on some systems) around the
-edge of the town represent the walls that surround the the town. You cannot
+edge of the town represent the walls that surround the town. You cannot
 leave the town above ground, although some games derived from Angband
 (called "variants") have an overground element.
 
@@ -172,7 +172,7 @@ your character. So far, you have used the 'w' and 't' commands, which
 take energy, and the 'e', 'i', 'l', and '/' commands, which are
 "free" commands, and so do not take any energy. In general, the only
 commands which take energy are the ones which require your character to
-perform ome action in the world of the game, such as moving around,
+perform some action in the world of the game, such as moving around,
 attacking monsters, and interacting with objects.
 
 If there were any monsters near your character while you were experimenting
@@ -240,7 +240,7 @@ flasks of oil and press the 'p' key to purchase some. If you are asked
 how many you want, just hit enter. Any time you are asked a question and 
 there is already something under the cursor, pressing return will accept 
 that choice. Hit enter to accept the price. Many commands work inside the 
-store, for example, use the 'i' command to ee your inventory, with the 
+store, for example, use the 'i' command to see your inventory, with the 
 new flask of oil. Note that your inventory is always kept sorted in a 
 semi-logical order, so the indexes of some of the objects may change as 
 your inventory changes.

--- a/lib/help/guide.txt
+++ b/lib/help/guide.txt
@@ -43,7 +43,7 @@ So, let me recap, the vital points of Angband are:
 From this point, the guide assumes that you are playing a fighting class
 (warrior, ranger, rogue or paladin) and race (Dunedain, High-Elf, Dwarf,
 Half-Orc, Half-Troll.) First, use the 'cost-based' stats selection, and create
-a charcter with 3 or 4 blows (Don't pick a class/race combinations, like Dwarf
+a character with 3 or 4 blows (Don't pick a class/race combinations, like Dwarf
 Ranger, that can only get 2 blows.)
 
 First, set your stats to get maximum blows. If you have a combination with good
@@ -210,7 +210,7 @@ What to avoid
 On Bad Luck
 -----------
 
-This is rule number one of angband: don't take unnecessary risks. If you take
+This is rule number one of Angband: don't take unnecessary risks. If you take
 enough low-probability chances of death, you'll never survive to fight Sauron.
 Such deaths are generally called 'stupid', but that's not always accurate.
 Sometimes it's just bad luck. But given enough chances, you are guaranteed to
@@ -229,7 +229,7 @@ following is intended to state what many perceive to be blatantly obvious,
 hence "you did WHAT!" face-palm deaths. This really should be cleaned up and
 refactored, but placing here for now.
 
-WARNING. I have yet to defeat angband. This is a compilation of some of the
+WARNING. I have yet to defeat Angband. This is a compilation of some of the
 better tips I've learned while trying to explore the depths... (to Level ~35).
 Additional advice would be greatly appreciated!
 

--- a/lib/help/help.hlp
+++ b/lib/help/help.hlp
@@ -18,7 +18,7 @@ Browser/help commands:
   #     go to line         %  go to file         ?  go to last file/main menu
   SPACE advance 1 page     -  back up 1 page     /  search for text
   RET   advance 1 line     =  back up 1 line     &  show (highlight) some text
-  +     advance 1/2 page   _  back up 1/2 page   !  toggle case sentitivity
+  +     advance 1/2 page   _  back up 1/2 page   !  toggle case sensitivity
   
 .. menu:: [a] general.txt
 

--- a/lib/help/modifying.txt
+++ b/lib/help/modifying.txt
@@ -106,7 +106,7 @@ p_race.txt
   handled as for classes.
 
 body.txt
-  Every player race has a body, which defines what equipment thay can use.
+  Every player race has a body, which defines what equipment they can use.
   Currently there is only one body, which all races use, but this is easily
   changeable for significant effect.
 

--- a/lib/help/option.txt
+++ b/lib/help/option.txt
@@ -89,7 +89,7 @@ Show damage player deals to monsters '[show_damage]'
   
 .. _show_target:
 
-Hightlight target with cursor '[show_target]'
+Highlight target with cursor '[show_target]'
   Highlights the current targeted monster with a cursor.  Useful when 
   combined with "use old target by default"
 
@@ -153,7 +153,7 @@ Randomize the artifacts (except a very few) '[birth_randarts]'
   ones. This is intended primarily for people who have played enough to
   know what most of the standard artifacts do and want some variety. The
   number, findability and power of random artifacts will all match the
-  tandard set - approximately.
+  standard set - approximately.
 
 .. _birth_keep_randarts:
 
@@ -219,8 +219,8 @@ Lose artifacts when leaving level '[birth_lose_arts]'
 
 Generate connected stairs '[birth_connect_stairs]'
   With this option turned on, if you go down stairs, you start the new level
-  on an up staircase, and vice versa (if you go up stairs, you start the next
-  level on a down staircase).
+  on an up staircase, and vice versa (if you go up stairs, you start the
+  next level on a down staircase).
 
   With this option off, you will never start on a staircase - but other
   staircases up and down elsewhere on the level will still be generated.
@@ -306,7 +306,7 @@ Display player (compact)
   stats.
 
 Display map view
-  Display the area around the player or around the target while targetting.
+  Display the area around the player or around the target while targeting.
   This allows using graphical tiles in their original size.
 
 Display messages
@@ -317,7 +317,7 @@ Display overhead view
 
 Display monster recall
   Display a description of the most monster which has been most recently
-  attacked, targetted, or examined in some way.
+  attacked, targeted, or examined in some way.
 
 Display object recall
   Display a description of the most recently selected object. Currently

--- a/lib/help/playing.txt
+++ b/lib/help/playing.txt
@@ -131,7 +131,7 @@ Original Keyset Command Summary
   _    Enter store                     ^P    Show previous messages
   |+|    Alter grid                      ^Q    (unused)
   =    Set options                     ^R    Redraw the screen
-  ;    Walk (with pickup)              ^S    Save and dont quit
+  ;    Walk (with pickup)              ^S    Save and don't quit
   :    Take notes                      ^T    (unused)
   '    Target closest monster          ^U    (unused)
   "    Enter a user pref command       ^V    (unused)
@@ -197,7 +197,7 @@ Roguelike Keyset Command Summary
   _    Enter store                     ^P   Show previous messages
   |+|    Alter grid                      ^Q   (unused)
   =    Set options                     ^R   Redraw the screen
-  ;    Walk (with pickup)              ^S   Save and dont quit
+  ;    Walk (with pickup)              ^S   Save and don't quit
   :    Take notes                      ^T   Dig a tunnel
   '    Target closest monster          ^U   (alter - north east)
   "    Enter a user pref command       ^V   Repeat previous command
@@ -222,7 +222,7 @@ control keys, and often, you can disable their special effects.
 If you are playing on a UNIX or similar system, then 'Ctrl-C' will
 interrupt Angband. The second and third interrupt will induce a warning
 bell, and the fourth will induce both a warning bell and a special message,
-ince the fifth will quit the game, after killing your character. Also,
+since the fifth will quit the game, after killing your character. Also,
 'Ctrl-Z' will suspend the game, and return you to the original command
 shell, until you resume the game with the 'fg' command. There is now a
 compilation option to force the game to prevent the "double 'ctrl-z'
@@ -238,7 +238,7 @@ Pressing backslash ('\\') before a command will bypass all keymaps, and
 the next keypress will be interpreted as an "underlying command" key,
 unless it is a caret ('^'), in which case the keypress after that will be
 turned into a control-key and interpreted as a command in the underlying
-angband keyset. The backslash key is useful for creating actions which are
+Angband keyset. The backslash key is useful for creating actions which are
 not affected by any keymap definitions that may be in force, for example,
 the sequence '\\' + '.' + '6' will always mean "run east", even if the
 '.' key has been mapped to a different underlying command.

--- a/lib/help/version.txt
+++ b/lib/help/version.txt
@@ -2,7 +2,7 @@
 Version Information
 ===================
 
-The current version is 3.4.  Detailed information about this version and
+The current version is 4.0.5. Detailed information about this version and
 previous versions can be found at http://rephial.org.  Also additional
 information can be found at the angband forums (http://angband.oook.cz)
 or the newsgroup (rec.games.roguelike.angband).  
@@ -58,7 +58,7 @@ Angband 2.6.1 (and Angband 2.6.2) in late 1994. Some of the changes during
 this period were based on suggestions from the "net", and from various
 related games, including "UMoria 5.5", "PC Angband 1.4", and "FAngband".
 
-Angband 2.6.1 was primarily targetted towards Unix/NeXT machines, and it
+Angband 2.6.1 was primarily targeted towards Unix/NeXT machines, and it
 required the use of the low level "curses" commands for all screen
 manipulation and keypress interaction. Each release had to be ported from
 scratch to any new platforms, normally by creating visual display code that
@@ -97,7 +97,7 @@ of minor tweaks and some new features.
 
 After Angband 2.7.8 was released, Ben created a web site to keep track of
 all the changes made in each version (though a few may have been missed),
-and acquired the use of a new developement ftp server to supplement the
+and acquired the use of a new development ftp server to supplement the
 official "mirror" server. This web site is now permanently located at the
 Official Angband Home Page (http://www.thangorodrim.net/). Unfortunately,
 the next six versions were numbered Angband 2.7.9v1 to Angband 2.7.9v6, but
@@ -225,7 +225,7 @@ an option to improve monster AI (believed to have originally started out
 life in a patch written by Keldon Jones), and a patch to allow easier
 handling of opening and closing doors and disarming traps (by Tim Baker).
 For Angband 2.9.1 has also come such things as the ability to increase the
-size of the editable textfiles and thus the number of monsters, artifacts,
+size of the editable text files and thus the number of monsters, artifacts,
 items, ego-items and vaults in the game (many new vaults were written by
 Chris Weisiger, some by others, and the number of vaults in the game at
 this time was doubled), and much greater customizability of ego-items has


### PR DESCRIPTION
Just went through help and spell checked a bunch of stuff. I also reformatted a couple of places where the text was over 80 characters, with a few changes to word choice just to make that easier. 

I didn't change spelling mistakes in Robert Alan Koeneke's email excerpt in Version Information, for historical reasons, and also because I thought it was super cute :3 

Thanks!