### PR TITLE
Link against tinfow or tinfo if needed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -252,6 +252,7 @@ if test "$enable_curses" = "yes"; then
 			LIBS="${LIBS} -lncursesw"
 			MAINFILES="${MAINFILES} \$(GCUMAINFILES)"
 		])
+		AC_SEARCH_LIBS([keypad], [tinfow tinfo])
 	fi
 fi
 


### PR DESCRIPTION
It is needed on systems where libtinfo is separate from libncurses.
See: https://bugs.gentoo.org/679942