### PR TITLE
Use LDFLAGS when linking angband.o

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -31,7 +31,7 @@ win/$(PROGNAME).res: win/$(PROGNAME).rc
 	$(RC) $< -O coff -o $@
 
 $(PROGNAME).o: $(OBJECTS)
-	$(LD) -nostdlib -r -o $@ $(OBJECTS)
+	$(LD) $(LDFLAGS) -nostdlib -r -o $@ $(OBJECTS)
 	@printf "%10s %-20s\n" LINK $@
 
 tests: $(PROGNAME).o


### PR DESCRIPTION
This ensures any `LDFLAGS` the user has requested are used.