### PR TITLE
GCU fixes: solid walls & black background

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ lib/scores/scores.*
 *.exe
 *.elf
 *.map
+angband
 angband.nds
 lib/save/*
 .project
@@ -33,4 +34,5 @@ Debug/
 Release/
 # And personal copies of the vcxproj files should not be checked into the root
 /*.vcxproj*
-
+.idea/
+cmake-build-debug/

--- a/src/main-gcu.c
+++ b/src/main-gcu.c
@@ -174,9 +174,16 @@ static int can_use_color = false;
  */
 static int colortable[BASIC_COLORS];
 
+/**
+ * Same colors as in the colortable, except fg and bg are both set to the fg value.
+ * These pairs are used for drawing solid walls.
+ */
+static int same_colortable[BASIC_COLORS];
+
 /* Screen info: use one big Term 0, or other subwindows? */
 static bool bold_extended = false;
 static bool ascii_walls = false;
+static bool use_default_background = false;
 static int term_count = 1;
 
 /**
@@ -193,6 +200,14 @@ static int bg_color = COLOR_BLACK;
 #define PAIR_MAGENTA 5
 #define PAIR_CYAN 6
 #define PAIR_BLACK 7
+#define PAIR_WHITE_WHITE 8
+#define PAIR_RED_RED 9
+#define PAIR_GREEN_GREEN 10
+#define PAIR_YELLOW_YELLOW 11
+#define PAIR_BLUE_BLUE 12
+#define PAIR_MAGENTA_MAGENTA 13
+#define PAIR_CYAN_CYAN 14
+#define PAIR_BLACK_BLACK 15
 
 #endif
 
@@ -314,15 +329,16 @@ static errr Term_xtra_gcu_alive(int v) {
 	return 0;
 }
 
-const char help_gcu[] = "Text mode, subopts\n              -a     Use ASCII walls\n              -B     Use brighter bold characters\n              -nN    Use N terminals (up to 6)";
+const char help_gcu[] = "Text mode, subopts\n              -a     Use ASCII walls\n              -B     Use brighter bold characters\n              -D     Use terminal default background color\n              -nN    Use N terminals (up to 6)";
 
 /**
  * Usage:
  *
- * angband -mgcu -- [-a] [-B] [-nN]
+ * angband -mgcu -- [-a] [-B] [-D] [-nN]
  *
  *   -a      Use ASCII walls
  *   -B      Use brighter bold characters
+ *   -D      Use terminal default background color
  *   -nN     Use N terminals (up to 6)
  */
 
@@ -739,6 +755,8 @@ static errr Term_xtra_gcu_react(void) {
 			int isbold = bold_extended ? A_BRIGHT : A_NORMAL;
 			init_pair(i + 1, fg, bg_color);
 			colortable[i] = COLOR_PAIR(i + 1) | isbold;
+			init_pair(BASIC_COLORS + i, fg, fg);
+			same_colortable[i] = COLOR_PAIR(BASIC_COLORS + i) | isbold;
 		}
 	}
 #endif
@@ -828,12 +846,21 @@ static errr Term_text_gcu(int x, int y, int n, int a, const wchar_t *s) {
 
 #ifdef A_COLOR
 	if (can_use_color) {
+
 		/* the lower 7 bits of the attribute indicate the fg/bg */
 		int attr = a & 127;
-		int color = colortable[attr];
 
 		/* the high bit of the attribute indicates a reversed fg/bg */
 		bool reversed = a > 127;
+
+		int color;
+
+		/* Set bg and fg to the same color when drawing solid walls */
+		if (a / MAX_COLORS == BG_SAME) {
+			color = same_colortable[attr];
+		} else {
+			color = colortable[attr];
+		}
 
 		/* the following check for A_BRIGHT is to avoid #1813 */
 		int mode;
@@ -983,6 +1010,8 @@ errr init_gcu(int argc, char **argv) {
 			term_count = atoi(&argv[i][2]);
 			if (term_count > MAX_TERM_DATA) term_count = MAX_TERM_DATA;
 			else if (term_count < 1) term_count = 1;
+		} else if (prefix(argv[i], "-D")) {
+			use_default_background = true;
 		}
 	}
 
@@ -1011,7 +1040,7 @@ errr init_gcu(int argc, char **argv) {
 
 #ifdef HAVE_USE_DEFAULT_COLORS
 	/* Should we use curses' "default color" */
-	if (use_default_colors() == OK) bg_color = -1;
+	if (use_default_background && use_default_colors() == OK) bg_color = -1;
 #endif
 
 	/* Attempt to use colors */
@@ -1025,6 +1054,16 @@ errr init_gcu(int argc, char **argv) {
 		init_pair(PAIR_MAGENTA, COLOR_MAGENTA, bg_color);
 		init_pair(PAIR_CYAN, COLOR_CYAN, bg_color);
 		init_pair(PAIR_BLACK, COLOR_BLACK, bg_color);
+
+		/* These pairs are used for drawing solid walls */
+		init_pair(PAIR_WHITE_WHITE, COLOR_WHITE, COLOR_WHITE);
+		init_pair(PAIR_RED_RED, COLOR_RED, COLOR_RED);
+		init_pair(PAIR_GREEN_GREEN, COLOR_GREEN, COLOR_GREEN);
+		init_pair(PAIR_YELLOW_YELLOW, COLOR_YELLOW, COLOR_YELLOW);
+		init_pair(PAIR_BLUE_BLUE, COLOR_BLUE, COLOR_BLUE);
+		init_pair(PAIR_MAGENTA_MAGENTA, COLOR_MAGENTA, COLOR_MAGENTA);
+		init_pair(PAIR_CYAN_CYAN, COLOR_CYAN, COLOR_CYAN);
+		init_pair(PAIR_BLACK_BLACK, COLOR_BLACK, COLOR_BLACK);
 
 		/* Prepare the colors */
 		colortable[COLOUR_DARK]     = (COLOR_PAIR(PAIR_BLACK));
@@ -1056,6 +1095,36 @@ errr init_gcu(int argc, char **argv) {
 		colortable[COLOUR_MUSTARD]     = (COLOR_PAIR(PAIR_YELLOW));
 		colortable[COLOUR_BLUE_SLATE]  = (COLOR_PAIR(PAIR_BLUE));
 		colortable[COLOUR_DEEP_L_BLUE] = (COLOR_PAIR(PAIR_BLUE));
+
+		same_colortable[COLOUR_DARK]     = (COLOR_PAIR(PAIR_BLACK_BLACK));
+		same_colortable[COLOUR_WHITE]    = (COLOR_PAIR(PAIR_WHITE_WHITE) | A_BRIGHT);
+		same_colortable[COLOUR_SLATE]    = (COLOR_PAIR(PAIR_WHITE_WHITE));
+		same_colortable[COLOUR_ORANGE]   = (COLOR_PAIR(PAIR_YELLOW_YELLOW) | A_BRIGHT);
+		same_colortable[COLOUR_RED]      = (COLOR_PAIR(PAIR_RED_RED));
+		same_colortable[COLOUR_GREEN]    = (COLOR_PAIR(PAIR_GREEN_GREEN));
+		same_colortable[COLOUR_BLUE]     = (COLOR_PAIR(PAIR_BLUE_BLUE));
+		same_colortable[COLOUR_UMBER]    = (COLOR_PAIR(PAIR_YELLOW_YELLOW));
+		same_colortable[COLOUR_L_DARK]   = (COLOR_PAIR(PAIR_BLACK_BLACK) | A_BRIGHT);
+		same_colortable[COLOUR_L_WHITE]  = (COLOR_PAIR(PAIR_WHITE_WHITE));
+		same_colortable[COLOUR_L_PURPLE] = (COLOR_PAIR(PAIR_MAGENTA_MAGENTA));
+		same_colortable[COLOUR_YELLOW]   = (COLOR_PAIR(PAIR_YELLOW_YELLOW) | A_BRIGHT);
+		same_colortable[COLOUR_L_RED]    = (COLOR_PAIR(PAIR_MAGENTA_MAGENTA) | A_BRIGHT);
+		same_colortable[COLOUR_L_GREEN]  = (COLOR_PAIR(PAIR_GREEN_GREEN) | A_BRIGHT);
+		same_colortable[COLOUR_L_BLUE]   = (COLOR_PAIR(PAIR_BLUE_BLUE) | A_BRIGHT);
+		same_colortable[COLOUR_L_UMBER]  = (COLOR_PAIR(PAIR_YELLOW_YELLOW));
+
+		same_colortable[COLOUR_PURPLE]      = (COLOR_PAIR(PAIR_MAGENTA_MAGENTA));
+		same_colortable[COLOUR_VIOLET]      = (COLOR_PAIR(PAIR_MAGENTA_MAGENTA));
+		same_colortable[COLOUR_TEAL]        = (COLOR_PAIR(PAIR_CYAN_CYAN));
+		same_colortable[COLOUR_MUD]         = (COLOR_PAIR(PAIR_YELLOW_YELLOW));
+		same_colortable[COLOUR_L_YELLOW]    = (COLOR_PAIR(PAIR_YELLOW_YELLOW) | A_BRIGHT);
+		same_colortable[COLOUR_MAGENTA]     = (COLOR_PAIR(PAIR_MAGENTA_MAGENTA) | A_BRIGHT);
+		same_colortable[COLOUR_L_TEAL]      = (COLOR_PAIR(PAIR_CYAN_CYAN) | A_BRIGHT);
+		same_colortable[COLOUR_L_VIOLET]    = (COLOR_PAIR(PAIR_MAGENTA_MAGENTA) | A_BRIGHT);
+		same_colortable[COLOUR_L_PINK]      = (COLOR_PAIR(PAIR_MAGENTA_MAGENTA) | A_BRIGHT);
+		same_colortable[COLOUR_MUSTARD]     = (COLOR_PAIR(PAIR_YELLOW));
+		same_colortable[COLOUR_BLUE_SLATE]  = (COLOR_PAIR(PAIR_BLUE));
+		same_colortable[COLOUR_DEEP_L_BLUE] = (COLOR_PAIR(PAIR_BLUE));
 	}
 #endif
 

--- a/src/main-gcu.c
+++ b/src/main-gcu.c
@@ -182,7 +182,6 @@ static int same_colortable[BASIC_COLORS];
 
 /* Screen info: use one big Term 0, or other subwindows? */
 static bool bold_extended = false;
-static bool ascii_walls = false;
 static bool use_default_background = false;
 static int term_count = 1;
 
@@ -329,14 +328,13 @@ static errr Term_xtra_gcu_alive(int v) {
 	return 0;
 }
 
-const char help_gcu[] = "Text mode, subopts\n              -a     Use ASCII walls\n              -B     Use brighter bold characters\n              -D     Use terminal default background color\n              -nN    Use N terminals (up to 6)";
+const char help_gcu[] = "Text mode, subopts\n              -B     Use brighter bold characters\n              -D     Use terminal default background color\n              -nN    Use N terminals (up to 6)";
 
 /**
  * Usage:
  *
- * angband -mgcu -- [-a] [-B] [-D] [-nN]
+ * angband -mgcu -- [-B] [-D] [-nN]
  *
- *   -a      Use ASCII walls
  *   -B      Use brighter bold characters
  *   -D      Use terminal default background color
  *   -nN     Use N terminals (up to 6)
@@ -709,32 +707,6 @@ static int create_color(int i, int scale) {
  * React to changes
  */
 static errr Term_xtra_gcu_react(void) {
-	if (ascii_walls) {
-		int i;
-		ascii_walls = false;
-		for (i = 0; i < 4; i++) {
-			// magma as %:D
-			feat_x_char[i][FEAT_MAGMA] = 0x23;
-			feat_x_attr[i][FEAT_MAGMA] = 0x01;
-
-			// quartz as %:D
-			feat_x_char[i][FEAT_QUARTZ] = 0x23;
-			feat_x_attr[i][FEAT_QUARTZ] = 0x01;
-
-			// quartz/magma w treasure as *:o
-			feat_x_char[i][FEAT_MAGMA_K] = feat_x_char[i][FEAT_QUARTZ_K] = 0x2A;
-			feat_x_attr[i][FEAT_MAGMA_K] = feat_x_attr[i][FEAT_QUARTZ_K] = 0x03;
-
-			// granite walls as #:D
-			feat_x_char[i][FEAT_GRANITE] = 0x23;
-			feat_x_attr[i][FEAT_GRANITE] = 0x01;
-
-			// permanent walls as #:r
-			feat_x_char[i][FEAT_PERM] = 0x23;
-			feat_x_attr[i][FEAT_PERM] = 0x04;
-		}
-	}
-
 #ifdef A_COLOR
 	if (COLORS == 256 || COLORS == 88) {
 		/* If we have more than 16 colors, find the best matches. These numbers
@@ -1004,8 +976,6 @@ errr init_gcu(int argc, char **argv) {
 	for (i = 1; i < argc; i++) {
 		if (prefix(argv[i], "-B")) {
 			bold_extended = true;
-		} else if (prefix(argv[i], "-a")) {
-			ascii_walls = true;
 		} else if (prefix(argv[i], "-n")) {
 			term_count = atoi(&argv[i][2]);
 			if (term_count > MAX_TERM_DATA) term_count = MAX_TERM_DATA;

--- a/src/ui-map.c
+++ b/src/ui-map.c
@@ -124,10 +124,12 @@ static void grid_get_attr(struct grid_data *g, int *a)
 		}
 	}
 
-	/* Hybrid or block walls -- for GCU, then for everyone else */
+	/* Add the attr inversion back for GCU */
 	if (a0) {
 		*a = a0 | *a;
-	} else if (use_graphics == GRAPHICS_NONE && feat_is_wall(g->f_idx)) {
+	}
+	/* Hybrid or block walls */
+	if (use_graphics == GRAPHICS_NONE && feat_is_wall(g->f_idx)) {
 		if (OPT(player, hybrid_walls))
 			*a = *a + (MAX_COLORS * BG_DARK);
 		else if (OPT(player, solid_walls))


### PR DESCRIPTION
This PR fixes two GCU issues.

1. It fixes the bug where solid walls are displayed as hybrid walls (described [here](http://angband.oook.cz/forum/showthread.php?t=9353)). The problem was that it was just inverting the bg and fg colors rather than setting them both to the same color.
1. I adds a new flag `-D` for instructing it to NOT use the terminal's default background color. I use a color scheme with a light background color and the game is unplayable with it. Personally, I think Angband should use black by default (since this is known to be playable) and have a flag if you want to use your terminal default, but I didn't want to change existing behavior.

Let me know if you want any changes.