### PR TITLE
Changes for VS 2019 compilation

### DIFF
--- a/src/h-basic.h
+++ b/src/h-basic.h
@@ -21,14 +21,6 @@
 
 #else
 
-/**
- * Native MSVC compiler doesn't understand inline or snprintf
- */
-#ifdef _MSC_VER
-#	define inline __inline
-#	define snprintf _snprintf
-#endif
-
 /* Necessary? */
 #ifdef NDS
 # include <fat.h>

--- a/src/load.c
+++ b/src/load.c
@@ -849,7 +849,7 @@ int rd_ignore(void)
 
 	for (i = 0; i < file_e_max; i++) {
 		if (i < z_info->e_max) {
-			bitflag flags, itypes[itype_size];
+			bitflag flags, itypes[ITYPE_SIZE];
 			
 			/* Read and extract the everseen flag */
 			rd_byte(&flags);

--- a/src/z-file.c
+++ b/src/z-file.c
@@ -54,6 +54,13 @@
 # define my_mkdir(path, perms) false
 #endif
 
+/* Suppress MSC C4996 error */
+#if defined(_MSC_VER)
+#define open _open
+#define fdopen _fdopen
+#define mkdir _mkdir
+#endif
+
 /**
  * Player info
  */


### PR DESCRIPTION
Changes will enable compilation using VS2019 (tested), and I think VS2017 and VS2015 (not tested), but deprecate VS2013 and earlier.