### PR TITLE
Use =g<n> (i.e. =g8) inscription to limit auto pickup

### DIFF
--- a/docs/customize.rst
+++ b/docs/customize.rst
@@ -93,7 +93,14 @@ Inscribing an item with '!!':
 
 Inscribing an item with '=g':
 	This marks an item as 'always pick up'.  This is sometimes useful for
-	picking up ammunition after a shootout.
+	picking up ammunition after a shootout.  If there is a number
+	immediately after the 'g', then the amount picked up automatically
+	will be limited.  If you have inscribed a spellbook with '=g4' and have
+	four or more copies in your pack, you will not automatially pick up
+	any more copies when you have the 'pickup if in inventory' option
+	enabled.  If you have three copies in your pack with that inscription
+	and happen to find a pile of two copies, you'll automatically pick up
+	one so there is four in the pack.
 
 Inscribing an item with ``!`` followed by a command letter or ``*``:
 	This means "ask me before using this item".  '!w' means 'ask me before

--- a/src/obj-util.c
+++ b/src/obj-util.c
@@ -356,6 +356,44 @@ unsigned check_for_inscrip(const struct object *obj, const char *inscrip)
 	return i;
 }
 
+/**
+ * Looks if "inscrip" immediately followed by a decimal integer without a
+ * leading sign character is present on the given object.  Returns the number
+ * of times such an inscription occurs and, if that value is at least one,
+ * sets *ival to the value of the integer that followed the first such
+ * inscription.
+ */
+unsigned check_for_inscrip_with_int(const struct object *obj, const char *inscrip, int* ival)
+{
+	unsigned i = 0;
+	size_t inlen = strlen(inscrip);
+	const char *s;
+
+	if (!obj->note) return 0;
+
+	s = quark_str(obj->note);
+
+	/* Needing this implies there are bad instances of obj->note around,
+	 * but I haven't been able to track down their origins - NRM */
+	if (!s) return 0;
+
+	do {
+		s = strstr(s, inscrip);
+		if (!s) break;
+		if (isdigit(s[inlen])) {
+			if (i == 0) {
+				long inarg = strtol(s + inlen, 0, 10);
+
+				*ival = (inarg < INT_MAX) ? (int) inarg : INT_MAX;
+			}
+			i++;
+		}
+		s++;
+	} while (s);
+
+	return i;
+}
+
 /*** Object kind lookup functions ***/
 
 /**

--- a/src/obj-util.h
+++ b/src/obj-util.h
@@ -33,6 +33,7 @@ bool object_test(item_tester tester, const struct object *o);
 bool item_test(item_tester tester, int item);
 bool is_unknown(const struct object *obj);
 unsigned check_for_inscrip(const struct object *obj, const char *inscrip);
+unsigned check_for_inscrip_with_int(const struct object *obj, const char *insrip, int *ival);
 struct object_kind *lookup_kind(int tval, int sval);
 struct object_kind *objkind_byid(int kidx);
 struct artifact *lookup_artifact_name(const char *name);

--- a/src/tests/object/util.c
+++ b/src/tests/object/util.c
@@ -16,10 +16,13 @@ int setup_tests(void **state) {
 	z_info->fuel_torch = 5000;
 	z_info->fuel_lamp = 15000;
 	z_info->default_lamp = 7500;
+
+	quarks_init();
     return 0;
 }
 
 int teardown_tests(void **state) {
+	quarks_free();
 	mem_free(z_info);
 	return 0;
 }
@@ -60,8 +63,54 @@ int test_obj_can_refill(void *state) {
     ok;
 }
 
+/* Test basic functionality of check_for_inscrip_with_int(). */
+int test_basic_check_for_inscrip_with_int(void *state) {
+    struct object obj;
+    int dummy = 8974;
+    int inarg;
+
+    /* No inscription should return zero and leave inarg unchanged. */
+    memset(&obj, 0, sizeof(obj));
+    inarg = dummy;
+    eq(check_for_inscrip_with_int(&obj, "=g", &inarg), 0);
+    eq(inarg, dummy);
+
+    /* An inscription not containing the search string should return zero and
+     * leave inarg unchanged. */
+    obj.note = quark_add("@m1@b1@G1");
+    inarg = dummy;
+    eq(check_for_inscrip_with_int(&obj, "=g", &inarg), 0);
+    eq(inarg, dummy);
+
+    /* An inscription containing the search string but not followed by an
+     * integer should return zero and leave inarg unchanged. */
+    obj.note = quark_add("=g@m1@b1@G1");
+    inarg = dummy;
+    eq(check_for_inscrip_with_int(&obj, "=g", &inarg), 0);
+    eq(inarg, dummy);
+
+    /* An inscription containing one instance of the search string followed
+     * by a nonnegative integer should return one and set inarg to the value
+     * of the integer. */
+    obj.note = quark_add("=g5@m1@b1@G1");
+    inarg = dummy;
+    eq(check_for_inscrip_with_int(&obj, "=g", &inarg), 1);
+    eq(inarg, 5);
+
+    /* An inscription containing two instances of the search string followed
+     * by a nonnegative integer should return two and set inarg to the value
+     * of the integer following the first instance. */
+    obj.note = quark_add("@m1@b1=g8@G1=g5");
+    inarg = dummy;
+    eq(check_for_inscrip_with_int(&obj, "=g", &inarg), 2);
+    eq(inarg, 8);
+
+    ok;
+}
+
 const char *suite_name = "object/util";
 struct test tests[] = {
     { "obj_can_refill", test_obj_can_refill },
+    { "basic_check_for_inscrip_with_uint", test_basic_check_for_inscrip_with_int },
     { NULL, NULL }
 };


### PR DESCRIPTION
To address #2658 and #2932 , changes cmd-pickup.c to look for =g<number> inscriptions (as in Unangband) to limit the number of item's automatically picked up to be max(number - number in pack, 0).  Since 4.2.0 allows the 'always pickup' option to override !g inscriptions, it also overrides the =g<number> inscription in this version.  The 'pickup if in inventory' option honors the =g<number> inscription.

This doesn't implement the =d<number> and =i<number> inscriptions mentioned in #2658 and in the Unangband documentation.  Though it does not use the Max=# form suggested in #2932 , it addresses the same issue.  The autoinscription mentioned in #2932 is not implemented; presumably a player could configure it with the existing autoinscription feature.
