### PR TITLE
Fix target cursor bug

### DIFF
--- a/src/ui-game.c
+++ b/src/ui-game.c
@@ -30,6 +30,7 @@
 #include "player-path.h"
 #include "player-util.h"
 #include "savefile.h"
+#include "target.h"
 #include "ui-birth.h"
 #include "ui-command.h"
 #include "ui-context.h"
@@ -366,7 +367,13 @@ void pre_turn_refresh(void)
 		player->upkeep->redraw |= (PR_MONLIST | PR_ITEMLIST);
 		handle_stuff(player);
 
-		move_cursor_relative(player->px, player->py);
+		if (OPT(show_target) && target_sighted()) {
+			int col, row;
+			target_get(&col, &row);
+			move_cursor_relative(row, col);
+		} else {
+			move_cursor_relative(player->px, player->py);
+		}
 
 		for (j = 0; j < ANGBAND_TERM_MAX; j++) {
 			if (!angband_term[j]) continue;

--- a/src/ui-game.c
+++ b/src/ui-game.c
@@ -372,7 +372,7 @@ void pre_turn_refresh(void)
 			target_get(&col, &row);
 			move_cursor_relative(row, col);
 		} else {
-			move_cursor_relative(player->px, player->py);
+			move_cursor_relative(player->py, player->px);
 		}
 
 		for (j = 0; j < ANGBAND_TERM_MAX; j++) {


### PR DESCRIPTION
At least, I think that fixes it... Btw, textui seems to have a lot
of places with x, y (or y, x) in wrong order; see cmd_set_arg_point()
in ui-target.c, for example... Whose idea was to use y, x order for
coordinates?