### PR TITLE
GCU: remove custom treasure mappings

### DIFF
--- a/lib/customize/font-gcu.prf
+++ b/lib/customize/font-gcu.prf
@@ -7,9 +7,3 @@
 
 # open floor
 feat:open floor:*:0x01:0xb7
-
-# magma vein with treasure
-feat:magma vein with treasure:*:0x83:0x2591
-# quartz vein with treasure
-feat:quartz vein with treasure:*:0x83:0x2591
-


### PR DESCRIPTION
As discussed in [this thread](http://angband.oook.cz/forum/showpost.php?p=143936&postcount=20), there's probably no need for the treasure tiles to be specially mapped to the block character in the GCU version any more. I suspect that this is a hold over from when solid walls were originally implemented. I think it makes more sense for everything to be ascii by default and only use blocks when solid walls are enabled.