### PR TITLE
Show hit chances in lore

### DIFF
--- a/lib/gamedata/blow_effects.txt
+++ b/lib/gamedata/blow_effects.txt
@@ -3,7 +3,7 @@
 #
 # Fields:
 # name - blow effect name as in monster.txt
-# pow - used for attack quality in check_hit()
+# power - used for attack quality in check_hit()
 # eval - used for power evaluation in eval_blow_effect()
 # desc - description for monster recall
 # lore-color-base - base color for lore

--- a/src/mon-lore.c
+++ b/src/mon-lore.c
@@ -1518,6 +1518,23 @@ void lore_append_attack(textblock *tb, const struct monster_race *race,
 					textblock_append_c(tb, COLOUR_L_GREEN, "M%d", dice.m_bonus);
 			}
 
+			/* Describe hit chances */
+			long chance = 0, chance2 = 0;
+			// These calculations are based on check_hit() and test_hit();
+			// make sure to keep it in sync
+			chance = (race->blow[i].effect->power + (race->level * 3));
+			if (chance < 9) {
+				chance = 9;
+			}
+			chance2 = 12 + (100 - 12 - 5) * (chance - ((player->state.ac + player->state.to_a) * 2 / 3)) / chance;
+			if (chance2 < 12) {
+				chance2 = 12;
+			}
+			textblock_append(tb, " with a");
+			if ((chance2 == 8) || ((chance2 / 10) == 8))
+				textblock_append(tb, "n");
+			textblock_append_c(tb, COLOUR_L_BLUE, " %d", chance2);
+			textblock_append(tb, " percent chance to hit");
 		}
 
 		described_count++;


### PR DESCRIPTION
This produces an overly verbose output, but teaches the player how
effective their armor class is against the monsters they're facing.

AC 119:
```
The forest wight ('W')
...
It can hit to attack with damage 1d6 with a 36
percent chance to hit, hit to attack with damage 1d6 with a 36 percent chance
to hit, and touch to lower experience with a 23 percent chance to hit.
```

AC 78:
```
The forest wight ('W')
...
It can hit to attack with damage 1d6 with a 56
percent chance to hit, hit to attack with damage 1d6 with a 56 percent chance
to hit, and touch to lower experience with a 48 percent chance to hit.
```