### PR TITLE
OS X:  don't save size to defaults at end of live resize if transitioning to/from fullscreen

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -407,6 +407,9 @@ static int resize_pending_changes(struct PendingChanges* pc, int nrow)
      */
     int ncol_pre, ncol_post;
 
+    /* Flags whether or not a fullscreen transition is in progress. */
+    BOOL in_fullscreen_transition;
+
 @private
 
     BOOL _hasSubwindowFlags;
@@ -1131,6 +1134,8 @@ static int compare_advances(const void *ap, const void *bp)
 	self->ncol_pre = 0;
 	self->ncol_post = 0;
 
+	self->in_fullscreen_transition = NO;
+
         /* Make the image. Since we have no views, it'll just be a puny 1x1 image. */
         [self updateImage];
 
@@ -1724,24 +1729,36 @@ static NSMenuItem *superitem(NSMenuItem *self)
 {
     NSWindow *window = [notification object];
     NSRect contentRect = [window contentRectForFrameRect: [window frame]];
-    [self resizeTerminalWithContentRect: contentRect saveToDefaults: YES];
+    [self resizeTerminalWithContentRect: contentRect saveToDefaults: !(self->in_fullscreen_transition)];
 }
 
 /*- (NSSize)windowWillResize: (NSWindow *)sender toSize: (NSSize)frameSize
 {
 } */
 
+- (void)windowWillEnterFullScreen: (NSNotification *)notification
+{
+    self->in_fullscreen_transition = YES;
+}
+
 - (void)windowDidEnterFullScreen: (NSNotification *)notification
 {
     NSWindow *window = [notification object];
     NSRect contentRect = [window contentRectForFrameRect: [window frame]];
+    self->in_fullscreen_transition = NO;
     [self resizeTerminalWithContentRect: contentRect saveToDefaults: NO];
+}
+
+- (void)windowWillExitFullScreen: (NSNotification *)notification
+{
+    self->in_fullscreen_transition = YES;
 }
 
 - (void)windowDidExitFullScreen: (NSNotification *)notification
 {
     NSWindow *window = [notification object];
     NSRect contentRect = [window contentRectForFrameRect: [window frame]];
+    self->in_fullscreen_transition = NO;
     [self resizeTerminalWithContentRect: contentRect saveToDefaults: NO];
 }
 


### PR DESCRIPTION
Changed to skip saving the window size to the defaults from windowDidEndLiveResize() if resize is due to transitioning to or from full screen mode.  That fixes Angband issue 4114 ( https://github.com/angband/angband/issues/4114 ):  exiting Angband while in fullscreen mode and then restarting leaves terminal 0 acting as if it was the full screen size even though the actual window is not that size (because the attempt to resize to the size saved in the defaults presumably failed).