### PR TITLE
OS X:  correct regression for changing font or tile set and character generation

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -2765,8 +2765,14 @@ static errr Term_xtra_cocoa_react(void)
 	    /* Reset visuals */
 	    reset_visuals(TRUE);
 
-	    /* Reset the panel */
-	    verify_panel();
+	    if (character_dungeon) {
+		/*
+		 * Reset the panel.  Only do so if have a dungeon; otherwise
+		 * can see crashes if changing graphics or the font before
+		 * or during character generation.
+		 */
+		verify_panel();
+	    }
 
 	    tile_multipliers_changed = 0;
 	}


### PR DESCRIPTION
The change to better handle font changes during play had the side effect of causing a crash if the font or tile set was changed on the splash screen and then the player proceeded with character generation.  It would also cause a crash if the font or tile set was changed during character generation.

This pull request fixes that.