### PR TITLE
Fix wrong if-conditions for monster timed effects

### DIFF
--- a/src/target.c
+++ b/src/target.c
@@ -74,7 +74,7 @@ void look_mon_desc(char *buf, size_t max, int m_idx)
 	/* Effect status */
 	if (mon->m_timed[MON_TMD_SLEEP]) my_strcat(buf, ", asleep", max);
 	if (mon->m_timed[MON_TMD_HOLD]) my_strcat(buf, ", held", max);
-	if (mon->m_timed[MON_TMD_HOLD]) my_strcat(buf, ", disenchanted", max);
+	if (mon->m_timed[MON_TMD_DISEN]) my_strcat(buf, ", disenchanted", max);
 	if (mon->m_timed[MON_TMD_CONF]) my_strcat(buf, ", confused", max);
 	if (mon->m_timed[MON_TMD_FEAR]) my_strcat(buf, ", afraid", max);
 	if (mon->m_timed[MON_TMD_STUN]) my_strcat(buf, ", stunned", max);

--- a/src/ui-display.c
+++ b/src/ui-display.c
@@ -389,7 +389,7 @@ byte monster_health_attr(void)
 		if (mon->m_timed[MON_TMD_DISEN]) attr = COLOUR_L_UMBER;
 
 		/* Commanded */
-		if (mon->m_timed[MON_TMD_DISEN]) attr = COLOUR_L_PURPLE;
+		if (mon->m_timed[MON_TMD_COMMAND]) attr = COLOUR_L_PURPLE;
 
 		/* Confused */
 		if (mon->m_timed[MON_TMD_CONF]) attr = COLOUR_UMBER;


### PR DESCRIPTION
This results wrong monster description when 'l'ooked and
wrong color for the monster health bar.