### PR TITLE
Fallback to AC_CHECK_LIB if pkg-config check fails

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -235,7 +235,16 @@ if test "$enable_curses" = "yes"; then
 		CFLAGS="${CFLAGS} ${NCURSES_CFLAGS}"
 		LIBS="${LIBS} ${NCURSES_LIBS}"
 		MAINFILES="${MAINFILES} \$(GCUMAINFILES)"
-	fi 
+	else
+		AC_CHECK_LIB([ncursesw], [initscr], [
+			AC_DEFINE(USE_NCURSES, 1, [Define to 1 if NCurses is found.])
+			AC_DEFINE(USE_GCU, 1, [Define to 1 if using the Curses frontend.])
+			AC_DEFINE(_XOPEN_SOURCE_EXTENDED, 1, [Defined for systems that guard ncurses decls with _XOPEN_SOURCE_EXTENDED])
+			with_curses=yes
+			LIBS="${LIBS} -lncursesw"
+			MAINFILES="${MAINFILES} \$(GCUMAINFILES)"
+		])
+	fi
 fi
 
 AC_CHECK_FUNCS([mvwaddnwstr use_default_colors can_change_color])


### PR DESCRIPTION
Some systems (like OpenBSD) do not ship pkg-config/ncurses5-config information
for ncurses, since it's part of their base system, and not necessary. In that
case, fallback to checking for a function (`initscr`) in `libncursesw`.

Additionally, define `_XOPEN_SOURCE_EXTENDED`, which ensures that angband
picks up the right definitions of `mvwaddnwstr`.

This fixes #1638, #1682, #1939 and #1976 in trac.