### PR TITLE
.gitignore all save files on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ configure
 lib/scores/scores.*
 *.out
 *.exe
-lib/save/1000.*
+lib/save/*
 .project
 .cproject
 *.orig


### PR DESCRIPTION
Updating .gitignore because save files on Linux are now based on user name rather than user id.