### PR TITLE
Ensure press is on a list item before showing the context menu

### DIFF
--- a/src/ui-store.c
+++ b/src/ui-store.c
@@ -990,7 +990,7 @@ static bool store_menu_handle(struct menu *m, const ui_event *event, int oid)
 					return false;
 
 				action = true;
-			} else if (event->mouse.y == 4+oid) {
+			} else if ((event->mouse.y >= 4) && (event->mouse.y == 4+oid)) {
 				/* if press is on a list item, so store item context */
 				context_menu_store_item(ctx, oid, event->mouse.x,
 										event->mouse.y);

--- a/src/ui-store.c
+++ b/src/ui-store.c
@@ -990,7 +990,7 @@ static bool store_menu_handle(struct menu *m, const ui_event *event, int oid)
 					return false;
 
 				action = true;
-			} else if ((event->mouse.y >= 4) && (event->mouse.y == 4+oid)) {
+			} else if ((oid >= 0) && (event->mouse.y == m->active.row + oid)) {
 				/* if press is on a list item, so store item context */
 				context_menu_store_item(ctx, oid, event->mouse.x,
 										event->mouse.y);


### PR DESCRIPTION
If Player is in a store/home and clicks the header line (line 3,
where "Store/Home Inventry" is displayed) and the store/home is
empty (hence oid is -1 because cursor is not on a list item),
the game still thinks press is on a list item and tries to
show the store item context menu for non-existant item and make
an illegal memory access.

Checking if clicked location is actually on a list item (if y is
more than or equal to 4) ensures this does not happen.