### PR TITLE
OS X: constrain incremental size changes to the windows by the user

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -1087,11 +1087,11 @@ struct PendingCellChange {
 - (void)resizeTerminalWithContentRect: (NSRect)contentRect saveToDefaults: (BOOL)saveToDefaults;
 
 /*
- * Change the minimum size for the window associated with the context.
- * termIdx is the index for the terminal:  pass it so this function can be
- * used when self->terminal has not yet been set.
+ * Change the minimum size and size increments for the window associated with
+ * the context.  termIdx is the index for the terminal:  pass it so this
+ * function can be used when self->terminal has not yet been set.
  */
-- (void)setMinimumWindowSize:(int)termIdx;
+- (void)constrainWindowSize:(int)termIdx;
 
 /* Called from the view to indicate that it is starting or ending live resize */
 - (void)viewWillStartLiveResize:(AngbandView *)view;
@@ -1802,7 +1802,7 @@ static int compare_advances(const void *ap, const void *bp)
 	    [self.primaryWindow
 		 contentRectForFrameRect: [self.primaryWindow frame]];
 
-	[self setMinimumWindowSize:[self terminalIndex]];
+	[self constrainWindowSize:[self terminalIndex]];
 	NSSize size = self.primaryWindow.contentMinSize;
 	BOOL windowNeedsResizing = NO;
 	if (contentRect.size.width < size.width) {
@@ -2167,7 +2167,7 @@ static __strong NSFont* gDefaultFont = nil;
     Term_activate( old );
 }
 
-- (void)setMinimumWindowSize:(int)termIdx
+- (void)constrainWindowSize:(int)termIdx
 {
     NSSize minsize;
 
@@ -2183,6 +2183,7 @@ static __strong NSFont* gDefaultFont = nil;
     minsize.height =
         minsize.height * self.tileSize.height + self.borderSize.height * 2.0;
     [[self makePrimaryWindow] setContentMinSize:minsize];
+    self.primaryWindow.contentResizeIncrements = self.tileSize;
 }
 
 - (void)saveWindowVisibleToDefaults: (BOOL)windowVisible
@@ -2554,7 +2555,7 @@ static void Term_init_cocoa(term *t)
 	{
 	    [window setTitle:[NSString stringWithFormat:@"Term %d", termIdx]];
 	}
-	[context setMinimumWindowSize:termIdx];
+	[context constrainWindowSize:termIdx];
     
 	/*
 	 * If this is the first term, and we support full screen (Mac OS X Lion


### PR DESCRIPTION
Make the increment in x the current width for a column.  Make the increment in y the current height for a row.  Increments less than that just add unused border space on the right and bottom.  Could factor in the tile scaling to the increments for the same reason, but I was concerned that, at least for the Shockbolt tiles with the default scaling, that coarse of an increment wouldn't feel natural during resizes.