### PR TITLE
Plug memory leak when an unidentified worthless item is sold

### DIFF
--- a/src/store.c
+++ b/src/store.c
@@ -1941,7 +1941,14 @@ void do_cmd_sell(struct command *cmd)
 	handle_stuff(player);
 
 	/* The store gets that (known) object */
-	store_carry(store, sold_item);
+	if (! store_carry(store, sold_item)) {
+		/* The store rejected it; delete. */
+		if (sold_item->known) {
+			object_delete(&sold_item->known);
+			sold_item->known = NULL;
+		}
+		object_delete(&sold_item);
+	}
 
 	event_signal(EVENT_STORECHANGED);
 	event_signal(EVENT_INVENTORY);


### PR DESCRIPTION
This is related to [issue 4335](https://github.com/angband/angband/issues/4335) but didn't come up in those runs.