### PR TITLE
Move clearing of the commanded monster status from player_kill_monst…

### DIFF
--- a/src/mon-make.c
+++ b/src/mon-make.c
@@ -32,6 +32,7 @@
 #include "obj-tval.h"
 #include "obj-util.h"
 #include "player-calcs.h"
+#include "player-timed.h"
 #include "target.h"
 
 /**
@@ -328,6 +329,11 @@ void delete_monster_idx(int m_idx)
 	/* Hack -- remove tracked monster */
 	if (player->upkeep->health_who == mon)
 		health_track(player->upkeep, NULL);
+
+	/* Hack -- remove any command status */
+	if (mon->m_timed[MON_TMD_COMMAND]) {
+		(void) player_clear_timed(player, TMD_COMMAND, true);
+	}
 
 	/* Monster is gone from square and group */
 	square_set_mon(cave, grid, 0);

--- a/src/mon-util.c
+++ b/src/mon-util.c
@@ -1007,11 +1007,6 @@ static void player_kill_monster(struct monster *mon, const char *note)
 		history_add(player, buf, HIST_SLAY_UNIQUE);
 	}
 
-	/* Remove any command status */
-	if (mon->m_timed[MON_TMD_COMMAND]) {
-		(void) player_clear_timed(player, TMD_COMMAND, true);
-	}
-
 	/* Gain experience */
 	player_exp_gain(player, new_exp);
 


### PR DESCRIPTION
…er() to delete_monster_idx() so it happens for all forms of monster death (trampling, banishment, ...).  That should resolve https://github.com/angband/angband/issues/4230 .

Since polymorph deletes the previous form and doesn't transfer of timed effects to the new form, it will cancel the command spell which is something that the player might not expect.