### PR TITLE
Reduce the supply of gold, in line with its value in older versions

### DIFF
--- a/src/obj-make.c
+++ b/src/obj-make.c
@@ -1200,10 +1200,10 @@ struct object_kind *money_kind(const char *name, int value)
  */
 struct object *make_gold(int lev, char *coin_type)
 {
-	/* This average is 20 at dlev0, 100 at dlev40, 220 at dlev100. */
-	s32b avg = (18 * lev)/10 + 18;
-	s32b spread = lev + 10;
-	s32b value = rand_spread(avg, spread);
+	/* This average is 16 at dlev0, 80 at dlev40, 176 at dlev100. */
+	int avg = (16 * lev)/10 + 16;
+	int spread = lev + 10;
+	int value = rand_spread(avg, spread);
 	struct object *new_gold = mem_zalloc(sizeof(*new_gold)); 
 
 	/* Increase the range to infinite, moving the average to 110% */
@@ -1215,11 +1215,12 @@ struct object *make_gold(int lev, char *coin_type)
 
 	/* If we're playing with no_selling, increase the value */
 	if (OPT(player, birth_no_selling) && player->depth)
-		value = value * MIN(5, player->depth);
+		value *= MIN(5, player->depth);
 
 	/* Cap gold at max short (or alternatively make pvals s32b) */
-	if (value > SHRT_MAX)
-		value = SHRT_MAX;
+	if (value >= SHRT_MAX) {
+		value = SHRT_MAX - randint0(200);
+	}
 
 	new_gold->pval = value;
 


### PR DESCRIPTION
When I removed the CHR stat, I dropped the amount of gold created by 10% to compensate for the lower prices.  Looking at the actual values again, I noticed that in the early game CHR would increase prices by more like 20% compared to current.  This change thus reduces the amount of gold generated by 20% compared to versions that had CHR, a further 10% reduction from 3.5.

Also, avoid capping gold at SHORT_MAX - instead reduce the amount by 1d200 so it doesn't feel quite so much like you're maxxing out game internals.

(File under 'making things harder')