### PR TITLE
init: fix some memory leaks

### DIFF
--- a/src/effects.c
+++ b/src/effects.c
@@ -4989,6 +4989,7 @@ void free_effect(struct effect *source)
 	while (e) {
 		e_next = e->next;
 		dice_free(e->dice);
+		string_free(e->msg);
 		mem_free(e);
 		e = e_next;
 	}

--- a/src/init.c
+++ b/src/init.c
@@ -745,11 +745,11 @@ static void cleanup_game_constants(void)
  * ------------------------------------------------------------------------ */
 static enum parser_error parse_world_level(struct parser *p) {
 	const int depth = parser_getint(p, "depth");
-    const char *name = parser_getsym(p, "name");
-    const char *up = parser_getsym(p, "up");
-    const char *down = parser_getsym(p, "down");
-    struct level *last = parser_priv(p);
-    struct level *lev = mem_zalloc(sizeof *lev);
+	const char *name = parser_getsym(p, "name");
+	const char *up = parser_getsym(p, "up");
+	const char *down = parser_getsym(p, "down");
+	struct level *last = parser_priv(p);
+	struct level *lev = mem_zalloc(sizeof *lev);
 
 	if (last) {
 		last->next = lev;
@@ -757,11 +757,11 @@ static enum parser_error parse_world_level(struct parser *p) {
 		world = lev;
 	}
 	lev->depth = depth;
-    lev->name = string_make(name);
+	lev->name = string_make(name);
 	lev->up = streq(up, "None") ? NULL : string_make(up);
 	lev->down = streq(down, "None") ? NULL : string_make(down);
-    parser_setpriv(p, lev);
-    return PARSE_ERROR_NONE;
+	parser_setpriv(p, lev);
+	return PARSE_ERROR_NONE;
 }
 
 struct parser *init_parse_world(void) {
@@ -813,12 +813,13 @@ static void cleanup_world(void)
 {
 	struct level *level = world;
 	while (level) {
+		struct level *old = level;
 		string_free(level->name);
 		string_free(level->up);
 		string_free(level->down);
 		level = level->next;
+		mem_free(old);
 	}
-	mem_free(world);
 }
 
 static struct file_parser world_parser = {
@@ -2550,8 +2551,8 @@ static enum parser_error parse_shape_effect_msg(struct parser *p) {
 
 	while (effect->next) effect = effect->next;
 
-    effect->msg = string_append(effect->msg, parser_getstr(p, "text"));
-    return PARSE_ERROR_NONE;
+	effect->msg = string_append(effect->msg, parser_getstr(p, "text"));
+	return PARSE_ERROR_NONE;
 }
 
 static enum parser_error parse_shape_blow(struct parser *p) {
@@ -3119,8 +3120,8 @@ static enum parser_error parse_class_effect_msg(struct parser *p) {
 
 	while (effect->next) effect = effect->next;
 
-    effect->msg = string_append(effect->msg, parser_getstr(p, "text"));
-    return PARSE_ERROR_NONE;
+	effect->msg = string_append(effect->msg, parser_getstr(p, "text"));
+	return PARSE_ERROR_NONE;
 }
 
 static enum parser_error parse_class_desc(struct parser *p) {

--- a/src/main.c
+++ b/src/main.c
@@ -202,6 +202,7 @@ static void change_path(const char *info)
 			/* the directory may not exist and may need to be created. */
 			path_build(dirpath, sizeof(dirpath), dir, "");
 			if (!dir_create(dirpath)) quit_fmt("Cannot create '%s'", dirpath);
+			string_free(info_copy);
 			return;
 		}
 	}

--- a/src/obj-init.c
+++ b/src/obj-init.c
@@ -1237,6 +1237,7 @@ static void cleanup_curse(void)
 		if (curses[idx].obj) {
 			free_effect(curses[idx].obj->effect);
 			mem_free(curses[idx].obj->effect_msg);
+			object_free(curses[idx].obj->known);
 			mem_free(curses[idx].obj);
 		}
 		mem_free(curses[idx].poss);


### PR DESCRIPTION
This change fixes:
1) struct effect's msg member is leaked in free_effect()
2) the world level parser only freeing the first level in the list
3) change_path() leaking a copy of the argument string
4) cleanup_curse() leaking curse.obj->known