### PR TITLE
Change object handling in the cave for issues 4348 and 4335

### DIFF
--- a/src/cave.c
+++ b/src/cave.c
@@ -378,13 +378,20 @@ struct chunk *cave_new(int height, int width) {
  * Free a chunk
  */
 void cave_free(struct chunk *c) {
-	int y, x;
+	int y, x, i;
 
 	while (c->join) {
 		struct connector *current = c->join;
 		mem_free(current->info);
 		c->join = current->next;
 		mem_free(current);
+	}
+
+	/* Look for orphaned objects and delete them. */
+	for (i = 1; i < c->obj_max; i++) {
+		if (c->objects[i] && loc_is_zero(c->objects[i]->grid)) {
+			object_delete(&c->objects[i]);
+		}
 	}
 
 	for (y = 0; y < c->height; y++) {

--- a/src/mon-util.c
+++ b/src/mon-util.c
@@ -1401,8 +1401,8 @@ void steal_monster_item(struct monster *mon, int midx)
 				object_delete(&obj);
 			} else {
 				object_grab(player, obj);
-				delist_object(cave, obj);
 				delist_object(player->cave, obj->known);
+				delist_object(cave, obj);
 				/* Drop immediately if ignored to prevent pack overflow */
 				if (ignore_item_ok(obj)) {
 					char o_name[80];

--- a/src/mon-util.c
+++ b/src/mon-util.c
@@ -1284,6 +1284,10 @@ bool monster_carry(struct chunk *c, struct monster *mon, struct object *obj)
 
 	/* Add the object to the monster's inventory */
 	list_object(c, obj);
+	if (obj->known) {
+		obj->known->oidx = obj->oidx;
+		player->cave->objects[obj->oidx] = obj->known;
+	}
 	pile_insert(&mon->held_obj, obj);
 
 	/* Result */

--- a/src/obj-knowledge.c
+++ b/src/obj-knowledge.c
@@ -949,17 +949,13 @@ void object_grab(struct player *p, struct object *obj)
 
 	/* Make new known objects, fully know sensed ones, relocate old ones */
 	if (known_obj == NULL) {
-		/* Make and/or list the new object */
+		/* Make a new one */
 		struct object *new_obj;
 
-		/* Check whether we need to make a new one or list the old one */
-		if (obj->known) {
-			new_obj = obj->known;
-		} else {
-			new_obj = object_new();
-			obj->known = new_obj;
-			object_set_base_known(obj);
-		}
+		assert(! obj->known);
+		new_obj = object_new();
+		obj->known = new_obj;
+		object_set_base_known(obj);
 		p->cave->objects[obj->oidx] = new_obj;
 		new_obj->oidx = obj->oidx;
 	} else {
@@ -968,7 +964,10 @@ void object_grab(struct player *p, struct object *obj)
 		/* Make sure knowledge is correct */
 		assert(known_obj == obj->known);
 
-		/* Detach from any old (incorrect) floor pile */
+		/* Detach from any old (incorrect) floor pile
+		 * This will be dead code once compatibility with old savefiles
+		 * isn't needed.  It (and the declaration of old above) can be
+		 * removed in 4.3.0. */
 		if (!loc_is_zero(old) && square_holds_object(p->cave, old, known_obj)) {
 			square_excise_object(p->cave, old, known_obj);
 		}

--- a/src/obj-pile.c
+++ b/src/obj-pile.c
@@ -887,6 +887,16 @@ bool floor_carry(struct chunk *c, struct loc grid, struct object *drop,
 	/* Record in the level list */
 	list_object(c, drop);
 
+	/* If there's a known version, put it in the player's view of the
+	 * cave but at an unknown location.  square_note_spot() will move
+	 * it to the correct place if seen. */
+	if (drop->known) {
+		drop->known->oidx = drop->oidx;
+		drop->known->held_m_idx = 0;
+		drop->known->grid = loc(0, 0);
+		player->cave->objects[drop->oidx] = drop->known;
+	}
+
 	/* Redraw */
 	square_note_spot(c, grid);
 	square_light_spot(c, grid);


### PR DESCRIPTION
The first part of the change is to enforce that an object in the cave or a monster's inventory which has a known version will have that known version included in the object list of the player's cave.  If that known version has a position that's unknown (it either hasn't been sensed or detected since the object was dropped in the cave or is in a monster's inventory) the known version will have it's grid location set to (0,0) but it is not in the pile at (0,0).  From my understanding of how the savefiles are written and loaded, this does not break compatibility with old savefiles (any known objects which weren't in the object list of the player's cave would not have been recorded in the savefile).

The second part of the change is for what happens when a monster picks up an object or an object is moved with push_object().  If the player has a memory of the position of the object, the result of that change always leave the placeholder with a purely imaginary known version while a copy of the original object and its known version (but at an unknown location) are used for all subsequent processing of the real object.  That's to avoid cases of revealing information that the player wasn't in a position to observe, but it introduces a regression compared to the current version.  In cases where the player drops that something that's unlikely to occur elsewhere, a monster picks that up out of the line of sight, and then the player kills the monster, and sees the drop.  With the current code, the mark on the player's map for the original drop location goes away.  In the changed version, it does not until the player sees/senses/detects that location.  I didn't see a way to avoid that regression without either revealing what should be unavailable information in other cases or introducing a one-to-many relationship between the real object and its known versions which would break savefile compatibility.

The third part of the change adjusts the logic in object_sense(), object_see(), and object_grab() to use the fact that the known version, if present, will always be in the object list of the player's cave.

Finally, there's some changes to bookkeeping so that it's safe to scan the object list for orphaned objects and delete them to avoid memory leaks.  The scan is done in cave_free() and would be the first thing to disable if crashes or corruption of game state are seen upon leaving a level (due to things looking like orphans but which have already been deleted or are still live in the player's inventory or floor piles).