### PR TITLE
OS X - recalculate minimum size in response to font change

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -475,6 +475,9 @@ static int resize_pending_changes(struct PendingChanges* pc, int nrow)
  * defaults */
 - (void)resizeTerminalWithContentRect: (NSRect)contentRect saveToDefaults: (BOOL)saveToDefaults;
 
+/* Change the minimum size for the window associated with the context. */
+- (void)setMinimumWindowSize;
+
 /* Called from the view to indicate that it is starting or ending live resize */
 - (void)viewWillStartLiveResize:(AngbandView *)view;
 - (void)viewDidEndLiveResize:(AngbandView *)view;
@@ -1100,6 +1103,23 @@ static int compare_advances(const void *ap, const void *bp)
         /* Adjust terminal to fit window with new font; save the new columns
 		 * and rows since they could be changed */
         NSRect contentRect = [self->primaryWindow contentRectForFrameRect: [self->primaryWindow frame]];
+
+	[self setMinimumWindowSize];
+	NSSize size = self->primaryWindow.contentMinSize;
+	BOOL windowNeedsResizing = NO;
+	if (contentRect.size.width < size.width) {
+	    contentRect.size.width = size.width;
+	    windowNeedsResizing = YES;
+	}
+	if (contentRect.size.height < size.height) {
+	    contentRect.size.height = size.height;
+	    windowNeedsResizing = YES;
+	}
+	if (windowNeedsResizing) {
+	    size.width = contentRect.size.width;
+	    size.height = contentRect.size.height;
+	    [self->primaryWindow setContentSize:size];
+	}
         [self resizeTerminalWithContentRect: contentRect saveToDefaults: YES];
     }
 
@@ -1667,6 +1687,24 @@ static NSMenuItem *superitem(NSMenuItem *self)
     Term_activate( old );
 }
 
+- (void)setMinimumWindowSize
+{
+    NSSize minsize;
+
+    if ([self terminalIndex] == 0) {
+	minsize.width = 80;
+	minsize.height = 24;
+    } else {
+	minsize.width = 1;
+	minsize.height = 1;
+    }
+    minsize.width =
+	minsize.width * self->tileSize.width + self->borderSize.width * 2.0;
+    minsize.height =
+        minsize.height * self->tileSize.height + self->borderSize.height * 2.0;
+    [[self makePrimaryWindow] setContentMinSize:minsize];
+}
+
 - (void)saveWindowVisibleToDefaults: (BOOL)windowVisible
 {
 	int termIndex = [self terminalIndex];
@@ -2005,23 +2043,12 @@ static void Term_init_cocoa(term *t)
     if (termIdx == 0)
     {
         [window setTitle:@"Angband"];
-
-        /* Set minimum size (80x24) */
-        NSSize minsize;
-        minsize.width = 80 * context->tileSize.width + context->borderSize.width * 2.0;
-        minsize.height = 24 * context->tileSize.height + context->borderSize.height * 2.0;
-        [window setContentMinSize:minsize];
     }
     else
     {
         [window setTitle:[NSString stringWithFormat:@"Term %d", termIdx]];
-        /* Set minimum size (1x1) */
-        NSSize minsize;
-        minsize.width = context->tileSize.width + context->borderSize.width * 2.0;
-        minsize.height = context->tileSize.height + context->borderSize.height * 2.0;
-        [window setContentMinSize:minsize];
     }
-    
+    [context setMinimumWindowSize];
     
     /* If this is the first term, and we support full screen (Mac OS X Lion or
 	 * later), then allow it to go full screen (sweet). Allow other terms to be


### PR DESCRIPTION
If the font is changed, update the minimum window size and force the window to be at least that size.  Put the minimum window size calculation in a separate function so it can be called at initialization and in response to font changes.