### PR TITLE
In interactive targeting, add some coercion for coordinates from mouse events

### DIFF
--- a/src/ui-target.c
+++ b/src/ui-target.c
@@ -1048,6 +1048,16 @@ bool target_set_interactive(int mode, int x, int y)
 							done = true;
 						} else {
 							bell("Illegal target!");
+							/*
+							 * So there's something
+							 * to work with in the
+							 * next pass through
+							 * the loop.
+							 */
+							if (! square_in_bounds(cave, loc(x, y))) {
+							    x = player->grid.x;
+							    y = player->grid.y;
+							}
 						}
 					} else if (press.mouse.mods & KC_MOD_ALT) {
 						/* go to spot - same as 'g' command below */
@@ -1078,6 +1088,10 @@ bool target_set_interactive(int mode, int x, int y)
 						}
 					} else {
 						flag = false;
+						if (! square_in_bounds(cave, loc(x, y))) {
+						    x = player->grid.x;
+						    y = player->grid.y;
+						}
 					}
 				}
 			} else


### PR DESCRIPTION
For cases where the potential target coordinates are reset via the mouse, the targeting loop isn't done, and the coordinates aren't otherwise known to be valid, check that they're valid.  If not, reset them to the player's location.  That avoids more of the triggers for the infinite loop in issue 4217 (resizing the window while in targeting mode on OS X no longer seems to fall into the infinite loop for instance).