### PR TITLE
Show speed multipliers in lore, if enabled

### DIFF
--- a/src/mon-lore.c
+++ b/src/mon-lore.c
@@ -612,9 +612,9 @@ void lore_multiplier_speed(textblock *tb, const struct monster_race *race)
 	}
 	else if (player->state.speed < race->speed) {
 		char buf[13] = "";
-		multiplier = 10 * extract_energy[race->speed] / extract_energy[player->state.speed];
-		int_mul = multiplier / 10;
-		dec_mul = multiplier % 10;
+		multiplier = 100 * extract_energy[race->speed] / extract_energy[player->state.speed];
+		int_mul = multiplier / 100;
+		dec_mul = ((multiplier + 9) / 10) % 10;
 		strnfmt(buf, sizeof(buf), "%d.%dx faster ", int_mul, dec_mul);
 		textblock_append_c(tb, COLOUR_RED, buf);
 	}

--- a/src/ui-display.c
+++ b/src/ui-display.c
@@ -466,7 +466,7 @@ static void prt_speed(int row, int col)
 		int multiplier = 10 * extract_energy[i] / extract_energy[110];
 		int int_mul = multiplier / 10;
 		int dec_mul = multiplier % 10;
-		strnfmt(buf, sizeof(buf), "%s (x%d.%d)", type, int_mul, dec_mul);
+		strnfmt(buf, sizeof(buf), "%s (%d.%dx)", type, int_mul, dec_mul);
 	}
 
 	/* Display the speed */

--- a/src/ui-player.c
+++ b/src/ui-player.c
@@ -729,9 +729,9 @@ static const char *show_speed(void)
 	int int_mul = multiplier / 10;
 	int dec_mul = multiplier % 10;
 	if (OPT(player, effective_speed))
-		strnfmt(buffer, sizeof(buffer), "x%d.%d (%d)", int_mul, dec_mul, tmp - 110);
+		strnfmt(buffer, sizeof(buffer), "%d.%dx (%d)", int_mul, dec_mul, tmp - 110);
 	else
-		strnfmt(buffer, sizeof(buffer), "%d (x%d.%d)", tmp - 110, int_mul, dec_mul);
+		strnfmt(buffer, sizeof(buffer), "%d (%d.%dx)", tmp - 110, int_mul, dec_mul);
 	return buffer;
 }
 


### PR DESCRIPTION
- [x] So far only shows the speed relative to normal speed.
- [x] I plan to also add a speed relative to the player.
- :disappointed: Unfortunately, I had to import `game-world` into `mon-lore` to get at `extract_energy`.