### PR TITLE
Don't prevent map redraws when player is running

### DIFF
--- a/src/player-calcs.c
+++ b/src/player-calcs.c
@@ -2416,7 +2416,7 @@ void redraw_stuff(struct player *p)
 
 	/* Hack - rarely update while resting or running, makes it over quicker */
 	if (((player_resting_count(p) % 100) || (p->upkeep->running % 100))
-		&& !(redraw & PR_MESSAGE))
+		&& !(redraw & PR_MESSAGE) && !(redraw & PR_MAP))
 		return;
 
 	/* For each listed flag, send the appropriate signal to the UI */


### PR DESCRIPTION
I think this whole optimization should be done by the ui, actually.