### PR TITLE
Fix for #4276

### DIFF
--- a/src/player-attack.c
+++ b/src/player-attack.c
@@ -1346,12 +1346,14 @@ void do_cmd_throw(struct command *cmd) {
 	int range;
 	struct object *obj;
 
+	player->upkeep->command_wrk = USE_INVEN;
+
 	/* Get arguments */
 	if (cmd_get_item(cmd, "item", &obj,
 			/* Prompt */ "Throw which item?",
 			/* Error  */ "You have nothing to throw.",
 			/* Filter */ NULL,
-			/* Choice */ USE_QUIVER | USE_INVEN | USE_FLOOR | QUIVER_TAGS)
+			/* Choice */ USE_QUIVER | USE_INVEN | USE_FLOOR /*| QUIVER_TAGS*/)
 		!= CMD_OK)
 		return;
 


### PR DESCRIPTION
Changes default list for 'v' command to inventory instead of quiver, which allows v0 to work for things inscribed with @v0. To throw the first item in the quiver, you now have to type v|0