### PR TITLE
Allow count for running

### DIFF
--- a/src/cave-square.c
+++ b/src/cave-square.c
@@ -821,6 +821,20 @@ bool square_in_bounds_fully(struct chunk *c, int y, int x)
 	return x > 0 && x < c->width - 1 && y > 0 && y < c->height - 1;
 }
 
+/**
+ * Checks if a square is thought by the player to block projections
+ */
+bool square_isbelievedwall(struct chunk *c, int y, int x)
+{
+	// the edge of the world is definitely gonna block things
+	if (!square_in_bounds_fully(c, y, x)) return true;
+	// if we dont know assume its projectable
+	if (!square_isknown(cave, y, x)) return false;
+	// report what we think (we may be wrong)
+	return !square_isprojectable(player->cave, y, x);
+}
+
+
 
 /**
  * OTHER SQUARE FUNCTIONS

--- a/src/cave.h
+++ b/src/cave.h
@@ -335,6 +335,8 @@ bool square_dtrap_edge(struct chunk *c, int y, int x);
 bool square_changeable(struct chunk *c, int y, int x);
 bool square_in_bounds(struct chunk *c, int y, int x);
 bool square_in_bounds_fully(struct chunk *c, int y, int x);
+bool square_isbelievedwall(struct chunk *c, int y, int x);
+
 
 struct feature *square_feat(struct chunk *c, int y, int x);
 struct monster *square_monster(struct chunk *c, int y, int x);

--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -1174,6 +1174,15 @@ void do_cmd_run(struct command *cmd)
 		x = player->px + ddx[dir];
 		if (!do_cmd_walk_test(y, x))
 			return;
+			
+		/* Hack: convert repeat count to running count */
+		if (cmd->nrepeats > 0) {
+			player->upkeep->running = cmd->nrepeats;
+			cmd->nrepeats = 0;
+		}
+		else {
+			player->upkeep->running = 0;
+		}
 	}
 
 	/* Start run */

--- a/src/cmd-core.c
+++ b/src/cmd-core.c
@@ -68,7 +68,7 @@ static const struct command_info game_cmds[] =
 	{ CMD_GO_UP, "go up stairs", do_cmd_go_up, false, 0 },
 	{ CMD_GO_DOWN, "go down stairs", do_cmd_go_down, false, 0 },
 	{ CMD_WALK, "walk", do_cmd_walk, true, 0 },
-	{ CMD_RUN, "run", do_cmd_run, false, 0 },
+	{ CMD_RUN, "run", do_cmd_run, true, 0 },
 	{ CMD_JUMP, "jump", do_cmd_jump, false, 0 },
 	{ CMD_OPEN, "open", do_cmd_open, true, 99 },
 	{ CMD_CLOSE, "close", do_cmd_close, true, 99 },

--- a/src/player-path.c
+++ b/src/player-path.c
@@ -820,17 +820,18 @@ void run_step(int dir)
 		}
 	}
 
-	/* Decrease counter if it hasn't been cancelled */
-	if (player->upkeep->running)
-		player->upkeep->running--;
-	else if (!player->upkeep->running_withpathfind)
-		return;
-
 	/* Take time */
 	player->upkeep->energy_use = z_info->move_energy;
 
 	/* Move the player; running straight into a trap == trying to disarm */
 	move_player(run_cur_dir, dir && disarm ? true : false);
+
+	/* Decrease counter if it hasn't been cancelled */
+	/* occurs after movement so that using p->u->running as flag works */
+	if (player->upkeep->running) {
+		player->upkeep->running--;
+	} else if (!player->upkeep->running_withpathfind)
+		return;
 
 	/* Prepare the next step */
 	if (player->upkeep->running) {

--- a/src/player-path.c
+++ b/src/player-path.c
@@ -729,8 +729,9 @@ void run_step(int dir)
 		/* Initialize */
 		run_init(dir);
 
-		/* Hack -- Set the run counter */
-		player->upkeep->running = 1000;
+		/* Hack -- Set the run counter if no count given */
+		if (player->upkeep->running == 0)
+			player->upkeep->running = 9999;
 
 		/* Calculate torch radius */
 		player->upkeep->update |= (PU_TORCH);

--- a/src/project.c
+++ b/src/project.c
@@ -197,8 +197,11 @@ int project_path(struct loc *gp, int range, int y1, int x1, int y2, int x2, int 
 			if (!(flg & (PROJECT_THRU)))
 				if ((x == x2) && (y == y2)) break;
 
-			/* Always stop at non-initial wall grids */
-			if ((n > 0) && !square_isprojectable(cave, y, x)) break;
+			/* Stop at non-initial wall grids, except where that would
+			 * leak info during targetting */
+			if (!(flg & (PROJECT_INFO))) {
+				if ((n > 0) && !square_isprojectable(cave, y, x)) break;
+			} else if ((n > 0) && square_isbelievedwall(cave,y,x)) break;
 
 			/* Sometimes stop at non-initial monsters/players */
 			if (flg & (PROJECT_STOP))
@@ -251,8 +254,11 @@ int project_path(struct loc *gp, int range, int y1, int x1, int y2, int x2, int 
 			if (!(flg & (PROJECT_THRU)))
 				if ((x == x2) && (y == y2)) break;
 
-			/* Always stop at non-initial wall grids */
-			if ((n > 0) && !square_isprojectable(cave, y, x)) break;
+			/* Stop at non-initial wall grids, except where that would
+			 * leak info during targetting */
+			if (!(flg & (PROJECT_INFO))) {			
+				if ((n > 0) && !square_isprojectable(cave, y, x)) break;
+			} else if ((n > 0) && square_isbelievedwall(cave,y,x)) break;
 
 			/* Sometimes stop at non-initial monsters/players */
 			if (flg & (PROJECT_STOP))
@@ -299,8 +305,11 @@ int project_path(struct loc *gp, int range, int y1, int x1, int y2, int x2, int 
 			if (!(flg & (PROJECT_THRU)))
 				if ((x == x2) && (y == y2)) break;
 
-			/* Always stop at non-initial wall grids */
-			if ((n > 0) && !square_isprojectable(cave, y, x)) break;
+			/* Stop at non-initial wall grids, except where that would
+			 * leak info during targetting */
+			if (!(flg & (PROJECT_INFO))) {
+				if ((n > 0) && !square_isprojectable(cave, y, x)) break;
+			} else if ((n > 0) && square_isbelievedwall(cave,y,x)) break;
 
 			/* Sometimes stop at non-initial monsters/players */
 			if (flg & (PROJECT_STOP))

--- a/src/project.h
+++ b/src/project.h
@@ -72,22 +72,24 @@ enum
  *   SAFE: Doesn't affect monsters of the same race as the caster
  *   ARC: Projection is a sector of circle radiating from the caster
  *   PLAY: May affect the player
+ *   INFO: Use believed map rather than truth for player ui
  */
 enum
 {
-	PROJECT_NONE  = 0x000,
-	PROJECT_JUMP  = 0x001,
-	PROJECT_BEAM  = 0x002,
-	PROJECT_THRU  = 0x004,
-	PROJECT_STOP  = 0x008,
-	PROJECT_GRID  = 0x010,
-	PROJECT_ITEM  = 0x020,
-	PROJECT_KILL  = 0x040,
-	PROJECT_HIDE  = 0x080,
-	PROJECT_AWARE = 0x100,
-	PROJECT_SAFE  = 0x200,
-	PROJECT_ARC   = 0x400,
-	PROJECT_PLAY  = 0x800
+	PROJECT_NONE  = 0x0000,
+	PROJECT_JUMP  = 0x0001,
+	PROJECT_BEAM  = 0x0002,
+	PROJECT_THRU  = 0x0004,
+	PROJECT_STOP  = 0x0008,
+	PROJECT_GRID  = 0x0010,
+	PROJECT_ITEM  = 0x0020,
+	PROJECT_KILL  = 0x0040,
+	PROJECT_HIDE  = 0x0080,
+	PROJECT_AWARE = 0x0100,
+	PROJECT_SAFE  = 0x0200,
+	PROJECT_ARC   = 0x0400,
+	PROJECT_PLAY  = 0x0800,
+	PROJECT_INFO  = 0x1000
 };
 
 /* Display attrs and chars */

--- a/src/ui-target.c
+++ b/src/ui-target.c
@@ -795,6 +795,7 @@ static int draw_path(u16b path_n, struct loc *path_g, wchar_t *c, int *a,
 {
 	int i;
 	bool on_screen;
+	bool pastknown = false;
 
 	/* No path, so do nothing. */
 	if (path_n < 1) return 0;
@@ -834,7 +835,11 @@ static int draw_path(u16b path_n, struct loc *path_g, wchar_t *c, int *a,
 		Term_what(Term->scr->cx, Term->scr->cy, a+i, c+i);
 
 		/* Choose a colour. */
-		if (mon && monster_is_visible(mon)) {
+		if (pastknown) {
+			/* Once we pass an unknown square, we no longer know
+			 * if we will reach later squares */
+			colour = COLOUR_L_DARK;
+		} else if (mon && monster_is_visible(mon)) {
 			/* Mimics act as objects */
 			if (monster_is_camouflaged(mon)) 
 				colour = COLOUR_YELLOW;
@@ -850,11 +855,12 @@ static int draw_path(u16b path_n, struct loc *path_g, wchar_t *c, int *a,
 			/* Known walls are blue. */
 			colour = COLOUR_BLUE;
 
-		else if (!square_isknown(cave, y, x) && !square_isseen(cave, y, x))
+		else if (!square_isknown(cave, y, x) && !square_isseen(cave, y, x)) {
 			/* Unknown squares are grey. */
+			pastknown = true;
 			colour = COLOUR_L_DARK;
 
-		else
+		} else
 			/* Unoccupied squares are white. */
 			colour = COLOUR_WHITE;
 
@@ -1003,7 +1009,7 @@ bool target_set_interactive(int mode, int x, int y)
 
 			/* Find the path. */
 			path_n = project_path(path_g, z_info->max_range, py, px, y, x,
-								  PROJECT_THRU);
+								  PROJECT_THRU | PROJECT_INFO);
 
 			/* Draw the path in "target" mode. If there is one */
 			if (mode & (TARGET_KILL))
@@ -1223,7 +1229,7 @@ bool target_set_interactive(int mode, int x, int y)
 
 			/* Find the path. */
 			path_n = project_path(path_g, z_info->max_range, py, px, y, x,
-								  PROJECT_THRU);
+								  PROJECT_THRU | PROJECT_INFO);
 
 			/* Draw the path in "target" mode. If there is one */
 			if (mode & (TARGET_KILL))


### PR DESCRIPTION
Running count for distances between "I want RSI" and "I want to feed my character to anything that wanders in from outside detection range". This exposed a bug where p->u->running drops to 0 that wasn't plausible without running count (technically you could use earthquake or something to make a loop to run around or something, but...)

Targeting changes prevent an information leak by showing where a target is blocked by unseen barriers

This should have been two separate pulls, but I think I needed to make a sub-fork before I started or something.