### PR TITLE
Implement variable slot sizes by item base

### DIFF
--- a/lib/gamedata/constants.txt
+++ b/lib/gamedata/constants.txt
@@ -131,14 +131,14 @@ carry-cap:pack-size:23
 # Max number of quiver slots for carrying missiles
 carry-cap:quiver-size:10
 
+# Max number of missiles per quiver slot
+carry-cap:quiver-slot-size:40
+
 # Maximum number of objects allowed in a single dungeon grid.
 #
 # The main screen originally had a minimum size of 24 rows, so it could always
 # display 23 objects + 1 header line.
 carry-cap:floor-size:23
-
-# Max number of pack slots for carrying inventory
-carry-cap:stack-size:40
 
 
 #---------------------------------------------------------------------

--- a/lib/gamedata/object_base.txt
+++ b/lib/gamedata/object_base.txt
@@ -13,143 +13,175 @@
 # flags: default flags
 
 default:break-chance:10
+default:max-stack:40
 
 name:chest:Chest~
 graphics:slate
+# max-stack:1
 flags:HATES_ACID | HATES_FIRE
 
 name:shot:Shot~
 graphics:light umber
 break:25
+# max-stack:40
 flags:SHOW_DICE
 
 name:arrow:Arrow~
 graphics:light umber
 break:35
+# max-stack:40
 flags:HATES_ACID | HATES_FIRE
 flags:SHOW_DICE
 
 name:bolt:Bolt~
 graphics:light umber
 break:25
+# max-stack:40
 flags:HATES_ACID
 flags:SHOW_DICE
 
 name:bow:Bow~
 graphics:umber
+# max-stack:1
 flags:HATES_ACID | HATES_FIRE
 flags:SHOW_MULT
 
 name:digger:Digger~
 graphics:slate
+# max-stack:1
 flags:SHOW_DICE
 
 name:hafted:Hafted weapon~
 graphics:white
+# max-stack:1
 flags:HATES_ACID | HATES_FIRE
 flags:SHOW_DICE
 
 name:polearm:Polearm~
 graphics:white
+# max-stack:1
 flags:HATES_ACID | HATES_FIRE
 flags:SHOW_DICE
 
 name:sword:Bladed weapon~
 graphics:white
+# max-stack:1
 flags:HATES_ACID
 flags:SHOW_DICE
 
 name:boots:Boot~
 graphics:light umber
+# max-stack:1
 flags:HATES_ACID | HATES_FIRE
 
 name:gloves:Glove~
 graphics:light umber
+# max-stack:1
 flags:HATES_ACID | HATES_FIRE
 
 name:helm:Helm~
 graphics:light umber
+# max-stack:1
 flags:HATES_ACID
 
 name:crown:Crown~
 graphics:light umber
+# max-stack:1
 flags:HATES_ACID
 
 name:shield:Shield~
 graphics:light umber
+# max-stack:1
 flags:HATES_ACID
 
 name:cloak:Cloak~
 graphics:light umber
+# max-stack:1
 flags:HATES_ACID | HATES_FIRE
 
 name:soft armor:Soft Armor~
 graphics:slate
+# max-stack:1
 flags:HATES_ACID | HATES_FIRE
 
 name:hard armor:Hard Armor~
 graphics:slate
+# max-stack:1
 flags:HATES_ACID
 
 name:dragon armor:Dragon Armor~
 graphics:slate
+# max-stack:1
 
 name:light:Light~
 graphics:yellow
 break:50
+# max-stack:10
 flags:HATES_FIRE
 
 name:amulet:Amulet~
 graphics:orange
+# max-stack:2
 
 name:ring:Ring~
 graphics:red
+# max-stack:5
 flags:HATES_ELEC
 
 name:staff:Staff~
 graphics:light umber
+# max-stack:5
 flags:HATES_ACID | HATES_FIRE | EASY_KNOW
 
 name:wand:Wand~
 graphics:green
+# max-stack:5
 flags:HATES_ELEC | EASY_KNOW
 
 name:rod:Rod~
 graphics:light purple
+# max-stack:5
 flags:HATES_ELEC | EASY_KNOW
 
 name:scroll:Scroll~
 graphics:white
+# max-stack:20
 flags:HATES_ACID | HATES_FIRE | EASY_KNOW
 
 name:potion:Potion~
 graphics:light blue
 break:100
+# max-stack:20
 flags:HATES_COLD | HATES_SOUND | HATES_SHARD | HATES_ICE | HATES_FORCE
 flags:EASY_KNOW
 
 name:flask:Flask~
 graphics:yellow
 break:100
+# max-stack:20
 flags:HATES_COLD | HATES_SOUND | HATES_SHARD | HATES_ICE | HATES_FORCE
 flags:EASY_KNOW
 
 name:food:Food
 graphics:light umber
 break:100
+# max-stack:10
 flags:EASY_KNOW
 
 name:mushroom:Mushroom~
 graphics:light umber
 break:100
+# max-stack:10
 flags:EASY_KNOW
 
 name:magic book:Magic Book~
 graphics:light red
+# max-stack:5
 flags:HATES_FIRE | EASY_KNOW
 
 name:prayer book:Prayer Book~
 graphics:light green
+# max-stack:5
 flags:HATES_FIRE | EASY_KNOW
 
 name:gold

--- a/src/init.c
+++ b/src/init.c
@@ -500,10 +500,10 @@ static enum parser_error parse_constants_carry_cap(struct parser *p) {
 		z->pack_size = value;
 	else if (streq(label, "quiver-size"))
 		z->quiver_size = value;
+	else if (streq(label, "quiver-slot-size"))
+		z->quiver_slot_size = value;
 	else if (streq(label, "floor-size"))
 		z->floor_size = value;
-	else if (streq(label, "stack-size"))
-		z->stack_size = value;
 	else
 		return PARSE_ERROR_UNDEFINED_DIRECTIVE;
 

--- a/src/init.h
+++ b/src/init.h
@@ -96,8 +96,8 @@ struct angband_constants
 	/* Carrying capacity constants, read from constants.txt */
 	u16b pack_size;		/**< Maximum number of pack slots */
 	u16b quiver_size;	/**< Maximum number of quiver slots */
+	u16b quiver_slot_size;	/**< Maximum number of missiles per quiver slot */
 	u16b floor_size;	/**< Maximum number of items per floor grid */
-	u16b stack_size;	/**< Maximum number of items per stack */
 
 	/* Store parameters, read from constants.txt */
 	u16b store_inven_max;	/**< Maximum number of objects in store inventory */

--- a/src/main-stats.c
+++ b/src/main-stats.c
@@ -547,7 +547,7 @@ static int stats_dump_objects(void)
 
 		err = sqlite3_bind_int(info_stmt, 1, idx);
 		if (err) return err;
-		err = sqlite3_bind_text(info_stmt, 2, kind->name, 
+		err = sqlite3_bind_text(info_stmt, 2, kind->name,
 			strlen(kind->name), SQLITE_STATIC);
 		if (err) return err;
 		err = stats_db_bind_ints(info_stmt, 13, 2,

--- a/src/obj-init.c
+++ b/src/obj-init.c
@@ -448,6 +448,8 @@ static enum parser_error parse_object_base_defaults(struct parser *p) {
 
 	if (streq(label, "break-chance"))
 		d->defaults.break_perc = value;
+	else if (streq(label, "max-stack"))
+		d->defaults.max_stack = value;
 	else
 		return PARSE_ERROR_UNDEFINED_DIRECTIVE;
 
@@ -509,6 +511,19 @@ static enum parser_error parse_object_base_break(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
+static enum parser_error parse_object_base_max_stack(struct parser *p) {
+
+	struct kb_parsedata *d = parser_priv(p);
+	assert(d);
+
+	struct object_base *kb = d->kb;
+	assert(kb);
+
+	kb->max_stack = parser_getint(p, "size");
+
+	return PARSE_ERROR_NONE;
+}
+
 static enum parser_error parse_object_base_flags(struct parser *p) {
 	struct object_base *kb;
 	char *s, *t;
@@ -548,6 +563,7 @@ struct parser *init_parse_object_base(void) {
 	parser_reg(p, "name sym tval ?str name", parse_object_base_name);
 	parser_reg(p, "graphics sym color", parse_object_base_graphics);
 	parser_reg(p, "break int breakage", parse_object_base_break);
+	parser_reg(p, "max-stack int size", parse_object_base_max_stack);
 	parser_reg(p, "flags str flags", parse_object_base_flags);
 	return p;
 }

--- a/src/obj-make.c
+++ b/src/obj-make.c
@@ -1133,8 +1133,8 @@ struct object *make_object(struct chunk *c, int lev, bool good, bool great,
 	if (kind->gen_mult_prob >= randint1(100))
 		new_obj->number = randcalc(kind->stack_size, lev, RANDOMISE);
 
-	if (new_obj->number > z_info->stack_size)
-		new_obj->number = z_info->stack_size;
+	if (new_obj->number > new_obj->kind->base->max_stack)
+		new_obj->number = new_obj->kind->base->max_stack;
 
 	/* Get the value */
 	if (value)

--- a/src/obj-pile.c
+++ b/src/obj-pile.c
@@ -409,7 +409,7 @@ bool object_similar(const struct object *obj1, const struct object *obj2,
 	int total = obj1->number + obj2->number;
 
 	/* Check against stacking limit - except in stores which absorb anyway */
-	if (!(mode & OSTACK_STORE) && (total > z_info->stack_size))
+	if (!(mode & OSTACK_STORE) && (total > obj1->kind->base->max_stack))
 		return false;
 
 	return object_stackable(obj1, obj2, mode);
@@ -502,7 +502,7 @@ void object_absorb_partial(struct object *obj1, struct object *obj2)
 {
 	int smallest = MIN(obj1->number, obj2->number);
 	int largest = MAX(obj1->number, obj2->number);
-	int difference = (z_info->stack_size) - largest;
+	int difference = obj1->kind->base->max_stack - largest;
 	obj1->number = largest + difference;
 	obj2->number = smallest - difference;
 
@@ -517,7 +517,7 @@ void object_absorb(struct object *obj1, struct object *obj2)
 	int total = obj1->number + obj2->number;
 
 	/* Add together the item counts */
-	obj1->number = (total < z_info->stack_size ? total : z_info->stack_size);
+	obj1->number = MIN(total, obj1->kind->base->max_stack);
 
 	object_absorb_merge(obj1, obj2);
 	object_delete(&obj2);

--- a/src/object.h
+++ b/src/object.h
@@ -143,6 +143,7 @@ struct object_base {
 	struct element_info el_info[ELEM_MAX];
 
 	int break_perc;
+	int max_stack;
 	int num_svals;
 };
 

--- a/src/store.c
+++ b/src/store.c
@@ -713,7 +713,7 @@ static void mass_produce(struct object *obj)
 	}
 
 	/* Save the total pile size */
-	obj->number = size;
+	obj->number = MIN(size, obj->kind->base->max_stack);
 }
 
 
@@ -759,7 +759,7 @@ static void store_object_absorb(struct object *old, struct object *new)
 	int total = old->number + new->number;
 
 	/* Combine quantity, lose excess items */
-	old->number = (total > z_info->stack_size) ? z_info->stack_size : total;
+	old->number = MIN(total, old->kind->base->max_stack);
 
 	/* If rods are stacking, add the charging timeouts */
 	if (tval_can_have_timeout(old))
@@ -1291,8 +1291,8 @@ static void store_maint(struct store *s)
 				obj = store_create_item(s, kind);
 
 			/* Ensure a full stack */
-			obj->number = z_info->stack_size;
-			obj->known->number = z_info->stack_size;
+			obj->number = obj->kind->base->max_stack;
+			obj->known->number = obj->kind->base->max_stack;
 		}
 	}
 

--- a/src/ui-object.c
+++ b/src/ui-object.c
@@ -398,7 +398,7 @@ static void show_obj_list(olist_detail_t mode)
 	/* For the inventory: print the quiver count */
 	if (mode & OLIST_QUIVER) {
 		int count, j;
-		int quiver_slots = (player->upkeep->quiver_cnt + z_info->stack_size - 1) / z_info->stack_size;
+		int quiver_slots = (player->upkeep->quiver_cnt + z_info->quiver_slot_size - 1) / z_info->quiver_slot_size;
 
 		/* Quiver may take multiple lines */
 		for (j = 0; j < quiver_slots; j++, i++) {
@@ -407,9 +407,9 @@ static void show_obj_list(olist_detail_t mode)
 
 			/* Number of missiles in this "slot" */
 			if (j == quiver_slots - 1)
-				count = player->upkeep->quiver_cnt - (z_info->stack_size * (quiver_slots - 1));
+				count = player->upkeep->quiver_cnt - (z_info->quiver_slot_size * (quiver_slots - 1));
 			else
-				count = z_info->stack_size;
+				count = z_info->quiver_slot_size;
 
 			/* Clear the line */
 			prt("", row + i, MAX(col - 2, 0));
@@ -942,8 +942,8 @@ static void item_menu_browser(int oid, void *data, const region *local_area)
 {
 	char tmp_val[80];
 	int count, j, i = num_obj;
-	int quiver_slots = (player->upkeep->quiver_cnt + z_info->stack_size - 1)
-		/ z_info->stack_size;
+	int quiver_slots = (player->upkeep->quiver_cnt + z_info->quiver_slot_size - 1)
+		/ z_info->quiver_slot_size;
 
 	/* Set up to output below the menu */
 	text_out_hook = text_out_to_screen;
@@ -962,10 +962,10 @@ static void item_menu_browser(int oid, void *data, const region *local_area)
 
 			/* Number of missiles in this "slot" */
 			if (j == quiver_slots - 1)
-				count = player->upkeep->quiver_cnt - (z_info->stack_size *
+				count = player->upkeep->quiver_cnt - (z_info->quiver_slot_size *
 													  (quiver_slots - 1));
 			else
-				count = z_info->stack_size;
+				count = z_info->quiver_slot_size;
 
 			/* Print the (disabled) label */
 			strnfmt(tmp_val, sizeof(tmp_val), "%c) ", letter);


### PR DESCRIPTION
So e.g. you can only have a stack of 1 weapon, but a stack of 20 potions or
40 ammo.  This is not currently used (every base has a max of 40 items), but suggested reduced values are in object_base.txt commented out.