### PR TITLE
Check the validity of the direction returned from cmd_get_arg_direction()

### DIFF
--- a/src/cmd-core.c
+++ b/src/cmd-core.c
@@ -589,7 +589,7 @@ int cmd_get_direction(struct command *cmd, const char *arg, int *dir,
 {
 	if (cmd_get_arg_direction(cmd, arg, dir) == CMD_OK) {
 		/* Validity check */
-		if (dir != DIR_UNKNOWN)
+		if (*dir != DIR_UNKNOWN)
 			return CMD_OK;
 	}
 


### PR DESCRIPTION
Check against the value pointed by the pointer 'dir' instead of the value of  the pointer.
The bug was introduced in the following change.

Commit: 02c1db88fd2c659e7478d4ce859458f98cc53794 [02c1db8]
Parents: 7c5a0c4d14
Author: Andi Sidwell <andi@takkaria.org>
Date: 4 Mar 2014 2:00:24
Committer: Andi Sidwell
Commit Date: 5 Mar 2014 16:55:28
Remove some replicated code