### PR TITLE
Correct loop logic in Term_big_queue_char()

### DIFF
--- a/src/ui-term.c
+++ b/src/ui-term.c
@@ -546,48 +546,43 @@ void Term_queue_char(term *t, int x, int y, int a, wchar_t c, int ta,
 void Term_big_queue_char(term *t, int x, int y, int a, wchar_t c, int a1,
 						 wchar_t c1)
 {
-        int hor, vert;
+	/* Leave space on bottom for status */
+	int vmax = (y + tile_height < t->hgt - 1) ?
+	    tile_height : t->hgt - 1 - y;
+	int hor, vert;
 
 	/* Avoid warning */
 	(void)c;
 
 	/* No tall skinny tiles */
 	if (tile_width > 1) {
-	        /* Horizontal first */
-	        for (hor = 0; hor <= tile_width; hor++) {
+	        /* Horizontal first; skip already marked upper left corner */
+	        for (hor = 1; hor < tile_width; hor++) {
 		        /* Queue dummy character */
-		        if (hor != 0) {
-			        if (a & 0x80)
-				        Term_queue_char(t, x + hor, y, 255, -1, 0, 0);
-					else
-				        Term_queue_char(t, x + hor, y, COLOUR_WHITE, ' ', a1, c1);
-				}
+			if (a & 0x80)
+				Term_queue_char(t, x + hor, y, 255, -1, 0, 0);
+			else
+				Term_queue_char(t, x + hor, y, COLOUR_WHITE, ' ', a1, c1);
+		}
 
-				/* Now vertical */
-				for (vert = 1; vert <= tile_height; vert++){
-			
-					/* Leave space on bottom for status */
-					if (y + vert + 1 < t-> hgt) {
-						/* Queue dummy character */
-						if (a & 0x80)
-							Term_queue_char(t, x + hor, y + vert, 255, -1, 0, 0);
-						else
-							Term_queue_char(t, x + hor, y + vert, COLOUR_WHITE, ' ', a1, c1);
-					}
-				}
-			}
-	} else {
-		/* Only vertical */
-		for (vert = 1; vert <= tile_height; vert++) {	
-			
-			/* Leave space on bottom for status */
-			if (y + vert + 1 < t->hgt) {
+		/* Now vertical */
+		for (vert = 1; vert < vmax; vert++) {
+			for (hor = 0; hor < tile_width; hor++) {
 				/* Queue dummy character */
 				if (a & 0x80)
-					Term_queue_char(t, x, y + vert, 255, -1, 0, 0);
+					Term_queue_char(t, x + hor, y + vert, 255, -1, 0, 0);
 				else
-					Term_queue_char(t, x, y + vert, COLOUR_WHITE, ' ', a1, c1);
+					Term_queue_char(t, x + hor, y + vert, COLOUR_WHITE, ' ', a1, c1);
 			}
+		}
+	} else {
+		/* Only vertical */
+		for (vert = 1; vert < vmax; vert++) {
+			/* Queue dummy character */
+			if (a & 0x80)
+				Term_queue_char(t, x, y + vert, 255, -1, 0, 0);
+			else
+				Term_queue_char(t, x, y + vert, COLOUR_WHITE, ' ', a1, c1);
 		}
 	}
 }


### PR DESCRIPTION
The padding of scaled up tiles seems wrong:  the current logic adds dummy characters to a (tile_width + 1) x (tile_height + 1) box skipping the uppermost row and clipping by the status message row.  I had expected dummy characters in a tile_width x tile_height box skipping the upper left corner (already marked with the real tile information) and clipping by the status message row.

Adding an assertion for x + hor < t->wid in Term_big_queue_char() and running with the new OS X tile scaling (default scaling; Menlo regular 13 point font; 123 column x 31 row main window, I could trigger the assertion when I changed from classic ASCII to Adam Bolt's tiles while in the dungeon.

The pull request changes the loop logic to add dummy characters to a tile_width x tile_height box skipping the upper left corner and clipping by the status message row.