### PR TITLE
Some refactorings

### DIFF
--- a/lib/gamedata/player_timed.txt
+++ b/lib/gamedata/player_timed.txt
@@ -6,19 +6,23 @@
 # Changing code or fail may have unpredictable results.
 # Changing the name, reordering, or adding whole new entires will severely
 # disrupt the game, and should only be done when list-player-timed.h
-# (and other code) is also  being changed, and the game recompiled. 
+# (and other code) is also  being changed, and the game recompiled.
 #
 # Fields:
-# name - the effect name 
+# name - the effect name
 # desc - the effect description
 # on-begin - the message on beginning the effect
 # on-end - the message on ending the effect
 # on-increase - the message on the effect increasing
 # on-decrease - the message on the effect decreasing
 # msgt - the message type for this effect
-# code - determines what flag type makes the effect fail: 1 means object flag,
-#        2 means resist, 3 means vulnerability
-# fail - the actual flag that causes the failure
+# fail - determines what makes the effect fail.
+#        param one:
+#          1 - object flag
+#          2 - resist
+#          3 - vulnerability
+#        param two:
+#          the actual flag that causes the failure
 #
 
 name:FAST
@@ -32,24 +36,21 @@ desc:slowness
 on-begin:You feel yourself moving slower!
 on-end:You feel yourself speed up.
 msgt:SLOW
-code:1
-fail:FREE_ACT
+fail:1:FREE_ACT
 
 name:BLIND
 desc:blindness
 on-begin:You are blind.
 on-end:You blink and your eyes clear.
 msgt:BLIND
-code:1
-fail:PROT_BLIND
+fail:1:PROT_BLIND
 
 name:PARALYZED
 desc:paralysis
 on-begin:You are paralysed!
 on-end:You can move again.
 msgt:PARALYZED
-code:1
-fail:FREE_ACT
+fail:1:FREE_ACT
 
 name:CONFUSED
 desc:confusion
@@ -58,8 +59,7 @@ on-end:You are no longer confused.
 on-increase:You are more confused!
 on-decrease:You feel a little less confused.
 msgt:CONFUSED
-code:1
-fail:PROT_CONF
+fail:1:PROT_CONF
 
 name:AFRAID
 desc:fear
@@ -68,8 +68,7 @@ on-end:You feel bolder now.
 on-increase:You are more scared!
 on-decrease:You feel a little less scared.
 msgt:AFRAID
-code:1
-fail:PROT_FEAR
+fail:1:PROT_FEAR
 
 name:IMAGE
 desc:hallucination
@@ -78,8 +77,7 @@ on-end:You can see clearly again.
 on-increase:You feel more drugged!
 on-decrease:You feel less drugged.
 msgt:DRUGGED
-code:2
-fail:CHAOS
+fail:2:CHAOS
 
 name:POISONED
 desc:poisoning
@@ -88,16 +86,14 @@ on-end:You are no longer poisoned.
 on-increase:You are more poisoned!
 on-decrease:You are less poisoned.
 msgt:POISONED
-code:2
-fail:POIS
+fail:2:POIS
 
 name:CUT
 desc:wounds
 
 name:STUN
 desc:stunning
-code:1
-fail:PROT_STUN
+fail:1:PROT_STUN
 
 name:PROTEVIL
 desc:protection from evil
@@ -168,8 +164,7 @@ on-end:You are no longer resistant to acid.
 on-increase:You feel more resistant to acid!
 on-decrease:You feel less resistant to acid.
 msgt:RES_ACID
-code:3
-fail:ACID
+fail:3:ACID
 
 name:OPP_ELEC
 desc:electricity resistance
@@ -178,8 +173,7 @@ on-end:You are no longer resistant to electricity.
 on-increase:You feel more resistant to electricity!
 on-decrease:You feel less resistant to electricity.
 msgt:RES_ELEC
-code:3
-fail:ELEC
+fail:3:ELEC
 
 name:OPP_FIRE
 desc:fire resistance
@@ -188,8 +182,7 @@ on-end:You are no longer resistant to fire.
 on-increase:You feel more resistant to fire!
 on-decrease:You feel less resistant to fire.
 msgt:RES_FIRE
-code:3
-fail:FIRE
+fail:3:FIRE
 
 name:OPP_COLD
 desc:cold resistance
@@ -198,8 +191,7 @@ on-end:You are no longer resistant to cold.
 on-increase:You feel more resistant to cold!
 on-decrease:You feel less resistant to cold.
 msgt:RES_COLD
-code:3
-fail:COLD
+fail:3:COLD
 
 name:OPP_POIS
 desc:poison resistance
@@ -262,8 +254,7 @@ on-end:Your body reasserts its true nature.
 on-increase:You are more scrambled!
 on-decrease:You are less scrambled.
 msgt:SCRAMBLE
-code:2
-fail:NEXUS
+fail:2:NEXUS
 
 name:TRAPSAFE
 desc:safety from traps

--- a/src/Makefile.src
+++ b/src/Makefile.src
@@ -158,6 +158,7 @@ ANGFILES = \
 	save.o \
 	savefile.o \
 	sound-core.o \
+	source.o \
 	store.o \
 	target.o \
 	trap.o \

--- a/src/cave-square.c
+++ b/src/cave-square.c
@@ -957,7 +957,7 @@ void square_add_door(struct chunk *c, int y, int x, bool closed) {
 
 void square_open_door(struct chunk *c, int y, int x)
 {
-	square_remove_trap(c, y, x, false, -1);
+	square_remove_all_traps(c, y, x);
 	square_set_feat(c, y, x, FEAT_OPEN);
 }
 
@@ -968,7 +968,7 @@ void square_close_door(struct chunk *c, int y, int x)
 
 void square_smash_door(struct chunk *c, int y, int x)
 {
-	square_remove_trap(c, y, x, false, -1);
+	square_remove_all_traps(c, y, x);
 	square_set_feat(c, y, x, FEAT_BROKEN);
 }
 
@@ -979,13 +979,13 @@ void square_unlock_door(struct chunk *c, int y, int x) {
 
 void square_destroy_door(struct chunk *c, int y, int x) {
 	assert(square_isdoor(c, y, x));
-	square_remove_trap(c, y, x, false, -1);
+	square_remove_all_traps(c, y, x);
 	square_set_feat(c, y, x, FEAT_FLOOR);
 }
 
 void square_destroy_trap(struct chunk *c, int y, int x)
 {
-	square_remove_trap(c, y, x, false, -1);
+	square_remove_all_traps(c, y, x);
 }
 
 void square_disable_trap(struct chunk *c, int y, int x)
@@ -1038,9 +1038,10 @@ void square_earthquake(struct chunk *c, int y, int x) {
 
 void square_remove_ward(struct chunk *c, int y, int x)
 {
-	struct trap_kind *rune = lookup_trap("glyph of warding");
 	assert(square_iswarded(c, y, x));
-	square_remove_trap(c, y, x, true, rune->tidx);
+
+	struct trap_kind *rune = lookup_trap("glyph of warding");
+	square_remove_trap(c, y, x, rune->tidx);
 }
 
 /**

--- a/src/cave.h
+++ b/src/cave.h
@@ -151,7 +151,7 @@ struct chunk {
 
 	int height;
 	int width;
-	
+
 	u16b feeling_squares; /* How many feeling squares the player has visited */
 	int *feat_count;
 
@@ -164,8 +164,6 @@ struct chunk {
 	u16b mon_max;
 	u16b mon_cnt;
 	int mon_current;
-
-	struct trap *trap_current;
 };
 
 /*** Feature Indexes (see "lib/gamedata/terrain.txt") ***/

--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -716,8 +716,10 @@ static bool do_cmd_disarm_aux(int y, int x)
 		skill = player->state.skills[SKILL_DISARM_PHYS];
 
 	/* Penalize some conditions */
-	if (player->timed[TMD_BLIND] || no_light() || player->timed[TMD_CONFUSED] ||
-		player->timed[TMD_IMAGE])
+	if (player->timed[TMD_BLIND] ||
+			no_light() ||
+			player->timed[TMD_CONFUSED] ||
+			player->timed[TMD_IMAGE])
 		skill = skill / 10;
 
 	/* Extract trap power */

--- a/src/cmd-obj.c
+++ b/src/cmd-obj.c
@@ -502,7 +502,14 @@ static void use_aux(struct command *cmd, struct object *obj, enum use use,
 		boost = MAX(player->state.skills[SKILL_DEVICE] - level, 0);
 
 		/* Do effect */
-		used = effect_do(effect, obj, &ident, was_aware, dir, beam, boost);
+		used = effect_do(effect,
+							source_player(),
+							obj,
+							&ident,
+							was_aware,
+							dir,
+							beam,
+							boost);
 
 		/* Quit if the item wasn't used and no knowledge was gained */
 		if (!used && (was_aware || !ident)) return;

--- a/src/effects.h
+++ b/src/effects.h
@@ -19,6 +19,7 @@
 #ifndef INCLUDED_EFFECTS_H
 #define INCLUDED_EFFECTS_H
 
+#include "source.h"
 #include "object.h"
 
 /* Types of effect */
@@ -40,8 +41,20 @@ const char *effect_info(struct effect *effect);
 const char *effect_desc(struct effect *effect);
 effect_index effect_lookup(const char *name);
 int effect_param(int index, const char *type);
-bool effect_do(struct effect *effect, struct object *obj, bool *ident,
-			   bool aware, int dir, int beam, int boost);
-void effect_simple(int index, const char* dice_string, int p1, int p2, int p3, bool *ident);
+bool effect_do(struct effect *effect,
+	struct source origin,
+	struct object *obj,
+	bool *ident,
+	bool aware,
+	int dir,
+	int beam,
+	int boost);
+void effect_simple(int index,
+	struct source origin,
+	const char *dice_string,
+	int p1,
+	int p2,
+	int p3,
+	bool *ident);
 
 #endif /* INCLUDED_EFFECTS_H */

--- a/src/game-world.c
+++ b/src/game-world.c
@@ -24,8 +24,8 @@
 #include "mon-make.h"
 #include "mon-move.h"
 #include "mon-util.h"
-#include "obj-desc.h"
 #include "obj-curse.h"
+#include "obj-desc.h"
 #include "obj-gear.h"
 #include "obj-knowledge.h"
 #include "obj-tval.h"
@@ -33,6 +33,7 @@
 #include "player-calcs.h"
 #include "player-timed.h"
 #include "player-util.h"
+#include "source.h"
 #include "target.h"
 #include "trap.h"
 
@@ -532,8 +533,8 @@ void process_world(struct chunk *c)
 			} else {
 				/* Otherwise do something disastrous */
 				msgt(MSG_TPLEVEL, "You are thrown back in an explosion!");
-				effect_simple(EF_DESTRUCTION, "0", 0, 5, 0, NULL);
-			}		
+				effect_simple(EF_DESTRUCTION, source_none(), "0", 0, 5, 0, NULL);
+			}
 		}
 	}
 }
@@ -642,7 +643,7 @@ void process_player(void)
 				!player->timed[TMD_PARALYZED] &&
 				!player->timed[TMD_TERROR] &&
 				!player->timed[TMD_AFRAID])
-				effect_simple(EF_DETECT_GOLD, "3d3", 1, 0, 0, NULL);
+				effect_simple(EF_DETECT_GOLD, source_none(), "3d3", 1, 0, 0, NULL);
 		}
 
 		/* Paralyzed or Knocked Out player gets no turn */

--- a/src/init.c
+++ b/src/init.c
@@ -88,14 +88,6 @@ char *ANGBAND_DIR_SAVE;
 char *ANGBAND_DIR_SCORES;
 char *ANGBAND_DIR_INFO;
 
-static const char *timed_name_list[] = {
-	#define TMD(a, b, c) #a,
-	#include "list-player-timed.h"
-	#undef TMD
-	"MAX",
-    NULL
-};
-
 static const char *slots[] = {
 	#define EQUIP(a, b, c, d, e, f) #a,
 	#include "list-equip-slots.h"
@@ -103,7 +95,7 @@ static const char *slots[] = {
 	NULL
 };
 
-static const char *obj_flags[] = {
+const char *list_obj_flag_names[] = {
 	"NONE",
 	#define STAT(a, b, c, d, e, f, g, h, i) #c,
 	#include "list-stats.h"
@@ -114,7 +106,7 @@ static const char *obj_flags[] = {
 	NULL
 };
 
-static const char *elements[] = {
+const char *list_element_names[] = {
 	#define ELEM(a, b, c, d, e, f, g, h, i, col) #a,
 	#include "list-elements.h"
 	#undef ELEM
@@ -655,191 +647,6 @@ static void cleanup_game_constants(void)
 
 /**
  * ------------------------------------------------------------------------
- * Initialize player timed effects
- * ------------------------------------------------------------------------ */
-
-static enum parser_error parse_player_timed_name(struct parser *p) {
-	struct timed_effect_data *h = parser_priv(p);
-	struct timed_effect_data *t = mem_zalloc(sizeof *t);
-	const char *name = parser_getstr(p, "name");
-	int index;
-	t->next = h;
-	if (grab_name("timed effect", name, timed_name_list,
-				  N_ELEMENTS(timed_name_list), &index))
-		return PARSE_ERROR_INVALID_SPELL_NAME;
-	t->name = string_make(name);
-	t->index = index;
-	parser_setpriv(p, t);
-	return PARSE_ERROR_NONE;
-}
-
-static enum parser_error parse_player_timed_desc(struct parser *p) {
-	struct timed_effect_data *t = parser_priv(p);
-	assert(t);
-
-	t->desc = string_append(t->desc, parser_getstr(p, "text"));
-	return PARSE_ERROR_NONE;
-}
-
-static enum parser_error parse_player_timed_begin_message(struct parser *p) {
-	struct timed_effect_data *t = parser_priv(p);
-	assert(t);
-
-	t->on_begin = string_append(t->on_begin, parser_getstr(p, "text"));
-	return PARSE_ERROR_NONE;
-}
-
-static enum parser_error parse_player_timed_end_message(struct parser *p) {
-	struct timed_effect_data *t = parser_priv(p);
-	assert(t);
-
-	t->on_end = string_append(t->on_end, parser_getstr(p, "text"));
-	return PARSE_ERROR_NONE;
-}
-
-static enum parser_error parse_player_timed_increase_message(struct parser *p) {
-	struct timed_effect_data *t = parser_priv(p);
-	assert(t);
-
-	t->on_increase = string_append(t->on_increase, parser_getstr(p, "text"));
-	return PARSE_ERROR_NONE;
-}
-
-static enum parser_error parse_player_timed_decrease_message(struct parser *p) {
-	struct timed_effect_data *t = parser_priv(p);
-	assert(t);
-
-	t->on_decrease = string_append(t->on_decrease, parser_getstr(p, "text"));
-	return PARSE_ERROR_NONE;
-}
-
-static enum parser_error parse_player_timed_message_type(struct parser *p)
-{
-	int msg_index;
-	const char *type;
-	struct timed_effect_data *t = parser_priv(p);
-	assert(t);
-
-	type = parser_getsym(p, "type");
-
-	msg_index = message_lookup_by_name(type);
-
-	if (msg_index < 0)
-		return PARSE_ERROR_INVALID_MESSAGE;
-
-	t->msgt = msg_index;
-	return PARSE_ERROR_NONE;
-}
-
-static enum parser_error parse_player_timed_fail_code(struct parser *p) {
-	struct timed_effect_data *t = parser_priv(p);
-	assert(t);
-
-	t->fail_code = parser_getuint(p, "code");
-	return PARSE_ERROR_NONE;
-}
-
-static enum parser_error parse_player_timed_fail_flag(struct parser *p) {
-	struct timed_effect_data *t = parser_priv(p);
-	const char *name;
-	assert(t);
-
-	name = parser_getstr(p, "flag");
-	if (t->fail_code == TMD_FAIL_FLAG_OBJECT) {
-		int flag = lookup_flag(obj_flags, name);
-		if (flag == FLAG_END)
-			return PARSE_ERROR_INVALID_FLAG;
-		else
-			t->fail = flag;
-	} else if ((t->fail_code == TMD_FAIL_FLAG_RESIST) ||
-			   (t->fail_code == TMD_FAIL_FLAG_VULN)) {
-		size_t i = 0;
-		while (elements[i] && !streq(elements[i], name))
-			i++;
-
-		if (i == N_ELEMENTS(elements))
-			return PARSE_ERROR_INVALID_FLAG;
-		else
-			t->fail = i;
-	} else {
-		return PARSE_ERROR_INVALID_FLAG;
-	}
-	return PARSE_ERROR_NONE;
-}
-
-struct parser *init_parse_player_timed(void) {
-	struct parser *p = parser_new();
-	parser_setpriv(p, NULL);
-	parser_reg(p, "name str name", parse_player_timed_name);
-	parser_reg(p, "desc str text", parse_player_timed_desc);
-	parser_reg(p, "on-begin str text", parse_player_timed_begin_message);
-	parser_reg(p, "on-end str text", parse_player_timed_end_message);
-	parser_reg(p, "on-increase str text", parse_player_timed_increase_message);
-	parser_reg(p, "on-decrease str text", parse_player_timed_decrease_message);
-	parser_reg(p, "msgt sym type", parse_player_timed_message_type);
-	parser_reg(p, "code uint code", parse_player_timed_fail_code);
-	parser_reg(p, "fail str flag", parse_player_timed_fail_flag);
-	return p;
-}
-
-static errr run_parse_player_timed(struct parser *p) {
-	return parse_file_quit_not_found(p, "player_timed");
-}
-
-static errr finish_parse_player_timed(struct parser *p) {
-	struct timed_effect_data *timed, *next = NULL;
-	int count = TMD_MAX - 1;
-
-	/* Allocate the direct access list and copy the data to it */
-	timed_effects = mem_zalloc((TMD_MAX + 1) * sizeof(*timed));
-	for (timed = parser_priv(p); timed; timed = next, count--) {
-		memcpy(&timed_effects[count], timed, sizeof(*timed));
-		next = timed->next;
-		assert(timed->index == count);
-		if (count < TMD_MAX - 1)
-			timed_effects[count].next = &timed_effects[count + 1];
-		else
-			timed_effects[count].next = NULL;
-
-		mem_free(timed);
-	}
-
-	parser_destroy(p);
-	return 0;
-}
-
-static void cleanup_player_timed(void)
-{
-	struct timed_effect_data *timed = timed_effects;
-	struct timed_effect_data *next;
-
-	while (timed) {
-		next = timed->next;
-		if (timed->on_begin)
-			string_free(timed->on_begin);
-		if (timed->on_end)
-			string_free(timed->on_end);
-		if (timed->on_increase)
-			string_free(timed->on_increase);
-		if (timed->on_decrease)
-			string_free(timed->on_decrease);
-		string_free(timed->desc);
-		string_free(timed->name);
-		timed = next;
-	}
-	mem_free(timed_effects);
-}
-
-struct file_parser player_timed_parser = {
-	"player timed",
-	init_parse_player_timed,
-	run_parse_player_timed,
-	finish_parse_player_timed,
-	cleanup_player_timed
-};
-
-/**
- * ------------------------------------------------------------------------
  * Intialize random names
  * ------------------------------------------------------------------------ */
 
@@ -1254,7 +1061,7 @@ static enum parser_error parse_trap_save_flags(struct parser *p) {
 	u = strtok(s, " |");
 	while (u) {
 		bool found = false;
-		if (!grab_flag(t->save_flags, OF_SIZE, obj_flags, u))
+		if (!grab_flag(t->save_flags, OF_SIZE, list_obj_flag_names, u))
 			found = true;
 		if (!found)
 			break;
@@ -1958,7 +1765,7 @@ static enum parser_error parse_p_race_obj_flags(struct parser *p) {
 	flags = string_make(parser_getstr(p, "flags"));
 	s = strtok(flags, " |");
 	while (s) {
-		if (grab_flag(r->flags, OF_SIZE, obj_flags, s))
+		if (grab_flag(r->flags, OF_SIZE, list_obj_flag_names, s))
 			break;
 		s = strtok(NULL, " |");
 	}
@@ -2000,7 +1807,7 @@ static enum parser_error parse_p_race_values(struct parser *p) {
 		int value = 0;
 		int index = 0;
 		bool found = false;
-		if (!grab_index_and_int(&value, &index, elements, "RES_", t)) {
+		if (!grab_index_and_int(&value, &index, list_element_names, "RES_", t)) {
 			found = true;
 			r->el_info[index].res_level = value;
 		}

--- a/src/init.h
+++ b/src/init.h
@@ -121,6 +121,9 @@ struct init_module {
 	void (*cleanup)(void);
 };
 
+extern const char *list_element_names[];
+extern const char *list_obj_flag_names[];
+
 extern struct angband_constants *z_info;
 
 extern const char *ANGBAND_SYS;
@@ -156,7 +159,6 @@ extern struct parser *init_parse_names(void);
 extern struct parser *init_parse_hints(void);
 extern struct parser *init_parse_trap(void);
 extern struct parser *init_parse_quest(void);
-extern struct parser *init_parse_player_timed(void);
 
 errr grab_effect_data(struct parser *p, struct effect *effect);
 extern void init_file_paths(const char *config, const char *lib, const char *data);

--- a/src/mon-attack.c
+++ b/src/mon-attack.c
@@ -654,7 +654,7 @@ bool make_attack_normal(struct monster *mon, struct player *p)
 		char dice[5];
 		msg("There is a puff of smoke!");
 		strnfmt(dice, sizeof(dice), "%d", z_info->max_sight * 2 + 5);
-		effect_simple(EF_TELEPORT, dice, 0, 0, 0, NULL);
+		effect_simple(EF_TELEPORT, source_monster(mon->midx), dice, 0, 0, 0, NULL);
 	}
 
 	/* Always notice cause of death */

--- a/src/mon-blows.c
+++ b/src/mon-blows.c
@@ -216,7 +216,13 @@ static void melee_effect_stat(melee_effect_handler_context_t *context, int stat)
 		return;
 
 	/* Damage (stat) */
-	effect_simple(EF_DRAIN_STAT, "0", stat, 0, 0, &context->obvious);
+	effect_simple(EF_DRAIN_STAT,
+			source_monster(context->mon->midx),
+			"0",
+			stat,
+			0,
+			0,
+			&context->obvious);
 }
 
 /**
@@ -321,7 +327,7 @@ static void melee_effect_handler_DISENCHANT(melee_effect_handler_context_t *cont
 
 	/* Apply disenchantment if no resist */
 	if (!player_resists(context->p, ELEM_DISEN))
-		effect_simple(EF_DISENCHANT, "0", 0, 0, 0, &context->obvious);
+		effect_simple(EF_DISENCHANT, source_monster(context->mon->midx), "0", 0, 0, 0, &context->obvious);
 
 	/* Learn about the player */
 	update_smart_learn(context->mon, context->p, 0, 0, ELEM_DISEN);
@@ -615,7 +621,13 @@ static void melee_effect_handler_EAT_LIGHT(melee_effect_handler_context_t *conte
 		return;
 
 	/* Drain the light source */
-	effect_simple(EF_DRAIN_LIGHT, "250+1d250", 0, 0, 0, &context->obvious);
+	effect_simple(EF_DRAIN_LIGHT,
+			source_monster(context->mon->midx),
+			"250+1d250",
+			0,
+			0,
+			0,
+			&context->obvious);
 }
 
 /**
@@ -743,11 +755,11 @@ static void melee_effect_handler_LOSE_ALL(melee_effect_handler_context_t *contex
 		return;
 
 	/* Damage (stats) */
-	effect_simple(EF_DRAIN_STAT, "0", STAT_STR, 0, 0, &context->obvious);
-	effect_simple(EF_DRAIN_STAT, "0", STAT_DEX, 0, 0, &context->obvious);
-	effect_simple(EF_DRAIN_STAT, "0", STAT_CON, 0, 0, &context->obvious);
-	effect_simple(EF_DRAIN_STAT, "0", STAT_INT, 0, 0, &context->obvious);
-	effect_simple(EF_DRAIN_STAT, "0", STAT_WIS, 0, 0, &context->obvious);
+	effect_simple(EF_DRAIN_STAT, source_monster(context->mon->midx), "0", STAT_STR, 0, 0, &context->obvious);
+	effect_simple(EF_DRAIN_STAT, source_monster(context->mon->midx), "0", STAT_DEX, 0, 0, &context->obvious);
+	effect_simple(EF_DRAIN_STAT, source_monster(context->mon->midx), "0", STAT_CON, 0, 0, &context->obvious);
+	effect_simple(EF_DRAIN_STAT, source_monster(context->mon->midx), "0", STAT_INT, 0, 0, &context->obvious);
+	effect_simple(EF_DRAIN_STAT, source_monster(context->mon->midx), "0", STAT_WIS, 0, 0, &context->obvious);
 }
 
 /**
@@ -773,7 +785,7 @@ static void melee_effect_handler_SHATTER(melee_effect_handler_context_t *context
 		int px_old = context->p->px;
 		int py_old = context->p->py;
 
-		effect_simple(EF_EARTHQUAKE, "0", 0, 8, 0, NULL);
+		effect_simple(EF_EARTHQUAKE, source_monster(context->mon->midx), "0", 0, 8, 0, NULL);
 
 		/* Stop the blows if the player is pushed away */
 		if ((px_old != context->p->px) ||

--- a/src/mon-spell.c
+++ b/src/mon-spell.c
@@ -167,7 +167,7 @@ void do_mon_spell(int index, struct monster *mon, bool seen)
 				randint0(100) < player->state.skills[SKILL_SAVE]) {
 			msg("%s", spell->save_message);
 		} else {
-			effect_do(spell->effect, NULL, &ident, true, 0, 0, 0);
+			effect_do(spell->effect, source_monster(mon->midx), NULL, &ident, true, 0, 0, 0);
 		}
 	}
 }

--- a/src/obj-chest.c
+++ b/src/obj-chest.c
@@ -308,32 +308,32 @@ static void chest_trap(int y, int x, struct object *obj)
 	if (trap & (CHEST_LOSE_STR)) {
 		msg("A small needle has pricked you!");
 		take_hit(player, damroll(1, 4), "a poison needle");
-		effect_simple(EF_DRAIN_STAT, "0", STAT_STR, 0, 0, NULL);
+		effect_simple(EF_DRAIN_STAT, source_object(obj), "0", STAT_STR, 0, 0, NULL);
 	}
 
 	/* Lose constitution */
 	if (trap & (CHEST_LOSE_CON)) {
 		msg("A small needle has pricked you!");
 		take_hit(player, damroll(1, 4), "a poison needle");
-		effect_simple(EF_DRAIN_STAT, "0", STAT_CON, 0, 0, NULL);
+		effect_simple(EF_DRAIN_STAT, source_object(obj), "0", STAT_CON, 0, 0, NULL);
 	}
 
 	/* Poison */
 	if (trap & (CHEST_POISON)) {
 		msg("A puff of green gas surrounds you!");
-		effect_simple(EF_TIMED_INC, "10+1d20", TMD_POISONED, 0, 0, NULL);
+		effect_simple(EF_TIMED_INC, source_object(obj), "10+1d20", TMD_POISONED, 0, 0, NULL);
 	}
 
 	/* Paralyze */
 	if (trap & (CHEST_PARALYZE)) {
 		msg("A puff of yellow gas surrounds you!");
-		effect_simple(EF_TIMED_INC, "10+1d20", TMD_PARALYZED, 0, 0, NULL);
+		effect_simple(EF_TIMED_INC, source_object(obj), "10+1d20", TMD_PARALYZED, 0, 0, NULL);
 	}
 
 	/* Summon monsters */
 	if (trap & (CHEST_SUMMON)) {
 		msg("You are enveloped in a cloud of smoke!");
-		effect_simple(EF_SUMMON, "2+1d3", 0, 0, 0, NULL);
+		effect_simple(EF_SUMMON, source_object(obj), "2+1d3", 0, 0, 0, NULL);
 	}
 
 	/* Explode */

--- a/src/obj-curse.c
+++ b/src/obj-curse.c
@@ -151,6 +151,6 @@ bool do_curse_effect(int i)
 	if (curse->obj->effect_msg) {
 		msgt(MSG_GENERIC, curse->obj->effect_msg);
 	}
-	effect_do(effect, NULL, &ident, was_aware, dir, 0, 0);
+	effect_do(effect, source_object(curse->obj), NULL, &ident, was_aware, dir, 0, 0);
 	return !was_aware && ident;
 }

--- a/src/player-attack.c
+++ b/src/player-attack.c
@@ -250,7 +250,7 @@ static bool blow_after_effects(int y, int x, bool quake)
 {
 	/* Apply earthquake brand */
 	if (quake) {
-		effect_simple(EF_EARTHQUAKE, "0", 0, 10, 0, NULL);
+		effect_simple(EF_EARTHQUAKE, source_player(), "0", 0, 10, 0, NULL);
 
 		/* Monster may be dead or moved */
 		if (!square_monster(cave, y, x))

--- a/src/player-spell.c
+++ b/src/player-spell.c
@@ -411,7 +411,7 @@ bool spell_cast(int spell_index, int dir)
 		msg("You failed to concentrate hard enough!");
 	} else {
 		/* Cast the spell */
-		if (!effect_do(spell->effect, NULL, ident, true, dir, beam, false)) {
+		if (!effect_do(spell->effect, source_player(), NULL, ident, true, dir, beam, false)) {
 			mem_free(ident);
 			return false;
 		}

--- a/src/player-timed.c
+++ b/src/player-timed.c
@@ -3,7 +3,7 @@
  * \brief Timed effects handling
  *
  * Copyright (c) 1997 Ben Harrison
- * Copyright (c) 2007 A Sidwell <andi@takkaria.org>
+ * Copyright (c) 2007 Andi Sidwell
  *
  * This work is free software; you can redistribute it and/or modify it
  * under the terms of either:
@@ -19,14 +19,13 @@
 
 #include "angband.h"
 #include "cave.h"
+#include "init.h"
 #include "mon-util.h"
 #include "obj-knowledge.h"
+#include "parser.h"
 #include "player-calcs.h"
 #include "player-timed.h"
 #include "player-util.h"
-
-
-struct timed_effect_data *timed_effects;
 
 /**
  * The "stun" and "cut" statuses need to be handled by special functions of
@@ -36,12 +35,7 @@ struct timed_effect_data *timed_effects;
 static bool set_stun(struct player *p, int v);
 static bool set_cut(struct player *p, int v);
 
-
-static struct timed_effect {
-	const char *name;
-	u32b flag_redraw;
-	u32b flag_update;
-} effects[] = {
+struct timed_effect_data timed_effects[TMD_MAX] = {
 	#define TMD(a, b, c)	{ #a, b, c },
 	#include "list-player-timed.h"
 	#undef TMD
@@ -49,32 +43,60 @@ static struct timed_effect {
 
 int timed_name_to_idx(const char *name)
 {
-    size_t i;
-    for (i = 0; i < N_ELEMENTS(effects); i++) {
-        if (!my_stricmp(name, effects[i].name))
+    for (size_t i = 0; i < N_ELEMENTS(timed_effects); i++) {
+        if (my_stricmp(name, timed_effects[i].name) == 0) {
             return i;
+        }
     }
 
     return -1;
 }
 
 /**
- * Set a timed event (except timed resists, cutting and stunning).
+ * Undo scrambled stats when effect runs out.
+ */
+void player_fix_scramble(struct player *p)
+{
+	/* Figure out what stats should be */
+	int new_cur[STAT_MAX];
+	int new_max[STAT_MAX];
+
+	for (int i = 0; i < STAT_MAX; i++) {
+		new_cur[p->stat_map[i]] = p->stat_cur[i];
+		new_max[p->stat_map[i]] = p->stat_max[i];
+	}
+
+	/* Apply new stats and clear the stat_map */
+	for (int i = 0; i < STAT_MAX; i++) {
+		p->stat_cur[i] = new_cur[i];
+		p->stat_max[i] = new_max[i];
+		p->stat_map[i] = i;
+	}
+}
+
+/**
+ * Set a timed effect.
  */
 bool player_set_timed(struct player *p, int idx, int v, bool notify)
 {
-	struct timed_effect_data *effect;
+	assert(idx >= 0);
+	assert(idx < TMD_MAX);
 
-	/* Hack -- Force good values */
-	v = (v > 10000) ? 10000 : (v < 0) ? 0 : v;
-	if ((idx < 0) || (idx > TMD_MAX)) return false;
+	struct timed_effect_data *effect = &timed_effects[idx];
+
+	/* Limit values */
+	v = MIN(v, 10000);
+	v = MAX(v, 0);
 
 	/* No change */
-	if (p->timed[idx] == v) return false;
+	if (p->timed[idx] == v)
+		return false;
 
 	/* Hack -- call other functions */
-	if (idx == TMD_STUN) return set_stun(p, v);
-	else if (idx == TMD_CUT) return set_cut(p, v);
+	if (idx == TMD_STUN)
+		return set_stun(p, v);
+	else if (idx == TMD_CUT)
+		return set_cut(p, v);
 
 	/* Don't mention effects which already match the player state. */
 	if (idx == TMD_OPP_ACID && player_is_immune(p, ELEM_ACID))
@@ -87,9 +109,6 @@ bool player_set_timed(struct player *p, int idx, int v, bool notify)
 		notify = false;
 	else if (idx == TMD_OPP_CONF && player_of_has(p, OF_PROT_CONF))
 		notify = false;
-
-	/* Find the effect */
-	effect = &timed_effects[idx];
 
 	/* Always mention start or finish, otherwise on request */
 	if (v == 0) {
@@ -112,40 +131,75 @@ bool player_set_timed(struct player *p, int idx, int v, bool notify)
 	p->timed[idx] = v;
 
 	/* Sort out the sprint effect */
-	if (idx == TMD_SPRINT && v == 0)
+	if (idx == TMD_SPRINT && v == 0) {
 		player_inc_timed(p, TMD_SLOW, 100, true, false);
+	}
 
 	/* Undo stat swap */
 	if (idx == TMD_SCRAMBLE && v == 0) {
-		/* Figure out what stats should be */
-		int new_cur[STAT_MAX];
-		int new_max[STAT_MAX];
-		for (int i = 0; i < STAT_MAX; ++i) {
-			new_cur[player->stat_map[i]] = player->stat_cur[i];
-			new_max[player->stat_map[i]] = player->stat_max[i];
+		player_fix_scramble(p);
+	}
+
+	if (notify) {
+		/* Disturb */
+		disturb(p, 0);
+
+		/* Update the visuals, as appropriate. */
+		p->upkeep->update |= effect->flag_update;
+		p->upkeep->redraw |= (PR_STATUS | effect->flag_redraw);
+
+		/* Handle stuff */
+		handle_stuff(p);
+	}
+
+	return notify;
+}
+
+bool player_inc_check(struct timed_effect_data *effect, struct player *p)
+{
+	/* Check that @ can be affected by this effect */
+	if (!effect->fail_code) {
+		return true;
+	}
+
+	/* Determine whether an effect can be prevented by a flag */
+	if (effect->fail_code == TMD_FAIL_FLAG_OBJECT) {
+		/* If the effect is from a monster action, extra stuff happens */
+		struct monster *mon = cave->mon_current > 0 ?
+				cave_monster(cave, cave->mon_current) : NULL;
+
+		/* Effect is inhibited by an object flag */
+		equip_learn_flag(p, effect->fail);
+
+		if (mon) {
+			update_smart_learn(mon, player, effect->fail, 0, -1);
 		}
-		/* Apply new stats and clear the stat_map */
-		for (int i = 0; i < STAT_MAX; ++i) {
-			player->stat_cur[i] = new_cur[i];
-			player->stat_max[i] = new_max[i];
-			player->stat_map[i] = i;
+
+		if (player_of_has(p, effect->fail)) {
+			if (mon) {
+				msg("You resist the effect!");
+			}
+			return false;
+		}
+	} else if (effect->fail_code == TMD_FAIL_FLAG_RESIST) {
+		/* Effect is inhibited by a resist */
+		equip_learn_element(p, effect->fail);
+		if (p->state.el_info[effect->fail].res_level > 0) {
+			return false;
+		}
+	} else if (effect->fail_code == TMD_FAIL_FLAG_VULN) {
+		equip_learn_element(p, effect->fail);
+		/* Effect is inhibited by a vulnerability
+		 * the asymmetry with resists is OK for now - NRM */
+		if (p->state.el_info[effect->fail].res_level < 0) {
+			return false;
 		}
 	}
 
-	/* Nothing to notice */
-	if (!notify) return false;
+	/* Special case */
+	if (effect->index == TMD_POISONED && p->timed[TMD_OPP_POIS])
+		return false;
 
-	/* Disturb */
-	disturb(p, 0);
-
-	/* Update the visuals, as appropriate. */
-	p->upkeep->update |= effects[idx].flag_update;
-	p->upkeep->redraw |= (PR_STATUS | effects[idx].flag_redraw);
-
-	/* Handle stuff */
-	handle_stuff(p);
-
-	/* Result */
 	return true;
 }
 
@@ -155,58 +209,24 @@ bool player_set_timed(struct player *p, int idx, int v, bool notify)
  */
 bool player_inc_timed(struct player *p, int idx, int v, bool notify, bool check)
 {
-	struct timed_effect_data *effect;
+	assert(idx >= 0);
+	assert(idx < TMD_MAX);
 
-	/* Find the effect */
-	effect = &timed_effects[idx];
+	struct timed_effect_data *effect = &timed_effects[idx];
 
-	/* Check we have a valid effect */
-	if ((idx < 0) || (idx > TMD_MAX)) return false;
-
-	/* Check that @ can be affected by this effect */
-	if (check && effect->fail_code) {
-		/* If the effect is from a monster action, extra stuff happens */
-		struct monster *mon = cave->mon_current > 0 ?
-			cave_monster(cave, cave->mon_current) : NULL;
-
-		/* Determine whether an effect can be prevented by a flag */
-		if (effect->fail_code == TMD_FAIL_FLAG_OBJECT) {
-			/* Effect is inhibited by an object flag */
-			equip_learn_flag(p, effect->fail);
-			if (mon) 
-				update_smart_learn(mon, player, effect->fail, 0, -1);
-			if (player_of_has(p, effect->fail)) {
-				if (mon)
-				msg("You resist the effect!");
-				return false;
-			}
-		} else if (effect->fail_code == TMD_FAIL_FLAG_RESIST) {
-			/* Effect is inhibited by a resist */
-			equip_learn_element(p, effect->fail);
-			if (p->state.el_info[effect->fail].res_level > 0)
-				return false;
-		} else if (effect->fail_code == TMD_FAIL_FLAG_VULN) {
-			/* Effect is inhibited by a vulnerability 
-			 * the asymmetry with resists is OK for now - NRM */
-			if (p->state.el_info[effect->fail].res_level < 0) {
-				equip_learn_element(p, effect->fail);
-				return false;
-			}
-		}
-
-		/* Special case */
-		if (idx == TMD_POISONED && p->timed[TMD_OPP_POIS])
+	if (check == false || player_inc_check(effect, p) == true) {
+		/* Paralysis should be non-cumulative */
+		if (idx == TMD_PARALYZED && p->timed[TMD_PARALYZED] > 0) {
 			return false;
+		} else {
+			return player_set_timed(p,
+					idx,
+					p->timed[idx] + v,
+					notify);
+		}
 	}
 
-	/* Paralysis should be non-cumulative */
-	if (idx == TMD_PARALYZED && p->timed[TMD_PARALYZED] > 0)
-		return false;
-
-	/* Set v */
-	v = v + p->timed[idx];
-
-	return player_set_timed(p, idx, v, notify);
+	return false;
 }
 
 /**
@@ -214,13 +234,13 @@ bool player_inc_timed(struct player *p, int idx, int v, bool notify, bool check)
  */
 bool player_dec_timed(struct player *p, int idx, int v, bool notify)
 {
-	/* Check we have a valid effect */
-	if ((idx < 0) || (idx > TMD_MAX)) return false;
+	assert(idx >= 0);
+	assert(idx < TMD_MAX);
 
-	/* Set v */
-	v = p->timed[idx] - v;
-
-	return player_set_timed(p, idx, v, notify);
+	return player_set_timed(p,
+			idx,
+			p->timed[idx] - v,
+			notify);
 }
 
 /**
@@ -228,10 +248,11 @@ bool player_dec_timed(struct player *p, int idx, int v, bool notify)
  */
 bool player_clear_timed(struct player *p, int idx, bool notify)
 {
+	assert(idx >= 0);
+	assert(idx < TMD_MAX);
+
 	return player_set_timed(p, idx, 0, notify);
 }
-
-
 
 /**
  * Set "player->timed[TMD_STUN]", notice observable changes
@@ -330,7 +351,6 @@ static bool set_stun(struct player *p, int v)
 	/* Result */
 	return (true);
 }
-
 
 /**
  * Set "player->timed[TMD_CUT]", notice observable changes
@@ -478,7 +498,6 @@ static bool set_cut(struct player *p, int v)
 	return (true);
 }
 
-
 /**
  * Set "player->food", notice observable changes
  *
@@ -572,4 +591,185 @@ bool player_set_food(struct player *p, int v)
 	return (true);
 }
 
+/*
+ * Parsing functions for player_timed.txt
+ */
 
+/**
+ * List of timed effect names
+ */
+static const char *list_timed_effect_names[] = {
+	#define TMD(a, b, c) #a,
+	#include "list-player-timed.h"
+	#undef TMD
+	"MAX",
+	NULL
+};
+
+static enum parser_error parse_player_timed_name(struct parser *p)
+{
+	const char *name = parser_getstr(p, "name");
+	int index;
+
+	if (grab_name("timed effect",
+			name,
+			list_timed_effect_names,
+			N_ELEMENTS(list_timed_effect_names),
+			&index)) {
+		/* XXX not a desctiptive error */
+		return PARSE_ERROR_INVALID_SPELL_NAME;
+	}
+
+	struct timed_effect_data *t = &timed_effects[index];
+
+	t->index = index;
+	parser_setpriv(p, t);
+
+	return PARSE_ERROR_NONE;
+}
+
+static enum parser_error parse_player_timed_desc(struct parser *p)
+{
+	struct timed_effect_data *t = parser_priv(p);
+	assert(t);
+
+	t->desc = string_append(t->desc, parser_getstr(p, "text"));
+	return PARSE_ERROR_NONE;
+}
+
+static enum parser_error parse_player_timed_begin_message(struct parser *p)
+{
+	struct timed_effect_data *t = parser_priv(p);
+	assert(t);
+
+	t->on_begin = string_append(t->on_begin, parser_getstr(p, "text"));
+	return PARSE_ERROR_NONE;
+}
+
+static enum parser_error parse_player_timed_end_message(struct parser *p)
+{
+	struct timed_effect_data *t = parser_priv(p);
+	assert(t);
+
+	t->on_end = string_append(t->on_end, parser_getstr(p, "text"));
+	return PARSE_ERROR_NONE;
+}
+
+static enum parser_error parse_player_timed_increase_message(struct parser *p)
+{
+	struct timed_effect_data *t = parser_priv(p);
+	assert(t);
+
+	t->on_increase = string_append(t->on_increase, parser_getstr(p, "text"));
+	return PARSE_ERROR_NONE;
+}
+
+static enum parser_error parse_player_timed_decrease_message(struct parser *p)
+{
+	struct timed_effect_data *t = parser_priv(p);
+	assert(t);
+
+	t->on_decrease = string_append(t->on_decrease, parser_getstr(p, "text"));
+	return PARSE_ERROR_NONE;
+}
+
+static enum parser_error parse_player_timed_message_type(struct parser *p)
+{
+	struct timed_effect_data *t = parser_priv(p);
+	assert(t);
+
+	t->msgt = message_lookup_by_name(parser_getsym(p, "type"));
+
+	return t->msgt < 0 ?
+				PARSE_ERROR_INVALID_MESSAGE :
+				PARSE_ERROR_NONE;
+}
+
+static enum parser_error parse_player_timed_fail(struct parser *p)
+{
+	struct timed_effect_data *t = parser_priv(p);
+	assert(t);
+
+	t->fail_code = parser_getuint(p, "code");
+
+	const char *name = parser_getstr(p, "flag");
+	if (t->fail_code == TMD_FAIL_FLAG_OBJECT) {
+		int flag = lookup_flag(list_obj_flag_names, name);
+		if (flag == FLAG_END)
+			return PARSE_ERROR_INVALID_FLAG;
+		else
+			t->fail = flag;
+	} else if ((t->fail_code == TMD_FAIL_FLAG_RESIST) ||
+			   (t->fail_code == TMD_FAIL_FLAG_VULN)) {
+		size_t i = 0;
+		while (list_element_names[i] && !streq(list_element_names[i], name))
+			i++;
+
+		if (i == ELEM_MAX)
+			return PARSE_ERROR_INVALID_FLAG;
+		else
+			t->fail = i;
+	} else {
+		return PARSE_ERROR_INVALID_FLAG;
+	}
+
+	return PARSE_ERROR_NONE;
+}
+
+static struct parser *init_parse_player_timed(void)
+{
+	struct parser *p = parser_new();
+	parser_setpriv(p, NULL);
+	parser_reg(p, "name str name", parse_player_timed_name);
+	parser_reg(p, "desc str text", parse_player_timed_desc);
+	parser_reg(p, "on-begin str text", parse_player_timed_begin_message);
+	parser_reg(p, "on-end str text", parse_player_timed_end_message);
+	parser_reg(p, "on-increase str text", parse_player_timed_increase_message);
+	parser_reg(p, "on-decrease str text", parse_player_timed_decrease_message);
+	parser_reg(p, "msgt sym type", parse_player_timed_message_type);
+	parser_reg(p, "fail uint code str flag", parse_player_timed_fail);
+	return p;
+}
+
+static errr run_parse_player_timed(struct parser *p)
+{
+	return parse_file_quit_not_found(p, "player_timed");
+}
+
+static errr finish_parse_player_timed(struct parser *p)
+{
+	parser_destroy(p);
+	return 0;
+}
+
+static void cleanup_player_timed(void)
+{
+	for (size_t i = 0; i < TMD_MAX; i++) {
+		struct timed_effect_data *effect = &timed_effects[i];
+
+		string_free(effect->desc);
+
+		if (effect->on_begin)
+			string_free(effect->on_begin);
+		if (effect->on_end)
+			string_free(effect->on_end);
+		if (effect->on_increase)
+			string_free(effect->on_increase);
+		if (effect->on_decrease)
+			string_free(effect->on_decrease);
+
+		effect->desc        = NULL;
+		effect->on_begin    = NULL;
+		effect->on_end      = NULL;
+		effect->on_increase = NULL;
+		effect->on_decrease = NULL;
+	}
+}
+
+struct file_parser player_timed_parser = {
+	"player timed effects",
+	init_parse_player_timed,
+	run_parse_player_timed,
+	finish_parse_player_timed,
+	cleanup_player_timed
+};

--- a/src/player-timed.h
+++ b/src/player-timed.h
@@ -44,15 +44,6 @@
 #define TMD_CUT_DEEP    1000
 
 /**
- * Effect failure flag types
- */
-enum {
-	TMD_FAIL_FLAG_OBJECT = 1,
-	TMD_FAIL_FLAG_RESIST,
-	TMD_FAIL_FLAG_VULN
-};
-
-/**
  * Timed effects
  */
 enum
@@ -63,8 +54,23 @@ enum
 	TMD_MAX
 };
 
+/**
+ * Effect failure flag types
+ */
+enum {
+	TMD_FAIL_FLAG_OBJECT = 1,
+	TMD_FAIL_FLAG_RESIST,
+	TMD_FAIL_FLAG_VULN
+};
+
+/**
+ * Data struct
+ */
 struct timed_effect_data {
-	char *name;
+	const char *name;
+	u32b flag_redraw;
+	u32b flag_update;
+
 	int index;
 	char *desc;
 	char *on_begin;
@@ -74,10 +80,10 @@ struct timed_effect_data {
 	int msgt;
 	int fail_code;
 	int fail;
-	struct timed_effect_data *next;
 };
 
-struct timed_effect_data *timed_effects;
+extern struct file_parser player_timed_parser;
+extern struct timed_effect_data timed_effects[TMD_MAX];
 
 int timed_name_to_idx(const char *name);
 bool player_set_timed(struct player *p, int idx, int v, bool notify);

--- a/src/player.c
+++ b/src/player.c
@@ -243,11 +243,11 @@ static void adjust_level(struct player *p, bool verbose)
 			msgt(MSG_LEVEL, "Welcome to level %d.",	p->lev);
 		}
 
-		effect_simple(EF_RESTORE_STAT, "0", STAT_STR, 1, 0, NULL);
-		effect_simple(EF_RESTORE_STAT, "0", STAT_INT, 1, 0, NULL);
-		effect_simple(EF_RESTORE_STAT, "0", STAT_WIS, 1, 0, NULL);
-		effect_simple(EF_RESTORE_STAT, "0", STAT_DEX, 1, 0, NULL);
-		effect_simple(EF_RESTORE_STAT, "0", STAT_CON, 1, 0, NULL);
+		effect_simple(EF_RESTORE_STAT, source_none(), "0", STAT_STR, 1, 0, NULL);
+		effect_simple(EF_RESTORE_STAT, source_none(), "0", STAT_INT, 1, 0, NULL);
+		effect_simple(EF_RESTORE_STAT, source_none(), "0", STAT_WIS, 1, 0, NULL);
+		effect_simple(EF_RESTORE_STAT, source_none(), "0", STAT_DEX, 1, 0, NULL);
+		effect_simple(EF_RESTORE_STAT, source_none(), "0", STAT_CON, 1, 0, NULL);
 	}
 
 	while ((p->max_lev < PY_MAX_LEVEL) &&

--- a/src/project-feat.c
+++ b/src/project-feat.c
@@ -24,6 +24,7 @@
 #include "obj-util.h"
 #include "player-calcs.h"
 #include "player-timed.h"
+#include "source.h"
 #include "trap.h"
 
 
@@ -33,7 +34,7 @@
  * ------------------------------------------------------------------------ */
 
 typedef struct project_feature_handler_context_s {
-	const int who;
+	const struct source origin;
 	const int r;
 	const int y;
 	const int x;
@@ -589,7 +590,7 @@ static const project_feature_handler_f feature_handlers[] = {
  * Called for projections with the PROJECT_GRID flag set, which includes
  * beam, ball and breath effects.
  *
- * \param who is the monster list index of the caster
+ * \param origin is the origin of the effect
  * \param r is the distance from the centre of the effect
  * \param y the coordinates of the grid being handled
  * \param x the coordinates of the grid being handled
@@ -602,12 +603,12 @@ static const project_feature_handler_f feature_handlers[] = {
  *
  * Hack -- effects on grids which are memorized but not in view are also seen.
  */
-bool project_f(int who, int r, int y, int x, int dam, int typ)
+bool project_f(struct source origin, int r, int y, int x, int dam, int typ)
 {
 	bool obvious = false;
 
 	project_feature_handler_context_t context = {
-		who,
+		origin,
 		r,
 		y,
 		x,

--- a/src/project-mon.c
+++ b/src/project-mon.c
@@ -524,7 +524,7 @@ static void project_monster_handler_FORCE(project_monster_handler_context_t *con
 
 	/* Thrust monster away. */
 	strnfmt(grids_away, sizeof(grids_away), "%d", 3 + context->dam / 20);
-	effect_simple(EF_THRUST_AWAY, grids_away, context->y, context->x, 0, NULL);
+	effect_simple(EF_THRUST_AWAY, context->origin, grids_away, context->y, context->x, 0, NULL);
 }
 
 /* Time -- breathers resist */
@@ -955,7 +955,7 @@ static void project_m_apply_side_effects(project_monster_handler_context_t *cont
 	} else if (context->teleport_distance > 0) {
 		char dice[5];
 		strnfmt(dice, sizeof(dice), "%d", context->teleport_distance);
-		effect_simple(EF_TELEPORT, dice, context->y, context->x, 0, NULL);
+		effect_simple(EF_TELEPORT, context->origin, dice, context->y, context->x, 0, NULL);
 	} else {
 		int i;
 

--- a/src/project-mon.c
+++ b/src/project-mon.c
@@ -29,6 +29,8 @@
 #include "mon-util.h"
 #include "player-calcs.h"
 #include "project.h"
+#include "source.h"
+
 
 /**
  * Helper function -- return a "nearby" race for polymorphing
@@ -76,7 +78,7 @@ static struct monster_race *poly_race(struct monster_race *race)
  * ------------------------------------------------------------------------ */
 
 typedef struct project_monster_handler_context_s {
-	const int who;
+	const struct source origin;
 	const int r;
 	const int y;
 	const int x;
@@ -237,7 +239,7 @@ static void project_monster_timed_damage(project_monster_handler_context_t *cont
 	if (type < 0 || type >= MON_TMD_MAX)
 		return;
 
-	if (context->who > 0) {
+	if (context->origin.what == SRC_MONSTER) {
 		context->mon_timed[type] = monster_amount;
 		context->flag |= MON_TMD_MON_SOURCE;
 	} else {
@@ -833,7 +835,8 @@ static bool project_m_monster_attack(project_monster_handler_context_t *context,
 }
 
 /**
- * Deal damage to a monster from the player
+ * Deal damage to a monster from a non-monster source (usually a player,
+ * but could also be a trap)
  *
  * This is a helper for project_m(). It isn't a type handler, but we take a
  * handler context since that has a lot of what we need.
@@ -969,7 +972,7 @@ static void project_m_apply_side_effects(project_monster_handler_context_t *cont
 		}
 
 		/* If sleep is caused by the player, base time on the player's level. */
-		if (context->who == 0 && context->mon_timed[MON_TMD_SLEEP] > 0) {
+		if (context->origin.what == SRC_PLAYER && context->mon_timed[MON_TMD_SLEEP] > 0) {
 			context->mon_timed[MON_TMD_SLEEP] = 500 + player->lev * 10;
 		}
 
@@ -992,7 +995,7 @@ static void project_m_apply_side_effects(project_monster_handler_context_t *cont
  * Called for projections with the PROJECT_KILL flag set, which includes
  * bolt, beam, ball and breath effects.
  *
- * \param who is the monster list index of the caster
+ * \param origin is the monster list index of the caster
  * \param r is the distance from the centre of the effect
  * \param y the coordinates of the grid being handled
  * \param x the coordinates of the grid being handled
@@ -1045,8 +1048,9 @@ static void project_m_apply_side_effects(project_monster_handler_context_t *cont
  *
  * Hack -- effects on grids which are memorized but not in view are also seen.
  */
-void project_m(int who, int r, int y, int x, int dam, int typ, int flg,
-               bool *did_hit, bool *was_obvious)
+void project_m(struct source origin, int r, int y, int x,
+				int dam, int typ, int flg,
+				bool *did_hit, bool *was_obvious)
 {
 	struct monster *mon;
 	struct monster_lore *lore;
@@ -1059,13 +1063,13 @@ void project_m(int who, int r, int y, int x, int dam, int typ, int flg,
 	bool obvious = (flg & PROJECT_AWARE ? true : false);
 
 	/* Are we trying to id the source of this effect? */
-	bool id = who < 0 ? !obvious : false;
+	bool id = (origin.what == SRC_PLAYER) ? !obvious : false;
 
 	int m_idx = cave->squares[y][x].mon;
 
 	project_monster_handler_f monster_handler = monster_handlers[typ];
 	project_monster_handler_context_t context = {
-		who,
+		origin,
 		r,
 		y,
 		x,
@@ -1095,7 +1099,7 @@ void project_m(int who, int r, int y, int x, int dam, int typ, int flg,
 	if (!(m_idx > 0)) return;
 
 	/* Never affect projector */
-	if (m_idx == who) return;
+	if (origin.what == SRC_MONSTER && origin.which.monster == m_idx) return;
 
 	/* Obtain monster info */
 	mon = cave_monster(cave, m_idx);
@@ -1110,9 +1114,9 @@ void project_m(int who, int r, int y, int x, int dam, int typ, int flg,
 	}
 
 	/* Breathers may not blast members of the same race. */
-	if ((who > 0) && (flg & (PROJECT_SAFE))) {
+	if (origin.what == SRC_MONSTER && (flg & PROJECT_SAFE)) {
 		/* Point to monster information of caster */
-		struct monster *caster = cave_monster(cave, who);
+		struct monster *caster = cave_monster(cave, origin.which.monster);
 
 		/* Skip monsters with the same race */
 		if (caster->race == mon->race)
@@ -1137,7 +1141,7 @@ void project_m(int who, int r, int y, int x, int dam, int typ, int flg,
 	if (context.skipped) return;
 
 	/* Apply damage to the monster, based on who did the damage. */
-	if (who > 0)
+	if (origin.what == SRC_MONSTER)
 		mon_died = project_m_monster_attack(&context, m_idx);
 	else
 		mon_died = project_m_player_attack(&context);

--- a/src/project-obj.c
+++ b/src/project-obj.c
@@ -27,6 +27,8 @@
 #include "obj-tval.h"
 #include "obj-util.h"
 #include "player-calcs.h"
+#include "source.h"
+
 
 /**
  * Destroys a type of item on a given percent chance.
@@ -166,7 +168,7 @@ int inven_damage(struct player *p, int type, int cperc)
  * ------------------------------------------------------------------------ */
 
 typedef struct project_object_handler_context_s {
-	const int who;
+	const struct source origin;
 	const int r;
 	const int y;
 	const int x;
@@ -394,13 +396,13 @@ static const project_object_handler_f object_handlers[] = {
  * Called for projections with the PROJECT_ITEM flag set, which includes
  * beam, ball and breath effects.
  *
- * \param who is the monster list index of the caster
+ * \param origin is the origin of the effect
  * \param r is the distance from the centre of the effect
  * \param y the coordinates of the grid being handled
  * \param x the coordinates of the grid being handled
  * \param dam is the "damage" from the effect at distance r from the centre
  * \param typ is the projection (GF_) type
- * \param protected_obj is an object that should not be affected by the 
+ * \param protected_obj is an object that should not be affected by the
  *        projection, typically the object that created it
  * \return whether the effects were obvious
  *
@@ -409,7 +411,7 @@ static const project_object_handler_f object_handlers[] = {
  *
  * Hack -- effects on objects which are memorized but not in view are also seen.
  */
-bool project_o(int who, int r, int y, int x, int dam, int typ,
+bool project_o(struct source origin, int r, int y, int x, int dam, int typ,
 			   const struct object *protected_obj)
 {
 	struct object *obj = square_object(cave, y, x);
@@ -421,8 +423,10 @@ bool project_o(int who, int r, int y, int x, int dam, int typ,
 		bool do_kill = false;
 		const char *note_kill = NULL;
 		struct object *next = obj->next;
+
+		project_object_handler_f object_handler = object_handlers[typ];
 		project_object_handler_context_t context = {
-			who,
+			origin,
 			r,
 			y,
 			x,
@@ -434,7 +438,6 @@ bool project_o(int who, int r, int y, int x, int dam, int typ,
 			ignore,
 			note_kill,
 		};
-		project_object_handler_f object_handler = object_handlers[typ];
 
 		if (object_handler != NULL)
 			object_handler(&context);

--- a/src/project-player.c
+++ b/src/project-player.c
@@ -27,6 +27,7 @@
 #include "player-timed.h"
 #include "player-util.h"
 #include "project.h"
+#include "source.h"
 #include "trap.h"
 
 /**
@@ -152,14 +153,18 @@ static void project_player_swap_stats(void)
 }
 
 typedef struct project_player_handler_context_s {
-	const int who;
+	/* Input values */
+	const struct source origin;
 	const int r;
 	const int y;
 	const int x;
 	const int dam;
 	const int type;
+
+	/* Return values */
 	bool obvious;
 } project_player_handler_context_t;
+
 typedef void (*project_player_handler_f)(project_player_handler_context_t *);
 
 static void project_player_handler_ACID(project_player_handler_context_t *context)
@@ -244,7 +249,10 @@ static void project_player_handler_SHARD(project_player_handler_context_t *conte
 
 static void project_player_handler_NEXUS(project_player_handler_context_t *context)
 {
-	struct monster *mon = cave_monster(cave, context->who);
+	struct monster *mon = NULL;
+	if (context->origin.what == SRC_MONSTER) {
+		mon = cave_monster(cave, context->origin.which.monster);
+	}
 
 	if (player_resists(player, ELEM_NEXUS)) {
 		msg("You resist the effect!");
@@ -252,14 +260,13 @@ static void project_player_handler_NEXUS(project_player_handler_context_t *conte
 	}
 
 	/* Stat swap */
-    if (randint0(100) < player->state.skills[SKILL_SAVE]) {
-        msg("You avoid the effect!");
-    }
-    else {
-        project_player_swap_stats();
-    }
+	if (randint0(100) < player->state.skills[SKILL_SAVE]) {
+		msg("You avoid the effect!");
+	} else {
+		project_player_swap_stats();
+	}
 
-	if (one_in_(3)) { /* Teleport to */
+	if (one_in_(3) && mon) { /* Teleport to */
 		effect_simple(EF_TELEPORT_TO, "0", mon->fy, mon->fx, 0, NULL);
 	} else if (one_in_(4)) { /* Teleport level */
 		if (randint0(100) < player->state.skills[SKILL_SAVE]) {
@@ -493,7 +500,7 @@ static const project_player_handler_f player_handlers[] = {
  * Called for projections with the PROJECT_PLAY flag set, which includes
  * bolt, beam, ball and breath effects.
  *
- * \param who is the monster list index of the caster, or 0 for a trap
+ * \param src is the origin of the effect
  * \param r is the distance from the centre of the effect
  * \param y the coordinates of the grid being handled
  * \param x the coordinates of the grid being handled
@@ -507,22 +514,18 @@ static const project_player_handler_f player_handlers[] = {
  *
  * We assume the player is aware of some effect, and always return "true".
  */
-bool project_p(int who, int r, int y, int x, int dam, int typ)
+bool project_p(struct source origin, int r, int y, int x, int dam, int typ)
 {
 	bool blind = (player->timed[TMD_BLIND] ? true : false);
 	bool seen = !blind;
 	bool obvious = true;
-
-	/* Source monster or trap */
-	struct monster *mon = cave_monster(cave, who);
-	struct trap *trap = cave->trap_current;
 
 	/* Monster or trap name (for damage) */
 	char killer[80];
 
 	project_player_handler_f player_handler = player_handlers[typ];
 	project_player_handler_context_t context = {
-		who,
+		origin,
 		r,
 		y,
 		x,
@@ -532,46 +535,61 @@ bool project_p(int who, int r, int y, int x, int dam, int typ)
 	};
 
 	/* No player here */
-	if (!square_isplayer(cave, y, x)) return (false);
+	if (!square_isplayer(cave, y, x)) {
+		return false;
+	}
 
-	/* Never affect projector */
-	if (who < 0) return (false);
+	switch (origin.what) {
+		case SRC_PLAYER:
+			/* Never affect projector */
+			return false;
 
-	/* Monster or trap */
-	if (mon) {
-		/* Check it is visible */
-		if (!mflag_has(mon->mflag, MFLAG_VISIBLE))
-			seen = false;
+		case SRC_MONSTER: {
+			struct monster *mon = cave_monster(cave, origin.which.monster);
 
-		/* Get the monster's real name */
-		monster_desc(killer, sizeof(killer), mon, MDESC_DIED_FROM);
-	} else {
-		/* Ensure there's a trap */
-		assert(trap);
+			/* Check it is visible */
+			if (!mflag_has(mon->mflag, MFLAG_VISIBLE))
+				seen = false;
 
-		/* Get the trap name */
-		my_strcpy(killer, format("a %s", trap->kind->desc), sizeof(killer));
+			/* Get the monster's real name */
+			monster_desc(killer, sizeof(killer), mon, MDESC_DIED_FROM);
+
+			break;
+		}
+
+		case SRC_TRAP: {
+			struct trap *trap = origin.which.trap;
+
+			/* Get the trap name */
+			strnfmt(killer, sizeof(killer), "a %s", trap->kind->desc);
+
+			break;
+		}
 	}
 
 	/* Let player know what is going on */
-	if (!seen)
+	if (!seen) {
 		msg("You are hit by %s!", gf_blind_desc(typ));
+	}
 
 	/* Adjust damage for resistance, immunity or vulnerability, and apply it */
-	dam = adjust_dam(player, typ, dam, RANDOMISE,
-					 player->state.el_info[typ].res_level);
-	if (dam)
+	dam = adjust_dam(player,
+						typ,
+						dam,
+						RANDOMISE,
+						player->state.el_info[typ].res_level);
+	if (dam) {
 		take_hit(player, dam, killer);
+	}
 
 	/* Handle side effects */
-	if ((player_handler != NULL) && !player->is_dead)
+	if (player_handler != NULL && player->is_dead == false) {
 		player_handler(&context);
-
-	obvious = context.obvious;
+	}
 
 	/* Disturb */
 	disturb(player, 1);
 
 	/* Return "Anything seen?" */
-	return (obvious);
+	return context.obvious;
 }

--- a/src/project-player.c
+++ b/src/project-player.c
@@ -21,6 +21,7 @@
 #include "effects.h"
 #include "init.h"
 #include "mon-desc.h"
+#include "obj-desc.h"
 #include "obj-gear.h"
 #include "obj-knowledge.h"
 #include "player-calcs.h"
@@ -267,16 +268,16 @@ static void project_player_handler_NEXUS(project_player_handler_context_t *conte
 	}
 
 	if (one_in_(3) && mon) { /* Teleport to */
-		effect_simple(EF_TELEPORT_TO, "0", mon->fy, mon->fx, 0, NULL);
+		effect_simple(EF_TELEPORT_TO, context->origin, "0", mon->fy, mon->fx, 0, NULL);
 	} else if (one_in_(4)) { /* Teleport level */
 		if (randint0(100) < player->state.skills[SKILL_SAVE]) {
 			msg("You avoid the effect!");
 			return;
 		}
-		effect_simple(EF_TELEPORT_LEVEL, "0", 0, 0, 0, NULL);
+		effect_simple(EF_TELEPORT_LEVEL, context->origin, "0", 0, 0, 0, NULL);
 	} else { /* Teleport */
 		const char *miles = "200";
-		effect_simple(EF_TELEPORT, miles, 0, 1, 0, NULL);
+		effect_simple(EF_TELEPORT, context->origin, miles, 0, 1, 0, NULL);
 	}
 }
 
@@ -327,7 +328,7 @@ static void project_player_handler_DISEN(project_player_handler_context_t *conte
 	}
 
 	/* Disenchant gear */
-	effect_simple(EF_DISENCHANT, "0", 0, 0, 0, NULL);
+	effect_simple(EF_DISENCHANT, context->origin, "0", 0, 0, 0, NULL);
 }
 
 static void project_player_handler_WATER(project_player_handler_context_t *context)
@@ -361,7 +362,7 @@ static void project_player_handler_GRAVITY(project_player_handler_context_t *con
 	/* Blink */
 	if (randint1(127) > player->lev) {
 		const char *five = "5";
-		effect_simple(EF_TELEPORT, five, 0, 1, 0, NULL);
+		effect_simple(EF_TELEPORT, context->origin, five, 0, 1, 0, NULL);
 	}
 
 	/* Slow */
@@ -392,7 +393,7 @@ static void project_player_handler_FORCE(project_player_handler_context_t *conte
 
 	/* Thrust player away. */
 	strnfmt(grids_away, sizeof(grids_away), "%d", 3 + context->dam / 20);
-	effect_simple(EF_THRUST_AWAY, grids_away, context->y, context->x, 0, NULL);
+	effect_simple(EF_THRUST_AWAY, context->origin, grids_away, context->y, context->x, 0, NULL);
 }
 
 static void project_player_handler_TIME(project_player_handler_context_t *context)
@@ -563,6 +564,17 @@ bool project_p(struct source origin, int r, int y, int x, int dam, int typ)
 			/* Get the trap name */
 			strnfmt(killer, sizeof(killer), "a %s", trap->kind->desc);
 
+			break;
+		}
+
+		case SRC_OBJECT: {
+			struct object *obj = origin.which.object;
+			object_desc(killer, sizeof(killer), obj, ODESC_PREFIX | ODESC_BASE);
+			break;
+		}
+
+		case SRC_NONE: {
+			/* Assume the caller has set the killer variable */
 			break;
 		}
 	}

--- a/src/project.c
+++ b/src/project.c
@@ -436,6 +436,33 @@ const char *gf_idx_to_name(int type)
  * ------------------------------------------------------------------------ */
 
 /**
+ * Given an origin, find its coordinates and return them
+ *
+ * If there is no origin, return (-1, -1)
+ */
+struct loc origin_get_loc(struct source origin)
+{
+	switch (origin.what) {
+		case SRC_MONSTER: {
+			struct monster *who = cave_monster(cave, origin.which.monster);
+			return loc(who->fx, who->fy);
+		}
+
+		case SRC_TRAP: {
+			struct trap *trap = origin.which.trap;
+			return loc(trap->fx, trap->fy);
+		}
+
+		case SRC_PLAYER:
+		case SRC_OBJECT:	/* At the moment only worn cursed objects use this */
+			return loc(player->py, player->py);
+
+		case SRC_NONE:
+			return loc(-1, -1);
+	}
+}
+
+/**
  * Generic "beam"/"bolt"/"ball" projection routine.
  *   -BEN-, some changes by -LM-
  *
@@ -637,25 +664,11 @@ bool project(struct source origin, int rad, int y, int x,
 		/* Clear the flag */
 		flg &= ~(PROJECT_JUMP);
 	} else {
+		source = origin_get_loc(origin);
+
 		/* Default to destination grid */
-		source = loc(x, y);
-
-		switch (origin.what) {
-			case SRC_TRAP: {
-				struct trap *trap = origin.which.trap;
-				source = loc(trap->fx, trap->fy);
-				break;
-			}
-
-			case SRC_PLAYER:
-				source = loc(player->px, player->py);
-				break;
-
-			case SRC_MONSTER: {
-				struct monster *mon = cave_monster(cave, origin.which.monster);
-				source = loc(mon->fx, mon->fy);
-				break;
-			}
+		if (source.y == -1 && source.x == -1) {
+			source = loc(x, y);
 		}
 	}
 

--- a/src/project.c
+++ b/src/project.c
@@ -26,6 +26,8 @@
 #include "player-calcs.h"
 #include "player-timed.h"
 #include "project.h"
+#include "source.h"
+#include "trap.h"
 
 /*
  * Specify attr/char pairs for visual special effects for project()
@@ -434,10 +436,10 @@ const char *gf_idx_to_name(int type)
  * ------------------------------------------------------------------------ */
 
 /**
- * Generic "beam"/"bolt"/"ball" projection routine.  
+ * Generic "beam"/"bolt"/"ball" projection routine.
  *   -BEN-, some changes by -LM-
  *
- *   \param who Index of "source" monster (negative for the character)
+ *   \param origin Origin of the projection
  *   \param rad Radius of explosion (0 = beam/bolt, 1 to 20 = ball), or maximum
  *	  length of arc from the source.
  *   \param y Target location (or location to travel towards)
@@ -579,7 +581,8 @@ const char *gf_idx_to_name(int type)
  * in the blast radius, in case the illumination of the grid was changed,
  * and "update_view()" and "update_monsters()" need to be called.
  */
-bool project(int who, int rad, int y, int x, int dam, int typ, int flg,
+bool project(struct source origin, int rad, int y, int x,
+			 int dam, int typ, int flg,
 			 int degrees_of_arc, byte diameter_of_source,
 			 const struct object *obj)
 {
@@ -628,33 +631,42 @@ bool project(int who, int rad, int y, int x, int dam, int typ, int flg,
 	handle_stuff(player);
 
 	/* No projection path - jump to target */
-	if (flg & (PROJECT_JUMP)) {
+	if (flg & PROJECT_JUMP) {
 		source = loc(x, y);
 
 		/* Clear the flag */
 		flg &= ~(PROJECT_JUMP);
-	}
-
-	/* Start at player */
-	else if (who < 0)
-		source = loc(player->px, player->py);
-
-	/* Start at monster */
-	else if (who > 0)
-		source = loc(cave_monster(cave, who)->fx, cave_monster(cave, who)->fy);
-
-	/* Implies no caster, so assume source is target */
-	else
+	} else {
+		/* Default to destination grid */
 		source = loc(x, y);
 
+		switch (origin.what) {
+			case SRC_TRAP: {
+				struct trap *trap = origin.which.trap;
+				source = loc(trap->fx, trap->fy);
+				break;
+			}
+
+			case SRC_PLAYER:
+				source = loc(player->px, player->py);
+				break;
+
+			case SRC_MONSTER: {
+				struct monster *mon = cave_monster(cave, origin.which.monster);
+				source = loc(mon->fx, mon->fy);
+				break;
+			}
+		}
+	}
+
 	/* Default destination */
-		destination = loc(x, y);
+	destination = loc(x, y);
 
 	/* Default center of explosion (if any) */
 	centre = loc(source.x, source.y);
 
-	/* 
-	 * An arc spell with no width and a non-zero radius is actually a 
+	/*
+	 * An arc spell with no width and a non-zero radius is actually a
 	 * beam of defined length.  Mark it as such.
 	 */
 	if ((flg & (PROJECT_ARC)) && (degrees_of_arc == 0) && (rad != 0)) {
@@ -666,9 +678,10 @@ bool project(int who, int rad, int y, int x, int dam, int typ, int flg,
 		flg |= (PROJECT_THRU);
 	}
 
-
-	/* If a single grid is both source and destination (for example
-	 * if PROJECT_JUMP is set), store it. */
+	/*
+	 * If a single grid is both source and destination (for example
+	 * if PROJECT_JUMP is set), store it.
+	 */
 	if ((source.x == destination.x) && (source.y == destination.y)) {
 		blast_grid[num_grids].y = y;
 		blast_grid[num_grids].x = x;
@@ -752,7 +765,7 @@ bool project(int who, int rad, int y, int x, int dam, int typ, int flg,
 		/* No special actions */
 	}
 
-	/* 
+	/*
 	 * All non-beam projections with a positive radius explode in some way.
 	 */
 	else if (rad > 0) {
@@ -956,7 +969,7 @@ bool project(int who, int rad, int y, int x, int dam, int typ, int flg,
 			x = blast_grid[i].x;
 
 			/* Affect the object in the grid */
-			if (project_o(who, distance_to_grid[i], y, x,
+			if (project_o(origin, distance_to_grid[i], y, x,
 						  dam_at_dist[distance_to_grid[i]], typ, obj))
 				notice = true;
 		}
@@ -988,7 +1001,7 @@ bool project(int who, int rad, int y, int x, int dam, int typ, int flg,
 				continue;
 
 			/* Affect the monster in the grid */
-			project_m(who, distance_to_grid[i], y, x,
+			project_m(origin, distance_to_grid[i], y, x,
 			          dam_at_dist[distance_to_grid[i]], typ, flg,
 			          &did_hit, &was_obvious);
 			if (was_obvious)
@@ -1003,7 +1016,9 @@ bool project(int who, int rad, int y, int x, int dam, int typ, int flg,
 		}
 
 		/* Player affected one monster (without "jumping") */
-		if ((who < 0) && (num_hit == 1) && !(flg & (PROJECT_JUMP))) {
+		if (origin.what == SRC_PLAYER &&
+				num_hit == 1 &&
+				!(flg & PROJECT_JUMP)) {
 			/* Location */
 			x = last_hit_x;
 			y = last_hit_y;
@@ -1030,7 +1045,7 @@ bool project(int who, int rad, int y, int x, int dam, int typ, int flg,
 			x = blast_grid[i].x;
 
 			/* Affect the player, or keep scanning */
-			if (project_p(who, distance_to_grid[i], y, x,
+			if (project_p(origin, distance_to_grid[i], y, x,
 						  dam_at_dist[distance_to_grid[i]], typ)) {
 				notice = true;
 				if (player->is_dead)
@@ -1049,7 +1064,7 @@ bool project(int who, int rad, int y, int x, int dam, int typ, int flg,
 			x = blast_grid[i].x;
 
 			/* Affect the feature in that grid */
-			if (project_f(who, distance_to_grid[i], y, x,
+			if (project_f(origin, distance_to_grid[i], y, x,
 						  dam_at_dist[distance_to_grid[i]], typ))
 				notice = true;
 		}

--- a/src/project.h
+++ b/src/project.h
@@ -6,6 +6,8 @@
 #ifndef PROJECT_H
 #define PROJECT_H
 
+#include "source.h"
+
 /**
  * Spell types used by project(), and related functions.
  */
@@ -66,19 +68,19 @@ enum
 #define PROJECT_ARC   0x400
 #define PROJECT_PLAY  0x800
 
-bool project_f(int who, int r, int y, int x, int dam, int typ);
-int inven_damage(struct player *p, int type, int cperc);
-bool project_o(int who, int r, int y, int x, int dam, int typ,
-			   const struct object *protected_obj);
-void project_m(int who, int r, int y, int x, int dam, int typ, int flg,
-               bool *did_hit, bool *was_obvious);
-int adjust_dam(struct player *p, int type, int dam, aspect dam_aspect, int resist);
-bool project_p(int who, int r, int y, int x, int dam, int typ);
-
-
-/* project.c */
+/* Display attrs and chars */
 extern byte gf_to_attr[GF_MAX][BOLT_MAX];
 extern wchar_t gf_to_char[GF_MAX][BOLT_MAX];
+
+int inven_damage(struct player *p, int type, int cperc);
+int adjust_dam(struct player *p, int type, int dam, aspect dam_aspect, int resist);
+
+bool project_f(struct source, int r, int y, int x, int dam, int typ);
+bool project_o(struct source, int r, int y, int x, int dam, int typ,
+			   const struct object *protected_obj);
+void project_m(struct source, int r, int y, int x, int dam, int typ, int flg,
+               bool *did_hit, bool *was_obvious);
+bool project_p(struct source, int r, int y, int x, int dam, int typ);
 
 int project_path(struct loc *gp, int range, int y1, int x1, int y2, int x2, int flg);
 bool projectable(struct chunk *c, int y1, int x1, int y2, int x2, int flg);
@@ -90,7 +92,7 @@ const char *gf_desc(int type);
 const char *gf_blind_desc(int type);
 int gf_name_to_idx(const char *name);
 const char *gf_idx_to_name(int type);
-bool project(int who, int rad, int y, int x, int dam, int typ, int flg,
+bool project(struct source, int rad, int y, int x, int dam, int typ, int flg,
 			 int degrees_of_arc, byte diameter_of_source,
 			 const struct object *obj);
 

--- a/src/project.h
+++ b/src/project.h
@@ -92,6 +92,9 @@ const char *gf_desc(int type);
 const char *gf_blind_desc(int type);
 int gf_name_to_idx(const char *name);
 const char *gf_idx_to_name(int type);
+
+struct loc origin_get_loc(struct source origin);
+
 bool project(struct source, int rad, int y, int x, int dam, int typ, int flg,
 			 int degrees_of_arc, byte diameter_of_source,
 			 const struct object *obj);

--- a/src/source.c
+++ b/src/source.c
@@ -1,0 +1,56 @@
+/**
+ * \file source.c
+ * \brief Type that allows various different origins for an effect
+ *
+ * Copyright (c) 2016 Andi Sidwell
+ *
+ * This work is free software; you can redistribute it and/or modify it
+ * under the terms of either:
+ *
+ * a) the GNU General Public License as published by the Free Software
+ *    Foundation, version 2, or
+ *
+ * b) the "Angband licence":
+ *    This software may be copied and distributed for educational, research,
+ *    and not for profit purposes provided that this copyright and statement
+ *    are included in all such copies.  Other copyrights may also apply.
+ */
+
+#include "source.h"
+
+struct source source_none(void)
+{
+	struct source src;
+	src.what = SRC_NONE;
+	return src;
+}
+
+struct source source_trap(struct trap *trap)
+{
+	struct source src;
+	src.what = SRC_TRAP;
+	src.which.trap = trap;
+	return src;
+}
+
+struct source source_monster(int who)
+{
+	struct source src;
+	src.what = SRC_MONSTER;
+	src.which.monster = who;
+	return src;
+}
+
+struct source source_player(void)
+{
+	struct source src = { SRC_PLAYER };
+	return src;
+}
+
+struct source source_object(struct object *object)
+{
+	struct source src;
+	src.what = SRC_OBJECT;
+	src.which.object = object;
+	return src;
+}

--- a/src/source.h
+++ b/src/source.h
@@ -1,0 +1,33 @@
+#ifndef EFFECT_SOURCE_H
+#define EFFECT_SOURCE_H
+
+/*
+ * Structure that tells you where an effect came from
+ */
+struct source {
+	enum {
+		SRC_NONE,
+		SRC_TRAP,
+		SRC_PLAYER,
+		SRC_MONSTER,
+		SRC_OBJECT
+	} what;
+
+	union {
+		struct trap *trap;
+		int monster;
+		struct object *object;
+	} which;
+};
+
+/*
+ * Generate different forms of the source for projection and effect
+ * functions
+ */
+struct source source_none(void);
+struct source source_trap(struct trap *);
+struct source source_monster(int who);
+struct source source_player(void);
+struct source source_object(struct object *);
+
+#endif /* EFFECT_SOURCE_H */

--- a/src/trap.c
+++ b/src/trap.c
@@ -397,9 +397,6 @@ extern void hit_trap(int y, int x)
 		if (!trf_has(trap->kind->flags, TRF_TRAP)) continue;
 		if (trap->timeout) continue;
 
-		/* Set this to be the current trap */
-		cave->trap_current = trap;
-	    
 		/* Disturb the player */
 		disturb(player, 0);
 
@@ -466,9 +463,6 @@ extern void hit_trap(int y, int x)
 		trf_on(trap->flags, TRF_VISIBLE);
 		square_memorize(cave, y, x);
 	}
-
-	/* Clear the current trap */
-	cave->trap_current = NULL;
 
     /* Verify traps (remove marker if appropriate) */
     (void)square_verify_trap(cave, y, x, 0);

--- a/src/trap.c
+++ b/src/trap.c
@@ -433,14 +433,14 @@ extern void hit_trap(int y, int x)
 			if (trap->kind->msg_bad)
 				msg(trap->kind->msg_bad);
 			effect = trap->kind->effect;
-			effect_do(effect, NULL, &ident, false, 0, 0, 0);
+			effect_do(effect, source_trap(trap), NULL, &ident, false, 0, 0, 0);
 
 			/* Do any extra effects */
 			if (trap->kind->effect_xtra && one_in_(2)) {
 				if (trap->kind->msg_xtra)
 					msg(trap->kind->msg_xtra);
 				effect = trap->kind->effect_xtra;
-				effect_do(effect, NULL, &ident, false, 0, 0, 0);
+				effect_do(effect, source_trap(trap), NULL, &ident, false, 0, 0, 0);
 			}
 		}
 

--- a/src/trap.h
+++ b/src/trap.h
@@ -96,7 +96,8 @@ bool square_player_trap_allowed(struct chunk *c, int y, int x);
 void place_trap(struct chunk *c, int y, int x, int t_idx, int trap_level);
 void square_free_trap(struct chunk *c, int y, int x);
 void wipe_trap_list(struct chunk *c);
-bool square_remove_trap(struct chunk *c, int y, int x, bool domsg, int t_idx);
+bool square_remove_all_traps(struct chunk *c, int y, int x);
+bool square_remove_trap(struct chunk *c, int y, int x, int t_idx);
 bool square_set_trap_timeout(struct chunk *c, int y, int x, bool domsg,
 							 int t_idx, int time);
 int square_trap_timeout(struct chunk *c, int y, int x, int t_idx);

--- a/src/wiz-debug.c
+++ b/src/wiz-debug.c
@@ -260,7 +260,7 @@ static void do_cmd_wiz_bamf(void)
 
 	/* Teleport to the target */
 	else
-		effect_simple(EF_TELEPORT_TO, "0", y, x, 0, NULL);
+		effect_simple(EF_TELEPORT_TO, source_player(), "0", y, x, 0, NULL);
 }
 
 
@@ -1359,14 +1359,14 @@ static void do_cmd_wiz_cure_all(void)
 	}
 
 	/* Restore stats */
-	effect_simple(EF_RESTORE_STAT, "0", STAT_STR, 0, 0, NULL);
-	effect_simple(EF_RESTORE_STAT, "0", STAT_INT, 0, 0, NULL);
-	effect_simple(EF_RESTORE_STAT, "0", STAT_WIS, 0, 0, NULL);
-	effect_simple(EF_RESTORE_STAT, "0", STAT_DEX, 0, 0, NULL);
-	effect_simple(EF_RESTORE_STAT, "0", STAT_CON, 0, 0, NULL);
+	effect_simple(EF_RESTORE_STAT, source_player(), "0", STAT_STR, 0, 0, NULL);
+	effect_simple(EF_RESTORE_STAT, source_player(), "0", STAT_INT, 0, 0, NULL);
+	effect_simple(EF_RESTORE_STAT, source_player(), "0", STAT_WIS, 0, 0, NULL);
+	effect_simple(EF_RESTORE_STAT, source_player(), "0", STAT_DEX, 0, 0, NULL);
+	effect_simple(EF_RESTORE_STAT, source_player(), "0", STAT_CON, 0, 0, NULL);
 
 	/* Restore the level */
-	effect_simple(EF_RESTORE_EXP, "0", 1, 0, 0, NULL);
+	effect_simple(EF_RESTORE_EXP, source_player(), "0", 1, 0, 0, NULL);
 
 	/* Heal the player */
 	player->chp = player->mhp;
@@ -1521,7 +1521,7 @@ static void do_cmd_wiz_summon(int num)
 	int i;
 
 	for (i = 0; i < num; i++)
-		effect_simple(EF_SUMMON, "1", 0, 0, 0, NULL);
+		effect_simple(EF_SUMMON, source_player(), "1", 0, 0, 0, NULL);
 }
 
 
@@ -1911,7 +1911,7 @@ void do_cmd_wiz_effect(void)
 	screen_load();
 
 	if (index > EF_NONE && index < EF_MAX)
-		effect_simple(index, dice, p1, p2, p3, &ident);
+		effect_simple(index, source_player(), dice, p1, p2, p3, &ident);
 	else
 		msg("No effect found.");
 
@@ -1994,16 +1994,16 @@ void get_debug_command(void)
 		/* Detect everything */
 		case 'd':
 		{
-			//effect_simple(EF_DETECT_TRAPS, "22d40", 0, 0, 0, NULL);
-			//effect_simple(EF_DETECT_DOORS, "22d40", 0, 0, 0, NULL);
-			//effect_simple(EF_DETECT_STAIRS, "22d40", 0, 0, 0, NULL);
-			effect_simple(EF_DETECT_GOLD, "22d40", 0, 0, 0, NULL);
-			effect_simple(EF_DETECT_OBJECTS, "22d40", 0, 0, 0, NULL);
-			effect_simple(EF_DETECT_VISIBLE_MONSTERS, "22d40", 0, 0, 0, NULL);
-			effect_simple(EF_DETECT_INVISIBLE_MONSTERS, "22d40", 0, 0, 0, NULL);
+//			effect_simple(EF_DETECT_TRAPS, source_player(), "22d40", 0, 0, 0, NULL);
+//			effect_simple(EF_DETECT_DOORS, source_player(), "22d40", 0, 0, 0, NULL);
+//			effect_simple(EF_DETECT_STAIRS, source_player(), "22d40", 0, 0, 0, NULL);
+			effect_simple(EF_DETECT_GOLD, source_player(), "22d40", 0, 0, 0, NULL);
+			effect_simple(EF_DETECT_OBJECTS, source_player(), "22d40", 0, 0, 0, NULL);
+			effect_simple(EF_DETECT_VISIBLE_MONSTERS, source_player(), "22d40", 0, 0, 0, NULL);
+			effect_simple(EF_DETECT_INVISIBLE_MONSTERS, source_player(), "22d40", 0, 0, 0, NULL);
 			break;
 		}
-		
+
 		/* Test for disconnected dungeon */
 		case 'D':
 		{
@@ -2066,7 +2066,7 @@ void get_debug_command(void)
 		/* Hit all monsters in LOS */
 		case 'H':
 		{
-			effect_simple(EF_PROJECT_LOS, "10000", GF_DISP_ALL, 0, 0, NULL);
+			effect_simple(EF_PROJECT_LOS, source_player(), "10000", GF_DISP_ALL, 0, 0, NULL);
 			break;
 		}
 
@@ -2094,7 +2094,7 @@ void get_debug_command(void)
 		/* Magic Mapping */
 		case 'm':
 		{
-			effect_simple(EF_MAP_AREA, "22d40", 0, 0, 0, NULL);
+			effect_simple(EF_MAP_AREA, source_player(), "22d40", 0, 0, 0, NULL);
 			break;
 		}
 
@@ -2146,7 +2146,7 @@ void get_debug_command(void)
 		case 'p':
 		{
 			const char *near = "10";
-			effect_simple(EF_TELEPORT, near, 0, 1, 0, NULL);
+			effect_simple(EF_TELEPORT, source_player(), near, 0, 1, 0, NULL);
 			break;
 		}
 
@@ -2240,7 +2240,7 @@ void get_debug_command(void)
 		case 't':
 		{
 			const char *far = "100";
-			effect_simple(EF_TELEPORT, far, 0, 1, 0, NULL);
+			effect_simple(EF_TELEPORT, source_player(), far, 0, 1, 0, NULL);
 			break;
 		}
 
@@ -2272,9 +2272,8 @@ void get_debug_command(void)
 		/* Un-hide all monsters */
 		case 'u':
 		{
-			effect_simple(EF_DETECT_VISIBLE_MONSTERS, "500d500", 0, 0, 0, NULL);
-			effect_simple(EF_DETECT_INVISIBLE_MONSTERS, "500d500", 0, 0, 0,
-						  NULL);
+			effect_simple(EF_DETECT_VISIBLE_MONSTERS, source_player(), "500d500", 0, 0, 0, NULL);
+			effect_simple(EF_DETECT_INVISIBLE_MONSTERS, source_player(), "500d500", 0, 0, 0, NULL);
 			break;
 		}
 


### PR DESCRIPTION
* Add a new 'source' type which provides the source of an effect.  Use this as a parameter to effect_do(), effect_simple(), and project().  Using this type consistently cleans up the logic of a few bits of code, and in the process I've added better support for traps and curses to some effect types.

* Remove `cave->trap_current` and significantly reduce use of `cave->mon_current` as a result of the above change.  I intend to get rid of `mon_current` altogether at some point, but ran out of steam so thought it made sense to get this in before it went out of date and do more work later.

* Refactor player-timed.c, moving the parsing bits into that file and only using one array to store all timed effect data.  Change format of timed effects file slightly to reduce verbosity.

* Simplify trap destruction logic.

Sadly it's a net gain of lines of code, but I think the clarity and flexibility gained, and the pseudo-globals removed, is worth it.