### PR TITLE
Use printf instead of echo -n in autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -27,7 +27,7 @@ run_or_die ()
     OPTIONS="$@"
 
     # print a message
-    echo -n "*info* running $COMMAND"
+    printf "*info* running %s" "$COMMAND"
     if test -n "$OPTIONS" ; then
         echo " ($OPTIONS)"
     else


### PR DESCRIPTION
This avoids a literal "-n" being printed on systems with strictly POSIX-compliant echo implementations, such as recent macOS.