### PR TITLE
Perform a null check before calling strlen() in textui_get_item()

### DIFF
--- a/src/ui-object.c
+++ b/src/ui-object.c
@@ -1410,7 +1410,7 @@ bool textui_get_item(struct object **choice, const char *pmt, const char *str,
 			newmenu = false;
 
 			/* Get an item choice */
-			*choice = item_menu(cmd, MAX(strlen(pmt), 15), mode);
+			*choice = item_menu(cmd, MAX(pmt ? strlen(pmt) : 0, 15), mode);
 
 			/* Fix the screen */
 			screen_load();


### PR DESCRIPTION
The game crashes in the following scenario.
1. The player character is on item(s).
2. The player right-clicks on the player character.
3. Choose "f) Floor" command from the context menu.

context_menu_player_display_floor() calls get_item() with
the parameter 'pmt' NULL and textui_get_item() calls
strlen() with it.