### PR TITLE
Fix Term_big_queue_char()

### DIFF
--- a/src/ui-term.c
+++ b/src/ui-term.c
@@ -554,7 +554,7 @@ void Term_big_queue_char(term *t, int x, int y, int a, wchar_t c, int a1,
 	/* No tall skinny tiles */
 	if (tile_width > 1) {
 	        /* Horizontal first */
-	        for (hor = 0; hor <= tile_width; hor++) {
+	        for (hor = 0; hor < tile_width; hor++) {
 		        /* Queue dummy character */
 		        if (hor != 0) {
 			        if (a & 0x80)
@@ -564,7 +564,7 @@ void Term_big_queue_char(term *t, int x, int y, int a, wchar_t c, int a1,
 				}
 
 				/* Now vertical */
-				for (vert = 1; vert <= tile_height; vert++){
+				for (vert = 1; vert < tile_height; vert++){
 			
 					/* Leave space on bottom for status */
 					if (y + vert + 1 < t-> hgt) {
@@ -578,7 +578,7 @@ void Term_big_queue_char(term *t, int x, int y, int a, wchar_t c, int a1,
 			}
 	} else {
 		/* Only vertical */
-		for (vert = 1; vert <= tile_height; vert++) {	
+		for (vert = 1; vert < tile_height; vert++) {	
 			
 			/* Leave space on bottom for status */
 			if (y + vert + 1 < t->hgt) {


### PR DESCRIPTION
Using <= was causing it to queue too many chars; for example,
with tile_width 2 and tile_height 2 it was queueing 3x3 region.
Noticeable with "center player" option turned on, when running to the left or up.