### PR TITLE
Only pass along mouse events if they fall in the terminal bounds.

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -3748,10 +3748,12 @@ static void AngbandHandleEventMouseDown( NSEvent *event )
 		/* Coordinates run from (0,0) to (cols-1, rows-1). */
 		BOOL mouseInMapSection = (x > 13 && x <= cols - 1 && y > 0  && y <= rows - 2);
 
-		/* If we are displaying a menu, allow clicks anywhere; if we are
-		 * displaying the main game interface, only allow clicks in the map
-		 * section */
-		if (!displayingMapInterface || (displayingMapInterface && mouseInMapSection))
+		/* If we are displaying a menu, allow clicks anywhere within
+		 * the terminal bounds; if we are displaying the main game
+		 * interface, only allow clicks in the map section */
+		if ((!displayingMapInterface && x >= 0 && x < cols &&
+		     y >= 0 && y < rows) ||
+		     (displayingMapInterface && mouseInMapSection))
 		{
 			/* [event buttonNumber] will return 0 for left click,
 			 * 1 for right click, but this is safer */


### PR DESCRIPTION
Clicks on the title bar were being passed on with a negative y coordinate and that was one source of invalid coordinates triggering an infinite loop in the interactive target selection, [issue 4217](https://github.com/angband/angband/issues/4217).  This isn't sufficient to resolve that issue:  even with this change resizing the window while in targeting can lead to a mouse event with coordinates that trigger the infinite loop.