### PR TITLE
Set nr_quarks in quarks_init()

### DIFF
--- a/src/z-quark.c
+++ b/src/z-quark.c
@@ -54,6 +54,7 @@ const char *quark_str(quark_t q)
 
 void quarks_init(void)
 {
+	nr_quarks = 1;
 	alloc_quarks = QUARKS_INIT;
 	quarks = mem_zalloc(alloc_quarks * sizeof(char*));
 }


### PR DESCRIPTION
That avoids the crash reported in [the current master post 4.2.0 thread](http://angband.oook.cz/forum/showpost.php?p=141629&postcount=70) : starting a new game without exiting crashes if the previous dead character has a manually inscribed object in the inventory.