### PR TITLE
Plug leak of memory for slays/brands/curses in wiz_reroll_item()

### DIFF
--- a/src/wiz-debug.c
+++ b/src/wiz-debug.c
@@ -985,7 +985,9 @@ static void wiz_reroll_item(struct object *obj)
 	/* Get new copy, hack off slays and brands */
 	new = mem_zalloc(sizeof(*new));
 	object_copy(new, obj);
+	mem_free(new->slays);
 	new->slays = NULL;
+	mem_free(new->brands);
 	new->brands = NULL;
 
 	/* Main loop. Ask for magification and artifactification */
@@ -1056,6 +1058,7 @@ static void wiz_reroll_item(struct object *obj)
 	}
 
 	/* Free the copy */
+	object_wipe(new);
 	mem_free(new);
 }
 


### PR DESCRIPTION
Was mentioned as a possibility in [this forum post](http://angband.oook.cz/forum/showthread.php?p=141118#post141118).  Verified that Xcode's Leaks instrument flagged memory leaks.