### PR TITLE
Fix warnings on macOS

### DIFF
--- a/src/effects.c
+++ b/src/effects.c
@@ -2898,10 +2898,14 @@ bool effect_handler_TELEPORT_TO(effect_handler_context_t *context)
 		aim = mon->grid;
 	} else {
 		/* Player choice */
-		get_aim_dir(&dir);
-		if ((dir == DIR_TARGET) && target_okay()) {
+		do
+			get_aim_dir(&dir);
+		while (dir == DIR_TARGET && !target_okay());
+
+		if (dir == DIR_TARGET)
 			target_get(&aim);
-		}
+		else
+			aim = loc_offset(start, ddx[dir], ddy[dir]);
 
 		/* Randomise the landing a bit if it's a vault */
 		if (square_isvault(cave, aim)) dis = 10;

--- a/src/main-gcu.c
+++ b/src/main-gcu.c
@@ -40,7 +40,8 @@
 # ifdef HAVE_STDbool_H
 #  define NCURSES_ENABLE_STDbool_H 0
 # endif
-
+/* Mac needs _XOPEN_SOURCE_EXTENDED to expose mvwaddnstr(). */
+# define _XOPEN_SOURCE_EXTENDED 1
 # include <ncurses.h>
 #else
 # include <curses.h>

--- a/src/obj-properties.c
+++ b/src/obj-properties.c
@@ -52,7 +52,7 @@ struct obj_property *lookup_obj_property(int type, int index)
  *
  * N.B. OFT_MAX must be the last item in the ... list
  */
-void create_obj_flag_mask(bitflag *f, bool id, ...)
+void create_obj_flag_mask(bitflag *f, int id, ...)
 {
 	int i, j;
 	va_list args;

--- a/src/obj-properties.h
+++ b/src/obj-properties.h
@@ -188,7 +188,7 @@ extern struct obj_property *obj_properties;
  * Functions
  * ------------------------------------------------------------------------ */
 struct obj_property *lookup_obj_property(int type, int index);
-void create_obj_flag_mask(bitflag *f, bool id, ...);
+void create_obj_flag_mask(bitflag *f, int id, ...);
 void flag_message(int flag, char *name);
 int sustain_flag(int stat);
 

--- a/src/z-type.c
+++ b/src/z-type.c
@@ -67,6 +67,11 @@ struct loc rand_loc(struct loc grid, int x_spread, int y_spread)
 	return loc(rand_spread(grid.x, x_spread), rand_spread(grid.y, y_spread));
 }
 
+struct loc loc_offset(struct loc grid, int dx, int dy)
+{
+	return loc(grid.x + dx, grid.y + dy);
+}
+
 /**
  * Utility functions to work with point_sets
  */

--- a/src/z-type.h
+++ b/src/z-type.h
@@ -32,6 +32,7 @@ bool loc_is_zero(struct loc grid);
 struct loc loc_sum(struct loc grid1, struct loc grid2);
 struct loc loc_diff(struct loc grid1, struct loc grid2);
 struct loc rand_loc(struct loc grid, int x_spread, int y_spread);
+struct loc loc_offset(struct loc grid, int dx, int dy);
 
 
 /**


### PR DESCRIPTION
1) Define _XOPEN_SOURCE_EXTENDED so macOS ncurses.h will provide mvwaddnstr()
2) Don't use a bool (which auto-promotes) as the last argument in a variadic
   function in create_obj_flag_mask()
3) Small rewrite in effect_handler_TELEPORT_TO() to fix a case where the player
   picks DIR_TARGET but has no valid target, or picks any other direction
   (although the latter should be impossible here).