### PR TITLE
OS X:  save menu entry and command menu entry sensitivity

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -4180,8 +4180,11 @@ static bool cocoa_get_file(const char *suggested_name, char *path, size_t len)
     else if( sel == @selector(sendAngbandCommand:) ||
 	     sel == @selector(saveGame:) )
     {
-        /* we only want to be able to send commands during an active game */
-        return !!game_in_progress;
+        /*
+         * we only want to be able to send commands during an active game
+         * after the birth screens
+         */
+        return !!game_in_progress && character_generated;
     }
     else return YES;
 }

--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -4177,7 +4177,8 @@ static bool cocoa_get_file(const char *suggested_name, char *path, size_t len)
         [menuItem setState: (tag == requestedGraphicsMode)];
         return YES;
     }
-    else if( sel == @selector(sendAngbandCommand:) )
+    else if( sel == @selector(sendAngbandCommand:) ||
+	     sel == @selector(saveGame:) )
     {
         /* we only want to be able to send commands during an active game */
         return !!game_in_progress;


### PR DESCRIPTION
Disable the save menu entry while on the splash screen and during player birth.  Disable the command menu entries during player birth.