### PR TITLE
Indentation fixes

### DIFF
--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -1266,8 +1266,8 @@ void do_cmd_rest(struct command *cmd)
 	 * A little sanity checking on the input - only the specified negative 
 	 * values are valid. 
 	 */
-    if (n < 0 && !player_resting_is_special(n))
-        return;
+	if (n < 0 && !player_resting_is_special(n))
+		return;
 
 	/* Do some upkeep on the first turn of rest */
 	if (!player_is_resting(player)) {

--- a/src/mon-init.c
+++ b/src/mon-init.c
@@ -585,7 +585,8 @@ static enum parser_error parse_monster_color(struct parser *p) {
 
 	if (!r)
 		return PARSE_ERROR_MISSING_RECORD_HEADER;
-		color = parser_getsym(p, "color");
+
+	color = parser_getsym(p, "color");
 	if (strlen(color) > 1)
 		attr = color_text_to_attr(color);
 	else


### PR DESCRIPTION
--

This was causing compilation warnings on gcc 6.1.1 (at least I *think* the compilation was using gcc... might have been clang 3.8.0).