### PR TITLE
Fix for issue 4222

### DIFF
--- a/src/cmd-core.c
+++ b/src/cmd-core.c
@@ -315,6 +315,25 @@ void cmdq_flush(void)
 }
 
 /**
+ * Return true if the previous command used an item from the floor.
+ * Otherwise, return false.
+ */
+bool cmdq_does_previous_use_floor_item(void)
+{
+	int cmd_prev = cmd_head - 1;
+
+	if (cmd_prev < 0) cmd_prev = CMD_QUEUE_SIZE - 1;
+	if (cmd_queue[cmd_prev].code != CMD_NULL) {
+		struct object *obj;
+
+		if (cmd_get_arg_item(&cmd_queue[cmd_prev], "item", &obj) == CMD_OK) {
+			return (obj->grid.x == 0 && obj->grid.y == 0) ? false : true;
+		}
+	}
+	return false;
+}
+
+/**
  * ------------------------------------------------------------------------
  * Handling of repeated commands
  * ------------------------------------------------------------------------ */

--- a/src/cmd-core.h
+++ b/src/cmd-core.h
@@ -254,6 +254,12 @@ void cmdq_execute(cmd_context ctx);
 void cmdq_flush(void);
 
 /**
+ * Return true if the previous command used an item from the floor.
+ * Otherwise, return false.
+ */
+bool cmdq_does_previous_use_floor_item(void);
+
+/**
  * ------------------------------------------------------------------------
  * Command repeat manipulation
  * ------------------------------------------------------------------------ */

--- a/src/game-world.c
+++ b/src/game-world.c
@@ -1006,6 +1006,11 @@ static void on_leave_level(void) {
 	/* Cancel any command */
 	player_clear_timed(player, TMD_COMMAND, false);
 
+	/* Don't allow command repeat if moved away from item used. */
+	if (cmdq_does_previous_use_floor_item()) {
+		cmd_disable_repeat();
+	}
+
 	/* Any pending processing */
 	notice_stuff(player);
 	update_stuff(player);

--- a/src/mon-util.c
+++ b/src/mon-util.c
@@ -17,6 +17,7 @@
  */
 
 #include "angband.h"
+#include "cmd-core.h"
 #include "effects.h"
 #include "game-world.h"
 #include "init.h"
@@ -560,6 +561,11 @@ void monster_swap(struct loc grid1, struct loc grid2)
 
 		/* Redraw monster list */
 		player->upkeep->redraw |= (PR_MONLIST);
+
+		/* Don't allow command repeat if moved away from item used. */
+		if (cmdq_does_previous_use_floor_item()) {
+			cmd_disable_repeat();
+		}
 	}
 
 	/* Monster 2 */
@@ -590,6 +596,11 @@ void monster_swap(struct loc grid1, struct loc grid2)
 
 		/* Redraw monster list */
 		player->upkeep->redraw |= (PR_MONLIST);
+
+		/* Don't allow command repeat if moved away from item used. */
+		if (cmdq_does_previous_use_floor_item()) {
+			cmd_disable_repeat();
+		}
 	}
 
 	/* Redraw */


### PR DESCRIPTION
 Disable repeating the previous command if the player moves due to changing a level or monster_swap() and the previous command used an object from the floor.  Fixes [issue 4222](https://github.com/angband/angband/issues/4222) and a similar bug present in 4.2:

1. Drop a stack of phase door scrolls.
2. Read one from the floor.
3. At new location, press 'n' to repeat the command.
4. The result is the player teleporting again having used a scroll from the stack at the original location.