### PR TITLE
Fix targeting line color

### DIFF
--- a/src/ui-target.c
+++ b/src/ui-target.c
@@ -840,8 +840,8 @@ static int draw_path(u16b path_n, struct loc *path_g, wchar_t *c, int *a,
 			/* Known objects are yellow. */
 			colour = COLOUR_YELLOW;
 
-		else if ((!square_isprojectable(cave, y, x) &&
-				  square_isknown(cave, y, x)) || square_isseen(cave, y, x))
+		else if (!square_isprojectable(cave, y, x) &&
+				  (square_isknown(cave, y, x) || square_isseen(cave, y, x)))
 			/* Known walls are blue. */
 			colour = COLOUR_BLUE;
 


### PR DESCRIPTION
It's supposed to be mostly white (as per comment), but an operator
precedence bug made it blue. Even if it's desirable for it to be blue,
that should be accomplished by changing the line with the comment
"Unoccupied squares are white" in draw_path() (line 854).