### PR TITLE
Set player->history NULL after saving it to birther

### DIFF
--- a/src/player-birth.c
+++ b/src/player-birth.c
@@ -159,6 +159,7 @@ static void save_roller_data(birther *tosave)
 		tosave->stat[i] = player->stat_birth[i];
 
 	tosave->history = player->history;
+	player->history = NULL;
 	my_strcpy(tosave->name, player->full_name, sizeof(tosave->name));
 }
 


### PR DESCRIPTION
When Player rolls a new character, the previous character's history is saved
but then freed in do_cmd_roll_stats(), making the saved history a dangling
pointer. If player goes back to the previous character and then reroll,
the game tries to free already free data.