### PR TITLE
Remove unused flag_comp_union()

### DIFF
--- a/src/cave.h
+++ b/src/cave.h
@@ -59,7 +59,6 @@ enum
 #define sqinfo_negate(f)           flag_negate(f, SQUARE_SIZE)
 #define sqinfo_copy(f1, f2)        flag_copy(f1, f2, SQUARE_SIZE)
 #define sqinfo_union(f1, f2)       flag_union(f1, f2, SQUARE_SIZE)
-#define sqinfo_comp_union(f1, f2)  flag_comp_union(f1, f2, SQUARE_SIZE)
 #define sqinfo_inter(f1, f2)       flag_inter(f1, f2, SQUARE_SIZE)
 #define sqinfo_diff(f1, f2)        flag_diff(f1, f2, SQUARE_SIZE)
 

--- a/src/mon-spell.h
+++ b/src/mon-spell.h
@@ -56,7 +56,6 @@ enum mon_spell_type {
 #define rsf_negate(f)          flag_negate(f, RSF_SIZE)
 #define rsf_copy(f1, f2)       flag_copy(f1, f2, RSF_SIZE)
 #define rsf_union(f1, f2)      flag_union(f1, f2, RSF_SIZE)
-#define rsf_comp_union(f1, f2) flag_comp_union(f1, f2, RSF_SIZE)
 #define rsf_inter(f1, f2)      flag_inter(f1, f2, RSF_SIZE)
 #define rsf_diff(f1, f2)       flag_diff(f1, f2, RSF_SIZE)
 

--- a/src/monster.h
+++ b/src/monster.h
@@ -57,7 +57,6 @@ enum
 #define mflag_negate(f)           flag_negate(f, MFLAG_SIZE)
 #define mflag_copy(f1, f2)        flag_copy(f1, f2, MFLAG_SIZE)
 #define mflag_union(f1, f2)       flag_union(f1, f2, MFLAG_SIZE)
-#define mflag_comp_union(f1, f2)  flag_comp_union(f1, f2, MFLAG_SIZE)
 #define mflag_inter(f1, f2)       flag_inter(f1, f2, MFLAG_SIZE)
 #define mflag_diff(f1, f2)        flag_diff(f1, f2, MFLAG_SIZE)
 

--- a/src/obj-properties.h
+++ b/src/obj-properties.h
@@ -107,7 +107,6 @@ enum object_flag_id {
 #define of_negate(f)           	flag_negate(f, OF_SIZE)
 #define of_copy(f1, f2)        	flag_copy(f1, f2, OF_SIZE)
 #define of_union(f1, f2)       	flag_union(f1, f2, OF_SIZE)
-#define of_comp_union(f1, f2)  	flag_comp_union(f1, f2, OF_SIZE)
 #define of_inter(f1, f2)       	flag_inter(f1, f2, OF_SIZE)
 #define of_diff(f1, f2)        	flag_diff(f1, f2, OF_SIZE)
 
@@ -127,7 +126,6 @@ enum object_flag_id {
 #define kf_negate(f)           	flag_negate(f, KF_SIZE)
 #define kf_copy(f1, f2)        	flag_copy(f1, f2, KF_SIZE)
 #define kf_union(f1, f2)       	flag_union(f1, f2, KF_SIZE)
-#define kf_comp_union(f1, f2)  	flag_comp_union(f1, f2, KF_SIZE)
 #define kf_inter(f1, f2)       	flag_inter(f1, f2, KF_SIZE)
 #define kf_diff(f1, f2)        	flag_diff(f1, f2, KF_SIZE)
 

--- a/src/player.h
+++ b/src/player.h
@@ -67,7 +67,6 @@ enum
 #define pf_negate(f)           flag_negate(f, PF_SIZE)
 #define pf_copy(f1, f2)        flag_copy(f1, f2, PF_SIZE)
 #define pf_union(f1, f2)       flag_union(f1, f2, PF_SIZE)
-#define pf_comp_union(f1, f2)  flag_comp_union(f1, f2, PF_SIZE)
 #define pf_inter(f1, f2)       flag_inter(f1, f2, PF_SIZE)
 #define pf_diff(f1, f2)        flag_diff(f1, f2, PF_SIZE)
 

--- a/src/trap.h
+++ b/src/trap.h
@@ -32,7 +32,6 @@ enum
 #define trf_negate(f)           flag_negate(f, TRF_SIZE)
 #define trf_copy(f1, f2)        flag_copy(f1, f2, TRF_SIZE)
 #define trf_union(f1, f2)       flag_union(f1, f2, TRF_SIZE)
-#define trf_comp_union(f1, f2)  flag_comp_union(f1, f2, TRF_SIZE)
 #define trf_inter(f1, f2)       flag_inter(f1, f2, TRF_SIZE)
 #define trf_diff(f1, f2)        flag_diff(f1, f2, TRF_SIZE)
 

--- a/src/z-bitflag.c
+++ b/src/z-bitflag.c
@@ -303,29 +303,6 @@ bool flag_union(bitflag *flags1, const bitflag *flags2, const size_t size)
 
 
 /**
- * Computes the union of one bitfield and the complement of another.
- *
- * For every unset flag in `flags2`, the corresponding flag is set in `flags1`.
- * The size of the bitfields is supplied in `size`. true is returned when
- * changes were made, and false otherwise.
- */
-bool flag_comp_union(bitflag *flags1, const bitflag *flags2, const size_t size)
-{
-	size_t i;
-	bool delta = false;
-
-	for (i = 0; i < size; i++) {
-		/* no equivalent fn */
-		if (!(~flags1[i] & ~flags2[i])) delta = true;
-
-		flags1[i] |= ~flags2[i];
-	}
-
-	return delta;
-}
-
-
-/**
  * Computes the intersection of two bitfields.
  *
  * For every unset flag in `flags2`, the corresponding flag is cleared in

--- a/src/z-bitflag.h
+++ b/src/z-bitflag.h
@@ -80,7 +80,6 @@ void flag_setall    (bitflag *flags, const size_t size);
 void flag_negate    (bitflag *flags, const size_t size);
 void flag_copy      (bitflag *flags1, const bitflag *flags2, const size_t size);
 bool flag_union     (bitflag *flags1, const bitflag *flags2, const size_t size);
-bool flag_comp_union(bitflag *flags1, const bitflag *flags2, const size_t size);
 bool flag_inter     (bitflag *flags1, const bitflag *flags2, const size_t size);
 bool flag_diff      (bitflag *flags1, const bitflag *flags2, const size_t size);
 


### PR DESCRIPTION
--

The code was causing a compiler warning:

```
z-bitflag.c: In function ‘flag_comp_union’:
z-bitflag.c:319:7: warning: promoted ~unsigned is always non-zero [-Wsign-compare]
   if (!(~flags1[i] & ~flags2[i])) delta = true;
       ^
```

... but looking into it I discovered that the function wasn't actually used anywhere, so it might as well be removed.