### PR TITLE
When reading monster memory, skip both kill and theft count if name unknown

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -481,7 +481,7 @@ int rd_messages(void)
  */
 int rd_monster_memory(void)
 {
-	u16b tmp16u;
+	u16b nkill, ntheft;
 	char buf[128];
 	int i;
 
@@ -506,18 +506,18 @@ int rd_monster_memory(void)
 	while (!streq(buf, "No more monsters")) {
 		struct monster_race *race = lookup_monster(buf);
 
-		/* Get the kill count, skip if monster invalid */
-		rd_u16b(&tmp16u);
+		/* Get the kill and theft counts, skip if monster invalid */
+		rd_u16b(&nkill);
+		rd_u16b(&ntheft);
 		if (!race) continue;
 
 		/* Store the kill count, ensure dead uniques stay dead */
-		l_list[race->ridx].pkills = tmp16u;
-		if (rf_has(race->flags, RF_UNIQUE) && tmp16u)
+		l_list[race->ridx].pkills = nkill;
+		if (rf_has(race->flags, RF_UNIQUE) && nkill)
 			race->max_num = 0;
 
-		/* Get the theft count */
-		rd_u16b(&tmp16u);
-		l_list[race->ridx].thefts = tmp16u;
+		/* Store the theft count */
+		l_list[race->ridx].thefts = ntheft;
 
 		/* Look for the next monster */
 		rd_string(buf, sizeof(buf));


### PR DESCRIPTION
It's possible that the previous code could explain Glorfindel's report of a unique coming back to life in issue 4245 ( https://github.com/angband/angband/issues/4245 ), i.e. if the previous entry had an invalid name and scanning that theft count plus Quaker's name caused Quaker's name to not be recognized, but that seems unlikely.  It wouldn't explain sinquen's report about Beorn since there the monster knowledge listed Beorn as dead.