### PR TITLE
gitignore VS build intermediates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,11 @@ mk/buildsys.mk
 *~
 .DS_Store
 *.sublime*
+# Added for VS build: ignore 3 trees of VS build stuff
+.vs/
+Debug/
+Release/
+# And personal copies of the vcxproj that should not be checked into the root
+/Angband.vcxproj
+/Angband.vcxproj.filters
+/Angband.vcxproj.user

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ mk/buildsys.mk
 .vs/
 Debug/
 Release/
-# And personal copies of the vcxproj that should not be checked into the root
-/Angband.vcxproj
-/Angband.vcxproj.filters
-/Angband.vcxproj.user
+# And personal copies of the vcxproj files should not be checked into the root
+/*.vcxproj*
+


### PR DESCRIPTION
VS creates a lot of intermediate files that should never be checked in. 
They are all in 3 sub-folders immediately under the project root, and this update
to .gitignore ignores the 3 folders. 
Also, to use VS, the developer will copy the angband.vcxproj* files from src\win\vs2019 to the root of
the angband tree, and those files should not be checked in from there, so ignore them too.
