### PR TITLE
Various refactorings

### DIFF
--- a/src/angband.h
+++ b/src/angband.h
@@ -33,7 +33,6 @@
 #include "config.h"
 #include "game-event.h"
 #include "message.h"
-#include "option.h"
 #include "player.h"
 
 

--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -292,7 +292,7 @@ void do_cmd_open(struct command *cmd)
 			msg("There is a monster in the way!");
 
 			/* Attack */
-			py_attack(y, x);
+			py_attack(player, y, x);
 		}
 	} else if (obj) {
 		/* Chest */
@@ -415,7 +415,7 @@ void do_cmd_close(struct command *cmd)
 	/* Monster - alert, then attack */
 	if (cave->squares[y][x].mon > 0) {
 		msg("There is a monster in the way!");
-		py_attack(y, x);
+		py_attack(player, y, x);
 	} else
 		/* Door - close it */
 		more = do_cmd_close_aux(y, x);
@@ -591,7 +591,7 @@ void do_cmd_tunnel(struct command *cmd)
 	/* Attack any monster we run into */
 	if (cave->squares[y][x].mon > 0) {
 		msg("There is a monster in the way!");
-		py_attack(y, x);
+		py_attack(player, y, x);
 	} else {
 		/* Tunnel through walls */
 		more = do_cmd_tunnel_aux(y, x);
@@ -814,7 +814,7 @@ void do_cmd_disarm(struct command *cmd)
 	/* Monster */
 	if (cave->squares[y][x].mon > 0) {
 		msg("There is a monster in the way!");
-		py_attack(y, x);
+		py_attack(player, y, x);
 	} else if (obj)
 		/* Chest */
 		more = do_cmd_disarm_chest(y, x, obj);
@@ -863,7 +863,7 @@ void do_cmd_alter_aux(int dir)
 	/* Action depends on what's there */
 	if (cave->squares[y][x].mon > 0)
 		/* Attack monsters */
-		py_attack(y, x);
+		py_attack(player, y, x);
 	else if (square_isdiggable(cave, y, x))
 		/* Tunnel through walls and rubble */
 		more = do_cmd_tunnel_aux(y, x);
@@ -920,7 +920,7 @@ void move_player(int dir, bool disarm)
 			mon_clear_timed(mon, MON_TMD_SLEEP, MON_TMD_FLG_NOMESSAGE, false);
 
 		} else {
-			py_attack(y, x);
+			py_attack(player, y, x);
 		}
 	} else if (disarm && square_isknown(cave, y, x) && alterable) {
 		/* Auto-repeat if not already repeating */

--- a/src/cmd-misc.c
+++ b/src/cmd-misc.c
@@ -114,5 +114,5 @@ void do_cmd_note(void)
 	msg("%s", &note[3]);
 
 	/* Add a history entry */
-	history_add(note, HIST_USER_INPUT, 0);
+	history_add(player, note, HIST_USER_INPUT, 0);
 }

--- a/src/cmd-misc.c
+++ b/src/cmd-misc.c
@@ -114,5 +114,5 @@ void do_cmd_note(void)
 	msg("%s", &note[3]);
 
 	/* Add a history entry */
-	history_add(player, note, HIST_USER_INPUT, 0);
+	history_add(player, note, HIST_USER_INPUT);
 }

--- a/src/cmd-misc.c
+++ b/src/cmd-misc.c
@@ -103,10 +103,10 @@ void do_cmd_note(void)
 
 	/* Format the note correctly, supporting some cute /me commands */
 	if (strncmp(tmp, "/say ", 5) == 0)
-		strnfmt(note, sizeof(note), "-- %s says: \"%s\"", op_ptr->full_name,
+		strnfmt(note, sizeof(note), "-- %s says: \"%s\"", player->full_name,
 				&tmp[5]);
 	else if (strncmp(tmp, "/me", 3) == 0)
-		strnfmt(note, sizeof(note), "-- %s%s", op_ptr->full_name, &tmp[3]);
+		strnfmt(note, sizeof(note), "-- %s%s", player->full_name, &tmp[3]);
 	else
 		strnfmt(note, sizeof(note), "-- Note: %s", tmp);
 

--- a/src/effects.c
+++ b/src/effects.c
@@ -2973,7 +2973,7 @@ bool effect_handler_DESTRUCTION(effect_handler_context_t *context)
 							!(obj->known && obj->known->artifact))
 							obj->artifact->created = false;
 						else
-							history_lose_artifact(obj->artifact);
+							history_lose_artifact(player, obj->artifact);
 					}
 					obj = obj->next;
 				}

--- a/src/generate.c
+++ b/src/generate.c
@@ -829,11 +829,13 @@ static void cave_clear(struct chunk *c, struct player *p)
 			while (obj) {
 				if (obj->artifact) {
 					bool found = obj->known && obj->known->artifact;
-					if (!OPT(birth_lose_arts) && !found)
+					if (OPT(birth_lose_arts) || found) {
+						history_lose_artifact(p, obj->artifact);
+					} else {
 						obj->artifact->created = false;
-					else
-						history_lose_artifact(obj->artifact);
+					}
 				}
+
 				obj = obj->next;
 			}
 		}

--- a/src/init.c
+++ b/src/init.c
@@ -5212,9 +5212,6 @@ void cleanup_angband(void)
 		cave = NULL;
 	}
 
-	/* Free the history */
-	history_clear(player);
-
 	monster_list_finalize();
 	object_list_finalize();
 

--- a/src/init.c
+++ b/src/init.c
@@ -5213,7 +5213,7 @@ void cleanup_angband(void)
 	}
 
 	/* Free the history */
-	history_clear();
+	history_clear(player);
 
 	monster_list_finalize();
 	object_list_finalize();

--- a/src/load.c
+++ b/src/load.c
@@ -395,15 +395,15 @@ int rd_options(void)
 
 	/* Read "delay_factor" */
 	rd_byte(&b);
-	op_ptr->delay_factor = b;
+	player->opts.delay_factor = b;
 
 	/* Read "hitpoint_warn" */
 	rd_byte(&b);
-	op_ptr->hitpoint_warn = b;
+	player->opts.hitpoint_warn = b;
 
 	/* Read lazy movement delay */
 	rd_u16b(&tmp16u);
-	op_ptr->lazymove_delay = (tmp16u < 1000) ? tmp16u : 0;
+	player->opts.lazymove_delay = (tmp16u < 1000) ? tmp16u : 0;
 
 
 	/* Read options */
@@ -643,7 +643,7 @@ int rd_player(void)
 	}
 
 	/* Numeric name suffix */
-	rd_byte(&op_ptr->name_suffix);
+	rd_byte(&player->opts.name_suffix);
 
 	/* Special Race/Class info */
 	rd_byte(&player->hitdie);

--- a/src/load.c
+++ b/src/load.c
@@ -1521,7 +1521,7 @@ int rd_history(void)
 	u32b tmp32u;
 	size_t i, j;
 	
-	history_clear();
+	history_clear(player);
 
 	/* History type flags */
 	rd_byte(&hist_size);
@@ -1546,7 +1546,7 @@ int rd_history(void)
 		rd_byte(&art_name);
 		rd_string(text, sizeof(text));
 		
-		history_add_full(type, &a_info[art_name], dlev, clev, turnno, text);
+		history_add_full(player, type, &a_info[art_name], dlev, clev, turnno, text);
 	}
 
 	return 0;

--- a/src/load.c
+++ b/src/load.c
@@ -618,7 +618,7 @@ int rd_player(void)
 	byte stat_max = 0;
 	char buf[80];
 
-	rd_string(op_ptr->full_name, sizeof(op_ptr->full_name));
+	rd_string(player->full_name, sizeof(player->full_name));
 	rd_string(player->died_from, 80);
 	player->history = mem_zalloc(250);
 	rd_string(player->history, 250);

--- a/src/load.c
+++ b/src/load.c
@@ -1535,7 +1535,7 @@ int rd_history(void)
 		s32b turnno;
 		s16b dlev, clev;
 		bitflag type[HIST_SIZE];
-		byte art_name;
+		byte aidx;
 		char text[80];
 
 		for (j = 0; j < hist_size; j++)		
@@ -1543,10 +1543,10 @@ int rd_history(void)
 		rd_s32b(&turnno);
 		rd_s16b(&dlev);
 		rd_s16b(&clev);
-		rd_byte(&art_name);
+		rd_byte(&aidx);
 		rd_string(text, sizeof(text));
 		
-		history_add_full(player, type, &a_info[art_name], dlev, clev, turnno, text);
+		history_add_full(player, type, aidx, dlev, clev, turnno, text);
 	}
 
 	return 0;

--- a/src/main-win.c
+++ b/src/main-win.c
@@ -3839,7 +3839,7 @@ static void process_menus(WORD wCmd)
 
 			time( &ltime );
 			today = localtime( &ltime );
-			strnfmt(filename, sizeof(filename), "%s", op_ptr->full_name);
+			strnfmt(filename, sizeof(filename), "%s", player->full_name);
 			len = strlen(filename);
 			strftime(filename+len, sizeof(filename)-len, "_%Y%b%d_%H%M%S.png",
 					 today);

--- a/src/main-win.c
+++ b/src/main-win.c
@@ -3104,8 +3104,8 @@ static void start_screensaver(void)
 	/* Set the name for process_player_name() */
 	my_strcpy(op_ptr->full_name, saverfilename, sizeof(op_ptr->full_name));
 
-	/* Set 'savefile' to a valid name */
-	savefile_set_name(player_safe_name(player, false));
+	/* Set 'savefile' to a safe name */
+	savefile_set_name(op_ptr->full_name, true, false);
 
 	/* Does the savefile already exist? */
 	file_exist = file_exists(savefile);

--- a/src/main-win.c
+++ b/src/main-win.c
@@ -3101,11 +3101,8 @@ static void start_screensaver(void)
 {
 	bool file_exist;
 
-	/* Set the name for process_player_name() */
-	my_strcpy(op_ptr->full_name, saverfilename, sizeof(op_ptr->full_name));
-
 	/* Set 'savefile' to a safe name */
-	savefile_set_name(op_ptr->full_name, true, false);
+	savefile_set_name(saverfilename, true, false);
 
 	/* Does the savefile already exist? */
 	file_exist = file_exists(savefile);

--- a/src/main.c
+++ b/src/main.c
@@ -379,7 +379,8 @@ int main(int argc, char *argv[])
 			case 'u': {
 
 				if (!*arg) goto usage;
-				my_strcpy(op_ptr->full_name, arg, sizeof op_ptr->full_name);
+
+				my_strcpy(arg_name, arg, sizeof(arg_name));
 
 				/* The difference here is because on setgid we have to be
 				 * careful to only let the player have savefiles stored in
@@ -390,9 +391,9 @@ int main(int argc, char *argv[])
 				 * can do whatever the hell they want.
 				 */
 #ifdef SETGID
-				savefile_set_name(op_ptr->full_name, true, false);
+				savefile_set_name(arg, true, false);
 #else
-				savefile_set_name(op_ptr->full_name);
+				savefile_set_name(arg, false, false);
 #endif /* SETGID */
 
 				continue;
@@ -499,11 +500,11 @@ int main(int argc, char *argv[])
 #ifdef UNIX
 
 	/* Get the "user name" as default player name, unless set with -u switch */
-	if (!op_ptr->full_name[0]) {
-		user_name(op_ptr->full_name, sizeof(op_ptr->full_name), player_uid);
+	if (!arg_name[0]) {
+		user_name(arg_name, sizeof(arg_name), player_uid);
 
 		/* Sanitise name and set as savefile */
-		savefile_set_name(op_ptr->full_name, true, false);
+		savefile_set_name(arg_name, true, false);
 	}
 
 	/* Create any missing directories */

--- a/src/main.c
+++ b/src/main.c
@@ -390,9 +390,9 @@ int main(int argc, char *argv[])
 				 * can do whatever the hell they want.
 				 */
 #ifdef SETGID
-				savefile_set_name(player_safe_name(player, false));
+				savefile_set_name(op_ptr->full_name, true, false);
 #else
-				savefile_set_name(arg);
+				savefile_set_name(op_ptr->full_name);
 #endif /* SETGID */
 
 				continue;
@@ -502,8 +502,8 @@ int main(int argc, char *argv[])
 	if (!op_ptr->full_name[0]) {
 		user_name(op_ptr->full_name, sizeof(op_ptr->full_name), player_uid);
 
-		/* Set the savefile to load */
-		savefile_set_name(player_safe_name(player, false));
+		/* Sanitise name and set as savefile */
+		savefile_set_name(op_ptr->full_name, true, false);
 	}
 
 	/* Create any missing directories */

--- a/src/main.c
+++ b/src/main.c
@@ -377,7 +377,6 @@ int main(int argc, char *argv[])
 				break;
 
 			case 'u': {
-
 				if (!*arg) goto usage;
 
 				my_strcpy(arg_name, arg, sizeof(arg_name));

--- a/src/mon-lore.c
+++ b/src/mon-lore.c
@@ -1175,7 +1175,7 @@ void lore_append_toughness(textblock *tb, const struct monster_race *race,
 		textblock_append(tb, ".  ");
 
 		/* Player's chance to hit it */
-		chance = py_attack_hit_chance(weapon);
+		chance = py_attack_hit_chance(player, weapon);
 
 		/* The following calculations are based on test_hit();
 		 * make sure to keep it in sync */

--- a/src/mon-make.c
+++ b/src/mon-make.c
@@ -1520,7 +1520,7 @@ bool mon_take_hit(struct monster *mon, int dam, bool *fear, const char *note)
 
 			/* Log the slaying of a unique */
 			strnfmt(buf, sizeof(buf), "Killed %s", unique_name);
-			history_add(player, buf, HIST_SLAY_UNIQUE, 0);
+			history_add(player, buf, HIST_SLAY_UNIQUE);
 		}
 
 		/* Gain experience */

--- a/src/mon-make.c
+++ b/src/mon-make.c
@@ -1520,7 +1520,7 @@ bool mon_take_hit(struct monster *mon, int dam, bool *fear, const char *note)
 
 			/* Log the slaying of a unique */
 			strnfmt(buf, sizeof(buf), "Killed %s", unique_name);
-			history_add(buf, HIST_SLAY_UNIQUE, 0);
+			history_add(player, buf, HIST_SLAY_UNIQUE, 0);
 		}
 
 		/* Gain experience */

--- a/src/obj-knowledge.c
+++ b/src/obj-knowledge.c
@@ -956,7 +956,7 @@ void object_touch(struct player *p, struct object *obj)
 
 	/* Log artifacts if found */
 	if (obj->artifact)
-		history_add_artifact(obj->artifact, true, true);
+		history_add_artifact(p, obj->artifact, true, true);
 }
 
 

--- a/src/obj-knowledge.c
+++ b/src/obj-knowledge.c
@@ -956,7 +956,7 @@ void object_touch(struct player *p, struct object *obj)
 
 	/* Log artifacts if found */
 	if (obj->artifact)
-		history_add_artifact(p, obj->artifact, true, true);
+		history_find_artifact(p, obj->artifact);
 }
 
 

--- a/src/obj-make.c
+++ b/src/obj-make.c
@@ -670,7 +670,7 @@ static bool make_artifact(struct object *obj)
  * Since this is now in no way marked as fake, we must make sure this function
  * is never used to create an actual game object
  */
-bool make_fake_artifact(struct object *obj, struct artifact *artifact)
+bool make_fake_artifact(struct object *obj, const struct artifact *artifact)
 {
 	struct object_kind *kind;
 
@@ -683,7 +683,7 @@ bool make_fake_artifact(struct object *obj, struct artifact *artifact)
 
 	/* Create the artifact */
 	object_prep(obj, kind, 0, MAXIMISE);
-	obj->artifact = artifact;
+	obj->artifact = (struct artifact *)artifact;
 	copy_artifact_data(obj, artifact);
 	apply_curse_knowledge(obj);
 

--- a/src/obj-make.h
+++ b/src/obj-make.h
@@ -29,7 +29,7 @@
 
 void ego_apply_magic(struct object *obj, int level);
 void copy_artifact_data(struct object *obj, const struct artifact *art);
-bool make_fake_artifact(struct object *obj, struct artifact *artifact);
+bool make_fake_artifact(struct object *obj, const struct artifact *artifact);
 void object_prep(struct object *obj, struct object_kind *kind, int lev,
 				 aspect rand_aspect);
 int apply_magic(struct object *obj, int lev, bool okay, bool good,

--- a/src/option.c
+++ b/src/option.c
@@ -105,7 +105,24 @@ void options_init_cheat(void)
 }
 
 /**
- * Initialise options to defaults
+ * Set player default options
+ */
+void options_init_defaults(void)
+{
+	/* Set defaults */
+	int opt;
+	for (opt = 0; opt < OPT_MAX; opt++)
+		player->opts.opt[opt] = options[opt].normal;
+
+	/* 40ms for the delay factor */
+	player->opts.delay_factor = 40;
+
+	/* 30% of HP */
+	player->opts.hitpoint_warn = 3;
+}
+
+/**
+ * Initialise options package
  */
 void init_options(void)
 {
@@ -121,18 +138,7 @@ void init_options(void)
 		while (page_opts < OPT_PAGE_PER)
 			option_page[page][page_opts++] = OPT_none;
 	}
-
-	/* Set defaults */
-	for (opt = 0; opt < OPT_MAX; opt++)
-		player->opts.opt[opt] = options[opt].normal;
-
-	/* 40ms for the delay factor */
-	player->opts.delay_factor = 40;
-
-	/* 30% of HP */
-	player->opts.hitpoint_warn = 3;
 }
-
 
 struct init_module options_module = {
 	.name = "options",

--- a/src/option.c
+++ b/src/option.c
@@ -80,14 +80,28 @@ bool option_set(const char *name, int val)
 		if (!options[opt].name || !streq(options[opt].name, name))
 			continue;
 
-		op_ptr->opt[opt] = val ? true : false;
+		player->opts.opt[opt] = val ? true : false;
 		if (val && option_is_cheat(opt))
-			op_ptr->opt[opt + 1] = true;
+			player->opts.opt[opt + 1] = true;
 
 		return true;
 	}
 
 	return false;
+}
+
+/**
+ * Set score options from cheat options
+ */
+void options_init_cheat(void)
+{
+	int i;
+
+	for (i = 0; i < OPT_MAX; i++) {
+		if (option_is_cheat(i))
+			player->opts.opt[i + 1] = player->opts.opt[i];
+	}
+
 }
 
 /**
@@ -110,13 +124,13 @@ void init_options(void)
 
 	/* Set defaults */
 	for (opt = 0; opt < OPT_MAX; opt++)
-		op_ptr->opt[opt] = options[opt].normal;
+		player->opts.opt[opt] = options[opt].normal;
 
 	/* 40ms for the delay factor */
-	op_ptr->delay_factor = 40;
+	player->opts.delay_factor = 40;
 
 	/* 30% of HP */
-	op_ptr->hitpoint_warn = 3;
+	player->opts.hitpoint_warn = 3;
 }
 
 

--- a/src/option.h
+++ b/src/option.h
@@ -39,12 +39,11 @@ enum
  */
 enum
 {
-    #define OP(a, b, c, d) OPT_##a,
-    #include "list-options.h"
-    #undef OP
+	#define OP(a, b, c, d) OPT_##a,
+	#include "list-options.h"
+	#undef OP
 	OPT_MAX
 };
-
 
 #define OPT(opt_name)	player->opts.opt[OPT_##opt_name]
 
@@ -68,7 +67,8 @@ const char *option_name(int opt);
 const char *option_desc(int opt);
 int option_type(int opt);
 bool option_set(const char *opt, int val);
+void options_init_cheat(void);
+void options_init_defaults(void);
 void init_options(void);
-
 
 #endif /* !INCLUDED_OPTIONS_H */

--- a/src/option.h
+++ b/src/option.h
@@ -46,7 +46,7 @@ enum
 };
 
 
-#define OPT(opt_name)	op_ptr->opt[OPT_##opt_name]
+#define OPT(opt_name)	player->opts.opt[OPT_##opt_name]
 
 /**
  * Information for "do_cmd_options()".
@@ -61,8 +61,9 @@ enum
 extern int option_page[OPT_PAGE_MAX][OPT_PAGE_PER];
 
 /**
- * Functions 
-*/
+ * Functions
+ */
+void options_init_cheat(void);
 const char *option_name(int opt);
 const char *option_desc(int opt);
 int option_type(int opt);

--- a/src/player-attack.c
+++ b/src/player-attack.c
@@ -64,18 +64,21 @@ int breakage_chance(const struct object *obj, bool hit_target) {
 	return perc;
 }
 
-static int chance_of_missile_hit(struct player *p, struct object *missile,
-								 struct object *launcher, int y, int x)
+static int chance_of_missile_hit(const struct player *p,
+		const struct object *missile,
+		const struct object *launcher,
+		int y,
+		int x)
 {
 	bool throw = (launcher ? false : true);
 	int bonus = p->state.to_h + missile->to_h;
 	int chance;
 
-	if (throw)
+	if (throw) {
 		chance = p->state.skills[SKILL_TO_HIT_THROW] + bonus * BTH_PLUS_ADJ;
-	else {
+	} else {
 		bonus += launcher->to_h;
-		chance = player->state.skills[SKILL_TO_HIT_BOW] + bonus * BTH_PLUS_ADJ;
+		chance = p->state.skills[SKILL_TO_HIT_BOW] + bonus * BTH_PLUS_ADJ;
 	}
 
 	return chance - distance(p->py, p->px, y, x);
@@ -154,8 +157,11 @@ static int ranged_damage(struct object *missile, struct object *launcher,
  *
  * Factor in item weight, total plusses, and player level.
  */
-static int critical_shot(int weight, int plus, int dam, u32b *msg_type) {
-	int chance = weight + (player->state.to_h + plus) * 4 + player->lev * 2;
+static int critical_shot(const struct player *p,
+		int weight, int plus,
+		int dam, u32b *msg_type)
+{
+	int chance = weight + (p->state.to_h + plus) * 4 + p->lev * 2;
 	int power = weight + randint1(500);
 
 	if (randint1(5000) > chance) {
@@ -182,8 +188,11 @@ static int critical_shot(int weight, int plus, int dam, u32b *msg_type) {
  *
  * Factor in weapon weight, total plusses, player level.
  */
-static int critical_norm(int weight, int plus, int dam, u32b *msg_type) {
-	int chance = weight + (player->state.to_h + plus) * 5 + player->lev * 3;
+static int critical_norm(const struct player *p,
+		int weight, int plus,
+		int dam, u32b *msg_type)
+{
+	int chance = weight + (p->state.to_h + plus) * 5 + p->lev * 3;
 	int power = weight + randint1(650);
 
 	if (randint1(5000) > chance) {
@@ -269,20 +278,20 @@ static const struct {
 /**
  * Return the player's chance to hit with a particular weapon.
  */
-int py_attack_hit_chance(const struct object *weapon)
+int py_attack_hit_chance(const struct player *p, const struct object *weapon)
 {
-	int chance, bonus = player->state.to_h;
+	int chance, bonus = p->state.to_h;
 
 	if (weapon)
 		bonus += weapon->to_h;
-	chance = player->state.skills[SKILL_TO_HIT_MELEE] + bonus * BTH_PLUS_ADJ;
+	chance = p->state.skills[SKILL_TO_HIT_MELEE] + bonus * BTH_PLUS_ADJ;
 	return chance;
 }
 
 /**
  * Attack the monster at the given location with a single blow.
  */
-static bool py_attack_real(int y, int x, bool *fear)
+static bool py_attack_real(struct player *p, int y, int x, bool *fear)
 {
 	size_t i;
 
@@ -292,10 +301,10 @@ static bool py_attack_real(int y, int x, bool *fear)
 	bool stop = false;
 
 	/* The weapon used */
-	struct object *obj = equipped_item_by_slot_name(player, "weapon");
+	struct object *obj = equipped_item_by_slot_name(p, "weapon");
 
 	/* Information about the attack */
-	int chance = py_attack_hit_chance(obj);
+	int chance = py_attack_hit_chance(p, obj);
 	bool do_quake = false;
 	bool success = false;
 
@@ -313,14 +322,14 @@ static bool py_attack_real(int y, int x, bool *fear)
 
 	/* Auto-Recall if possible and visible */
 	if (mflag_has(mon->mflag, MFLAG_VISIBLE))
-		monster_race_track(player->upkeep, mon->race);
+		monster_race_track(p->upkeep, mon->race);
 
 	/* Track a new monster */
 	if (mflag_has(mon->mflag, MFLAG_VISIBLE))
-		health_track(player->upkeep, mon);
+		health_track(p->upkeep, mon);
 
 	/* Handle player fear (only for invisible monsters) */
-	if (player_of_has(player, OF_AFRAID)) {
+	if (player_of_has(p, OF_AFRAID)) {
 		msgt(MSG_AFRAID, "You are too afraid to attack %s!", m_name);
 		return false;
 	}
@@ -348,8 +357,8 @@ static bool py_attack_real(int y, int x, bool *fear)
 
 		/* Get the best attack from all slays or
 		 * brands on all non-launcher equipment */
-		for (j = 2; j < player->body.count; j++) {
-			struct object *obj_local = slot_object(player, j);
+		for (j = 2; j < p->body.count; j++) {
+			struct object *obj_local = slot_object(p, j);
 			if (obj_local)
 				improve_attack_modifier(obj_local, mon, &b, &s, verb, false, true);
 		}
@@ -357,19 +366,19 @@ static bool py_attack_real(int y, int x, bool *fear)
 		improve_attack_modifier(obj, mon, &b, &s, verb, false, true);
 
 		dmg = melee_damage(obj, b, s);
-		dmg = critical_norm(obj->weight, obj->to_h, dmg, &msg_type);
+		dmg = critical_norm(p, obj->weight, obj->to_h, dmg, &msg_type);
 
-		if (player_of_has(player, OF_IMPACT) && dmg > 50) {
+		if (player_of_has(p, OF_IMPACT) && dmg > 50) {
 			do_quake = true;
-			equip_learn_flag(player, OF_IMPACT);
+			equip_learn_flag(p, OF_IMPACT);
 		}
 	}
 
 	/* Learn by use */
-	equip_learn_on_melee_attack(player);
+	equip_learn_on_melee_attack(p);
 
 	/* Apply the player damage bonuses */
-	dmg += player_damage_bonus(&player->state);
+	dmg += player_damage_bonus(&p->state);
 
 	/* No negative damage; change verb if no damage done */
 	if (dmg <= 0) {
@@ -395,7 +404,7 @@ static bool py_attack_real(int y, int x, bool *fear)
 	}
 
 	/* Pre-damage side effects */
-	blow_side_effects(player, mon);
+	blow_side_effects(p, mon);
 
 	/* Damage, check for fear and death */
 	stop = mon_take_hit(mon, dmg, fear, NULL);
@@ -419,25 +428,25 @@ static bool py_attack_real(int y, int x, bool *fear)
  * We don't allow @ to spend more than 100 energy in one go, to avoid slower
  * monsters getting double moves.
  */
-void py_attack(int y, int x)
+void py_attack(struct player *p, int y, int x)
 {
-	int blow_energy = 100 * z_info->move_energy / player->state.num_blows;
+	int blow_energy = 100 * z_info->move_energy / p->state.num_blows;
 	int blows = 0;
 	bool fear = false;
 	struct monster *mon = square_monster(cave, y, x);
 	
 	/* disturb the player */
-	disturb(player, 0);
+	disturb(p, 0);
 
 	/* Initialize the energy used */
-	player->upkeep->energy_use = 0;
+	p->upkeep->energy_use = 0;
 
 	/* Attack until energy runs out or enemy dies. We limit energy use to 100
 	 * to avoid giving monsters a possible double move. */
-	while (player->energy >= blow_energy * (blows + 1)) {
-		bool stop = py_attack_real(y, x, &fear);
-		player->upkeep->energy_use += blow_energy;
-		if (player->upkeep->energy_use + blow_energy > z_info->move_energy ||
+	while (p->energy >= blow_energy * (blows + 1)) {
+		bool stop = py_attack_real(player, y, x, &fear);
+		p->upkeep->energy_use += blow_energy;
+		if (p->upkeep->energy_use + blow_energy > z_info->move_energy ||
 			stop) break;
 		blows++;
 	}
@@ -472,8 +481,9 @@ static const struct {
  * logic, while using the 'attack' parameter to do work particular to each
  * kind of attack.
  */
-static void ranged_helper(struct object *obj, int dir, int range, int shots,
-						  ranged_attack attack)
+static void ranged_helper(struct player *p,
+		struct object *obj, int dir, int range, int shots,
+		ranged_attack attack)
 {
 	int i, j;
 
@@ -483,8 +493,8 @@ static void ranged_helper(struct object *obj, int dir, int range, int shots,
 	struct loc path_g[256];
 
 	/* Start at the player */
-	int x = player->px;
-	int y = player->py;
+	int x = p->px;
+	int y = p->py;
 
 	/* Predict the "target" location */
 	int ty = y + 99 * ddy[dir];
@@ -516,17 +526,17 @@ static void ranged_helper(struct object *obj, int dir, int range, int shots,
 	object_desc(o_name, sizeof(o_name), obj, ODESC_FULL | ODESC_SINGULAR);
 
 	/* Actually "fire" the object -- Take a partial turn */
-	player->upkeep->energy_use = (z_info->move_energy / shots);
+	p->upkeep->energy_use = (z_info->move_energy / shots);
 
 	/* Calculate the path */
 	path_n = project_path(path_g, range, y, x, ty, tx, 0);
 
 	/* Hack -- Handle stuff */
-	handle_stuff(player);
+	handle_stuff(p);
 
 	/* Start at the player */
-	x = player->px;
-	y = player->py;
+	x = p->px;
+	y = p->py;
 
 	/* Project along the path */
 	for (i = 0; i < path_n; ++i) {
@@ -556,7 +566,7 @@ static void ranged_helper(struct object *obj, int dir, int range, int shots,
 			const char *note_dies = monster_is_unusual(mon->race) ? 
 				" is destroyed." : " dies.";
 
-			struct attack_result result = attack(obj, y, x);
+			struct attack_result result = attack(p, obj, y, x);
 			int dmg = result.dmg;
 			u32b msg_type = result.msg_type;
 			char hit_verb[20];
@@ -566,10 +576,10 @@ static void ranged_helper(struct object *obj, int dir, int range, int shots,
 			if (result.success) {
 				hit_target = true;
 
-				missile_learn_on_ranged_attack(player, obj);
+				missile_learn_on_ranged_attack(p, obj);
 
 				/* Learn by use for other equipped items */
-				equip_learn_on_ranged_attack(player);
+				equip_learn_on_ranged_attack(p);
 
 				/* No negative damage; change verb if no damage done */
 				if (dmg <= 0) {
@@ -605,8 +615,8 @@ static void ranged_helper(struct object *obj, int dir, int range, int shots,
 					
 					/* Track this monster */
 					if (mflag_has(mon->mflag, MFLAG_VISIBLE)) {
-						monster_race_track(player->upkeep, mon->race);
-						health_track(player->upkeep, mon);
+						monster_race_track(p->upkeep, mon->race);
+						health_track(p->upkeep, mon);
 					}
 				}
 
@@ -632,7 +642,7 @@ static void ranged_helper(struct object *obj, int dir, int range, int shots,
 	}
 
 	/* Get the missile */
-	if (object_is_carried(player, obj))
+	if (object_is_carried(p, obj))
 		missile = gear_object_for_use(obj, 1, true, &none_left);
 	else
 		missile = floor_object_for_use(obj, 1, true, &none_left);
@@ -645,14 +655,15 @@ static void ranged_helper(struct object *obj, int dir, int range, int shots,
 /**
  * Helper function used with ranged_helper by do_cmd_fire.
  */
-static struct attack_result make_ranged_shot(struct object *ammo, int y, int x)
+static struct attack_result make_ranged_shot(struct player *p,
+		struct object *ammo, int y, int x)
 {
 	char *hit_verb = mem_alloc(20 * sizeof(char));
 	struct attack_result result = {false, 0, 0, hit_verb};
-	struct object *bow = equipped_item_by_slot_name(player, "shooting");
+	struct object *bow = equipped_item_by_slot_name(p, "shooting");
 	struct monster *mon = square_monster(cave, y, x);
-	int chance = chance_of_missile_hit(player, ammo, bow, y, x);
-	int multiplier = player->state.ammo_mult;
+	int chance = chance_of_missile_hit(p, ammo, bow, y, x);
+	int multiplier = p->state.ammo_mult;
 	const struct brand *b = NULL;
 	const struct slay *s = NULL;
 
@@ -668,10 +679,10 @@ static struct attack_result make_ranged_shot(struct object *ammo, int y, int x)
 	improve_attack_modifier(bow, mon, &b, &s, result.hit_verb, true, true);
 
 	result.dmg = ranged_damage(ammo, bow, b, s, multiplier);
-	result.dmg = critical_shot(ammo->weight, ammo->to_h, result.dmg,
+	result.dmg = critical_shot(player, ammo->weight, ammo->to_h, result.dmg,
 							   &result.msg_type);
 
-	missile_learn_on_ranged_attack(player, bow);
+	missile_learn_on_ranged_attack(p, bow);
 
 	return result;
 }
@@ -680,12 +691,13 @@ static struct attack_result make_ranged_shot(struct object *ammo, int y, int x)
 /**
  * Helper function used with ranged_helper by do_cmd_throw.
  */
-static struct attack_result make_ranged_throw(struct object *obj, int y, int x)
+static struct attack_result make_ranged_throw(struct player *p,
+	struct object *obj, int y, int x)
 {
 	char *hit_verb = mem_alloc(20*sizeof(char));
 	struct attack_result result = {false, 0, 0, hit_verb};
 	struct monster *mon = square_monster(cave, y, x);
-	int chance = chance_of_missile_hit(player, obj, NULL, y, x);
+	int chance = chance_of_missile_hit(p, obj, NULL, y, x);
 	int multiplier = 1;
 	const struct brand *b = NULL;
 	const struct slay *s = NULL;
@@ -701,7 +713,7 @@ static struct attack_result make_ranged_throw(struct object *obj, int y, int x)
 	improve_attack_modifier(obj, mon, &b, &s, result.hit_verb, true, true);
 
 	result.dmg = ranged_damage(obj, NULL, b, s, multiplier);
-	result.dmg = critical_norm(obj->weight, obj->to_h, result.dmg,
+	result.dmg = critical_norm(player, obj->weight, obj->to_h, result.dmg,
 							   &result.msg_type);
 
 	/* Direct adjustment for exploding things (flasks of oil) */
@@ -757,7 +769,7 @@ void do_cmd_fire(struct command *cmd) {
 		return;
 	}
 
-	ranged_helper(obj, dir, range, shots, attack);
+	ranged_helper(player, obj, dir, range, shots, attack);
 }
 
 
@@ -798,7 +810,7 @@ void do_cmd_throw(struct command *cmd) {
 		return;
 	}
 
-	ranged_helper(obj, dir, range, shots, attack);
+	ranged_helper(player, obj, dir, range, shots, attack);
 }
 
 /**

--- a/src/player-attack.h
+++ b/src/player-attack.h
@@ -35,7 +35,7 @@ struct attack_result {
  * keeping the core projectile tracking, monster cleanup, and display code
  * in common.
  */
-typedef struct attack_result (*ranged_attack) (struct object *obj, int y, int x);
+typedef struct attack_result (*ranged_attack) (struct player *p, struct object *obj, int y, int x);
 
 extern void do_cmd_fire(struct command *cmd);
 extern void do_cmd_fire_at_nearest(void);
@@ -44,7 +44,7 @@ extern void do_cmd_throw(struct command *cmd);
 
 extern int breakage_chance(const struct object *obj, bool hit_target);
 extern bool test_hit(int chance, int ac, int vis);
-extern void py_attack(int y, int x);
-int py_attack_hit_chance(const struct object *weapon);
+extern void py_attack(struct player *p, int y, int x);
+int py_attack_hit_chance(const struct player *p, const struct object *weapon);
 
 #endif /* !PLAYER_ATTACK_H */

--- a/src/player-birth.c
+++ b/src/player-birth.c
@@ -103,6 +103,7 @@ struct birther
 	s16b stat[STAT_MAX];
 
 	char *history;
+	char name[PLAYER_NAME_LEN];
 };
 
 
@@ -156,6 +157,7 @@ static void save_roller_data(birther *tosave)
 		tosave->stat[i] = player->stat_birth[i];
 
 	tosave->history = player->history;
+	my_strcpy(tosave->name, player->full_name, sizeof(tosave->name));
 }
 
 
@@ -199,6 +201,7 @@ static void load_roller_data(birther *saved, birther *prev_player)
 
 	/* Load previous history */
 	player->history = saved->history;
+	my_strcpy(player->full_name, saved->name, sizeof(player->full_name));
 
 	/* Save the current data if the caller is interested in it. */
 	if (prev_player)
@@ -927,16 +930,17 @@ void do_cmd_birth_init(struct command *cmd)
 	}
 
 	/* Handle incrementing name suffix */
-	buf = find_roman_suffix_start(op_ptr->full_name);
+	buf = find_roman_suffix_start(player->full_name);
 	if (buf) {
 		/* Try to increment the roman suffix */
-		int success = int_to_roman((roman_to_int(buf) + 1), buf,
-			(sizeof(op_ptr->full_name) - (buf -
-			(char *)&op_ptr->full_name)));
-			
+		int success = int_to_roman(
+				roman_to_int(buf) + 1,
+				buf,
+				sizeof(player->full_name) - (buf - (char *)&player->full_name));
+
 		if (!success) msg("Sorry, could not deal with suffix");
 	}
-	
+
 	/* We're ready to start the birth process */
 	event_signal_flag(EVENT_ENTER_BIRTH, quickstart_allowed);
 }
@@ -1058,7 +1062,7 @@ void do_cmd_choose_name(struct command *cmd)
 	cmd_get_arg_string(cmd, "name", &str);
 
 	/* Set player name */
-	my_strcpy(op_ptr->full_name, str, sizeof(op_ptr->full_name));
+	my_strcpy(player->full_name, str, sizeof(player->full_name));
 
 	string_free((char *) str);
 }

--- a/src/player-birth.c
+++ b/src/player-birth.c
@@ -434,6 +434,8 @@ void player_init(struct player *p)
 	p->timed = mem_zalloc(TMD_MAX * sizeof(s16b));
 	p->obj_k = mem_zalloc(sizeof(struct object));
 
+	options_init_defaults();
+
 	/* First turn. */
 	turn = 1;
 	p->total_energy = 0;

--- a/src/player-birth.c
+++ b/src/player-birth.c
@@ -1091,8 +1091,8 @@ void do_cmd_accept_character(struct command *cmd)
 	ignore_birth_init();
 
 	/* Clear old messages, add new starting message */
-	history_clear();
-	history_add("Began the quest to destroy Morgoth.", HIST_PLAYER_BIRTH, 0);
+	history_clear(player);
+	history_add(player, "Began the quest to destroy Morgoth.", HIST_PLAYER_BIRTH, 0);
 
 	/* Note player birth in the message recall */
 	message_add(" ", MSG_GENERIC);

--- a/src/player-birth.c
+++ b/src/player-birth.c
@@ -1092,7 +1092,7 @@ void do_cmd_accept_character(struct command *cmd)
 
 	/* Clear old messages, add new starting message */
 	history_clear(player);
-	history_add(player, "Began the quest to destroy Morgoth.", HIST_PLAYER_BIRTH, 0);
+	history_add(player, "Began the quest to destroy Morgoth.", HIST_PLAYER_BIRTH);
 
 	/* Note player birth in the message recall */
 	message_add(" ", MSG_GENERIC);

--- a/src/player-birth.c
+++ b/src/player-birth.c
@@ -1084,13 +1084,7 @@ void do_cmd_choose_history(struct command *cmd)
 
 void do_cmd_accept_character(struct command *cmd)
 {
-	int i;
-
-	/* Reset score options from cheat options */
-	for (i = 0; i < OPT_MAX; i++) {
-		if (option_type(i) == OP_CHEAT)
-			op_ptr->opt[i + 1] = op_ptr->opt[i];
-	}
+	options_init_cheat();
 
 	roll_hp();
 

--- a/src/player-history.c
+++ b/src/player-history.c
@@ -25,7 +25,7 @@
 #include "player-history.h"
 
 /**
- * Number of slots available at birth in the player history list.
+ * Memory allocation constants.
  */
 #define HISTORY_LEN_INIT		20
 #define HISTORY_LEN_INCR		20
@@ -45,7 +45,7 @@ static void history_init(struct player_history *h)
  */
 static void history_realloc(struct player_history *h)
 {
-	h->length = h->length + HISTORY_LEN_INCR;
+	h->length += HISTORY_LEN_INCR;
 	h->entries = mem_realloc(h->entries,
 			h->length * sizeof *h->entries);
 }
@@ -119,24 +119,6 @@ static bool history_add_with_flags(struct player *p,
 		p->lev,
 		p->total_energy / 100,
 		text);
-}
-
-/**
- * Adds an entry to the history ledger with an artifact attached.
- */
-static bool history_add_with_artifact(struct player *p,
-		const char *text,
-		int type,
-		const struct artifact *artifact)
-{
-	bitflag flags[HIST_SIZE];
-	hist_wipe(flags);
-	hist_on(flags, type);
-
-	return history_add_with_flags(p,
-		text,
-		flags,
-		artifact);
 }
 
 /**
@@ -252,7 +234,11 @@ void history_find_artifact(struct player *p, const struct artifact *artifact)
 		get_artifact_name(o_name, sizeof(o_name), artifact);
 		strnfmt(text, sizeof(text), "Found %s", o_name);
 
-		history_add_with_artifact(p, text, HIST_ARTIFACT_KNOWN, artifact);
+		bitflag flags[HIST_SIZE];
+		hist_wipe(flags);
+		hist_on(flags, HIST_ARTIFACT_KNOWN);
+
+		history_add_with_flags(p, text, flags, artifact);
 	}
 }
 

--- a/src/player-history.c
+++ b/src/player-history.c
@@ -59,9 +59,9 @@ void history_clear(struct player *p)
 
 	if (h->entries) {
 		mem_free(h->entries);
+		h->entries = NULL;
 	}
 
-	h->entries = NULL;
 	h->next = 0;
 	h->length = 0;
 }

--- a/src/player-history.c
+++ b/src/player-history.c
@@ -130,10 +130,7 @@ bool history_add(struct player *p, const char *text, int type)
 	hist_wipe(flags);
 	hist_on(flags, type);
 
-	return history_add_with_flags(p,
-		text,
-		flags,
-		0);
+	return history_add_with_flags(p, text, flags, 0);
 }
 
 /**

--- a/src/player-history.c
+++ b/src/player-history.c
@@ -247,12 +247,12 @@ void history_find_artifact(struct player *p, const struct artifact *artifact)
 	/* Try revealing any existing artifact, otherwise log it */
 	if (!history_mark_artifact_known(&p->hist, artifact)) {
 		char o_name[80];
-		char buf[80];
+		char text[80];
 
 		get_artifact_name(o_name, sizeof(o_name), artifact);
-		strnfmt(buf, sizeof(buf), "Found %s", o_name);
+		strnfmt(text, sizeof(text), "Found %s", o_name);
 
-		history_add_with_artifact(p, buf, HIST_ARTIFACT_KNOWN, artifact);
+		history_add_with_artifact(p, text, HIST_ARTIFACT_KNOWN, artifact);
 	}
 }
 

--- a/src/player-history.c
+++ b/src/player-history.c
@@ -184,7 +184,7 @@ static bool history_mark_artifact_known(struct player_history *h,
 	size_t i = h->next;
 	while (i--) {
 		if (h->entries[i].a_idx == artifact->aidx) {
-			hist_wipe(h->entries[i].type);
+			hist_off(h->entries[i].type, HIST_ARTIFACT_UNKNOWN);
 			hist_on(h->entries[i].type, HIST_ARTIFACT_KNOWN);
 			return true;
 		}
@@ -204,7 +204,6 @@ static bool history_mark_artifact_lost(struct player_history *h,
 	size_t i = h->next;
 	while (i--) {
 		if (h->entries[i].a_idx == artifact->aidx) {
-			hist_wipe(h->entries[i].type);
 			hist_on(h->entries[i].type, HIST_ARTIFACT_LOST);
 			return true;
 		}

--- a/src/player-history.c
+++ b/src/player-history.c
@@ -75,10 +75,10 @@ void history_clear(struct player *p)
  */
 bool history_add_full(struct player *p,
 		bitflag *type,
-		const struct artifact *artifact,
-		s16b dlev,
-		s16b clev,
-		s32b turnno,
+		int aidx,
+		int dlev,
+		int clev,
+		int turnno,
 		const char *text)
 {
 	struct player_history *h = &p->hist;
@@ -93,7 +93,7 @@ bool history_add_full(struct player *p,
 	hist_copy(h->entries[h->next].type, type);
 	h->entries[h->next].dlev = dlev;
 	h->entries[h->next].clev = clev;
-	h->entries[h->next].a_idx = artifact ? artifact->aidx : 0;
+	h->entries[h->next].a_idx = aidx;
 	h->entries[h->next].turn = turnno;
 	my_strcpy(h->entries[h->next].event,
 			text,
@@ -114,7 +114,7 @@ static bool history_add_with_flags(struct player *p,
 {
 	return history_add_full(p,
 		flags,
-		artifact,
+		artifact ? artifact->aidx : 0,
 		p->depth,
 		p->lev,
 		p->total_energy / 100,
@@ -130,7 +130,7 @@ bool history_add(struct player *p, const char *text, int type)
 	hist_wipe(flags);
 	hist_on(flags, type);
 
-	return history_add_with_flags(p, text, flags, 0);
+	return history_add_with_flags(p, text, flags, NULL);
 }
 
 /**

--- a/src/player-history.h
+++ b/src/player-history.h
@@ -61,13 +61,10 @@ bool history_add_full(struct player *p,
 		s16b clev,
 		s32b turn,
 		const char *text);
-bool history_add(struct player *p, const char *text, int type, const struct artifact *art);
+bool history_add(struct player *p, const char *text, int type);
 bool history_is_artifact_known(struct player *p, const struct artifact *artifact);
-bool history_add_artifact(struct player *p,
-		const struct artifact *artifact,
-		bool known,
-		bool found);
-bool history_lose_artifact(struct player *p, const struct artifact *artifact);
+void history_find_artifact(struct player *p, const struct artifact *artifact);
+void history_lose_artifact(struct player *p, const struct artifact *artifact);
 void history_unmask_unknown(struct player *p);
 size_t history_get_list(struct player *p, struct history_info **list);
 

--- a/src/player-history.h
+++ b/src/player-history.h
@@ -53,16 +53,22 @@ struct history_info {
 	char event[80];			/* The text of the item */
 };
 
-extern struct history_info *history_list;
-
-void history_clear(void);
-size_t history_get_num(void);
-bool history_add_full(bitflag *type, struct artifact *artifact, s16b dlev, s16b clev, s32b turn, const char *text);
-bool history_add(const char *event, int type, struct artifact *art);
-bool history_add_artifact(struct artifact *art, bool known, bool found);
-void history_unmask_unknown(void);
-bool history_lose_artifact(struct artifact *art);
-bool history_is_artifact_known(struct artifact *art);
-size_t history_get_list(struct history_info **list);
+void history_clear(struct player *p);
+bool history_add_full(struct player *p,
+		bitflag *type,
+		const struct artifact *artifact,
+		s16b dlev,
+		s16b clev,
+		s32b turn,
+		const char *text);
+bool history_add(struct player *p, const char *text, int type, const struct artifact *art);
+bool history_is_artifact_known(struct player *p, const struct artifact *artifact);
+bool history_add_artifact(struct player *p,
+		const struct artifact *artifact,
+		bool known,
+		bool found);
+bool history_lose_artifact(struct player *p, const struct artifact *artifact);
+void history_unmask_unknown(struct player *p);
+size_t history_get_list(struct player *p, struct history_info **list);
 
 #endif /* !HISTORY_H */

--- a/src/player-history.h
+++ b/src/player-history.h
@@ -56,10 +56,10 @@ struct history_info {
 void history_clear(struct player *p);
 bool history_add_full(struct player *p,
 		bitflag *type,
-		const struct artifact *artifact,
-		s16b dlev,
-		s16b clev,
-		s32b turn,
+		int aidx,
+		int dlev,
+		int clev,
+		int turn,
 		const char *text);
 bool history_add(struct player *p, const char *text, int type);
 bool history_is_artifact_known(struct player *p, const struct artifact *artifact);

--- a/src/player-util.c
+++ b/src/player-util.c
@@ -183,7 +183,7 @@ void death_knowledge(struct player *p)
 		obj->known->activation = obj->activation;
 	}
 
-	history_unmask_unknown();
+	history_unmask_unknown(p);
 
 	/* Get time of death */
 	(void)time(&death_time);

--- a/src/player-util.c
+++ b/src/player-util.c
@@ -99,7 +99,7 @@ void take_hit(struct player *p, int dam, const char *kb_str)
 {
 	int old_chp = p->chp;
 
-	int warning = (p->mhp * op_ptr->hitpoint_warn / 10);
+	int warning = (p->mhp * p->opts.hitpoint_warn / 10);
 
 	/* Paranoia */
 	if (p->is_dead) return;

--- a/src/player.c
+++ b/src/player.c
@@ -29,17 +29,6 @@
 #include "z-color.h"
 #include "z-util.h"
 
-
-/**
- * The player other record (static)
- */
-static player_other player_other_body;
-
-/**
- * Pointer to the player other record
- */
-player_other *op_ptr = &player_other_body;
-
 /**
  * Pointer to the player struct
  */
@@ -308,7 +297,7 @@ byte player_hp_attr(struct player *p)
 	
 	if (p->chp >= p->mhp)
 		attr = COLOUR_L_GREEN;
-	else if (p->chp > (p->mhp * op_ptr->hitpoint_warn) / 10)
+	else if (p->chp > (p->mhp * p->opts.hitpoint_warn) / 10)
 		attr = COLOUR_YELLOW;
 	else
 		attr = COLOUR_RED;
@@ -322,7 +311,7 @@ byte player_sp_attr(struct player *p)
 	
 	if (p->csp >= p->msp)
 		attr = COLOUR_L_GREEN;
-	else if (p->csp > (p->msp * op_ptr->hitpoint_warn) / 10)
+	else if (p->csp > (p->msp * p->opts.hitpoint_warn) / 10)
 		attr = COLOUR_YELLOW;
 	else
 		attr = COLOUR_RED;

--- a/src/player.c
+++ b/src/player.c
@@ -237,7 +237,7 @@ static void adjust_level(struct player *p, bool verbose)
 		if (verbose) {
 			/* Log level updates */
 			strnfmt(buf, sizeof(buf), "Reached level %d", p->lev);
-			history_add(buf, HIST_GAIN_LEVEL, 0);
+			history_add(p, buf, HIST_GAIN_LEVEL, 0);
 
 			/* Message */
 			msgt(MSG_LEVEL, "Welcome to level %d.",	p->lev);

--- a/src/player.c
+++ b/src/player.c
@@ -237,7 +237,7 @@ static void adjust_level(struct player *p, bool verbose)
 		if (verbose) {
 			/* Log level updates */
 			strnfmt(buf, sizeof(buf), "Reached level %d", p->lev);
-			history_add(p, buf, HIST_GAIN_LEVEL, 0);
+			history_add(p, buf, HIST_GAIN_LEVEL);
 
 			/* Message */
 			msgt(MSG_LEVEL, "Welcome to level %d.",	p->lev);

--- a/src/player.c
+++ b/src/player.c
@@ -397,6 +397,9 @@ static void init_player(void) {
 static void cleanup_player(void) {
 	int i;
 
+	/* Free the history */
+	history_clear(player);
+
 	/* Free the things that are always initialised */
 	mem_free(player->obj_k);
 	mem_free(player->timed);

--- a/src/player.c
+++ b/src/player.c
@@ -346,40 +346,44 @@ bool player_restore_mana(struct player *p, int amt) {
 
 /**
  * Return a version of the player's name safe for use in filesystems.
+ *
+ * XXX This does not belong here.
  */
-const char *player_safe_name(struct player *p, bool strip_suffix)
+void player_safe_name(char *safe, size_t safelen, const char *name, bool strip_suffix)
 {
-	static char buf[40];
-	int i;
-	int limit = 0;
+	size_t i;
+	size_t limit = 0;
 
-	if (op_ptr->full_name[0]) {
-		char *suffix = find_roman_suffix_start(op_ptr->full_name);
-		if (suffix)
-			limit = suffix - op_ptr->full_name - 1; /* -1 for preceding space */
-		else
-			limit = strlen(op_ptr->full_name);
+	if (name) {
+		char *suffix = find_roman_suffix_start(name);
+
+		if (suffix) {
+			limit = suffix - name - 1; /* -1 for preceding space */
+		} else {
+			limit = strlen(name);
+		}
 	}
 
+	/* Limit to maximum size of safename buffer */
+	limit = MIN(limit, safelen);
+
 	for (i = 0; i < limit; i++) {
-		char c = op_ptr->full_name[i];
+		char c = name[i];
 
 		/* Convert all non-alphanumeric symbols */
 		if (!isalpha((unsigned char)c) && !isdigit((unsigned char)c))
 			c = '_';
 
 		/* Build "base_name" */
-		buf[i] = c;
+		safe[i] = c;
 	}
 
 	/* Terminate */
-	buf[i] = '\0';
+	safe[i] = '\0';
 
 	/* Require a "base" name */
-	if (!buf[0])
-		my_strcpy(buf, "PLAYER", sizeof buf);
-
-	return buf;
+	if (!safe[0])
+		my_strcpy(safe, "PLAYER", safelen);
 }
 
 

--- a/src/player.h
+++ b/src/player.h
@@ -26,19 +26,16 @@
 #include "object.h"
 #include "option.h"
 
-
 /**
- * Indexes of the various "stats" (hard-coded by savefiles, etc).
+ * Indexes of the player stats (hard-coded by savefiles).
  */
-enum
-{
+enum {
 	#define STAT(a, b, c, d, e, f, g, h, i) STAT_##a,
 	#include "list-stats.h"
 	#undef STAT
 
 	STAT_MAX
 };
-
 
 /**
  * Player race and class flags
@@ -72,20 +69,15 @@ enum
 
 #define player_has(p, flag)       (pf_has(p->race->pflags, (flag)) || pf_has(p->class->pflags, (flag)))
 
-
 /**
  * The range of possible indexes into tables based upon stats.
  * Currently things range from 3 to 18/220 = 40.
  */
 #define STAT_RANGE 38
 
-
 /**
- * ------------------------------------------------------------------------
  * Player constants
- * ------------------------------------------------------------------------ */
-
-
+ */
 #define PY_MAX_EXP		99999999L	/* Maximum exp */
 #define PY_KNOW_LEVEL	30			/* Level to know all runes */
 #define PY_MAX_LEVEL	50			/* Maximum level */
@@ -111,46 +103,41 @@ enum
 };
 
 /**
- * player noscore flags
+ * Ways in which players can be marked as cheaters
  */
 #define NOSCORE_WIZARD		0x0002
 #define NOSCORE_DEBUG		0x0008
 #define NOSCORE_JUMPING     0x0010
 
 /**
- * Skill indexes
+ * Terrain that the player has a chance of digging through
  */
-enum
-{
-	SKILL_DISARM_PHYS,		/* Skill: Disarming - physical*/
-	SKILL_DISARM_MAGIC,		/* Skill: Disarming - magical */
-	SKILL_DEVICE,			/* Skill: Magic Devices */
-	SKILL_SAVE,				/* Skill: Saving throw */
-	SKILL_STEALTH,			/* Skill: Stealth factor */
-	SKILL_TO_HIT_MELEE,		/* Skill: To hit (normal) */
-	SKILL_TO_HIT_BOW,		/* Skill: To hit (shooting) */
-	SKILL_TO_HIT_THROW,		/* Skill: To hit (throwing) */
-	SKILL_DIGGING,			/* Skill: Digging */
-
-	SKILL_MAX
-};
-
-/* Terrain that the player has a chance of digging through */
-enum
-{
+enum {
 	DIGGING_RUBBLE = 0,
 	DIGGING_MAGMA,
 	DIGGING_QUARTZ,
 	DIGGING_GRANITE,
 	DIGGING_DOORS,
-	
+
 	DIGGING_MAX
 };
 
 /**
- * ------------------------------------------------------------------------
- * Player structures
- * ------------------------------------------------------------------------ */
+ * Skill indexes
+ */
+enum {
+	SKILL_DISARM_PHYS,		/* Disarming - physical */
+	SKILL_DISARM_MAGIC,		/* Disarming - magical */
+	SKILL_DEVICE,			/* Magic Devices */
+	SKILL_SAVE,				/* Saving throw */
+	SKILL_STEALTH,			/* Stealth factor */
+	SKILL_TO_HIT_MELEE,		/* To hit (normal) */
+	SKILL_TO_HIT_BOW,		/* To hit (shooting) */
+	SKILL_TO_HIT_THROW,		/* To hit (throwing) */
+	SKILL_DIGGING,			/* Digging */
+
+	SKILL_MAX
+};
 
 /**
  * Structure for the "quests"
@@ -167,7 +154,7 @@ struct quest
 };
 
 /**
- * Player body info
+ * A single equipment slot
  */
 struct equip_slot {
 	struct equip_slot *next;
@@ -177,6 +164,9 @@ struct equip_slot {
 	struct object *obj;
 };
 
+/**
+ * A player 'body'
+ */
 struct player_body {
 	struct player_body *next;
 	char *name;
@@ -184,44 +174,41 @@ struct player_body {
 	struct equip_slot *slots;
 };
 
-extern struct player_body *bodies;
-
 /**
- * Player racial info
+ * Player race info
  */
 struct player_race {
 	struct player_race *next;
 	const char *name;
-	
+
 	unsigned int ridx;
 
-	int r_adj[STAT_MAX];	/* Racial stat bonuses */
-	
-	int r_skills[SKILL_MAX];	/* racial skills */
-	
-	int r_mhp;			/* Race hit-dice modifier */
-	int r_exp;			/* Race experience factor */
-	
-	int b_age;			/* base age */
-	int m_age;			/* mod age */
-	
-	int base_hgt;		/* base height */
-	int mod_hgt;		/* mod height */
-	int base_wgt;		/* base weight */
-	int mod_wgt;		/* mod weight */
-	
-	int infra;			/* Infra-vision	range */
-	
-	int body;			/* Race body */
+	int r_mhp;		/**< Hit-dice modifier */
+	int r_exp;		/**< Experience factor */
+
+	int b_age;		/**< Base age */
+	int m_age;		/**< Mod age */
+
+	int base_hgt;	/**< Base height */
+	int mod_hgt;	/**< Mod height */
+	int base_wgt;	/**< Base weight */
+	int mod_wgt;	/**< Mod weight */
+
+	int infra;		/**< Infra-vision range */
+
+	int body;		/**< Race body */
+
+	int r_adj[STAT_MAX];		/**< Stat bonuses */
+
+	int r_skills[SKILL_MAX];	/**< Skills */
+
+	bitflag flags[OF_SIZE];		/**< Racial (object) flags */
+	bitflag pflags[PF_SIZE];	/**< Racial (player) flags */
+
 	struct history_chart *history;
-	
-	bitflag flags[OF_SIZE];   /* Racial (object) flags */
-	bitflag pflags[PF_SIZE];  /* Racial (player) flags */
 
-	struct element_info el_info[ELEM_MAX]; /* Racial resists */
+	struct element_info el_info[ELEM_MAX]; /**< Resists */
 };
-
-extern struct player_race *races;
 
 /**
  * Items the player starts with.  Used in player_class and specified in
@@ -229,12 +216,11 @@ extern struct player_race *races;
  */
 struct start_item {
 	struct object_kind *kind;
-	int min;	/* Minimum starting amount */
-	int max;	/* Maximum starting amount */
+	int min;	/**< Minimum starting amount */
+	int max;	/**< Maximum starting amount */
 
 	struct start_item *next;
 };
-
 
 /**
  * Structure for magic realms
@@ -248,8 +234,6 @@ struct magic_realm {
 	const char *adjective;
 };
 
-extern struct magic_realm realms[REALM_MAX];
-
 /**
  * A structure to hold class-dependent information on spells.
  */
@@ -259,39 +243,36 @@ struct class_spell {
 
 	struct effect *effect;	/**< The spell's effect */
 
-	int sidx;		/**< The index of this spell for this class */
-	int bidx;		/**< The index into the player's books array */
-	int slevel;	/**< Required level (to learn) */
-	int smana;		/**< Required mana (to cast) */
-	int sfail;		/**< Base chance of failure */
-	int sexp;		/**< Encoded experience bonus */
+	int sidx;				/**< The index of this spell for this class */
+	int bidx;				/**< The index into the player's books array */
+	int slevel;				/**< Required level (to learn) */
+	int smana;				/**< Required mana (to cast) */
+	int sfail;				/**< Base chance of failure */
+	int sexp;				/**< Encoded experience bonus */
 };
-
 
 /**
  * A structure to hold class-dependent information on spell books.
  */
 struct class_book {
-	int tval;			/**< Item type of the book */
-	int sval;			/**< Item sub-type for book (book number) */
-	int realm;			/**< The magic realm of this book */
-	int num_spells;	/**< Number of spells in this book */
+	int tval;					/**< Item type of the book */
+	int sval;					/**< Item sub-type for book (book number) */
+	int realm;					/**< The magic realm of this book */
+	int num_spells;				/**< Number of spells in this book */
 	struct class_spell *spells;	/**< Spells in the book*/
 };
-
 
 /**
  * Information about class magic knowledge
  */
 struct class_magic {
-	int spell_first;		/**< Level of first spell */
-	int spell_weight;		/**< Max armour weight to avoid mana penalties */
-	struct magic_realm *spell_realm;  		/**< Primary spellcasting realm */
-	int num_books;			/**< Number of spellbooks */
-	struct class_book *books;		/**< Details of spellbooks */
-	int total_spells;		/**< Number of spells for this class */
+	int spell_first;					/**< Level of first spell */
+	int spell_weight;					/**< Max armour weight to avoid mana penalties */
+	struct magic_realm *spell_realm;	/**< Primary spellcasting realm */
+	int num_books;						/**< Number of spellbooks */
+	struct class_book *books;			/**< Details of spellbooks */
+	int total_spells;					/**< Number of spells for this class */
 };
-
 
 /**
  * Player class info
@@ -300,32 +281,30 @@ struct player_class {
 	struct player_class *next;
 	const char *name;
 	unsigned int cidx;
-	
-	const char *title[10];    /* Titles */
-	
-	int c_adj[STAT_MAX]; /* Class stat modifier */
-	
-	int c_skills[SKILL_MAX];	/* class skills */
-	int x_skills[SKILL_MAX];	/* extra skills */
-	
-	int c_mhp;        /* Class hit-dice adjustment */
-	int c_exp;        /* Class experience factor */
-	
-	bitflag pflags[PF_SIZE]; /* Class (player) flags */
-	
-	int max_attacks;  /* Maximum possible attacks */
-	int min_weight;   /* Minimum weapon weight for calculations */
-	int att_multiply; /* Multiplier for attack calculations */
-	
-	int sense_base;   /* Base pseudo-id value */
-	int sense_div;    /* Pseudo-id divisor */
-	
-	struct start_item *start_items; /* Starting inventory */
-	
-	struct class_magic magic; /* Magic spells */
-};
 
-extern struct player_class *classes;
+	const char *title[10];		/**< Titles */
+
+	int c_adj[STAT_MAX];		/**< Stat modifier */
+
+	int c_skills[SKILL_MAX];	/**< Class skills */
+	int x_skills[SKILL_MAX];	/**< Extra skills */
+
+	int c_mhp;					/**< Hit-dice adjustment */
+	int c_exp;					/**< Experience factor */
+
+	bitflag pflags[PF_SIZE];	/**< (Player) flags */
+
+	int max_attacks;			/**< Maximum possible attacks */
+	int min_weight;				/**< Minimum weapon weight for calculations */
+	int att_multiply;			/**< Multiplier for attack calculations */
+
+	int sense_base;				/**< Base pseudo-id value */
+	int sense_div;				/**< Pseudo-id divisor */
+
+	struct start_item *start_items; /**< Starting inventory */
+
+	struct class_magic magic;	/**< Magic spells */
+};
 
 /**
  * Histories are a graph of charts; each chart contains a set of individual
@@ -365,23 +344,24 @@ struct history_chart {
 };
 
 /**
- * Some more player information
- * This information is retained across player lives
+ * Information retained across player lives
  *
- * XXX - options.c should store most of this, and struct player the rest
+ * This should be incorporated into struct player
+ *
+ * XXX some of this is UI specific - should we allow UI way to store
+ *     options in savefile?
  */
 typedef struct {
-	char full_name[32];		/* Full name */
-	
-	bool opt[OPT_MAX];		/* Options */
-	
-	byte hitpoint_warn;		/* Hitpoint warning (0 to 9) */
-	u16b lazymove_delay;	/* Delay in cs before moving to allow another key */
-	byte delay_factor;		/* Delay factor (0 to 9) */
-	
-	byte name_suffix;		/* numeric suffix for player name */
-} player_other;
+	char full_name[32];		/**< Full name */
 
+	bool opt[OPT_MAX];		/**< Options */
+
+	byte hitpoint_warn;		/**< Hitpoint warning (0 to 9) */
+	u16b lazymove_delay;	/**< Delay in cs before moving to allow another key */
+	byte delay_factor;		/**< Delay factor (0 to 9) */
+
+	byte name_suffix;		/**< Numeric suffix for player name */
+} player_other;
 
 /**
  * All the variable state that changes when you put on/take off equipment.
@@ -389,48 +369,48 @@ typedef struct {
  * learn them.
  */
 struct player_state {
-	s16b speed;		/* Current speed */
+	s16b stat_add[STAT_MAX];	/**< Equipment stat bonuses */
+	s16b stat_ind[STAT_MAX];	/**< Indexes into stat tables */
+	s16b stat_use[STAT_MAX];	/**< Current modified stats */
+	s16b stat_top[STAT_MAX];	/**< Maximal modified stats */
 
-	s16b num_blows;		/* Number of blows x100 */
-	s16b num_shots;		/* Number of shots */
+	s16b skills[SKILL_MAX];		/**< Skills */
 
-	byte ammo_mult;		/* Ammo multiplier */
-	byte ammo_tval;		/* Ammo variety */
+	s16b speed;			/**< Current speed */
 
-	s16b stat_add[STAT_MAX];	/* Equipment stat bonuses */
-	s16b stat_ind[STAT_MAX];	/* Indexes into stat tables */
-	s16b stat_use[STAT_MAX];	/* Current modified stats */
-	s16b stat_top[STAT_MAX];	/* Maximal modified stats */
+	s16b num_blows;		/**< Number of blows x100 */
+	s16b num_shots;		/**< Number of shots */
 
-	s16b ac;			/* Base ac */
-	s16b to_a;			/* Bonus to ac */
-	s16b to_h;			/* Bonus to hit */
-	s16b to_d;			/* Bonus to dam */
+	byte ammo_mult;		/**< Ammo multiplier */
+	byte ammo_tval;		/**< Ammo variety */
 
-	s16b see_infra;		/* Infravision range */
+	s16b ac;			/**< Base ac */
+	s16b to_a;			/**< Bonus to ac */
+	s16b to_h;			/**< Bonus to hit */
+	s16b to_d;			/**< Bonus to dam */
 
-	s16b cur_light;		/* Radius of light (if any) */
+	s16b see_infra;		/**< Infravision range */
 
-	s16b skills[SKILL_MAX];	/* Skills */
+	s16b cur_light;		/**< Radius of light (if any) */
 
-	int noise;			/* Derived from stealth */
+	int noise;			/**< Derived from stealth */
 
-	bool heavy_wield;	/* Heavy weapon */
-	bool heavy_shoot;	/* Heavy shooter */
-	bool icky_wield;	/* Icky weapon shooter */
+	bool heavy_wield;	/**< Heavy weapon */
+	bool heavy_shoot;	/**< Heavy shooter */
+	bool icky_wield;	/**< Icky weapon shooter */
 
-	bool cumber_armor;	/* Mana draining armor */
-	bool cumber_glove;	/* Mana draining gloves */
+	bool cumber_armor;	/**< Mana draining armor */
+	bool cumber_glove;	/**< Mana draining gloves */
 
-	bitflag flags[OF_SIZE];	/* Status flags from race and items */
-	bitflag pflags[PF_SIZE];	/* Player intrinsic flags */
-	struct element_info el_info[ELEM_MAX]; /* Resists from race and items */
+	bitflag flags[OF_SIZE];					/**< Status flags from race and items */
+	bitflag pflags[PF_SIZE];				/**< Player intrinsic flags */
+	struct element_info el_info[ELEM_MAX];	/**< Resists from race and items */
 };
 
 /**
  * Temporary, derived, player-related variables used during play but not saved
  *
- * Some of these probably should go to the UI
+ * XXX Some of these probably should go to the UI
  */
 struct player_upkeep {
 	bool playing;			/* True if player is playing */
@@ -447,13 +427,13 @@ struct player_upkeep {
 	struct object *object;				/* Object trackee */
 	struct object_kind *object_kind;	/* Object kind trackee */
 
-	u32b notice;		/* Bit flags for pending actions such as 
-						 * reordering inventory, ignoring, etc. */
-	u32b update;		/* Bit flags for recalculations needed 
-						 * such as HP, or visible area */
-	u32b redraw;	    /* Bit flags for things that /have/ changed,
-						 * and just need to be redrawn by the UI,
-						 * such as HP, Speed, etc.*/
+	u32b notice;			/* Bit flags for pending actions such as
+							 * reordering inventory, ignoring, etc. */
+	u32b update;			/* Bit flags for recalculations needed
+							 * such as HP, or visible area */
+	u32b redraw;			/* Bit flags for things that /have/ changed,
+							 * and just need to be redrawn by the UI,
+							 * such as HP, Speed, etc.*/
 
 	int command_wrk;		/* Used by the UI to decide whether
 							 * to start off showing equipment or
@@ -477,7 +457,6 @@ struct player_upkeep {
 	int quiver_cnt;				/* Number of items in the quiver */
 };
 
-
 /**
  * Most of the "player" information goes here.
  *
@@ -490,96 +469,90 @@ struct player_upkeep {
  * which can be recomputed as needed.
  */
 struct player {
-	s16b py;			/* Player location */
-	s16b px;			/* Player location */
-
 	const struct player_race *race;
 	const struct player_class *class;
 
-	byte hitdie;		/* Hit dice (sides) */
-	byte expfact;		/* Experience factor */
+	s16b py;		/* Player location */
+	s16b px;		/* Player location */
 
-	s16b age;			/* Characters age */
-	s16b ht;			/* Height */
-	s16b wt;			/* Weight */
+	byte hitdie;	/* Hit dice (sides) */
+	byte expfact;	/* Experience factor */
 
-	s32b au;			/* Current Gold */
+	s16b age;		/* Characters age */
+	s16b ht;		/* Height */
+	s16b wt;		/* Weight */
 
-	s16b max_depth;		/* Max depth */
-	s16b depth;			/* Cur depth */
+	s32b au;		/* Current Gold */
 
-	s16b max_lev;		/* Max level */
-	s16b lev;			/* Cur level */
+	s16b max_depth;	/* Max depth */
+	s16b depth;		/* Cur depth */
 
-	s32b max_exp;		/* Max experience */
-	s32b exp;			/* Cur experience */
-	u16b exp_frac;		/* Cur exp frac (times 2^16) */
+	s16b max_lev;	/* Max level */
+	s16b lev;		/* Cur level */
 
-	s16b mhp;			/* Max hit pts */
-	s16b chp;			/* Cur hit pts */
-	u16b chp_frac;		/* Cur hit frac (times 2^16) */
+	s32b max_exp;	/* Max experience */
+	s32b exp;		/* Cur experience */
+	u16b exp_frac;	/* Cur exp frac (times 2^16) */
 
-	s16b msp;			/* Max mana pts */
-	s16b csp;			/* Cur mana pts */
-	u16b csp_frac;		/* Cur mana frac (times 2^16) */
+	s16b mhp;		/* Max hit pts */
+	s16b chp;		/* Cur hit pts */
+	u16b chp_frac;	/* Cur hit frac (times 2^16) */
+
+	s16b msp;		/* Max mana pts */
+	s16b csp;		/* Cur mana pts */
+	u16b csp_frac;	/* Cur mana frac (times 2^16) */
 
 	s16b stat_max[STAT_MAX];	/* Current "maximal" stat values */
 	s16b stat_cur[STAT_MAX];	/* Current "natural" stat values */
 	s16b stat_map[STAT_MAX];	/* Tracks remapped stats from temp stat swap */
 
-	s16b *timed;		/* Timed effects */
+	s16b *timed;				/* Timed effects */
 
-	s16b word_recall;	/* Word of recall counter */
-	s16b deep_descent;	/* Deep Descent counter */
+	s16b word_recall;			/* Word of recall counter */
+	s16b deep_descent;			/* Deep Descent counter */
 
-	s16b energy;		/* Current energy */
-	u32b total_energy;	/* Total energy used (including resting) */
-	u32b resting_turn;	/* Number of player turns spent resting */
+	s16b energy;				/* Current energy */
+	u32b total_energy;			/* Total energy used (including resting) */
+	u32b resting_turn;			/* Number of player turns spent resting */
 
-	s16b food;			/* Current nutrition */
+	s16b food;					/* Current nutrition */
 
-	byte confusing;		/* Glowing hands */
-	byte unignoring;	/* Unignoring */
+	byte confusing;				/* Glowing hands */
+	byte unignoring;			/* Unignoring */
 
-	byte *spell_flags; /* Spell flags */
-	byte *spell_order;	/* Spell order */
+	byte *spell_flags;			/* Spell flags */
+	byte *spell_order;			/* Spell order */
 
-	s16b player_hp[PY_MAX_LEVEL];	/* HP Array */
+	char died_from[80];			/* Cause of death */
+	char *history;				/* Player history */
+	struct quest *quests;		/* Quest history */
+	u16b total_winner;			/* Total winner */
 
-	char died_from[80];		/* Cause of death */
-	char *history;			/* Player history */
-	struct quest *quests;	/* Quest history */
-	u16b total_winner;		/* Total winner */
+	u16b noscore;				/* Cheating flags */
 
-	u16b noscore;			/* Cheating flags */
+	bool is_dead;				/* Player is dead */
 
-	bool is_dead;			/* Player is dead */
+	bool wizard;				/* Player is in wizard mode */
 
-	bool wizard;			/* Player is in wizard mode */
+	s16b player_hp[PY_MAX_LEVEL];		/* HP gained per level */
 
-	/* Generation fields (for quick start) */
-	s32b au_birth;          /* Birth gold when option birth_money is false */
-	s16b stat_birth[STAT_MAX]; /* Birth "natural" stat values */
-	s16b ht_birth;          /* Birth Height */
-	s16b wt_birth;          /* Birth Weight */
+	/* Saved values for quickstart */
+	s32b au_birth;						/* Birth gold when option birth_money is false */
+	s16b stat_birth[STAT_MAX];			/* Birth "natural" stat values */
+	s16b ht_birth;						/* Birth Height */
+	s16b wt_birth;						/* Birth Weight */
 
-	/* Variable and calculatable player state */
-	struct player_state state;
-	struct player_state known_state;
+	struct player_state state;			/* Calculatable state */
+	struct player_state known_state;	/* What the player can know of the above */
+	struct player_upkeep *upkeep;		/* Temporary player-related values */
 
-	/* Tracking of various temporary player-related values */
-	struct player_upkeep *upkeep;
+	struct object *gear;		/* Real gear */
+	struct object *gear_k;		/* Known gear */
 
-	/* Real gear */
-	struct object *gear;
-	/* Known gear */
-	struct object *gear_k;
-	/* Object knowledge ("runes") */
-	struct object *obj_k;
-	/* Known version of current level */
-	struct chunk *cave;
+	struct object *obj_k;		/* Object knowledge ("runes") */
+	struct chunk *cave;			/* Known version of current level */
 
-	struct player_body body;
+	struct player_body body;	/* What equipment slots are available */
 };
 
 
@@ -588,31 +561,32 @@ struct player {
  * Externs
  * ------------------------------------------------------------------------ */
 
+extern struct player_body *bodies;
+extern struct player_race *races;
+extern struct player_class *classes;
+extern struct magic_realm realms[REALM_MAX];
+
 extern const s32b player_exp[PY_MAX_LEVEL];
 extern player_other *op_ptr;
 extern struct player *player;
 
-
 /* player-class.c */
-extern struct player_class *player_id2class(guid id);
+struct player_class *player_id2class(guid id);
 
 /* player.c */
 int stat_name_to_idx(const char *name);
 const char *stat_idx_to_name(int type);
-extern bool player_stat_inc(struct player *p, int stat);
-extern bool player_stat_dec(struct player *p, int stat, bool permanent);
-extern void player_exp_gain(struct player *p, s32b amount);
-extern void player_exp_lose(struct player *p, s32b amount, bool permanent);
-extern void player_flags(struct player *p, bitflag f[OF_SIZE]);
-
-extern byte player_hp_attr(struct player *p);
-extern byte player_sp_attr(struct player *p);
-
-extern bool player_restore_mana(struct player *p, int amt);
-
-extern const char *player_safe_name(struct player *p, bool strip_suffix);
+bool player_stat_inc(struct player *p, int stat);
+bool player_stat_dec(struct player *p, int stat, bool permanent);
+void player_exp_gain(struct player *p, s32b amount);
+void player_exp_lose(struct player *p, s32b amount, bool permanent);
+void player_flags(struct player *p, bitflag f[OF_SIZE]);
+byte player_hp_attr(struct player *p);
+byte player_sp_attr(struct player *p);
+bool player_restore_mana(struct player *p, int amt);
+const char *player_safe_name(struct player *p, bool strip_suffix);
 
 /* player-race.c */
-extern struct player_race *player_id2race(guid id);
+struct player_race *player_id2race(guid id);
 
 #endif /* !PLAYER_H */

--- a/src/player.h
+++ b/src/player.h
@@ -343,6 +343,8 @@ struct history_chart {
 	unsigned int idx;
 };
 
+#define PLAYER_NAME_LEN		32
+
 /**
  * Information retained across player lives
  *
@@ -352,7 +354,7 @@ struct history_chart {
  *     options in savefile?
  */
 typedef struct {
-	char full_name[32];		/**< Full name */
+	char full_name[PLAYER_NAME_LEN];		/**< Full name */
 
 	bool opt[OPT_MAX];		/**< Options */
 

--- a/src/player.h
+++ b/src/player.h
@@ -351,7 +351,7 @@ struct history_chart {
  * XXX some of this is UI specific - should we allow UI way to store
  *     options in savefile?
  */
-typedef struct {
+struct player_options {
 	bool opt[OPT_MAX];		/**< Options */
 
 	byte hitpoint_warn;		/**< Hitpoint warning (0 to 9) */
@@ -359,7 +359,7 @@ typedef struct {
 	byte delay_factor;		/**< Delay factor (0 to 9) */
 
 	byte name_suffix;		/**< Numeric suffix for player name */
-} player_other;
+};
 
 /**
  * All the variable state that changes when you put on/take off equipment.
@@ -543,17 +543,19 @@ struct player {
 	s16b ht_birth;						/* Birth Height */
 	s16b wt_birth;						/* Birth Weight */
 
+	struct player_options opts;			/* Player options */
+
+	struct player_body body;			/* Equipment slots available */
+
+	struct object *gear;				/* Real gear */
+	struct object *gear_k;				/* Known gear */
+
+	struct object *obj_k;				/* Object knowledge ("runes") */
+	struct chunk *cave;					/* Known version of current level */
+
 	struct player_state state;			/* Calculatable state */
 	struct player_state known_state;	/* What the player can know of the above */
 	struct player_upkeep *upkeep;		/* Temporary player-related values */
-
-	struct object *gear;		/* Real gear */
-	struct object *gear_k;		/* Known gear */
-
-	struct object *obj_k;		/* Object knowledge ("runes") */
-	struct chunk *cave;			/* Known version of current level */
-
-	struct player_body body;	/* What equipment slots are available */
 };
 
 
@@ -568,7 +570,6 @@ extern struct player_class *classes;
 extern struct magic_realm realms[REALM_MAX];
 
 extern const s32b player_exp[PY_MAX_LEVEL];
-extern player_other *op_ptr;
 extern struct player *player;
 
 /* player-class.c */

--- a/src/player.h
+++ b/src/player.h
@@ -362,6 +362,17 @@ struct player_options {
 };
 
 /**
+ * Player history information
+ *
+ * See player-history.c/.h
+ */
+struct player_history {
+	struct history_info *entries;	/**< List of entries */
+	size_t next;					/**< First unused entry */
+	size_t length;					/**< Current length */
+};
+
+/**
  * All the variable state that changes when you put on/take off equipment.
  * Player flags are not currently variable, but useful here so monsters can
  * learn them.
@@ -544,6 +555,7 @@ struct player {
 	s16b wt_birth;						/* Birth Weight */
 
 	struct player_options opts;			/* Player options */
+	struct player_history hist;			/* Player history (see player-history.c) */
 
 	struct player_body body;			/* Equipment slots available */
 

--- a/src/player.h
+++ b/src/player.h
@@ -584,7 +584,7 @@ void player_flags(struct player *p, bitflag f[OF_SIZE]);
 byte player_hp_attr(struct player *p);
 byte player_sp_attr(struct player *p);
 bool player_restore_mana(struct player *p, int amt);
-const char *player_safe_name(struct player *p, bool strip_suffix);
+void player_safe_name(char *safe, size_t safelen, const char *name, bool strip_suffix);
 
 /* player-race.c */
 struct player_race *player_id2race(guid id);

--- a/src/player.h
+++ b/src/player.h
@@ -343,8 +343,6 @@ struct history_chart {
 	unsigned int idx;
 };
 
-#define PLAYER_NAME_LEN		32
-
 /**
  * Information retained across player lives
  *
@@ -354,8 +352,6 @@ struct history_chart {
  *     options in savefile?
  */
 typedef struct {
-	char full_name[PLAYER_NAME_LEN];		/**< Full name */
-
 	bool opt[OPT_MAX];		/**< Options */
 
 	byte hitpoint_warn;		/**< Hitpoint warning (0 to 9) */
@@ -459,6 +455,8 @@ struct player_upkeep {
 	int quiver_cnt;				/* Number of items in the quiver */
 };
 
+#define PLAYER_NAME_LEN		32
+
 /**
  * Most of the "player" information goes here.
  *
@@ -525,10 +523,11 @@ struct player {
 	byte *spell_flags;			/* Spell flags */
 	byte *spell_order;			/* Spell order */
 
-	char died_from[80];			/* Cause of death */
-	char *history;				/* Player history */
-	struct quest *quests;		/* Quest history */
-	u16b total_winner;			/* Total winner */
+	char full_name[PLAYER_NAME_LEN];	/* Full name */
+	char died_from[80];					/* Cause of death */
+	char *history;						/* Player history */
+	struct quest *quests;				/* Quest history */
+	u16b total_winner;					/* Total winner */
 
 	u16b noscore;				/* Cheating flags */
 

--- a/src/save.c
+++ b/src/save.c
@@ -971,11 +971,13 @@ void wr_chunks(void)
 void wr_history(void)
 {
 	size_t i, j;
-	u32b tmp32u = history_get_num();
+
+	struct history_info *history_list;
+	u32b length = history_get_list(&history_list);
 
 	wr_byte(HIST_SIZE);
-	wr_u32b(tmp32u);
-	for (i = 0; i < tmp32u; i++) {
+	wr_u32b(length);
+	for (i = 0; i < length; i++) {
 		for (j = 0; j < HIST_SIZE; j++)
 			wr_byte(history_list[i].type[j]);
 		wr_s32b(history_list[i].turn);

--- a/src/save.c
+++ b/src/save.c
@@ -283,18 +283,17 @@ void wr_options(void)
 	int i;
 
 	/* Special Options */
-	wr_byte(op_ptr->delay_factor);
-	wr_byte(op_ptr->hitpoint_warn);
-	wr_u16b(op_ptr->lazymove_delay);
+	wr_byte(player->opts.delay_factor);
+	wr_byte(player->opts.hitpoint_warn);
+	wr_u16b(player->opts.lazymove_delay);
 
 	/* Normal options */
 	for (i = 0; i < OPT_MAX; i++) {
 		const char *name = option_name(i);
-		if (!name)
-			continue;
-
-		wr_string(name);
-		wr_byte(op_ptr->opt[i]);
+		if (name) {
+			wr_string(name);
+			wr_byte(player->opts.opt[i]);
+		}
    }
 
 	/* Sentinel */
@@ -408,7 +407,7 @@ void wr_player(void)
 	/* Race/Class/Gender/Spells */
 	wr_byte(player->race->ridx);
 	wr_byte(player->class->cidx);
-	wr_byte(op_ptr->name_suffix);
+	wr_byte(player->opts.name_suffix);
 
 	wr_byte(player->hitdie);
 	wr_byte(player->expfact);

--- a/src/save.c
+++ b/src/save.c
@@ -47,11 +47,11 @@ void wr_description(void)
 
 	if (player->is_dead)
 		strnfmt(buf, sizeof buf, "%s, dead (%s)",
-				op_ptr->full_name,
+				player->full_name,
 				player->died_from);
 	else
 		strnfmt(buf, sizeof buf, "%s, L%d %s %s, at DL%d",
-				op_ptr->full_name,
+				player->full_name,
 				player->lev,
 				player->race->name,
 				player->class->name,
@@ -399,7 +399,7 @@ void wr_player(void)
 {
 	int i;
 
-	wr_string(op_ptr->full_name);
+	wr_string(player->full_name);
 
 	wr_string(player->died_from);
 

--- a/src/save.c
+++ b/src/save.c
@@ -973,7 +973,7 @@ void wr_history(void)
 	size_t i, j;
 
 	struct history_info *history_list;
-	u32b length = history_get_list(&history_list);
+	u32b length = history_get_list(player, &history_list);
 
 	wr_byte(HIST_SIZE);
 	wr_u32b(length);

--- a/src/score.c
+++ b/src/score.c
@@ -241,7 +241,7 @@ void enter_score(time_t *death_time)
 	for (j = 0; j < OPT_MAX; ++j) {
 		if (option_type(j) != OP_SCORE)
 			continue;
-		if (!op_ptr->opt[j])
+		if (!player->opts.opt[j])
 			continue;
 
 		msg("Score not registered for cheaters.");

--- a/src/score.c
+++ b/src/score.c
@@ -209,7 +209,7 @@ void build_score(high_score *entry, const char *died_from, time_t *death_time)
 		my_strcpy(entry->day, "TODAY", sizeof(entry->day));
 
 	/* Save the player name (15 chars) */
-	strnfmt(entry->who, sizeof(entry->who), "%-.15s", op_ptr->full_name);
+	strnfmt(entry->who, sizeof(entry->who), "%-.15s", player->full_name);
 
 	/* Save the player info XXX XXX XXX */
 	strnfmt(entry->uid, sizeof(entry->uid), "%7u", player_uid);

--- a/src/store.c
+++ b/src/store.c
@@ -1862,7 +1862,7 @@ void do_cmd_sell(struct command *cmd)
 	/* Update the auto-history if selling an artifact that was previously
 	 * un-IDed. (Ouch!) */
 	if (obj->artifact)
-		history_add_artifact(player, obj->artifact, true, true);
+		history_find_artifact(player, obj->artifact);
 
 	/* Update the gear */
 	player->upkeep->update |= (PU_INVEN);

--- a/src/store.c
+++ b/src/store.c
@@ -1063,8 +1063,9 @@ static void store_delete_random(struct store *store)
 
 	assert (num <= obj->number);
 
-	if (obj->artifact)
-		history_lose_artifact(obj->artifact);
+	if (obj->artifact) {
+		history_lose_artifact(player, obj->artifact);
+	}
 
 	/* Delete the item, wholly or in part */
 	store_delete(store, obj, num);
@@ -1861,7 +1862,7 @@ void do_cmd_sell(struct command *cmd)
 	/* Update the auto-history if selling an artifact that was previously
 	 * un-IDed. (Ouch!) */
 	if (obj->artifact)
-		history_add_artifact(obj->artifact, true, true);
+		history_add_artifact(player, obj->artifact, true, true);
 
 	/* Update the gear */
 	player->upkeep->update |= (PU_INVEN);

--- a/src/ui-birth.c
+++ b/src/ui-birth.c
@@ -1263,7 +1263,7 @@ static void ui_leave_birthscreen(game_event_type type, game_event_data *data,
 {
 	/* Set the savefile name if it's not already set */
 	if (!savefile[0])
-		savefile_set_name(player_safe_name(player, true));
+		savefile_set_name(op_ptr->full_name, true, true);
 
 	free_birth_menus();
 }

--- a/src/ui-birth.c
+++ b/src/ui-birth.c
@@ -31,6 +31,7 @@
 #include "ui-menu.h"
 #include "ui-options.h"
 #include "ui-player.h"
+#include "ui-prefs.h"
 #include "ui-target.h"
 
 /**
@@ -835,14 +836,16 @@ static enum birth_stage point_based_command(void)
 static enum birth_stage get_name_command(void)
 {
 	enum birth_stage next;
-	char name[32];
-	
-	if ( arg_force_name ) {
-		next = BIRTH_HISTORY_CHOICE;
+	char name[PLAYER_NAME_LEN];
+
+	/* Use frontend-provided savefile name if requested */
+	if (arg_name[0]) {
+		my_strcpy(player->full_name, arg_name, sizeof(player->full_name));
 	}
 
-	
-	else if (get_character_name(name, sizeof(name))) {
+	if (arg_force_name) {
+		next = BIRTH_HISTORY_CHOICE;
+	} else if (get_character_name(name, sizeof(name))) {
 		cmdq_push(CMD_NAME_CHOICE);
 		cmd_set_arg_string(cmdq_peek(), "name", name);
 		next = BIRTH_HISTORY_CHOICE;
@@ -1263,7 +1266,7 @@ static void ui_leave_birthscreen(game_event_type type, game_event_data *data,
 {
 	/* Set the savefile name if it's not already set */
 	if (!savefile[0])
-		savefile_set_name(op_ptr->full_name, true, true);
+		savefile_set_name(player->full_name, true, true);
 
 	free_birth_menus();
 }

--- a/src/ui-death.c
+++ b/src/ui-death.c
@@ -84,7 +84,7 @@ static void print_tomb(void)
 
 	line = 7;
 
-	put_str_centred(line++, 8, 8+31, "%s", op_ptr->full_name);
+	put_str_centred(line++, 8, 8+31, "%s", player->full_name);
 	put_str_centred(line++, 8, 8+31, "the");
 	if (player->total_winner)
 		put_str_centred(line++, 8, 8+31, "Magnificent");
@@ -155,7 +155,7 @@ static void death_file(const char *title, int row)
 	char ftmp[80];
 
 	/* Get the filesystem-safe name and append .txt */
-	player_safe_name(ftmp, sizeof(ftmp), op_ptr->full_name, false);
+	player_safe_name(ftmp, sizeof(ftmp), player->full_name, false);
 	my_strcat(ftmp, ".txt", sizeof(ftmp));
 
 	if (get_file(ftmp, buf, sizeof buf)) {

--- a/src/ui-death.c
+++ b/src/ui-death.c
@@ -154,7 +154,9 @@ static void death_file(const char *title, int row)
 	char buf[1024];
 	char ftmp[80];
 
-	strnfmt(ftmp, sizeof(ftmp), "%s.txt", player_safe_name(player, false));
+	/* Get the filesystem-safe name and append .txt */
+	player_safe_name(ftmp, sizeof(ftmp), op_ptr->full_name, false);
+	my_strcat(ftmp, ".txt", sizeof(ftmp));
 
 	if (get_file(ftmp, buf, sizeof buf)) {
 		bool success;

--- a/src/ui-display.c
+++ b/src/ui-display.c
@@ -1289,7 +1289,7 @@ static void display_explosion(game_event_type type, game_event_data *data,
 	bool new_radius = false;
 	bool drawn = false;
 	int i, y, x;
-	int msec = op_ptr->delay_factor;
+	int msec = player->opts.delay_factor;
 	int gf_type = data->explosion.gf_type;
 	int num_grids = data->explosion.num_grids;
 	int *distance_to_grid = data->explosion.distance_to_grid;
@@ -1372,7 +1372,7 @@ static void display_explosion(game_event_type type, game_event_data *data,
 static void display_bolt(game_event_type type, game_event_data *data,
 						 void *user)
 {
-	int msec = op_ptr->delay_factor;
+	int msec = player->opts.delay_factor;
 	int gf_type = data->bolt.gf_type;
 	bool drawing = data->bolt.drawing;
 	bool seen = data->bolt.seen;
@@ -1423,7 +1423,7 @@ static void display_bolt(game_event_type type, game_event_data *data,
 static void display_missile(game_event_type type, game_event_data *data,
 							void *user)
 {
-	int msec = op_ptr->delay_factor;
+	int msec = player->opts.delay_factor;
 	struct object *obj = data->missile.obj;
 	bool seen = data->missile.seen;
 	int y = data->missile.y;

--- a/src/ui-display.c
+++ b/src/ui-display.c
@@ -2335,8 +2335,10 @@ static void process_character_pref_files(void)
 	/* Process the "user.prf" file */
 	process_pref_file("user.prf", true, true);
 
-	/* Process the pref file based on the character name */
-	strnfmt(buf, sizeof(buf), "%s.prf", player_safe_name(player, true));
+	/* Get the filesystem-safe name and append .prf */
+	player_safe_name(buf, sizeof(buf), op_ptr->full_name, true);
+	my_strcat(buf, ".prf", sizeof(buf));
+
 	found = process_pref_file(buf, true, true);
 
     /* Try pref file using savefile name if we fail using character name */

--- a/src/ui-display.c
+++ b/src/ui-display.c
@@ -2321,6 +2321,7 @@ static void see_floor_items(game_event_type type, game_event_data *data,
  * ------------------------------------------------------------------------
  * Initialising
  * ------------------------------------------------------------------------ */
+
 /**
  * Process the user pref files relevant to a newly loaded character
  */
@@ -2336,7 +2337,7 @@ static void process_character_pref_files(void)
 	process_pref_file("user.prf", true, true);
 
 	/* Get the filesystem-safe name and append .prf */
-	player_safe_name(buf, sizeof(buf), op_ptr->full_name, true);
+	player_safe_name(buf, sizeof(buf), player->full_name, true);
 	my_strcat(buf, ".prf", sizeof(buf));
 
 	found = process_pref_file(buf, true, true);

--- a/src/ui-game.c
+++ b/src/ui-game.c
@@ -441,17 +441,28 @@ void play_game(bool new_game)
 /**
  * Set the savefile name.
  */
-void savefile_set_name(const char *fname)
+void savefile_set_name(const char *fname, bool make_safe, bool strip_suffix)
 {
 	char path[128];
+	size_t pathlen = sizeof path;
+	size_t off = 0;
 
 #if defined(SETGID)
-	/* Rename the savefile, using the player_uid and base_name */
-	strnfmt(path, sizeof(path), "%d.%s", player_uid, fname);
-#else
-	/* Rename the savefile, using the base name */
-	strnfmt(path, sizeof(path), "%s", fname);
+	/*
+	 * On SETGID systems, we prefix the filename with the user's UID so we
+	 * know whose is whose.
+	 */
+
+	strnfmt(path, pathlen, "%d.", player_uid);
+	off = strlen(path);
+	pathlen -= off;
 #endif
+
+	if (make_safe) {
+		player_safe_name(path + off, pathlen, fname, strip_suffix);
+	} else {
+		my_strcpy(path + off, fname, pathlen);
+	}
 
 	/* Save the path */
 	path_build(savefile, sizeof(savefile), ANGBAND_DIR_SAVE, path);

--- a/src/ui-game.h
+++ b/src/ui-game.h
@@ -35,7 +35,7 @@ errr textui_get_cmd(cmd_context context);
 void check_for_player_interrupt(game_event_type type, game_event_data *data,
 								void *user);
 void play_game(bool new_game);
-void savefile_set_name(const char *fname);
+void savefile_set_name(const char *fname, bool make_safe, bool strip_suffix);
 void save_game(void);
 void close_game(void);
 

--- a/src/ui-history.c
+++ b/src/ui-history.c
@@ -37,7 +37,7 @@ static void print_history_header(void)
 void history_display(void)
 {
 	struct history_info *history_list_local = NULL;
-	size_t max_item = history_get_list(&history_list_local);
+	size_t max_item = history_get_list(player, &history_list_local);
 	int row, wid, hgt, page_size;
 	char buf[120];
 	static size_t first_item = 0;
@@ -125,7 +125,7 @@ void history_display(void)
 void dump_history(ang_file *file)
 {
 	struct history_info *history_list_local = NULL;
-	size_t max_item = history_get_list(&history_list_local);
+	size_t max_item = history_get_list(player, &history_list_local);
 	size_t i;
 	char buf[120];
 

--- a/src/ui-input.c
+++ b/src/ui-input.c
@@ -1163,10 +1163,10 @@ bool textui_get_rep_dir(int *dp, bool allow_5)
 				if (this_dir)
 					dir = dir_transitions[dir][this_dir];
 
-				if (op_ptr->lazymove_delay == 0 || ++keypresses_handled > 1)
+				if (player->opts.lazymove_delay == 0 || ++keypresses_handled > 1)
 					break;
 
-				inkey_scan = op_ptr->lazymove_delay;
+				inkey_scan = player->opts.lazymove_delay;
 				ke = inkey_ex();
 			}
 
@@ -1269,12 +1269,12 @@ bool textui_get_aim_dir(int *dp)
 					else
 						break;
 
-					if (op_ptr->lazymove_delay == 0 || ++keypresses_handled > 1)
+					if (player->opts.lazymove_delay == 0 || ++keypresses_handled > 1)
 						break;
 
 					/* See if there's a second keypress within the defined
 					 * period of time. */
-					inkey_scan = op_ptr->lazymove_delay;
+					inkey_scan = player->opts.lazymove_delay;
 					ke = inkey_ex();
 				}
 			}

--- a/src/ui-input.c
+++ b/src/ui-input.c
@@ -794,7 +794,7 @@ bool get_character_name(char *buf, size_t buflen)
 	prt("Enter a name for your character (* for a random name): ", 0, 0);
 
 	/* Save the player name */
-	my_strcpy(buf, op_ptr->full_name, buflen);
+	my_strcpy(buf, player->full_name, buflen);
 
 	/* Ask the user for a string */
 	res = askfor_aux(buf, buflen, get_name_keypress);
@@ -804,7 +804,7 @@ bool get_character_name(char *buf, size_t buflen)
 
 	/* Revert to the old name if the player doesn't pick a new one. */
 	if (!res)
-		my_strcpy(buf, op_ptr->full_name, buflen);
+		my_strcpy(buf, player->full_name, buflen);
 
 	return res;
 }

--- a/src/ui-knowledge.c
+++ b/src/ui-knowledge.c
@@ -1469,7 +1469,7 @@ static void desc_art_fake(int a_idx)
 
 		/* Check the history entry, to see if it was fully known before it
 		 * was lost */
-		if (history_is_artifact_known(obj->artifact))
+		if (history_is_artifact_known(player, obj->artifact))
 			/* Be very careful not to influence anything but this object */
 			object_copy(known_obj, obj);
 	}

--- a/src/ui-options.c
+++ b/src/ui-options.c
@@ -53,7 +53,7 @@ static bool get_pref_path(const char *what, int row, char *buf, size_t max)
 	prt("File: ", row + 2, 0);
 
 	/* Get the filesystem-safe name and append .prf */
-	player_safe_name(ftmp, sizeof(ftmp), op_ptr->full_name, true);
+	player_safe_name(ftmp, sizeof(ftmp), player->full_name, true);
 	my_strcat(ftmp, ".prf", sizeof(ftmp));
 
 	/* Get a filename */
@@ -995,7 +995,7 @@ static void do_cmd_pref_file_hack(long row)
 	prt("File: ", row + 2, 0);
 
 	/* Get the filesystem-safe name and append .prf */
-	player_safe_name(ftmp, sizeof(ftmp), op_ptr->full_name, true);
+	player_safe_name(ftmp, sizeof(ftmp), player->full_name, true);
 	my_strcat(ftmp, ".prf", sizeof(ftmp));
 
 	/* Ask for a file (or cancel) */

--- a/src/ui-options.c
+++ b/src/ui-options.c
@@ -52,9 +52,10 @@ static bool get_pref_path(const char *what, int row, char *buf, size_t max)
 	prt(format("%s to a pref file", what), row, 0);
 	prt("File: ", row + 2, 0);
 
-	/* Default filename */
-	strnfmt(ftmp, sizeof ftmp, "%s.prf", player_safe_name(player, true));
-	
+	/* Get the filesystem-safe name and append .prf */
+	player_safe_name(ftmp, sizeof(ftmp), op_ptr->full_name, true);
+	my_strcat(ftmp, ".prf", sizeof(ftmp));
+
 	/* Get a filename */
 	ok = askfor_aux(ftmp, sizeof ftmp, NULL);
 	screen_load();
@@ -993,8 +994,9 @@ static void do_cmd_pref_file_hack(long row)
 	/* Prompt */
 	prt("File: ", row + 2, 0);
 
-	/* Default filename */
-	strnfmt(ftmp, sizeof ftmp, "%s.prf", player_safe_name(player, true));
+	/* Get the filesystem-safe name and append .prf */
+	player_safe_name(ftmp, sizeof(ftmp), op_ptr->full_name, true);
+	my_strcat(ftmp, ".prf", sizeof(ftmp));
 
 	/* Ask for a file (or cancel) */
 	if (askfor_aux(ftmp, sizeof ftmp, NULL)) {

--- a/src/ui-options.c
+++ b/src/ui-options.c
@@ -126,7 +126,7 @@ static bool option_toggle_handle(struct menu *m, const ui_event *event,
 		/* At birth, m->flags == MN_DBL_TAP. */
 		/* After birth, m->flags == MN_NO_TAGS */
 		if (!((option_type(oid) == OP_BIRTH) && (m->flags == MN_NO_TAGS))) {
-			option_set(option_name(oid), !op_ptr->opt[oid]);
+			option_set(option_name(oid), !player->opts.opt[oid]);
 		}
 	} else if (event->type == EVT_KBRD) {
 		if (event->key.code == 'y' || event->key.code == 'Y') {
@@ -136,7 +136,7 @@ static bool option_toggle_handle(struct menu *m, const ui_event *event,
 			option_set(option_name(oid), false);
 			next = true;
 		} else if (event->key.code == 't' || event->key.code == 'T') {
-			option_set(option_name(oid), !op_ptr->opt[oid]);
+			option_set(option_name(oid), !player->opts.opt[oid]);
 		} else if (event->key.code == '?') {
 			screen_save();
 			show_file(format("option.txt#%s", option_name(oid)), NULL, 0, 0);
@@ -202,7 +202,7 @@ static void option_toggle_menu(const char *name, int page)
 	}
 
 	/* Set the data to the player's options */
-	menu_setpriv(m, OPT_MAX, &op_ptr->opt);
+	menu_setpriv(m, OPT_MAX, &player->opts.opt);
 	menu_set_filter(m, option_page[page], i);
 	menu_layout(m, &SCREEN_REGION);
 
@@ -882,9 +882,9 @@ static bool askfor_aux_numbers(char *buf, size_t buflen, size_t *curs, size_t *l
 static void do_cmd_delay(const char *name, int row)
 {
 	char tmp[4] = "";
-	int msec = op_ptr->delay_factor;
+	int msec = player->opts.delay_factor;
 
-	strnfmt(tmp, sizeof(tmp), "%i", op_ptr->delay_factor);
+	strnfmt(tmp, sizeof(tmp), "%i", player->opts.delay_factor);
 
 	screen_save();
 
@@ -892,13 +892,13 @@ static void do_cmd_delay(const char *name, int row)
 	prt("Command: Base Delay Factor", 20, 0);
 
 	prt(format("Current base delay factor: %d msec",
-			   op_ptr->delay_factor, msec), 22, 0);
+			   player->opts.delay_factor, msec), 22, 0);
 	prt("New base delay factor (0-255): ", 21, 0);
 
 	/* Ask for a numeric value */
 	if (askfor_aux(tmp, sizeof(tmp), askfor_aux_numbers)) {
 		u16b val = (u16b) strtoul(tmp, NULL, 0);
-		op_ptr->delay_factor = MIN(val, 255);
+		player->opts.delay_factor = MIN(val, 255);
 	}
 
 	screen_load();
@@ -914,7 +914,7 @@ static void do_cmd_hp_warn(const char *name, int row)
 	char tmp[4] = "";
 	byte warn;
 
-	strnfmt(tmp, sizeof(tmp), "%i", op_ptr->hitpoint_warn);
+	strnfmt(tmp, sizeof(tmp), "%i", player->opts.hitpoint_warn);
 
 	screen_save();
 
@@ -922,7 +922,7 @@ static void do_cmd_hp_warn(const char *name, int row)
 	prt("Command: Hitpoint Warning", 20, 0);
 
 	prt(format("Current hitpoint warning: %d (%d%%)",
-			   op_ptr->hitpoint_warn, op_ptr->hitpoint_warn * 10), 22, 0);
+			   player->opts.hitpoint_warn, player->opts.hitpoint_warn * 10), 22, 0);
 	prt("New hitpoint warning (0-9): ", 21, 0);
 
 	/* Ask the user for a string */
@@ -936,7 +936,7 @@ static void do_cmd_hp_warn(const char *name, int row)
 		if (warn > 9)
 			warn = 0;
 
-		op_ptr->hitpoint_warn = warn;
+		player->opts.hitpoint_warn = warn;
 	}
 
 	screen_load();
@@ -951,7 +951,7 @@ static void do_cmd_lazymove_delay(const char *name, int row)
 	bool res;
 	char tmp[4] = "";
 
-	strnfmt(tmp, sizeof(tmp), "%i", op_ptr->lazymove_delay);
+	strnfmt(tmp, sizeof(tmp), "%i", player->opts.lazymove_delay);
 
 	screen_save();
 
@@ -959,7 +959,7 @@ static void do_cmd_lazymove_delay(const char *name, int row)
 	prt("Command: Movement Delay Factor", 20, 0);
 
 	prt(format("Current movement delay: %d (%d msec)",
-			   op_ptr->lazymove_delay, op_ptr->lazymove_delay * 10), 22, 0);
+			   player->opts.lazymove_delay, player->opts.lazymove_delay * 10), 22, 0);
 	prt("New movement delay: ", 21, 0);
 
 	/* Ask the user for a string */
@@ -967,7 +967,7 @@ static void do_cmd_lazymove_delay(const char *name, int row)
 
 	/* Process input */
 	if (res)
-		op_ptr->lazymove_delay = (u16b) strtoul(tmp, NULL, 0);
+		player->opts.lazymove_delay = (u16b) strtoul(tmp, NULL, 0);
 
 	screen_load();
 }

--- a/src/ui-player.c
+++ b/src/ui-player.c
@@ -696,7 +696,7 @@ static const byte colour_table[] =
 static struct panel *get_panel_topleft(void) {
 	struct panel *p = panel_allocate(6);
 
-	panel_line(p, COLOUR_L_BLUE, "Name", "%s", op_ptr->full_name);
+	panel_line(p, COLOUR_L_BLUE, "Name", "%s", player->full_name);
 	panel_line(p, COLOUR_L_BLUE, "Race",	"%s", player->race->name);
 	panel_line(p, COLOUR_L_BLUE, "Class", "%s", player->class->name);
 	panel_line(p, COLOUR_L_BLUE, "Title", "%s", show_title());
@@ -1170,8 +1170,8 @@ void do_cmd_change_name(void)
 
 					/* Set player name */
 					if (get_character_name(namebuf, sizeof namebuf))
-						my_strcpy(op_ptr->full_name, namebuf,
-								  sizeof(op_ptr->full_name));
+						my_strcpy(player->full_name, namebuf,
+								  sizeof(player->full_name));
 
 					break;
 				}
@@ -1181,7 +1181,7 @@ void do_cmd_change_name(void)
 					char fname[80];
 
 					/* Get the filesystem-safe name and append .txt */
-					player_safe_name(fname, sizeof(fname), op_ptr->full_name, false);
+					player_safe_name(fname, sizeof(fname), player->full_name, false);
 					my_strcat(fname, ".txt", sizeof(fname));
 
 					if (get_file(fname, buf, sizeof buf)) {

--- a/src/ui-player.c
+++ b/src/ui-player.c
@@ -1180,11 +1180,11 @@ void do_cmd_change_name(void)
 					char buf[1024];
 					char fname[80];
 
-					strnfmt(fname, sizeof fname, "%s.txt",
-							player_safe_name(player, false));
+					/* Get the filesystem-safe name and append .txt */
+					player_safe_name(fname, sizeof(fname), op_ptr->full_name, false);
+					my_strcat(fname, ".txt", sizeof(fname));
 
-					if (get_file(fname, buf, sizeof buf))
-					{
+					if (get_file(fname, buf, sizeof buf)) {
 						if (dump_save(buf))
 							msg("Character dump successful.");
 						else

--- a/src/ui-player.c
+++ b/src/ui-player.c
@@ -1100,7 +1100,7 @@ void write_character_dump(ang_file *fff)
 
 			file_putf(fff, "%-45s: %s (%s)\n",
 			        option_desc(opt),
-			        op_ptr->opt[opt] ? "yes" : "no ",
+			        player->opts.opt[opt] ? "yes" : "no ",
 			        option_name(opt));
 		}
 

--- a/src/ui-prefs.c
+++ b/src/ui-prefs.c
@@ -531,8 +531,6 @@ static const char *process_pref_file_expr(char **sp, char *fp)
 				v = player->race->name;
 			else if (streq(b+1, "CLASS"))
 				v = player->class->name;
-			else if (streq(b+1, "PLAYER"))
-				v = player_safe_name(player, true);
 		} else {
 			v = b;
 		}

--- a/src/ui-prefs.c
+++ b/src/ui-prefs.c
@@ -29,6 +29,7 @@
 #include "obj-util.h"
 #include "object.h"
 #include "project.h"
+#include "player.h"
 #include "trap.h"
 #include "ui-display.h"
 #include "ui-keymap.h"
@@ -36,6 +37,7 @@
 #include "ui-term.h"
 #include "sound.h"
 
+char arg_name[PLAYER_NAME_LEN];		/* Command arg -- request character name */
 int arg_graphics;			/* Command arg -- Request graphics mode */
 bool arg_graphics_nice;		/* Command arg -- Request nice graphics mode */
 int use_graphics;			/* The "graphics" mode is enabled */

--- a/src/ui-prefs.h
+++ b/src/ui-prefs.h
@@ -27,6 +27,7 @@
 #include "parser.h"
 #include "z-file.h"
 
+extern char arg_name[PLAYER_NAME_LEN];
 extern int use_graphics;
 extern int arg_graphics;
 extern bool arg_graphics_nice;

--- a/src/ui-store.c
+++ b/src/ui-store.c
@@ -166,7 +166,7 @@ static void prt_welcome(const struct owner *proprietor)
 		if ((i % 2) && randint0(2))
 			player_name = player->class->title[(player->lev - 1) / 5];
 		else if (randint0(2))
-			player_name = op_ptr->full_name;
+			player_name = player->full_name;
 		else
 			player_name = "valued customer";
 


### PR DESCRIPTION
@NickMcConnell, I noticed you added some 'struct player p' params to various functions and it reminded me that I've been meaning to spend an afternoon doing some more of that for a while.

This request:

1. Add player parameter to functions in player-attack.c
2. Moves player name out of op_ptr and into the player struct where it seems to more naturally fit.  Doing this meant a bunch of other changes disentangling the player name & savefile name.  The resulting code still isn't super clean but it's a big improvement in a difficult-to-reason-about bit of the code.
3. Removes op_ptr and adds an 'opts' member to the main player struct to hold options.
4. Moves the player history ledger into the player struct, refactors player-history.[ch] so that the functions are passed a player instance, and significantly cleans up the logic of the player history code