### PR TITLE
OS X: round down when calculating the number of columns

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -2131,7 +2131,7 @@ static __strong NSFont* gDefaultFont = nil;
     CGFloat newRows = floor(
 	(contentRect.size.height - (self.borderSize.height * 2.0)) /
 	self.tileSize.height);
-    CGFloat newColumns = ceil(
+    CGFloat newColumns = floor(
 	(contentRect.size.width - (self.borderSize.width * 2.0)) /
 	self.tileSize.width);
 


### PR DESCRIPTION
That makes the handling the same as the number of rows:  prefer empty space to a partially cutoff character.  It reverts a change in Ben Semmler's May 27th, 2013 commit, "Remove resize snapping for now".  If user changes to the size are limited to integral number of columns or rows, this change will only have an effect after font changes or for programmatic size changes (which aren't constrained by NSWindow's contentSizeIncrements).