### PR TITLE
Show recharge failure chances in item list

### DIFF
--- a/src/effects.h
+++ b/src/effects.h
@@ -58,5 +58,6 @@ void effect_simple(int index,
 	int y,
 	int x,
 	bool *ident);
+int recharge_failure_chance(const struct object *obj, int strength);
 
 #endif /* INCLUDED_EFFECTS_H */

--- a/src/game-input.h
+++ b/src/game-input.h
@@ -34,6 +34,7 @@
 #define SHOW_QUIVER   0x0080	/* Show quiver summary when in inventory */
 #define SHOW_EMPTY    0x0100	/* Show empty slots in equipment display */
 #define QUIVER_TAGS   0x0200	/* 0-9 are quiver slots when selecting */
+#define SHOW_RECHARGE 0x0400	/* Show item recharge failure in item lists */
 
 
 extern bool (*get_string_hook)(const char *prompt, char *buf, size_t len);

--- a/src/player.h
+++ b/src/player.h
@@ -473,6 +473,7 @@ struct player_upkeep {
 	int inven_cnt;			/* Number of items in inventory */
 	int equip_cnt;			/* Number of items in equipment */
 	int quiver_cnt;			/* Number of items in the quiver */
+	int recharge_pow;		/* Power of recharge effect */
 };
 
 /**

--- a/src/ui-object.c
+++ b/src/ui-object.c
@@ -220,6 +220,17 @@ static void show_obj(int obj_num, int row, int col, bool cursor,
 		ex_offset_ctr += 10;
 	}
 
+	/* Failure chances for recharging an item; see effect_handler_RECHARGE */
+	if (mode & OLIST_RECHARGE) {
+		int fail = 1000 / recharge_failure_chance(obj, player->upkeep->recharge_pow);
+		if (object_effect_is_known(obj))
+			strnfmt(buf, sizeof(buf), "%2d.%1d%% fail", fail / 10, fail % 10);
+		else
+			my_strcpy(buf, "    ? fail", sizeof(buf));
+		put_str(buf, row + obj_num, col + ex_offset_ctr);
+		ex_offset_ctr += 10;
+	}
+
 	/* Weight */
 	if (mode & OLIST_WEIGHT) {
 		int weight = obj->weight * obj->number;
@@ -1210,6 +1221,9 @@ bool textui_get_item(struct object **choice, const char *pmt, const char *str,
 
 	if (mode & SHOW_QUIVER)
 		olist_mode |= OLIST_QUIVER;
+
+	if (mode & SHOW_RECHARGE)
+		olist_mode |= OLIST_RECHARGE;
 
 	/* Paranoia XXX XXX XXX */
 	event_signal(EVENT_MESSAGE_FLUSH);

--- a/src/ui-object.h
+++ b/src/ui-object.h
@@ -36,7 +36,8 @@ typedef enum {
 	OLIST_PRICE  = 0x10,	/* Show item price */
 	OLIST_FAIL   = 0x20,	/* Show device failure */
 	OLIST_SEMPTY = 0x40,
-	OLIST_DEATH  = 0x80
+	OLIST_DEATH  = 0x80,
+	OLIST_RECHARGE = 0x100	/* Show failure for device recharging */
 } olist_detail_t;
 
 


### PR DESCRIPTION
Unfortunately had to use a new global in player->upkeep to keep track of
the power of the recharge effect from the effect_handler through several
layers of function calls to have it available for the show_obj code.

This version is based on advice from @takkaria.  Thanks for the advice!