### PR TITLE
Restructure use_aux() to avoid crash when a Rune of Protection scroll

### DIFF
--- a/src/cmd-obj.c
+++ b/src/cmd-obj.c
@@ -422,8 +422,8 @@ static void use_aux(struct command *cmd, struct object *obj, enum use use,
 					int snd)
 {
 	struct effect *effect = object_effect(obj);
-	bool ident = false, used = false, can_use = true;
-	bool was_aware;
+	bool can_use = true;
+	bool was_aware, from_floor;
 	bool known_aim = false;
 	bool none_left = false;
 	int dir = 5;
@@ -467,7 +467,9 @@ static void use_aux(struct command *cmd, struct object *obj, enum use use,
 	/* Execute the effect */
 	if (can_use) {
 		int beam = beam_chance(obj->tval);
-		int boost, level;
+		int boost, level, charges = 0;
+		bool ident = false, used;
+		struct object *work_obj;
 
 		/* Get the level */
 		if (obj->artifact)
@@ -489,7 +491,41 @@ static void use_aux(struct command *cmd, struct object *obj, enum use use,
 		/* Boost damage effects if skill > difficulty */
 		boost = MAX((player->state.skills[SKILL_DEVICE] - level) / 2, 0);
 
-		/* Do effect */
+		/*
+		 * Tentatively deduct the amount used - the effect could leave
+		 * the object inaccessible making it difficult to do after a
+		 * successful use.  For the same reason, get a copy of the
+		 * object to use for propagating knowledge.
+		 */
+		if (use == USE_SINGLE) {
+			if (object_is_carried(player, obj)) {
+				work_obj = gear_object_for_use(obj, 1, true, &none_left);
+				from_floor = false;
+			} else {
+				work_obj = floor_object_for_use(obj, 1, true, &none_left);
+				from_floor = true;
+			}
+		} else  {
+			if (use == USE_CHARGE) {
+				charges = obj->pval;
+				/* Use a single charge */
+				obj->pval--;
+			} else if (use == USE_TIMEOUT) {
+				charges = obj->timeout;
+				obj->timeout += randcalc(obj->time, 0, RANDOMISE);
+			}
+			work_obj = object_new();
+			object_copy(work_obj, obj);
+			work_obj->oidx = 0;
+			if (obj->known) {
+				work_obj->known = object_new();
+				object_copy(work_obj->known, obj->known);
+				work_obj->known->oidx = 0;
+			}
+			from_floor = !object_is_carried(player, obj);
+		}
+
+		/* Do effect; use original not copy (proj. effect handling) */
 		target_fix();
 		used = effect_do(effect,
 							source_player(),
@@ -501,61 +537,79 @@ static void use_aux(struct command *cmd, struct object *obj, enum use use,
 							boost);
 		target_release();
 
-		/* Quit if the item wasn't used and no knowledge was gained */
-		if (!used && (was_aware || !ident)) return;
-	}
+		if (!used) {
+			/* Restore the tentative deduction. */
+			if (use == USE_SINGLE) {
+				/* Drop copy to simplify subsequent logic */
+				struct object *dropped = object_new();
 
-	/* If the item is a null pointer or has been wiped, be done now */
-	if (!obj) return;
+				object_copy(dropped, work_obj);
+				if (work_obj->known) {
+					dropped->known = object_new();
+					object_copy(dropped->known, work_obj->known);
+				}
+				if (from_floor) {
+					drop_near(cave, &dropped, 0, player->grid, true);
+				} else {
+					inven_carry(player, dropped, true, true);
+				}
+			} else if (use == USE_CHARGE) {
+				obj->pval = charges;
+			} else if (use == USE_TIMEOUT) {
+				obj->timeout = charges;
+			}
+
+			/*
+			 * Quit if the item wasn't used and no knowledge was
+			 * gained
+			 */
+			if (was_aware || !ident) {
+				if (work_obj->known) {
+					object_delete(&work_obj->known);
+				}
+				object_delete(&work_obj);
+				return;
+			}
+		}
+
+		/* Increase knowledge */
+		if (use == USE_SINGLE) {
+			/* Single use items are automatically learned */
+			if (!was_aware) {
+				object_learn_on_use(player, work_obj);
+			}
+		} else {
+			/* Wearables may need update, other things become known or tried */
+			if (tval_is_wearable(work_obj)) {
+				update_player_object_knowledge(player);
+			} else if (!was_aware && ident) {
+				object_learn_on_use(player, work_obj);
+			} else {
+				object_flavor_tried(work_obj);
+			}
+		}
+
+		if (used && use == USE_CHARGE) {
+			/* Describe charges */
+			if (from_floor)
+				floor_item_charges(work_obj);
+			else
+				inven_item_charges(work_obj);
+		}
+
+		/* Clean up created copy. */
+		if (work_obj->known)
+			object_delete(&work_obj->known);
+		object_delete(&work_obj);
+	} else {
+		from_floor = !object_is_carried(player, obj);
+	}
 
 	/* Use the turn */
 	player->upkeep->energy_use = z_info->move_energy;
 
-	/* Increase knowledge */
-	if (use == USE_SINGLE) {
-		/* Single use items are automatically learned */
-		if (!was_aware) {
-			object_learn_on_use(player, obj);
-		}
-	} else {
-		/* Wearables may need update, other things become known or tried */
-		if (tval_is_wearable(obj)) {
-			update_player_object_knowledge(player);
-		} else if (!was_aware && ident) {
-			object_learn_on_use(player, obj);
-		} else if (can_use) {
-			object_flavor_tried(obj);
-		}
-	}
-
-	/* Chargeables act differently to single-used items when not used up */
-	if (used && use == USE_CHARGE) {
-		/* Use a single charge */
-		obj->pval--;
-
-		/* Describe charges */
-		if (object_is_carried(player, obj))
-			inven_item_charges(obj);
-		else
-			floor_item_charges(obj);
-	} else if (used && use == USE_TIMEOUT) {
-		obj->timeout += randcalc(obj->time, 0, RANDOMISE);
-	} else if (used && use == USE_SINGLE) {
-		struct object *used_obj;
-
-		/* Destroy an item in the pack */
-		if (object_is_carried(player, obj))
-			used_obj = gear_object_for_use(obj, 1, true, &none_left);
-		else
-			/* Destroy an item on the floor */
-			used_obj = floor_object_for_use(obj, 1, true, &none_left);
-		if (used_obj->known)
-			object_delete(&used_obj->known);
-		object_delete(&used_obj);
-	}
-
-	/* Autoinscribe if we still have any */
-	if (!none_left)
+	/* Autoinscribe if we are guaranteed to still have any */
+	if (!none_left && !from_floor)
 		apply_autoinscription(obj);
 
 	/* Mark as tried and redisplay */


### PR DESCRIPTION
is read from the floor.  Earlier change to push_object() left the object reference in use_aux() dangling.  Has the drawbacks of extra overhead (more copying of objects on use), more message spam (and extra call to drop_near() if on floor) for cases where a scroll isn't used, and the messages about removing a single-use item are printed before identification so they won't show the newly identified type on first use.

Resolves part of #4360 - Diego Gonzalez's report. sphara's report indicates that the rune of protection scroll was in the inventory when the crash happened.  I haven't been able to reproduce that and this change should not help in that case.