### PR TITLE
Few minor fixes.

### DIFF
--- a/lib/gamedata/class.txt
+++ b/lib/gamedata/class.txt
@@ -189,7 +189,7 @@ effect:LIGHT_AREA
 param:1:10
 dice:2d$S
 expr:S:PLAYER_LEVEL:/ 2
-desc:Lights up all squares in a level-dependant area, and hurts
+desc:Lights up all squares in a level-dependent area, and hurts
 desc: all light-sensitive monsters in the area of effect.
 desc:  If you are in a room, the entire room will be lit up as well.
 
@@ -214,7 +214,7 @@ spell:Confuse Monster:5:4:30:4
 effect:BOLT_AWARE:OLD_CONF
 dice:$B
 expr:B:PLAYER_LEVEL:+ 0
-desc:Attempts to confuse a single monster for a level-dependant duration.
+desc:Attempts to confuse a single monster for a level-dependent duration.
 desc:  Uniques and monsters that resist confusion are not affected.
 
 spell:Lightning Bolt:5:4:30:4
@@ -351,7 +351,7 @@ spell:Haste Self:25:12:65:10
 effect:TIMED_INC:FAST:5
 dice:$B+d20
 expr:B:PLAYER_LEVEL:+ 0
-desc:Hastes you (+10 to speed) for a level-dependant duration.
+desc:Hastes you (+10 to speed) for a level-dependent duration.
 
 spell:Mass Sleep:25:7:50:6
 effect:PROJECT_LOS:OLD_SLEEP
@@ -658,7 +658,7 @@ effect:LIGHT_AREA
 param:1:10
 dice:2d$S
 expr:S:PLAYER_LEVEL:/ 2
-desc:Lights up all squares in a level-dependant area, and hurts
+desc:Lights up all squares in a level-dependent area, and hurts
 desc: all light-sensitive monsters in the area of effect.
 desc:  If you are in a room, the entire room will be lit up as well.
 
@@ -681,7 +681,7 @@ spell:Scare Monster:5:4:29:3
 effect:BOLT_AWARE:TURN_ALL
 dice:$B
 expr:B:PLAYER_LEVEL:+ 0
-desc:Attempts to scare a single monster for a level-dependant duration.
+desc:Attempts to scare a single monster for a level-dependent duration.
 desc:  Uniques and monsters that resist fear are not affected.
 
 spell:Portal:5:4:30:4
@@ -767,7 +767,7 @@ spell:Protection from Evil:11:8:42:4
 effect:TIMED_INC:PROTEVIL
 dice:$B+d25
 expr:B:PLAYER_LEVEL:* 3
-desc:Protects you from evil for a level-dependant duration:
+desc:Protects you from evil for a level-dependent duration:
 desc: all melee attacks by evil monsters have a chance to be repelled,
 desc: unless the monster's level is higher than your character level.
 
@@ -802,7 +802,7 @@ effect:PROJECT_LOS_AWARE:TURN_UNDEAD
 dice:$B
 expr:B:PLAYER_LEVEL:+ 0
 desc:Attempts to scare each undead monster within line of sight,
-desc: causing it to flee in terror for a level-dependant duration.
+desc: causing it to flee in terror for a level-dependent duration.
 
 book:prayer book:[Exorcism and Dispelling]:6:2
 
@@ -1116,7 +1116,7 @@ effect:LIGHT_AREA
 param:1:10
 dice:2d$S
 expr:S:PLAYER_LEVEL:/ 2
-desc:Lights up all squares in a level-dependant area, and hurts
+desc:Lights up all squares in a level-dependent area, and hurts
 desc: all light-sensitive monsters in the area of effect.
 desc:  If you are in a room, the entire room will be lit up as well.
 
@@ -1148,7 +1148,7 @@ spell:Confuse Monster:15:6:75:1
 effect:BOLT_AWARE:OLD_CONF
 dice:$B
 expr:B:PLAYER_LEVEL:+ 0
-desc:Attempts to confuse a single monster for a level-dependant duration.
+desc:Attempts to confuse a single monster for a level-dependent duration.
 desc:  Uniques and monsters that resist confusion are not affected.
 
 spell:Disable Traps, Destroy Doors:14:7:60:2
@@ -1239,7 +1239,7 @@ spell:Haste Self:32:25:70:6
 effect:TIMED_INC:FAST:5
 dice:$B+d20
 expr:B:PLAYER_LEVEL:+ 0
-desc:Hastes you (+10 to speed) for a level-dependant duration.
+desc:Hastes you (+10 to speed) for a level-dependent duration.
 
 spell:Mass Sleep:24:15:80:10
 effect:PROJECT_LOS:OLD_SLEEP
@@ -1455,7 +1455,7 @@ effect:LIGHT_AREA
 param:1:10
 dice:2d$S
 expr:S:PLAYER_LEVEL:/ 2
-desc:Lights up all squares in a level-dependant area, and hurts
+desc:Lights up all squares in a level-dependent area, and hurts
 desc: all light-sensitive monsters in the area of effect.
 desc:  If you are in a room, the entire room will be lit up as well.
 
@@ -1490,7 +1490,7 @@ spell:Confuse Monster:7:6:40:2
 effect:BOLT_AWARE:OLD_CONF
 dice:$B
 expr:B:PLAYER_LEVEL:+ 0
-desc:Attempts to confuse a single monster for a level-dependant duration.
+desc:Attempts to confuse a single monster for a level-dependent duration.
 desc:  Uniques and monsters that resist confusion are not affected.
 
 spell:Lightning Bolt:9:7:40:3
@@ -1627,7 +1627,7 @@ spell:Haste Self:33:25:75:4
 effect:TIMED_INC:FAST:5
 dice:$B+d20
 expr:B:PLAYER_LEVEL:+ 0
-desc:Hastes you (+10 to speed) for a level-dependant duration.
+desc:Hastes you (+10 to speed) for a level-dependent duration.
 
 spell:Mass Sleep:23:20:60:4
 effect:PROJECT_LOS:OLD_SLEEP
@@ -1905,7 +1905,7 @@ effect:LIGHT_AREA
 param:1:10
 dice:2d$S
 expr:S:PLAYER_LEVEL:/ 2
-desc:Lights up all squares in a level-dependant area, and hurts
+desc:Lights up all squares in a level-dependent area, and hurts
 desc: all light-sensitive monsters in the area of effect.
 desc:  If you are in a room, the entire room will be lit up as well.
 
@@ -1928,7 +1928,7 @@ spell:Scare Monster:9:7:40:3
 effect:BOLT_AWARE:TURN_ALL
 dice:$B
 expr:B:PLAYER_LEVEL:+ 0
-desc:Attempts to scare a single monster for a level-dependant duration.
+desc:Attempts to scare a single monster for a level-dependent duration.
 desc:  Uniques and monsters that resist fear are not affected.
 
 spell:Portal:9:8:40:3
@@ -2014,7 +2014,7 @@ spell:Protection from Evil:19:15:50:4
 effect:TIMED_INC:PROTEVIL
 dice:$B+d25
 expr:B:PLAYER_LEVEL:* 3
-desc:Protects you from evil for a level-dependant duration:
+desc:Protects you from evil for a level-dependent duration:
 desc: all melee attacks by evil monsters have a chance to be repelled,
 desc: unless the monster's level is higher than your character level.
 
@@ -2049,7 +2049,7 @@ effect:PROJECT_LOS_AWARE:TURN_UNDEAD
 dice:$B
 expr:B:PLAYER_LEVEL:+ 0
 desc:Attempts to scare each undead monster within line of sight,
-desc: causing it to flee in terror for a level-dependant duration.
+desc: causing it to flee in terror for a level-dependent duration.
 
 book:prayer book:[Exorcism and Dispelling]:4:2
 

--- a/lib/gamedata/monster.txt
+++ b/lib/gamedata/monster.txt
@@ -3161,7 +3161,7 @@ color:B
 info:120:36:20:24:10
 power:18:2:12312:5:50
 blow:BITE:HURT:1d8
-flags:RAND_25 | BASH_DOOR | GROUP_AI
+flags:RAND_25 | BASH_DOOR | GROUP_AI | ATTR_FLICKER
 spell-freq:4
 spells:BLINK | TELE_TO
 friends:100:2d7:Same
@@ -3303,7 +3303,7 @@ power:20:2:50112:15:60
 blow:BITE:HURT:1d8
 blow:BITE:POISON:1d6
 blow:BITE:POISON:1d6
-flags:ANIMAL | WEIRD_MIND
+flags:ANIMAL | WEIRD_MIND | ATTR_FLICKER
 flags:IM_POIS | GROUP_AI
 spell-freq:5
 spells:BLINK | TELE_TO
@@ -3609,7 +3609,7 @@ color:b
 info:110:45:100:36:0
 power:21:1:1944:0:100
 blow:ENGULF:ELEC:3d3
-flags:HAS_LIGHT
+flags:HAS_LIGHT | ATTR_FLICKER
 flags:IM_ELEC
 spell-freq:6
 spells:BR_ELEC
@@ -4446,7 +4446,7 @@ info:110:144:2:36:0
 power:27:1:2300:0:140
 blow:SPORE:ELEC:5d4
 blow:SPORE:ELEC:5d4
-flags:EMPTY_MIND | STUPID | HAS_LIGHT
+flags:EMPTY_MIND | STUPID | HAS_LIGHT | ATTR_FLICKER
 flags:IM_ELEC
 desc:It is a strange growth on the dungeon floor, glowing and crackling with
 desc: sparks.
@@ -6315,14 +6315,14 @@ desc:A lump of rotting black flesh that slurrrrrrrps across the dungeon floor.
 
 name:399:Killer iridescent beetle
 base:killer beetle
-color:v
+color:b
 info:110:330:16:90:30
 power:37:2:119919:3:850
 blow:CLAW:ELEC:2d12
 blow:CLAW:ELEC:2d12
 blow:GAZE:PARALYZE
 flags:IM_ELEC
-flags:ATTR_MULTI
+flags:ATTR_FLICKER
 desc:It is a giant beetle, whose carapace shimmers with vibrant energies.
 
 name:400:Nexus vortex
@@ -6480,7 +6480,7 @@ info:140:176:100:48:0
 power:38:4:126720:3:800
 blow:ENGULF:BLIND:4d4
 blow:ENGULF:BLIND:4d4
-flags:HAS_LIGHT
+flags:HAS_LIGHT | ATTR_FLICKER
 flags:RAND_25
 spell-freq:4
 spells:SHRIEK

--- a/src/gen-room.c
+++ b/src/gen-room.c
@@ -372,7 +372,7 @@ void set_marked_granite(struct chunk *c, int y, int x, int flag)
  * \return success
  *
  * Starburst rooms are made in three steps:
- * 1: Choose a room size-dependant number of arcs.  Large rooms need to 
+ * 1: Choose a room size-dependent number of arcs.  Large rooms need to 
  *    look less granular and alter their shape more often, so they need 
  *    more arcs.
  * 2: For each of the arcs, calculate the portion of the full circle it 

--- a/src/init.c
+++ b/src/init.c
@@ -425,7 +425,7 @@ void add_game_slay(struct slay *s)
  * Find the default paths to all of our important sub-directories.
  *
  * All of the sub-directories should, by default, be located inside
- * the main directory, whose location is very system dependant and is 
+ * the main directory, whose location is very system dependent and is 
  * set by the ANGBAND_PATH environment variable, if it exists. (On multi-
  * user systems such as Linux this is not the default - see config.h for
  * more info.)
@@ -433,7 +433,7 @@ void add_game_slay(struct slay *s)
  * This function takes a writable buffers, initially containing the
  * "path" to the "config", "lib" and "data" directories, for example, 
  * "/etc/angband/", "/usr/share/angband" and "/var/games/angband" -
- * or a system dependant string, for example, ":lib:".  The buffer
+ * or a system dependent string, for example, ":lib:".  The buffer
  * must be large enough to contain at least 32 more characters.
  *
  * Various command line options may allow some of the important


### PR DESCRIPTION
Shimmering monsters should actually shimmer.  Iridescent beetle should shimmer blue (for electric attack.) dependent is not usually spelled dependant, and currently it is spelled both ways in various files.