### PR TITLE
Show recharge odds

### DIFF
--- a/src/effects.c
+++ b/src/effects.c
@@ -2289,7 +2289,7 @@ bool effect_handler_RECHARGE(effect_handler_context_t *context)
 		return (used);
 
 	/* Ease of recharge ranges from 9 down to 4 (wands) or 3 (staffs) */
-	ease_of_recharge = 100 - obj->kind->level / 10;
+	ease_of_recharge = (100 - obj->kind->level) / 10;
 
 	/* Chance of failure = 1 time in
 	 * [Spell_strength + ease_of_use - 2 * charge_per_item] */

--- a/src/effects.h
+++ b/src/effects.h
@@ -58,5 +58,6 @@ void effect_simple(int index,
 	int y,
 	int x,
 	bool *ident);
+int recharge_failure_chance(const struct object *obj, int strength);
 
 #endif /* INCLUDED_EFFECTS_H */

--- a/src/obj-info.c
+++ b/src/obj-info.c
@@ -1605,6 +1605,20 @@ static bool describe_effect(textblock *tb, const struct object *obj,
 			(1000 - failure_chance) / 10, (1000 - failure_chance) % 10);
 	}
 
+	if (tval_can_have_charges(obj)) {
+		int scroll_chance = 1000 - 1000 / recharge_failure_chance(obj, 11);
+
+		textblock_append(tb, "Your chance of recharging it with the scroll is %d.%d%%\n",
+			scroll_chance / 10, scroll_chance % 10);
+
+		if (player->class->magic.total_spells &&
+				player->class->magic.books[0].realm == lookup_realm("arcane")) {
+			int spell_chance = 1000 - 1000 / recharge_failure_chance(obj, player->lev);
+			textblock_append(tb, "Your chance of recharging it with the spell is %d.%d%%\n",
+				spell_chance / 10, spell_chance % 10);
+		}
+	}
+
 	return true;
 }
 


### PR DESCRIPTION
Adds one or two lines to item descriptions which describe recharge odds.  Gives the odds for the spell if your character is an arcane realm user, since both arcane classes have the Recharging spell.

```
...
Your chance of success is 93.4%
Your chance of recharging it with the scroll is 88.9%
Your chance of recharging it with the spell is 96.7%
```

Kind of hacky, as it's hardcoding the scroll power and the spell power.  If there's a better way to do it, I'm all for trying.