### PR TITLE
Fix build system for SDL2 port

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -207,7 +207,7 @@ dnl
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "SDL2.h"
+#include "SDL.h"
 
 char*
 my_strdup (char *str)
@@ -284,7 +284,7 @@ int main (int argc, char *argv[])
           LIBS="$LIBS $SDL2_LIBS"
           AC_TRY_LINK([
 #include <stdio.h>
-#include "SDL2.h"
+#include "SDL.h"
 ],      [ return 0; ],
         [ echo "*** The test program compiled, but did not run. This usually means"
           echo "*** that the run-time linker is not finding SDL2 or finding the wrong"

--- a/configure.ac
+++ b/configure.ac
@@ -274,7 +274,7 @@ fi
 
 dnl SDL2 checking
 if test "$enable_sdl2" = "yes"; then
-	AM_PATH_SDL(2.0.0,,)
+	AM_PATH_SDL2(2.0.0,,)
 
 	if test "$SDL2_CONFIG" = "no"; then
 		with_sdl2=no

--- a/src/main-sdl2.c
+++ b/src/main-sdl2.c
@@ -16,13 +16,14 @@
  *    are included in all such copies.  Other copyrights may also apply.
  */
 
+#include "angband.h"
+
 #ifdef USE_SDL2
 
 #include "SDL.h"
 #include "SDL_image.h"
 #include "SDL_ttf.h"
 
-#include "angband.h"
 #include "init.h"
 #include "ui-term.h"
 #include "buildid.h"


### PR DESCRIPTION
Looks like there were three things wrong:

1) main-sdl2.c: USE_SDL2 is defined in autoconf.h, so it must be
included (via angband.h) before "ifdef USE_SDL2".

2) configure.ac: AM_PATH_SDL2, of course, instead of AM_PATH_SDL.

3) acinclude.m4: SDL2 uses SDL.h and not SDL2.h (yes, it's strange).