### PR TITLE
Add a basic Travis CI to compile and run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: c
+
+compiler:
+  - clang
+  - gcc
+
+os:
+  - linux
+
+script:
+  - ./autogen.sh
+  - ./configure --with-no-install
+  - make
+  - make tests
+


### PR DESCRIPTION
After setting up an account for angband at https://travis-ci.org, this should automatically build the project and run the tests when pull requests are opened and when pushes are made.  See the same PR at [my fork](https://github.com/AlexMooney/angband/pull/1) for an example (make sure to click on `show all checks`).

You should be able to see, for instance, that using clang you get this warning:
```
obj-properties.c:62:17: warning: passing an object that undergoes default argument promotion to 'va_start' has undefined behavior [-Wvarargs]
        va_start(args, id);
                       ^
obj-properties.c:55:44: note: parameter of type 'bool' is declared here
void create_obj_flag_mask(bitflag *f, bool id, ...)
                                           ^
1 warning generated.
Successfully compiled obj-properties.c.
```

We could also set up CI to test the mac build and run whatever else comes to mind.