### PR TITLE
Show total expected monster damage in lore

### DIFF
--- a/src/mon-lore.c
+++ b/src/mon-lore.c
@@ -1497,7 +1497,7 @@ void lore_append_attack(textblock *tb, const struct monster_race *race,
 						const struct monster_lore *lore,
 						bitflag known_flags[RF_SIZE])
 {
-	int i, total_attacks, described_count;
+	int i, total_attacks, described_count, total_centidamage;
 	monster_sex_t msex = MON_SEX_NEUTER;
 
 	assert(tb && race && lore);
@@ -1530,6 +1530,7 @@ void lore_append_attack(textblock *tb, const struct monster_race *race,
 	}
 
 	described_count = 0;
+	total_centidamage = 99; // round up the final result to the next higher point
 
 	/* Describe each melee attack */
 	for (i = 0; i < z_info->mon_blows_max; i++) {
@@ -1593,12 +1594,16 @@ void lore_append_attack(textblock *tb, const struct monster_race *race,
 				textblock_append(tb, "n");
 			textblock_append_c(tb, COLOUR_L_BLUE, " %d", chance2);
 			textblock_append(tb, " percent chance to hit");
+
+			total_centidamage += (chance2 * randcalc(dice, 0, AVERAGE));
 		}
 
 		described_count++;
 	}
 
-	textblock_append(tb, ".  ");
+	textblock_append(tb, ", which is about");
+	textblock_append_c(tb, COLOUR_L_GREEN, " %d", total_centidamage/100);
+	textblock_append(tb, " damage per turn total.  ");
 }
 
 /**

--- a/src/mon-lore.c
+++ b/src/mon-lore.c
@@ -1565,7 +1565,7 @@ void lore_append_attack(textblock *tb, const struct monster_race *race,
 
 			/* Describe damage (if known) */
 			if (dice.base || dice.dice || dice.sides || dice.m_bonus) {
-				textblock_append(tb, " with damage ");
+				textblock_append(tb, " (");
 
 				if (dice.base)
 					textblock_append_c(tb, COLOUR_L_GREEN, "%d", dice.base);
@@ -1589,11 +1589,11 @@ void lore_append_attack(textblock *tb, const struct monster_race *race,
 			if (chance2 < 12) {
 				chance2 = 12;
 			}
-			textblock_append(tb, " with a");
+			textblock_append(tb, ", ");
 			if ((chance2 == 8) || ((chance2 / 10) == 8))
 				textblock_append(tb, "n");
 			textblock_append_c(tb, COLOUR_L_BLUE, " %d", chance2);
-			textblock_append(tb, " percent chance to hit");
+			textblock_append(tb, "%%)");
 
 			total_centidamage += (chance2 * randcalc(dice, 0, AVERAGE));
 		}
@@ -1601,9 +1601,12 @@ void lore_append_attack(textblock *tb, const struct monster_race *race,
 		described_count++;
 	}
 
-	textblock_append(tb, ", which is about");
+	textblock_append(tb, ", averaging");
+	if (described_count < z_info->mon_blows_max) {
+		textblock_append_c(tb, COLOUR_ORANGE, " at least");
+	}
 	textblock_append_c(tb, COLOUR_L_GREEN, " %d", total_centidamage/100);
-	textblock_append(tb, " damage per turn total.  ");
+	textblock_append(tb, " damage.  ");
 }
 
 /**


### PR DESCRIPTION
This will greatly improve the use of the monster lore by simply telling the player how bad the attacks are in aggregate.

> It can hit to attack with damage 4d8 with a 76 percent chance to hit, and hit to attack with damage 4d8 with a 76 percent chance to hit, which is about 28 damage per turn total.

Verified that `0.76*8*4.5 = 27.36`, which rounds up to 28.

> He can hit to shatter with damage 20d10 with an 89 percent chance to hit, hit to shatter with damage 20d10 with an 89 percent chance to hit, hit to reduce all stats with damage 10d12 with an 87 percent chance to hit, and touch to drain charges with an 88 percent chance to hit, which is about 253 damage per turn total.

Verified that `0.89*40*5.5 + 0.87*10*6.5 = 252.35`, which rounds up to 253.