### PR TITLE
Add option to display effective speed

### DIFF
--- a/lib/help/option.txt
+++ b/lib/help/option.txt
@@ -147,7 +147,14 @@ Notify on object recharge '[notify_recharge]'
   This causes the game to print a message when any rechargeable object
   (i.e. a rod or activatable weapon or armour item) finishes recharging. It
   is the equivalent of inscribing '{!!}' on all such items.  
-  
+
+.. _effective_speed:
+
+Show effective speed as multiplier '[effective_speed]'
+  Instead of showing absolute speed modifier (e.g. 'Slow (-2)' or 'Fast (+38)'),
+  show the effective rate at which the character is moving (e.g. 'Slow (x0.8)'
+  or 'Fast (x4.1)').
+
 
 Birth options
 =============

--- a/src/list-options.h
+++ b/src/list-options.h
@@ -2,7 +2,7 @@
  * \file list-options.h
  * \brief options
  *
- * Currently, if there are more than 20 of any option type, the later ones
+ * Currently, if there are more than 21 of any option type, the later ones
  * will be ignored
  * Cheat options need to be followed by corresponding score options
  */
@@ -50,6 +50,8 @@ INTERFACE, true)
 OP(mouse_movement,        "Allow mouse clicks to move the player",
 INTERFACE, true)
 OP(notify_recharge,       "Notify on object recharge",
+INTERFACE, false)
+OP(effective_speed,       "Show effective speed as multiplier",
 INTERFACE, false)
 OP(cheat_hear,            "Cheat: Peek into monster creation",
 CHEAT, false)

--- a/src/option.h
+++ b/src/option.h
@@ -53,7 +53,7 @@ enum
  * Information for "do_cmd_options()".
  */
 #define OPT_PAGE_MAX				OP_SCORE
-#define OPT_PAGE_PER				20
+#define OPT_PAGE_PER				21
 #define OPT_PAGE_BIRTH				1
 
 /**

--- a/src/ui-display.c
+++ b/src/ui-display.c
@@ -459,11 +459,18 @@ static void prt_speed(int row, int col)
 		type = "Slow";
 	}
 
-	if (type)
+	if (type && !OPT(player, effective_speed))
 		strnfmt(buf, sizeof(buf), "%s (%+d)", type, (i - 110));
+	else if (type && OPT(player, effective_speed))
+	{
+		int multiplier = 10 * extract_energy[i] / extract_energy[110];
+		int int_mul = multiplier / 10;
+		int dec_mul = multiplier % 10;
+		strnfmt(buf, sizeof(buf), "%s (x%d.%d)", type, int_mul, dec_mul);
+	}
 
 	/* Display the speed */
-	c_put_str(attr, format("%-10s", buf), row, col);
+	c_put_str(attr, format("%-11s", buf), row, col);
 }
 
 

--- a/src/ui-player.c
+++ b/src/ui-player.c
@@ -725,7 +725,13 @@ static const char *show_speed(void)
 	if (player->timed[TMD_FAST]) tmp -= 10;
 	if (player->timed[TMD_SLOW]) tmp += 10;
 	if (tmp == 110) return "Normal";
-	strnfmt(buffer, sizeof(buffer), "%d", tmp - 110);
+	int multiplier = 10 * extract_energy[tmp] / extract_energy[110];
+	int int_mul = multiplier / 10;
+	int dec_mul = multiplier % 10;
+	if (OPT(player, effective_speed))
+		strnfmt(buffer, sizeof(buffer), "x%d.%d (%d)", int_mul, dec_mul, tmp - 110);
+	else
+		strnfmt(buffer, sizeof(buffer), "%d (x%d.%d)", tmp - 110, int_mul, dec_mul);
 	return buffer;
 }
 


### PR DESCRIPTION
```
Show effective speed as multiplier '[effective_speed]'
  Instead of showing absolute speed modifier (e.g. 'Slow (-2)' or
  'Fast (+38)'), show the effective rate at which the character is
  moving (e.g. 'Slow (x0.8)' or 'Fast (x4.1)').
```

This was suggested on the forums as a way to help players understand the diminishing returns of ever higher speed numbers.