### PR TITLE
Added alternate file save method for server play

### DIFF
--- a/src/ui-input.c
+++ b/src/ui-input.c
@@ -976,10 +976,36 @@ static bool get_file_text(const char *suggested_name, char *path, size_t len)
 
 	/* Get filename */
 	my_strcpy(buf, suggested_name, sizeof buf);
-	if (!get_string("File name: ", buf, sizeof buf)) return false;
+	
+	if(!arg_force_name) {
+			
+			if (!get_string("File name: ", buf, sizeof buf)) return false;
 
-	/* Make sure it's actually a filename */
-	if (buf[0] == '\0' || buf[0] == ' ') return false;
+			/* Make sure it's actually a filename */
+			if (buf[0] == '\0' || buf[0] == ' ') return false;
+	}
+
+	else {
+	
+		int len;
+		time_t ltime;
+		struct tm *today;
+
+		/* Get the current time */
+		time(&ltime);
+		today = localtime(&ltime);
+
+		prt("File name: ", 0,0);
+
+		/* Overwrite the ".txt" that was added */
+		len = strlen(buf)-4;
+		strftime(buf+len, sizeof(buf)-len, "-%Y-%m-%d-%H-%M.txt", today);
+
+		/* Prompt the user to confirm or cancel the file dump */
+		if (!get_check(format("Confirm writing to %s? ", buf))) return false;
+
+
+	}
 
 	/* Build the path */
 	path_build(path, len, ANGBAND_DIR_USER, buf);

--- a/src/ui-input.h
+++ b/src/ui-input.h
@@ -64,6 +64,7 @@ extern u32b inkey_scan;
 extern bool inkey_flag;
 extern u16b lazymove_delay;
 extern bool msg_flag;
+extern bool arg_force_name;
 
 void flush(game_event_type unused, game_event_data *data, void *user);
 ui_event inkey_ex(void);

--- a/src/ui-options.c
+++ b/src/ui-options.c
@@ -57,7 +57,13 @@ static bool get_pref_path(const char *what, int row, char *buf, size_t max)
 	my_strcat(ftmp, ".prf", sizeof(ftmp));
 
 	/* Get a filename */
-	ok = askfor_aux(ftmp, sizeof ftmp, NULL);
+	
+	if(!arg_force_name)
+		ok = askfor_aux(ftmp, sizeof ftmp, NULL);
+	
+	else
+		ok = get_check(format("Confirm writing to %s? ", ftmp));
+
 	screen_load();
 
 	/* Build the filename */
@@ -985,6 +991,7 @@ static void do_cmd_lazymove_delay(const char *name, int row)
 static void do_cmd_pref_file_hack(long row)
 {
 	char ftmp[80];
+	bool ok;
 
 	screen_save();
 
@@ -998,8 +1005,13 @@ static void do_cmd_pref_file_hack(long row)
 	player_safe_name(ftmp, sizeof(ftmp), player->full_name, true);
 	my_strcat(ftmp, ".prf", sizeof(ftmp));
 
+	if(!arg_force_name)
+		ok = askfor_aux(ftmp, sizeof ftmp, NULL);
+	else
+		ok = get_check(format("Confirm loading %s? ", ftmp));
+	
 	/* Ask for a file (or cancel) */
-	if (askfor_aux(ftmp, sizeof ftmp, NULL)) {
+	if(ok) {
 		/* Process the given filename */
 		if (process_pref_file(ftmp, false, true) == false) {
 			/* Mention failure */

--- a/src/ui-options.h
+++ b/src/ui-options.h
@@ -22,6 +22,8 @@
 
 #include "obj-ignore.h"
 
+extern bool arg_force_name;
+
 void do_cmd_options_birth(void);
 int ego_item_name(char *buf, size_t buf_size, struct ego_desc *desc);
 bool ignore_tval(int tval);
@@ -30,3 +32,4 @@ void do_cmd_options(void);
 void cleanup_options(void);
 
 #endif
+

--- a/src/ui-player.c
+++ b/src/ui-player.c
@@ -1222,12 +1222,16 @@ void do_cmd_change_name(void)
 			switch (ke.key.code) {
 				case ESCAPE: more = false; break;
 				case 'c': {
+					if(arg_force_name)
+						msg("You are not allowed to change your name!");
+					else {
 					char namebuf[32] = "";
 
 					/* Set player name */
 					if (get_character_name(namebuf, sizeof namebuf))
 						my_strcpy(player->full_name, namebuf,
 								  sizeof(player->full_name));
+					}
 
 					break;
 				}

--- a/src/ui-player.h
+++ b/src/ui-player.h
@@ -6,6 +6,8 @@
 #ifndef UI_PLAYER_H
 #define UI_PLAYER_H
 
+extern bool arg_force_name;
+
 void display_player_stat_info(void);
 void display_player_xtra_info(void);
 void display_player(int mode);


### PR DESCRIPTION
The argument -f, force player names, was added to facilitate playing on a server, in my case for dgamelaunch. Currently, players can save to arbitrary files, which allows "/" and "." characters. This is not safe for playing on a shared system online. I added alternate file saving functions which checks for that argument.

Character dumps have file names consisting of the player name and timestamp. 
Players can no longer change their name in the Character menu ('C').
Player .pref files are saved in the pref directory, and the file name consists of their playername.pref.

Functionally, the game should perform normally without the -f argument given.