### PR TITLE
Change to allow the detect buried treasure effect to remove marks on the map

### DIFF
--- a/src/effects.c
+++ b/src/effects.c
@@ -1875,6 +1875,10 @@ bool effect_handler_DETECT_GOLD(effect_handler_context_t *context)
 
 				/* Detect */
 				gold_buried = true;
+			} else if (square_hasgoldvein(player->cave, grid)) {
+				/* Something removed previously seen or
+				 * detected buried gold.  Notice the change. */
+				square_forget(cave, grid);
 			}
 		}
 	}


### PR DESCRIPTION
Like the object sense/detect effects, the detect buried treasure effect currently can only add marks to the map.  This change allows it to remove previously seen or marked buried treasure if now none is detected at the location.

Probably most useful for dwarves who would have a bit of advance warning for an incoming umber hulk if there's some buried treasure in its way.