### PR TITLE
Add a convenience function, square_delete_object()

### DIFF
--- a/src/cave-square.c
+++ b/src/cave-square.c
@@ -1014,6 +1014,30 @@ void square_excise_pile(struct chunk *c, struct loc grid) {
 }
 
 /**
+ * Excise an object from a floor pile and delete it while doing the other
+ * necessary bookkeeping.  Normally, this is only called for the chunk
+ * representing the true nature of the environment and not the one
+ * representing the player's view of it.  If do_note is true, call
+ * square_note_spot().  If do_light is true, call square_light_spot().
+ * Unless calling this on the player's view, those both would be true
+ * except as an optimization/simplification when the caller would call
+ * square_note_spot()/square_light_spot() anyways or knows that those aren't
+ * necessary.
+ */
+void square_delete_object(struct chunk *c, struct loc grid, struct object *obj, bool do_note, bool do_light)
+{
+	square_excise_object(c, grid, obj);
+	delist_object(c, obj);
+	object_delete(&obj);
+	if (do_note) {
+		square_note_spot(c, grid);
+	}
+	if (do_light) {
+		square_light_spot(c, grid);
+	}
+}
+
+/**
  * Sense the existence of objects on a grid in the current level
  */
 void square_sense_pile(struct chunk *c, struct loc grid)

--- a/src/cave.h
+++ b/src/cave.h
@@ -388,6 +388,7 @@ struct trap *square_trap(struct chunk *c, struct loc grid);
 bool square_holds_object(struct chunk *c, struct loc grid, struct object *obj);
 void square_excise_object(struct chunk *c, struct loc grid, struct object *obj);
 void square_excise_pile(struct chunk *c, struct loc grid);
+void square_delete_object(struct chunk *c, struct loc grid, struct object *obj, bool do_note, bool do_light);
 void square_sense_pile(struct chunk *c, struct loc grid);
 void square_know_pile(struct chunk *c, struct loc grid);
 int square_num_walls_adjacent(struct chunk *c, struct loc grid);

--- a/src/cmd-pickup.c
+++ b/src/cmd-pickup.c
@@ -82,13 +82,9 @@ static void player_pickup_gold(struct player *p)
 
 		/* Delete the gold */
 		if (obj->known) {
-			square_excise_object(p->cave, p->grid, obj->known);
-			delist_object(p->cave, obj->known);
-			object_delete(&obj->known);
+			square_delete_object(p->cave, p->grid, obj->known, false, false);
 		}
-		square_excise_object(cave, p->grid, obj);
-		delist_object(cave, obj);
-		object_delete(&obj);
+		square_delete_object(cave, p->grid, obj, false, false);
 		obj = next;
 	}
 

--- a/src/effects.c
+++ b/src/effects.c
@@ -299,11 +299,7 @@ static bool uncurse_object(struct object *obj, int strength, char *dice_string)
 				object_delete(&destroyed->known);
 				object_delete(&destroyed);
 			} else {
-				square_excise_object(cave, obj->grid, obj);
-				delist_object(cave, obj);
-				object_delete(&obj);
-				square_note_spot(cave, player->grid);
-				square_light_spot(cave, player->grid);
+				square_delete_object(cave, obj->grid, obj, true, true);
 			}
 		} else {
 			/* Non-destructive failure */

--- a/src/mon-make.c
+++ b/src/mon-make.c
@@ -358,9 +358,7 @@ void delete_monster_idx(int m_idx)
 
 	/* Delete mimicked objects */
 	if (mon->mimicked_obj) {
-		square_excise_object(cave, mon->grid, mon->mimicked_obj);
-		delist_object(cave, mon->mimicked_obj);
-		object_delete(&mon->mimicked_obj);
+		square_delete_object(cave, mon->grid, mon->mimicked_obj, true, false);
 	}
 
 	/* Wipe the Monster */

--- a/src/mon-move.c
+++ b/src/mon-move.c
@@ -1319,11 +1319,7 @@ void monster_turn_grab_objects(struct chunk *c, struct monster *mon,
 				msgt(MSG_DESTROY, "%s crushes %s.", m_name, o_name);
 
 			/* Delete the object */
-			square_excise_object(c, new, obj);
-			delist_object(c, obj);
-			object_delete(&obj);
-			square_note_spot(c, new);
-			square_light_spot(c, new);
+			square_delete_object(c, new, obj, true, true);
 		}
 
 		/* Next object */

--- a/src/project-obj.c
+++ b/src/project-obj.c
@@ -561,13 +561,7 @@ bool project_o(struct source origin, int r, struct loc grid, int dam, int typ,
 					msgt(MSG_DESTROY, "The %s %s!", o_name, note_kill);
 
 				/* Delete the object */
-				square_excise_object(cave, grid, obj);
-				delist_object(cave, obj);
-				object_delete(&obj);
-
-				/* Redraw */
-				square_note_spot(cave, grid);
-				square_light_spot(cave, grid);
+				square_delete_object(cave, grid, obj, true, true);
 			}
 		}
 

--- a/src/wiz-stats.c
+++ b/src/wiz-stats.c
@@ -1410,9 +1410,7 @@ static void scan_for_objects(void)
 				get_obj_data(obj, y, x, false, false);
 
 				/* Delete the object */
-				square_excise_object(cave, grid, obj);
-				delist_object(cave, obj);
-				object_delete(&obj);
+				square_delete_object(cave, grid, obj, false, false);
 			}
 		}
 	}


### PR DESCRIPTION
Given the number of place that use the combination of square_excise_object(), delist_object(), object_delete(), square_note_spot(), and square_light_spot, it seems useful to have a convenience function to perform that sequence of operations.  This change calls it square_delete_object(), puts the prototype in cave.h, and puts the definition in cave-square.c.

The change makes use of the new function in the places where that combination appeared.   For the deletion of a mimicked object in delete_monster_idx(), the change has the effect of adding a call to square_note_spot().