### PR TITLE
OS X: refactor ARC changes to be more compatible with Hengband

### DIFF
--- a/src/cocoa/AppDelegate.h
+++ b/src/cocoa/AppDelegate.h
@@ -17,23 +17,6 @@
 #import <Cocoa/Cocoa.h>
 #import "TileSetScaling.h"
 
-@interface AngbandSoundCatalog : NSObject {
-@private
-    /**
-     * Stores instances of NSSound keyed by path so the same sound can be
-     * used for multiple events.
-     */
-    NSMutableDictionary *soundsByPath;
-    /**
-     * Stores arrays of NSSound keyed by event number.
-     */
-    NSMutableDictionary *soundArraysByEvent;
-}
-
-- (id)init;
-- (void)playSound:(int)event;
-@end
-
 @interface AngbandAppDelegate : NSObject <NSApplicationDelegate,
 					      TileSetDefaultScalingComputing,
 					      TileSetScalingChanging> {
@@ -43,13 +26,6 @@
 @property (strong, nonatomic, retain) IBOutlet NSMenu *commandMenu;
 @property (strong, nonatomic, retain) NSDictionary *commandMenuTagMap;
 @property (strong, nonatomic) TileSetScalingPanelController *scalingPanelController;
-@property NSFont *defaultFont;
-/*
- * Whether or not we allow sounds (only relevant for the screensaver, where
- * the user can't configure it in-game).
- */
-@property BOOL allowSounds;
-@property AngbandSoundCatalog *sounds;
 - (IBAction)newGame:(id)sender;
 - (IBAction)editFont:(id)sender;
 - (IBAction)openGame:(id)sender;

--- a/src/cocoa/AppDelegate.m
+++ b/src/cocoa/AppDelegate.m
@@ -60,18 +60,6 @@
 
 #import "AppDelegate.h"
 
-@implementation AngbandSoundCatalog
-
-- (id)init {
-    self = [super init];
-    return self;
-}
-
-- (void)playSound:(int)event {
-}
-
-@end
-
 @implementation AngbandAppDelegate
 
 @synthesize commandMenu=_commandMenu;


### PR DESCRIPTION
Porting the automatic reference counting (ARC) changes to Hengband revealed some parts that didn't work well with code derived from an older version of Angband.  Refactor so the OS X front end can be more similar for the two code bases and hopefully more useful to other variants or older versions.