### PR TITLE
With scaled up tiles, projection effects would occasionally wipe parts of the stats area

### DIFF
--- a/src/ui-map.c
+++ b/src/ui-map.c
@@ -475,7 +475,7 @@ static void print_rel_map(wchar_t c, byte a, int y, int x)
 		Term_queue_char(t, kx, ky, a, c, 0, 0);
 
 		if ((tile_width > 1) || (tile_height > 1))
-			Term_big_queue_char(Term, kx, ky, a, c, 0, 0);
+			Term_big_queue_char(t, kx, ky, a, c, 0, 0);
 	}
 }
 


### PR DESCRIPTION
That was seen with the current OS X front-end in post 4.2.0.  The subwindow flags were the default:  one terminal was set up as the overhead view.  This change (in print_rel_map() write the padding characters for the scaled up tile to the same terminal as the attributes for the tile) appears to fix that.