### PR TITLE
Change Term_resize() to handle all of the saved stack of terminals

### DIFF
--- a/src/ui-term.c
+++ b/src/ui-term.c
@@ -2168,6 +2168,7 @@ errr Term_resize(int w, int h)
 	term_win *hold_old;
 	term_win *hold_scr;
 	term_win *hold_mem;
+	term_win **hold_mem_dest;
 	term_win *hold_tmp;
 
 	ui_event evt = EVENT_EMPTY;
@@ -2225,15 +2226,29 @@ errr Term_resize(int w, int h)
 	term_win_copy(Term->scr, hold_scr, wid, hgt);
 
 	/* If needed */
-	if (hold_mem) {
+	hold_mem_dest = &Term->mem;
+	while (hold_mem != 0) {
+		term_win* trash;
+
 		/* Create new window */
-		Term->mem = mem_zalloc(sizeof(term_win));
+		*hold_mem_dest = mem_zalloc(sizeof(term_win));
 
 		/* Initialize new window */
-		term_win_init(Term->mem, w, h);
+		term_win_init(*hold_mem_dest, w, h);
 
 		/* Save the contents */
-		term_win_copy(Term->mem, hold_mem, wid, hgt);
+		term_win_copy(*hold_mem_dest, hold_mem, wid, hgt);
+
+		trash = hold_mem;
+		hold_mem = hold_mem->next;
+
+		if ((*hold_mem_dest)->cx >= w) (*hold_mem_dest)->cu = 1;
+		if ((*hold_mem_dest)->cy >= h) (*hold_mem_dest)->cu = 1;
+
+		hold_mem_dest = &((*hold_mem_dest)->next);
+
+		term_win_nuke(trash);
+		mem_free(trash);
 	}
 
 	/* If needed */
@@ -2271,19 +2286,6 @@ errr Term_resize(int w, int h)
 	/* Illegal cursor */
 	if (Term->scr->cx >= w) Term->scr->cu = 1;
 	if (Term->scr->cy >= h) Term->scr->cu = 1;
-
-	/* If needed */
-	if (hold_mem) {
-		/* Nuke */
-		term_win_nuke(hold_mem);
-
-		/* Kill */
-		mem_free(hold_mem);
-
-		/* Illegal cursor */
-		if (Term->mem->cx >= w) Term->mem->cu = 1;
-		if (Term->mem->cy >= h) Term->mem->cu = 1;
-	}
 
 	/* If needed */
 	if (hold_tmp) {


### PR DESCRIPTION
With the post 4.2.0 code base and either the X11 front end on Linux or the OS X front end, the following,

1. Bring up the knowledge menu with ~.
2. In that, bring up the monster recall for  a specific creature.
3. While that is displayed, resize the window.
4. Leave the knowledge menu.

, would leave uncleared characters on the screen.  This pull request, which handles all of the saved stack of terminals in Term_resize() and not just the uppermost one, appears to resolve that.