### PR TITLE
Have more of the 2nd character sheet controlled by the configuration files

### DIFF
--- a/lib/gamedata/Makefile
+++ b/lib/gamedata/Makefile
@@ -8,5 +8,6 @@ CONFIG = activation.txt artifact.txt body.txt blow_methods.txt \
  object_base.txt object_property.txt p_race.txt pain.txt pit.txt \
  player_property.txt player_timed.txt projection.txt quest.txt realm.txt \
  room_template.txt shape.txt slay.txt store.txt summon.txt terrain.txt \
- trap.txt vault.txt visuals.txt world.txt
+ trap.txt ui_entry.txt ui_entry_base.txt ui_entry_renderer.txt vault.txt \
+ visuals.txt world.txt
 PACKAGE = gamedata

--- a/lib/gamedata/object_property.txt
+++ b/lib/gamedata/object_property.txt
@@ -19,6 +19,17 @@
 #                attribute, currently only used by stats
 # msg: message printed on noticing a property, currently used for flags which
 #      are identified after time or on an effect
+# bindui: Binds the property to a user interface element in ui_entry.txt.
+#         Takes two additional integer parameters.  The first, if nonzero,
+#         specifies that the value bound be passed as an auxiliary value (a
+#         sustain for a stat, for instance).  The second is optional and is
+#         the value to pass when the object has the property (either on as a
+#         flag or a nonzero value for a modifier or resistance).  When not set,
+#         the value (0 for off flag, 1 for on flag, value for modifier,
+#         resistance level for a resistance) is sent.  bindui is currently only
+#         used for parts of the second character screen.  This field can appear
+#         multiple times to bind a property to more than one user interface
+#         element.
 # desc: an extra piece of descriptive text used in object information
 
 name:strength
@@ -28,6 +39,7 @@ power:9
 mult:13
 adjective:strong
 neg-adjective:weak
+bindui:stat_mod_ui_compact_0<STR>:0
 
 name:intelligence
 type:stat
@@ -36,6 +48,7 @@ power:5
 mult:10
 adjective:smart
 neg-adjective:stupid
+bindui:stat_mod_ui_compact_0<INT>:0
 
 name:wisdom
 type:stat
@@ -44,6 +57,7 @@ power:5
 mult:10
 adjective:wise
 neg-adjective:naive
+bindui:stat_mod_ui_compact_0<WIS>:0
 
 name:dexterity
 type:stat
@@ -53,6 +67,7 @@ mult:10
 type-mult:gloves:2
 adjective:dextrous
 neg-adjective:clumsy
+bindui:stat_mod_ui_compact_0<DEX>:0
 
 name:constitution
 type:stat
@@ -61,42 +76,49 @@ power:12
 mult:15
 adjective:healthy
 neg-adjective:sickly
+bindui:stat_mod_ui_compact_0<CON>:0
 
 name:stealth
 type:mod
 code:STEALTH
 power:8
 mult:12
+bindui:stealth_ui_compact_0:0
 
 name:searching skill
 type:mod
 code:SEARCH
 power:2
 mult:5
+bindui:search_ui_compact_0:0
 
 name:infravision
 type:mod
 code:INFRA
 power:4
 mult:8
+bindui:infravision_ui_compact_0:0
 
 name:tunneling
 type:mod
 code:TUNNEL
 power:3
 mult:8
+bindui:tunneling_ui_compact_0:0
 
 name:speed
 type:mod
 code:SPEED
 power:20
 mult:6
+bindui:speed_ui_compact_0:0
 
 name:damage reduction
 type:mod
 code:DAM_RED
 power:5
 mult:6
+bindui:damage_reduction_ui_compact_0:0
 
 name:attack speed
 type:mod
@@ -116,6 +138,7 @@ type-mult:helm:3
 type-mult:crown:3
 type-mult:gloves:3
 type-mult:boots:3
+bindui:blows_ui_compact_0:0
 
 name:shooting speed
 type:mod
@@ -138,6 +161,7 @@ type-mult:helm:4
 type-mult:crown:4
 type-mult:gloves:4
 type-mult:boots:4
+bindui:shots_ui_compact_0:0
 
 name:shooting power
 type:mod
@@ -160,6 +184,7 @@ type-mult:helm:0
 type-mult:crown:0
 type-mult:gloves:0
 type-mult:boots:0
+bindui:shooting_power_ui_compact_0:0
 
 name:movement speed
 type:mod
@@ -182,6 +207,7 @@ type-mult:helm:0
 type-mult:crown:0
 type-mult:gloves:0
 type-mult:boots:0
+bindui:movement_speed_ui_compact_0:0
 
 name:light
 type:mod
@@ -189,6 +215,7 @@ code:LIGHT
 power:3
 mult:6
 type-mult:light:3
+bindui:light_ui_compact_0:0
 
 name:sustain strength
 type:flag
@@ -197,6 +224,7 @@ id-type:on effect
 code:SUST_STR
 power:9
 msg:Your {name} glows.
+bindui:stat_mod_ui_compact_0<STR>:1
 
 name:sustain intelligence
 type:flag
@@ -205,6 +233,7 @@ id-type:on effect
 code:SUST_INT
 power:4
 msg:Your {name} glows.
+bindui:stat_mod_ui_compact_0<INT>:1
 
 name:sustain wisdom
 type:flag
@@ -213,6 +242,7 @@ id-type:on effect
 code:SUST_WIS
 power:4
 msg:Your {name} glows.
+bindui:stat_mod_ui_compact_0<WIS>:1
 
 name:sustain dexterity
 type:flag
@@ -221,6 +251,7 @@ id-type:on effect
 code:SUST_DEX
 power:7
 msg:Your {name} glows.
+bindui:stat_mod_ui_compact_0<DEX>:1
 
 name:sustain constitution
 type:flag
@@ -229,6 +260,7 @@ id-type:on effect
 code:SUST_CON
 power:8
 msg:Your {name} glows.
+bindui:stat_mod_ui_compact_0<CON>:1
 
 name:protection from fear
 type:flag
@@ -237,6 +269,7 @@ subtype:protection
 id-type:on effect
 power:6
 msg:Your {name} strengthens your courage.
+bindui:pfear_ui_compact_0:0
 desc:fear
 
 name:protection from blindness
@@ -246,6 +279,7 @@ subtype:protection
 id-type:on effect
 power:16
 msg:Your {name} soothes your eyes.
+bindui:pblind_ui_compact_0:0
 desc:blindness
 
 name:protection from confusion
@@ -255,6 +289,7 @@ subtype:protection
 id-type:on effect
 power:24
 msg:Your {name} clears your thoughts.
+bindui:pconf_ui_compact_0:0
 desc:confusion
 
 name:protection from stunning
@@ -264,6 +299,7 @@ subtype:protection
 id-type:on effect
 power:12
 msg:Your {name} steadies you.
+bindui:pstun_ui_compact_0:0
 desc:stunning
 
 name:slow digestion
@@ -273,6 +309,7 @@ id-type:timed
 code:SLOW_DIGEST
 power:2
 msg:You realise your {name} is slowing your metabolism.
+bindui:slow_digestion_ui_compact_0:0
 desc:Slows your metabolism
 
 name:feather falling
@@ -282,6 +319,7 @@ id-type:on effect
 code:FEATHER
 power:1
 msg:Your {name} slows your fall.
+bindui:feather_falling_ui_compact_0:0
 desc:Feather Falling
 
 name:regeneration
@@ -303,6 +341,7 @@ type-mult:crown:2
 type-mult:gloves:2
 type-mult:boots:2
 msg:You note that your {name} is speeding up your recovery.
+bindui:regen_ui_compact_0:0
 desc:Speeds regeneration
 
 name:telepathy
@@ -323,6 +362,7 @@ type-mult:crown:2
 type-mult:gloves:2
 type-mult:boots:2
 power:35
+bindui:esp_ui_compact_0:0
 desc:Grants telepathy
 
 name:see invisible
@@ -343,6 +383,7 @@ type-mult:crown:2
 type-mult:gloves:2
 type-mult:boots:2
 power:6
+bindui:see_invis_ui_compact_0:0
 desc:Grants the ability to see invisible things
 
 name:free action
@@ -364,6 +405,7 @@ type-mult:crown:2
 type-mult:gloves:5
 type-mult:boots:2
 msg:Your {name} keeps you moving.
+bindui:free_action_ui_compact_0:0
 desc:Prevents paralysis
 
 name:hold life
@@ -385,6 +427,7 @@ type-mult:crown:2
 type-mult:gloves:2
 type-mult:boots:2
 msg:Your {name} warms your spirit.
+bindui:holdlife_ui_compact_0:0
 desc:Sustains your life force
 
 name:earthquakes
@@ -428,6 +471,7 @@ type-mult:helm:0
 type-mult:crown:0
 type-mult:gloves:0
 type-mult:boots:0
+bindui:bless_ui_compact_0:0
 desc:Blessed by the gods
 
 name:burns out
@@ -506,6 +550,7 @@ id-type:timed
 code:IMPAIR_HP
 power:-8
 msg:You feel your {name} is slowing your recovery.
+bindui:imphp_ui_compact_0:0
 desc:Impairs hitpoint recovery
 
 name:impaired mana recovery
@@ -515,6 +560,7 @@ id-type:timed
 code:IMPAIR_MANA
 power:-8
 msg:You feel your {name} is slowing your mana recovery.
+bindui:impsp_ui_compact_0:0
 desc:Impairs mana recovery
 
 name:constant fear
@@ -523,6 +569,7 @@ subtype:bad
 id-type:on wield
 code:AFRAID
 power:-20
+bindui:fear_ui_compact_0:0
 desc:Makes you afraid of melee, and worse at shooting and casting spells
 
 name:teleportation ban
@@ -532,6 +579,7 @@ id-type:on effect
 code:NO_TELEPORT
 power:-20
 msg:Your {name} prevents you teleporting.
+bindui:noteleport_ui_compact_0:0
 desc:Prevents teleportation
 
 name:aggravation
@@ -541,6 +589,7 @@ id-type:timed
 code:AGGRAVATE
 power:-20
 msg:You notice your {name} aggravating things around you.
+bindui:aggravate_ui_compact_0:0
 desc:Aggravates creatures nearby
 
 name:experience drain
@@ -550,6 +599,7 @@ id-type:timed
 code:DRAIN_EXP
 power:-5
 msg:You sense your {name} is draining your life.
+bindui:drainxp_ui_compact_0:0
 desc:Drains experience
 
 name:stuck on
@@ -558,6 +608,7 @@ subtype:bad
 id-type:on wield
 code:STICKY
 power:-5
+bindui:sticky_ui_compact_0:0
 desc:Can't be removed
 
 name:fragile
@@ -566,6 +617,7 @@ subtype:bad
 id-type:on wield
 code:FRAGILE
 power:-1
+bindui:fragile_ui_compact_0:0
 desc:Can be destroyed if you attempt to remove its curses
 
 name:intensity 2 light
@@ -620,6 +672,7 @@ subtype:dig
 id-type:on wield
 code:DIG_1
 power:3
+bindui:tunneling_ui_compact_0:0:1
 
 name:power 2 digging
 type:flag
@@ -627,6 +680,7 @@ subtype:dig
 id-type:on wield
 code:DIG_2
 power:6
+bindui:tunneling_ui_compact_0:0:2
 
 name:power 3 digging
 type:flag
@@ -634,6 +688,7 @@ subtype:dig
 id-type:on wield
 code:DIG_3
 power:9
+bindui:tunneling_ui_compact_0:0:3
 
 name:explode
 type:flag
@@ -677,6 +732,7 @@ type-mult:crown:2
 type-mult:gloves:2
 type-mult:boots:2
 msg:Your {name} stops you from setting off the trap.
+bindui:trap_immunity_ui_compact_0:0
 desc:Gives immunity to traps
 
 name:throwing
@@ -710,104 +766,125 @@ name:acid resistance
 type:resistance
 code:ACID
 power:5
+bindui:resist_ui_compact_0<ACID>:0
 
 name:electricity resistance
 type:resistance
 code:ELEC
 power:6
+bindui:resist_ui_compact_0<ELEC>:0
 
 name:fire resistance
 type:resistance
 code:FIRE
 power:6
+bindui:resist_ui_compact_0<FIRE>:0
 
 name:cold resistance
 type:resistance
 code:COLD
 power:6
+bindui:resist_ui_compact_0<COLD>:0
 
 name:poison resistance
 type:resistance
 code:POIS
 power:28
+bindui:resist_ui_compact_0<POIS>:0
 
 name:light resistance
 type:resistance
 code:LIGHT
 power:6
+bindui:resist_ui_compact_0<LIGHT>:0
 
 name:dark resistance
 type:resistance
 code:DARK
 power:16
+bindui:resist_ui_compact_0<DARK>:0
 
 name:sound resistance
 type:resistance
 code:SOUND
 power:14
+bindui:resist_ui_compact_0<SOUND>:0
 
 name:shards resistance
 type:resistance
 code:SHARD
 power:8
+bindui:resist_ui_compact_0<SHARD>:0
 
 name:nexus resistance
 type:resistance
 code:NEXUS
 power:15
+bindui:resist_ui_compact_0<NEXUS>:0
 
 name:nether resistance
 type:resistance
 code:NETHER
 power:20
+bindui:resist_ui_compact_0<NETHER>:0
 
 name:chaos resistance
 type:resistance
 code:CHAOS
 power:20
+bindui:resist_ui_compact_0<CHAOS>:0
 
 name:disenchantment resistance
 type:resistance
 code:DISEN
 power:20
+bindui:resist_ui_compact_0<DISEN>:0
 
 name:acid vulnerability
 type:vulnerability
 code:ACID
 power:-6
+bindui:resist_ui_compact_0<ACID>:0
 
 name:lightning vulnerability
 type:vulnerability
 code:ELEC
 power:-6
+bindui:resist_ui_compact_0<ELEC>:0
 
 name:fire vulnerability
 type:vulnerability
 code:FIRE
 power:-6
+bindui:resist_ui_compact_0<FIRE>:0
 
 name:cold vulnerability
 type:vulnerability
 code:COLD
 power:-6
+bindui:resist_ui_compact_0<COLD>:0
 
 name:acid immunity
 type:immunity
 code:ACID
 power:43
+bindui:resist_ui_compact_0<ACID>:0
 
 name:lightning immunity
 type:immunity
 code:ELEC
 power:41
+bindui:resist_ui_compact_0<ELEC>:0
 
 name:fire immunity
 type:immunity
 code:FIRE
 power:46
+bindui:resist_ui_compact_0<FIRE>:0
 
 name:cold immunity
 type:immunity
 code:COLD
 power:43
+bindui:resist_ui_compact_0<COLD>:0
 

--- a/lib/gamedata/player_property.txt
+++ b/lib/gamedata/player_property.txt
@@ -18,6 +18,17 @@
 #    element - resistance, immunity or vulnerability to an element
 # code - the property name used by the game. Element codes are templates, and
 #        one is made for each element
+# bindui - Binds the property to a user interface element in ui_entry.txt.
+#          When binding an element property, the name will be parameterized
+#          with the element name.  Takes two parameters.  The first is an
+#          integer, which if nonzero, says the value is passed to the user
+#          interface element as an auxiliary one (used on some to indicate a
+#          sustain, for instance).  The second is the value to pass.  That can
+#          be an integer or "special" where the latter indicates that the
+#          value passed will be determined internally.  bindui currently only
+#          affects parts of the second character screen.  It can appear
+#          multiple times for the same entry to bind it to multiple user
+#          interface elements.
 # name - the name of the property
 # desc - the description of the property
 # value - value for elements; -1 (vulnerability), 1 (resistance) or 3 (immunity)
@@ -50,11 +61,13 @@ desc:You can sense ore in the walls.
 
 type:player
 code:FAST_SHOT
+bindui:shots_ui_compact_0:0:special
 name:Extra Shots
 desc:Your shooting speed improves with tension bows every 10 levels.
 
 type:player
 code:BRAVERY_30
+bindui:pfear_ui_compact_0:0:special
 name:Relentless [30]
 desc:You become immune to fear at level 30.
 
@@ -90,6 +103,7 @@ desc:You are extra persuasive to monsters.
 
 type:player
 code:UNLIGHT
+bindui:resist_ui_compact_0<DARK>:0:1
 name:Unlight
 desc:You gain stealth in, can see in, and resist the dark.
 
@@ -105,11 +119,13 @@ desc:You can bash monsters with a shield in melee.
 
 type:player
 code:EVIL
+bindui:resist_ui_compact_0<NETHER>:0:1
 name:Evil
 desc:You resist nether, but are hurt by holy attacks.
 
 type:player
 code:COMBAT_REGEN
+bindui:imphp_ui_compact_0:0:1
 name:Combat Regeneration
 desc:You draw power from the thrill of combat. This power is represented by
 desc: Spell Points (SP). You gain SP in combat when damaged by a monster or
@@ -124,81 +140,97 @@ desc: the character is, the bigger these HP gains will be.
 
 type:object
 code:SUST_STR
+bindui:stat_mod_ui_compact_0<STR>:1:1
 name:Sustain Strength
 desc:Your strength is sustained.
 
 type:object
 code:SUST_INT
+bindui:stat_mod_ui_compact_0<INT>:1:1
 name:Sustain Intelligence
 desc:Your intelligence is sustained.
 
 type:object
 code:SUST_WIS
+bindui:stat_mod_ui_compact_0<WIS>:1:1
 name:Sustain Wisdom
 desc:Your wisdom is sustained.
 
 type:object
 code:SUST_DEX
+bindui:stat_mod_ui_compact_0<DEX>:1:1
 name:Sustain Dexterity
 desc:Your dexterity is sustained.
 
 type:object
 code:SUST_CON
+bindui:stat_mod_ui_compact_0<CON>:1:1
 name:Sustain Constitution
 desc:Your constitution is sustained.
 
 type:object
 code:PROT_FEAR
+bindui:pfear_ui_compact_0:0:1
 name:Fear Immunity
 desc:You are immune to fear.
 
 type:object
 code:PROT_BLIND
+bindui:pblind_ui_compact_0:0:1
 name:Blindness Immunity
 desc:You cannot be blinded.
 
 type:object
 code:PROT_CONF
+bindui:pconf_ui_compact_0:0:1
 name:Confusion Immunity
 desc:You cannot be confused.
 
 type:object
 code:PROT_STUN
+bindui:pstun_ui_compact_0:0:1
 name:Stun Immunity
 desc:You cannot be stunned.
 
 type:object
 code:SLOW_DIGEST
+bindui:slow_digestion_ui_compact_0:0:1
 name:Slow Digestion
 desc:You have slow metabolism.
 
 type:object
 code:FEATHER
+bindui:feather_falling_ui_compact_0:0:1
 name:Feather Falling
 desc:You fall lightly.
 
 type:object
 code:REGEN
+bindui:regen_ui_compact_0:0:1
 name:Regeneration
 desc:You regenerate quickly.
 
 type:object
 code:TELEPATHY
+bindui:esp_ui_compact_0:0:1
 name:Telepathy
 desc:You have telepathy.
 
 type:object
 code:SEE_INVIS
+bindui:see_invis_ui_compact_0:0:1
 name:See Invisible
 desc:You can see invisible creatures.
 
 type:object
 code:FREE_ACT
+bindui:free_action_ui_compact_0:0:1
 name:Free Action
 desc:You are immune to paralysis.
 
 type:object
 code:HOLD_LIFE
+bindui:holdlife_ui_compact_0:0:1
 name:Hold Life
 desc:Your life force is sustained.
 
@@ -209,52 +241,62 @@ desc:You sometimes create earthquakes on impact.
 
 type:object
 code:IMPAIR_HP
+bindui:imphp_ui_compact_0:0:1
 name:Slow Regeneration
 desc:Your hitpoint recovery is impaired.
 
 type:object
 code:IMPAIR_MANA
+bindui:impsp_ui_compact_0:0:1
 name:Slow Mana Regeneration
 desc:Your mana recovery is impaired.
 
 type:object
 code:AFRAID
+bindui:fear_ui_compact_0:0:1
 name:Constant Fear
 desc:You are afraid of melee, and bad at shooting and casting spells.
 
 type:object
 code:NO_TELEPORT
+bindui: noteleport_ui_compact_0:0:1
 name:Teleport Ban
 desc:You cannot teleport.
 
 type:object
 code:AGGRAVATE
+bindui:aggravate_ui_compact_0:0:1
 name:Aggravate
 desc:You aggravate creatures nearby.
 
 type:object
 code:DRAIN_EXP
+bindui:drainxp_ui_compact_0:0:1
 name:Experience Drain
 desc:Your experience constantly drains away.
 
 type:object
 code:TRAP_IMMUNE
+bindui:trap_immunity_ui_compact_0:0:1
 name:Trap Immune
 desc:You are immune to traps.
 
 ## Element flags
 
 type:element
+bindui:resist_ui_compact_0:0:1
 name:Resistance
 desc:You resist
 value:1
 
 type:element
+bindui:resist_ui_compact_0:0:3
 name:Immunity
 desc:You are immune to
 value:3
 
 type:element
+bindui:resist_ui_compact_0:0:-1
 name:Vulnerability
 desc:You are vulnerable to
 value:-1

--- a/lib/gamedata/ui_entry.txt
+++ b/lib/gamedata/ui_entry.txt
@@ -15,11 +15,12 @@
 # element in list-elements.h) and "stat" (which will generate one entry for
 # each stat in list-stats.h).  The name of each entry will be the name
 # set followed by the name of the element or stat (for instance <ACID> or
-# <STR>).  The entries created from a generic one can be specialized later to
-# override fields.  Note that when a parameter is set, the undecorated name is
-# not entered into the list of user interface elements and can not be
-# successfully referenced from bindui in other files or template fields in
-# this one.
+# <STR>).  The label, if not set, of each entry will be the name of the
+# element or stat (for instance ACID or STR).  The entries created from a
+# generic one can be specialized later to override fields.  Note that when a
+# parameter is set, the undecorated name is not entered into the list of user
+# interface elements and can not be successfully referenced from bindui in
+# other files or template fields in this one.
 # The template field specifies that entry with that name be used as the
 # default values for the fields in this entry.  The template field is optional.
 # The renderer must be one of those set in ui_entry_renderer.txt.

--- a/lib/gamedata/ui_entry.txt
+++ b/lib/gamedata/ui_entry.txt
@@ -1,0 +1,348 @@
+# File: ui_entry.txt
+
+# Configure user interface elements to combine one or more object or player
+# properties and display them.  Currently only used for parts of the second
+# character screen.
+
+# Descriptions can be edited without bad effects.
+# The name is used to link the element from bindui fields in
+# player_property.txt and object_property.txt and the template fields in this
+# file.  Changing it will mean having to adjust those files to keep things
+# linked.
+# The parameter field, if set, means that this is a generic entry that will
+# be repeated for each known value of the parameter.  The only currently
+# understood parameters are "element" (which will generate one entry for each
+# element in list-elements.h) and "stat" (which will generate one entry for
+# each stat in list-stats.h).  The name of each entry will be the name
+# set followed by the name of the element or stat (for instance <ACID> or
+# <STR>).  The entries created from a generic one can be specialized later to
+# override fields.  Note that when a parameter is set, the undecorated name is
+# not entered into the list of user interface elements and can not be
+# successfully referenced from bindui in other files or template fields in
+# this one.
+# The template field specifies that entry with that name be used as the
+# default values for the fields in this entry.  The template field is optional.
+# The renderer must be one of those set in ui_entry_renderer.txt.
+# The label defines a label to be shown for the element.  Changing its value
+# can impact usability.  Optionally, shortened versions with
+# label followed by the number of characters as the field name can be
+# provided to override the default of using the first n characters of label
+# when an abbreviated version is needed.  The second character screen currently
+# uses 5 character labels so only label or label5 are relevant.
+# combine controls how the values of the properties linked to the element are
+# combined before display.  Possible values are limited by the code and must
+# be one of ADD, BITWISE_OR, FIRST, LOGICAL_OR, LARGEST, LAST, RESIST_0, or
+# SMALLEST.  RESIST_0 will use the largest positive value, if any are
+# positive.  If none are positive, it will use the most negative value.
+# Otherwise it will use zero.
+# The category and priority fields can be set multiple times.  The
+# categories are used to select if an entry appears in a screen.   If you want
+# an entry to be included in the second character screen, one of the categories
+# given must be CHAR_SCREEN1.
+# The value given for a priority must be a decimal integer or, for a generic
+# entry, of the special values "index" or "negative_index".  Otherwise, the
+# priority will be ignored.  The priority hints at what element to display
+# first (higher priority means shown first) and which elements to omit or
+# move to a different page if space is tight (lower priority means
+# omitted/moved first).  If a priority is set before any category, that is
+# used as the default priority for all categories.  Otherwise, the priority
+# is applied to the last category set.
+# The flags field is optional and sets one or more flags, separated by spaces
+# or |, to modify the interface element's behavior.  Only one flag is
+# currently used, TIMED_AS_AUX, which will map timed effects for the properties
+# bound to the element to the auxiliary values passed to the renderer.  When
+# that flag is used, any properties bound to the element as auxiliary values
+# will be ignored.
+
+name:stat_mod_ui_compact_0
+parameter:stat
+renderer:char_screen1_stat_mod_renderer
+combine:ADD
+priority:negative_index
+category:stat_modifiers
+category:CHAR_SCREEN1
+desc:Generic UI entry for compact display of modifier and sustain information
+desc: for one of the core statistics.  Given that this is linked to other
+desc: entries that are hardcoded, the priority should be negative_index and
+desc: this should be the only thing with stat_modifiers and CHAR_SCREEN1 as
+desc: categories.
+
+name:resist_ui_compact_0
+parameter:element
+renderer:char_screen1_resist_renderer
+combine:RESIST_0
+priority:negative_index
+category:resistances
+flags:TIMED_AS_AUX
+desc:Generic UI entry for compact display of a resistance flag with the
+desc: label colored by the combined resistance across several sources.
+desc:  It is used for rows in the second character screen's display of
+desc: resistances.  Specializations below set the label and categories for
+desc: particular screens.
+
+# Specializations for resist_ui_compact_0 to give labels and link to second
+# character screen.  There's no specializations for WATER, ICE, GRAVITY,
+# INERTIA, FORCE, or TIME since they are not shown on that panel.
+name:resist_ui_compact_0<ACID>
+label:Acid
+category:CHAR_SCREEN1
+
+name:resist_ui_compact_0<ELEC>
+label:Elec
+category:CHAR_SCREEN1
+
+name:resist_ui_compact_0<FIRE>
+label:Fire
+category:CHAR_SCREEN1
+
+name:resist_ui_compact_0<COLD>
+label:Cold
+category:CHAR_SCREEN1
+
+name:resist_ui_compact_0<POIS>
+label:Poison
+label5:Pois
+category:CHAR_SCREEN1
+
+name:resist_ui_compact_0<LIGHT>
+label:Light
+category:CHAR_SCREEN1
+
+name:resist_ui_compact_0<DARK>
+label:Dark
+category:CHAR_SCREEN1
+
+name:resist_ui_compact_0<SOUND>
+label:Sound
+category:CHAR_SCREEN1
+
+name:resist_ui_compact_0<SHARD>
+label:Shard
+category:CHAR_SCREEN1
+
+name:resist_ui_compact_0<NEXUS>
+label:Nexus
+category:CHAR_SCREEN1
+
+name:resist_ui_compact_0<NETHER>
+label:Nether
+label5:Nethr
+category:CHAR_SCREEN1
+
+name:resist_ui_compact_0<CHAOS>
+label:Chaos
+category:CHAR_SCREEN1
+
+name:resist_ui_compact_0<DISEN>
+label:Disenchant
+category:CHAR_SCREEN1
+
+# The following use good_flag_ui_compact_0 from ui_entry_base.txt.
+
+name:pfear_ui_compact_0
+template:good_flag_ui_compact_0
+label:Fear resistance
+label5:pFear
+label2:pF
+priority:0
+
+name:pblind_ui_compact_0
+template:good_flag_ui_compact_0
+label:Blindess resistance
+label5:pBlnd
+label2:pB
+priority:-1
+
+name:pconf_ui_compact_0
+template:good_flag_ui_compact_0
+label:Confusion resistance
+label5:pConf
+label2:pC
+priority:-2
+
+name:pstun_ui_compact_0
+template:good_flag_ui_compact_0
+label:Stun resistance
+label5:pStun
+label2:pS
+priority:-3
+
+name:holdlife_ui_compact_0
+template:good_flag_ui_compact_0
+label:Hold life
+label5:HLife
+label2:HL
+priority:-4
+
+name:regen_ui_compact_0
+template:good_flag_ui_compact_0
+label:Regeneration
+priority:-5
+
+name:esp_ui_compact_0
+template:good_flag_ui_compact_0
+label:ESP
+priority:-6
+
+name:see_invis_ui_compact_0
+template:good_flag_ui_compact_0
+label:See invisible
+label5:S.Inv
+label2:SI
+priority:-7
+
+name:free_action_ui_compact_0
+template:good_flag_ui_compact_0
+label:Free action
+label5:FrAct
+label2:FA
+priority:-8
+
+name:feather_falling_ui_compact_0
+template:good_flag_ui_compact_0
+label:Feather falling
+label5:Feath
+label2:Ft
+priority:-9
+
+name:slow_digestion_ui_compact_0
+template:good_flag_ui_compact_0
+label:Slow digestion
+label5:S.Dig
+label2:SD
+priority:-10
+
+name:trap_immunity_ui_compact_0
+template:good_flag_ui_compact_0
+label:Trap immunity
+label5:TrpIm
+label2:TI
+priority:-11
+
+name:bless_ui_compact_0
+template:good_flag_ui_compact_0
+label:Bless
+priority:-12
+
+# The following use other_flag_ui_compact_0 from ui_entry_base.txt.
+
+name:imphp_ui_compact_0
+template:other_flag_ui_compact_0
+label:Impaired HP recovery
+label5:ImpHP
+label2:IH
+priority:0
+
+name:impsp_ui_compact_0
+template:other_flag_ui_compact_0
+label:Impaired mana recovery
+label5:ImpSP
+label2:IS
+priority:-1
+
+name:fear_ui_compact_0
+template:other_flag_ui_compact_0
+label:Fear
+priority:-2
+
+name:aggravate_ui_compact_0
+template:other_flag_ui_compact_0
+label:Aggravate
+label5:Aggrv
+priority:-3
+
+name:noteleport_ui_compact_0
+template:other_flag_ui_compact_0
+label:No teleportation
+label5:NoTel
+label2:NT
+priority:-4
+
+name:drainxp_ui_compact_0
+template:other_flag_ui_compact_0
+label:Drain experience
+label5:DrExp
+label2:DE
+priority:-5
+
+name:sticky_ui_compact_0
+template:other_flag_ui_compact_0
+label:Sticky curse
+label5:Stick
+priority:-6
+
+name:fragile_ui_compact_0
+template:other_flag_ui_compact_0
+label:Fragile
+label5:Fragl
+priority:-7
+
+# The following use numeric_as_sign_ui_0 from ui_entry_base.txt.
+
+name:stealth_ui_compact_0
+template:numeric_as_sign_ui_0
+label:Stealth
+label5:Stea.
+priority:0
+
+name:search_ui_compact_0
+template:numeric_as_sign_ui_0
+label:Search
+label5:Sear.
+priority:-1
+
+name:infravision_ui_compact_0
+template:numeric_as_sign_ui_0
+label:Infravision
+priority:-2
+
+name:tunneling_ui_compact_0
+template:numeric_as_sign_ui_0
+label:Tunneling
+label5:Tunn.
+priority:-3
+
+name:speed_ui_compact_0
+template:numeric_as_sign_ui_0
+label:Speed
+priority:-4
+
+name:blows_ui_compact_0
+template:numeric_as_sign_ui_0
+label:Attack speed
+label5:Blows
+label2:Bl
+priority:-5
+
+name:shots_ui_compact_0
+template:numeric_as_sign_ui_0
+label:Shooting speed
+label5:Shots
+label2:Sh
+priority:-6
+
+name:shooting_power_ui_compact_0
+template:numeric_as_sign_ui_0
+label:Shooting power
+label5:Might
+label2:Mi
+priority:-7
+
+name:light_ui_compact_0
+template:numeric_as_sign_ui_0
+label:Light
+priority:-8
+
+name:damage_reduction_ui_compact_0
+template:numeric_as_sign_ui_0
+label:Damage reduction
+label5:D.Red
+label2:DR
+priority:-9
+
+name:movement_speed_ui_compact_0
+template:numeric_as_sign_ui_0
+label:Movement speed
+label5:Moves
+label2:MS
+priority:-10

--- a/lib/gamedata/ui_entry_base.txt
+++ b/lib/gamedata/ui_entry_base.txt
@@ -1,0 +1,36 @@
+# File: ui_entry_base.txt
+
+# Provide templates for ui_entry.txt.
+# Fields are the same as in ui_entry.txt but stuff configured here does not
+# appear directly in the user interface - has to have something in ui_entry.txt
+# that pulls it in as a template.
+
+name:good_flag_ui_compact_0
+renderer:char_screen1_flag_renderer
+combine:LOGICAL_OR
+category:CHAR_SCREEN1
+category:abilities
+flags:TIMED_AS_AUX
+desc:Template for one of the positive flags shown on the second character
+desc: screen.  Each occupies a row and has the label colored by the combination
+desc: of the flags across several sources.
+
+name:other_flag_ui_compact_0
+renderer:char_screen1_flag_renderer
+combine:LOGICAL_OR
+category:CHAR_SCREEN1
+category:hindrances
+flags:TIMED_AS_AUX
+desc:Template for one of the other flags shown on the second character
+desc: screen.  Each occupies a row and has the label colored by the combination
+desc: of the flags across several sources.
+
+name:numeric_as_sign_ui_0
+renderer:char_screen1_numeric_as_sign_renderer
+combine:ADD
+category:CHAR_SCREEN1
+category:modifiers
+flags:TIMED_AS_AUX
+desc:Template for one of the auxiliary statistics shown on the second
+desc: character screen.  Each occupies a row and has the label colored by
+desc: combination of the flags across several sources.

--- a/lib/gamedata/ui_entry_renderer.txt
+++ b/lib/gamedata/ui_entry_renderer.txt
@@ -1,0 +1,188 @@
+# File: ui_entry_renderer.txt
+
+# Configure how a quantity is rendered in the user interface.  Currently only
+# used for the parts of the second character screen.
+
+# The name is used to link the renderer with a user interface element in
+# ui_entry.txt so changes here would have to be mirrored there to keep the
+# link.
+# code binds the renderer to a specific backend in the executable.  It must
+# be one of the values listed in list-ui-entry-renderers.h.
+# colors and labelcolors configure the palette of colors used for either the
+# value or the label.  How indices into the palette are used depends on the
+# backend the renderer is bound to.  Changes to colors and labelcolors can
+# affect usability.  Both are optional; if not set, default values from the
+# backend are used.
+# symbols defines the palette of symbols the renderer uses if it converts
+# values to symbols (some of the rendering functions won't use the symbols
+# field).  How indices into the palette are used depends on the backend the
+# renderer is bound to.  Changes to symbols can affect usability.  It is
+# optional.  If not set, defaults values from the backend are used.
+# ndigit is the number of digits to display for a numeric value.  That is
+# only used by some renders and does not need to be set.  If set it must be a
+# positive integer.  If not set, the default value from the backend will be
+# used.
+# sign configures whether a sign indicator is shown with numeric values.  That
+# is only used by some renderers and does not need to be set.  If set, it
+# must be one of the following:  NO_SIGN, ALWAYS_SIGN, or NEGATIVE_SIGN.
+# NO_SIGN specifies that no sign indicator will be shown.  ALWAYS_SIGN
+# specifies that a sign indicator will always be shown (+ will be used for
+# zeros).  NEGATIVE_SIGN specifies that a sign indicator will only be shown
+# for negative values.  If not set, the default value from the backend will be
+# used.
+# units configures whether a label is shown immediately after numeric values.
+# This is only used by some renderers and does not need to be set.  By default,
+# numeric values will not be labeled with units.
+
+# COMPACT_RESIST_RENDERER_WITH_COMBINED_AUX renders one or more resistance
+# values with the label colored by the combined resistance.  The auxiliary
+# values are treated as timed resistances.  One of nine symbols (unknown,
+# not present, none, resist, vulnerable, immune, timed resist, timed
+# vulnerability, timed immunity) are used for each resistance value.  The
+# symbols for the timed effects are only used if the permanent effect is known
+# and is none.  Each of those symbols has a corresponding color (from the
+# first 9 colors) and alternate color (from the second 9 colors).  The
+# alternate color is used for every other resist.  A palette of 8 colors is
+# used for the label.  They are:
+# unknown rune
+# no permanent resistance or immunity and no timed effects
+# at least one permanent resistance and no permanent immunity
+# at least one permanent immunity
+# at least one permanent vulnerability and no permanent resistance or immunity
+# no permanent effects or timed immunity and at least one timed resistance
+# no permanent effects, timed resistance, or timed immunity and at least one
+#     timed vulnerability
+# no permanent effects and at last one timed immunity
+
+# COMPACT_FLAG_RENDERER_WITH_COMBINED_AUX renders one or more boolean flags
+# with the label colored by the combined (logical or) value.  The auxiliary
+# values are treated as timed effects.  One of five symbols (unknown, not
+# present, off, on, timed on) is used for each flag.  The symbol for the
+# timed effect is only used if the permanant effect is known and is off.  Each
+# of three symbols has a corresponding color (from the first five colors) and
+# alternate color (from the second five colors).  The alternate color is used
+# for every other flag.  A palette of four colors is used for the label.  They
+# are unknown rune, no flags are known to be on and there is no timed effect,
+# at least one flag is on, and no flags are known to be on but there is at
+# least one timed effect.
+
+# NUMERIC_AS_SIGN_RENDERER_WITH_COMBINED_AUX renders one or more integer
+# modifiers with the label colored by the combined (by addition) value.  The
+# auxiliary values are treated as timed effects.  One of seven symbols
+# (unknown, not present, zero, positive, negative, timed positive, timed
+# negative) is used for each modifier.  The symbols for the timed effects are
+# only used if the permanent effect is known and is zero.  Each of the symbols
+# has a corresponding color (from the first seven colors) and alternate color
+# (from the second seven colors).  The alternate color is used for every other
+# modifier.  A palette of six colors is used for the label.  They are:
+# unknown rune
+# the sum of the known effects is zero and the sum of the timed effects is zero
+# the sum of the known effects is positive
+# the sum of the known effects is negative
+# the sum of the known effects is zero; the sum of the timed effects is
+#     positive
+# the sum of the known effects is zero; the sum of the timed effects is
+#     negative
+
+# NUMERIC_RENDERER_WITH_COMBINED_AUX renders one or more integer values
+# as decimal integers with the label colored by the combined value.  The
+# auxiliary values are treated as timed effects.  One of seven colors (unknown,
+# not present, zero, positive, negative, timed positive, timed negative) or an
+# alternate set of seven colors for those same conditions is used for each
+# modifer.  The alternate colors are used for every other value.  The colors
+# for the timed effects are only used if the permanent effect is known and is
+# zero.  There are seven symbols that may be used.  The first symbol is used
+# in place of digits when the value is unknown.  The second symbol is used in
+# place of digts when the value is not present.  The third symbol is used when
+# both the value and the auxiliary value are zero.  If it is '0', then it may
+# be shown with a sign, depending on the the setting for the sign indicator
+# described below.  The fourth symbol is used in place of digits when the
+# known permanent effect is positive and the value is too large to display with
+# the given number of digits.  The fifth symbol is used in place of digits when
+# the known permanent effect is negative and the value is too large to display
+# with the given number of digits.  The sixth symbol is used in place of digits
+# when the known permanent effect is zero and the timed effect is positive but
+# too large to display with the given number of digits.  The seventh symbol is
+# used in place of digits when the known permanent effect is zero and the
+# timed effect is negative but too large to display with the given number of
+# digits.  A palette of six colors is used for the label.  They are:
+# unknown rune
+# the sum of the known effects is zero and the sum of the timed effects is zero
+# the sum of the known effects is positive
+# the sum of the known effects is negative
+# the sum of the known effects is zero; the sum of the timed effects is
+#     positive
+# the sum of the known effects is zero; the sum of the timed effects is
+#     negative
+#
+# The number of digits is used to configure the number of digits shown for
+# each value.  The default value for the number of digits is one.  The sign
+# display is used to configure whether the digits are shown with a sign
+# indicator.  By default, a sign indicator will not be shown.  By default, a
+# sign indicator will not be shown.  The units label configures whether that
+# label is shown after each numeric value.  By default, no such label is shown.
+
+# NUMERIC_RENDERER_WITH_BOOL_AUX renders one or more integer values
+# as decimal integers with the label colored by the combined value.  The
+# auxiliary values are treated as booleans (one use would be for sustains).
+# One of eight colors (unknown, not present, zero with the auxilary flag off,
+# zero with the auxiliary flag on, positive with the auxiliary flag off,
+# positive with the auxiliary flag on, negative with the auxiliary flag off,
+# negative with the auxiliary flag on) or an alternate set of eight colors for
+# those same conditions is used for each modifier.  The alternate colors are
+# used for every other value.  There are six symbols that may be used.  The
+# first symbol is used in place of digits when the value is unknown.  The
+# second symbol is used in place of digits when the value is not present.  The
+# third symbol is used when the value is zero and the auxiliary flag is off.
+# If it is '0', then it may be shown with a sign, depending on the the setting
+# for the sign indicator described below.  The fourth symbol is used when the
+# value is zero and auxiliary flag is on.  If it is '0', then it may be shown
+# with a sign, depending on the the setting for the sign indicator described
+# below.  The fifth symbol is used in place of digits when the value is
+# positive and too large to display with the given number of digits.  The
+# sixth symbol is used in place of digits when the value is negative and too
+# large to display with the given number of digits.  A palette of seven colors
+# is used for the label.  They are:
+# unknown rune
+# the sum of the known values is zero and none of the auxiliary flags are on
+# the sum of the known values is zero and at least one auxiliary flag is on
+# the sum of the known values is positive and none of the auxiliary flags is on
+# the sum of the known values is positive and at least one auxiliary flag is on
+# the sum of the known values is negative and none of the auxiliary flags is on
+# the sum of the known values is positive and at least one auxiliary flag is on
+#
+# The number of digits is used to configure the number of digits shown for
+# each value.  The default value for the number of digits is one.  The sign
+# display is used to configure whether the digits are shown with a sign
+# indicator.  By default, a sign indicator will not be shown.  The units label
+# configures whether that label is shown after each numeric value.  By default,
+# no such label is shown.
+
+name:char_screen1_resist_renderer
+code:COMPACT_RESIST_RENDERER_WITH_COMBINED_AUX
+colors:wwwwwwGwGWWWWWWGWG
+labelcolors:swBrgwww
+symbols:?..+-*!.!
+
+name:char_screen1_flag_renderer
+code:COMPACT_FLAG_RENDERER_WITH_COMBINED_AUX
+colors:wwwwGWWWWG
+labelcolors:swBw
+symbols:?..+!
+
+name:char_screen1_numeric_as_sign_renderer
+code:NUMERIC_AS_SIGN_RENDERER_WITH_COMBINED_AUX
+colors:wwwwwGwWWWWWGW
+labelcolors:swBrww
+symbols:?..+-!=
+
+# Currently, labelcolors has no impact on what's shown in the character screen
+# and what uses this internally expects ndigit to be one, sign to be NO_SIGN,
+# and nothing to be set for units.
+name:char_screen1_stat_mod_renderer
+code:NUMERIC_RENDERER_WITH_BOOL_AUX
+colors:sdsgGgrRwdsgGgrR
+labelcolors:wwwwwww
+symbols:? .s*=
+ndigit:1
+sign:NO_SIGN

--- a/src/Makefile.src
+++ b/src/Makefile.src
@@ -174,6 +174,8 @@ ANGFILES = \
 	ui-curse.o \
 	ui-death.o \
 	ui-display.o \
+	ui-entry.o \
+	ui-entry-renderers.o \
 	ui-event.o \
 	ui-game.o \
 	ui-help.o \

--- a/src/list-ui-entry-renderers.h
+++ b/src/list-ui-entry-renderers.h
@@ -1,0 +1,17 @@
+/**
+ * \file list-ui-entry-renderers.h
+ * \brief List of ways to render combinations of object or player properties.
+ *
+ * Additions here will have to have corresponding changes to
+ * ui-entry-renderers.c.  Changes only impact how the second character screen
+ * is drawn.  There's fuller descriptions of these renderers in
+ * ui_entry_renderer.txt.
+ */
+
+/* symbol, default colors, default label colors, default symbols,
+   default number of digits, sign indicator handling */
+UI_ENTRY_RENDERER(COMPACT_RESIST_RENDERER_WITH_COMBINED_AUX, "wwwwwwGGGWWWWWWGGG", "swBrgwww", "?..+-*!=%", 0, NO_SIGN)
+UI_ENTRY_RENDERER(COMPACT_FLAG_RENDERER_WITH_COMBINED_AUX, "wwwwGWWWWG", "swBw", "?..+!", 0, NO_SIGN)
+UI_ENTRY_RENDERER(NUMERIC_AS_SIGN_RENDERER_WITH_COMBINED_AUX, "wwwwwGGWWWWWGG", "swBrww", "?..+-!=", 0, NO_SIGN)
+UI_ENTRY_RENDERER(NUMERIC_RENDERER_WITH_COMBINED_AUX, "wwwBrbowwwBrbo", "swBrww", "?00****", 1, NO_SIGN)
+UI_ENTRY_RENDERER(NUMERIC_RENDERER_WITH_BOOL_AUX, "wdsgGgrRwdsgGgrR", "wwwwwww", "? .s*=", 1, NO_SIGN)

--- a/src/obj-init.c
+++ b/src/obj-init.c
@@ -43,6 +43,7 @@
 #include "option.h"
 #include "player-spell.h"
 #include "project.h"
+#include "ui-entry.h"
 
 static const char *mon_race_flags[] =
 {
@@ -3081,6 +3082,23 @@ static enum parser_error parse_object_property_desc(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
+static enum parser_error parse_object_property_bindui(struct parser* p) {
+	struct obj_property *prop = parser_priv(p);
+	const char *uiname = parser_getsym(p, "ui");
+	bool isaux = (parser_getint(p, "aux") != 0);
+	bool have_val = parser_hasval(p, "uival");
+	int val = (have_val) ? parser_getint(p, "uival") : 0;
+
+	if (!prop)
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	if (prop->type == OBJ_PROPERTY_NONE) {
+		return PARSE_ERROR_INVALID_PROPERTY;
+	}
+	(void) bind_object_property_to_ui_entry_by_name(uiname, prop->type,
+		prop->index, val, have_val, isaux);
+	return PARSE_ERROR_NONE;
+}
+
 struct parser *init_parse_object_property(void) {
 	struct parser *p = parser_new();
 	parser_setpriv(p, NULL);
@@ -3096,6 +3114,7 @@ struct parser *init_parse_object_property(void) {
 	parser_reg(p, "neg-adjective str neg_adj", parse_object_property_neg_adj);
 	parser_reg(p, "msg str msg", parse_object_property_msg);
 	parser_reg(p, "desc str desc", parse_object_property_desc);
+	parser_reg(p, "bindui sym ui int aux ?int uival", parse_object_property_bindui);
 	return p;
 }
 

--- a/src/player-calcs.c
+++ b/src/player-calcs.c
@@ -2033,6 +2033,8 @@ void calc_bonuses(struct player *p, struct player_state *state, bool known_only,
 	}
 
 	/* Other timed effects */
+	player_flags_timed(p, state->flags);
+
 	if (player_timed_grade_eq(p, TMD_STUN, "Heavy Stun")) {
 		state->to_h -= 20;
 		state->to_d -= 20;
@@ -2063,16 +2065,11 @@ void calc_bonuses(struct player *p, struct player_state *state, bool known_only,
 		state->to_a += 40;
 		state->speed -= 5;
 	}
-	if (p->timed[TMD_BOLD]) {
-		of_on(state->flags, OF_PROT_FEAR);
-	}
 	if (p->timed[TMD_HERO]) {
-		of_on(state->flags, OF_PROT_FEAR);
 		state->to_h += 12;
 		state->skills[SKILL_DEVICE] = state->skills[SKILL_DEVICE] * 105 / 100;
 	}
 	if (p->timed[TMD_SHERO]) {
-		of_on(state->flags, OF_PROT_FEAR);
 		state->skills[SKILL_TO_HIT_MELEE] += 75;
 		state->to_a -= 10;
 		state->skills[SKILL_DEVICE] = state->skills[SKILL_DEVICE] * 9 / 10;
@@ -2085,18 +2082,6 @@ void calc_bonuses(struct player *p, struct player_state *state, bool known_only,
 	}
 	if (p->timed[TMD_SINFRA]) {
 		state->see_infra += 5;
-	}
-	if (p->timed[TMD_TELEPATHY]) {
-		of_on(state->flags, OF_TELEPATHY);
-	}
-	if (p->timed[TMD_SINVIS]) {
-		of_on(state->flags, OF_SEE_INVIS);
-	}
-	if (p->timed[TMD_FREE_ACT]) {
-		of_on(state->flags, OF_FREE_ACT);
-	}
-	if (p->timed[TMD_AFRAID] || p->timed[TMD_TERROR]) {
-		of_on(state->flags, OF_AFRAID);
 	}
 	if (p->timed[TMD_TERROR]) {
 		state->speed += 10;
@@ -2115,9 +2100,6 @@ void calc_bonuses(struct player *p, struct player_state *state, bool known_only,
 	}
 	if (p->timed[TMD_OPP_POIS] && (state->el_info[ELEM_POIS].res_level < 2)) {
 			state->el_info[ELEM_POIS].res_level++;
-	}
-	if (p->timed[TMD_OPP_CONF]) {
-		of_on(state->flags, OF_PROT_CONF);
 	}
 	if (p->timed[TMD_CONFUSED]) {
 		state->skills[SKILL_DEVICE] = state->skills[SKILL_DEVICE] * 75 / 100;

--- a/src/player.c
+++ b/src/player.c
@@ -299,6 +299,32 @@ void player_flags(struct player *p, bitflag f[OF_SIZE])
 }
 
 
+/**
+ * Combine any flags due to timed effects on the player into those in f.
+ */
+void player_flags_timed(struct player *p, bitflag f[OF_SIZE])
+{
+	if (p->timed[TMD_BOLD] || p->timed[TMD_HERO] || p->timed[TMD_SHERO]) {
+		of_on(f, OF_PROT_FEAR);
+	}
+	if (p->timed[TMD_TELEPATHY]) {
+		of_on(f, OF_TELEPATHY);
+	}
+	if (p->timed[TMD_SINVIS]) {
+		of_on(f, OF_SEE_INVIS);
+	}
+	if (p->timed[TMD_FREE_ACT]) {
+		of_on(f, OF_FREE_ACT);
+	}
+	if (p->timed[TMD_AFRAID] || p->timed[TMD_TERROR]) {
+		of_on(f, OF_AFRAID);
+	}
+	if (p->timed[TMD_OPP_CONF]) {
+		of_on(f, OF_PROT_CONF);
+	}
+}
+
+
 byte player_hp_attr(struct player *p)
 {
 	byte attr;

--- a/src/player.h
+++ b/src/player.h
@@ -619,6 +619,7 @@ bool player_stat_dec(struct player *p, int stat, bool permanent);
 void player_exp_gain(struct player *p, s32b amount);
 void player_exp_lose(struct player *p, s32b amount, bool permanent);
 void player_flags(struct player *p, bitflag f[OF_SIZE]);
+void player_flags_timed(struct player *p, bitflag f[OF_SIZE]);
 byte player_hp_attr(struct player *p);
 byte player_sp_attr(struct player *p);
 bool player_restore_mana(struct player *p, int amt);

--- a/src/ui-entry-init.h
+++ b/src/ui-entry-init.h
@@ -1,0 +1,26 @@
+/**
+ * \file ui-entry-init.h
+ * \brief
+ *
+ * This work is free software; you can redistribute it and/or modify it
+ * under the terms of either:
+ *
+ * a) the GNU General Public License as published by the Free Software
+ *    Foundation, version 2, or
+ *
+ * b) the "Angband licence":
+ *    This software may be copied and distributed for educational, research,
+ *    and not for profit purposes provided that this copyright and statement
+ *    are included in all such copies.  Other copyrights may also apply.
+ */
+#ifndef INCLUDED_UI_ENTRY_INIT_H
+#define INCLUDED_UI_ENTRY_INIT_H
+
+#include "datafile.h"
+
+/* From ui-entry.c */
+extern struct file_parser ui_entry_parser;
+/* From ui-entry-renderers.c */
+extern struct file_parser ui_entry_renderer_parser;
+
+#endif /* INCLUDED_UI_ENTRY_INIT_H */

--- a/src/ui-entry-renderers.c
+++ b/src/ui-entry-renderers.c
@@ -41,7 +41,7 @@ typedef void (*renderer_func)(
 	const int *auxvals,
 	int n,
 	const struct ui_entry_details *details,
-	const struct renderer_info* info);
+	const struct renderer_info *info);
 typedef int (*valuewidth_func)(const struct renderer_info *info);
 
 static void format_int(int i, bool add_one, wchar_t zero, wchar_t overflow,
@@ -55,7 +55,7 @@ static void renderer_COMPACT_RESIST_RENDERER_WITH_COMBINED_AUX(
 	const int *auxvals,
 	int n,
 	const struct ui_entry_details *details,
-	const struct renderer_info* info);
+	const struct renderer_info *info);
 static int valuewidth_COMPACT_RESIST_RENDERER_WITH_COMBINED_AUX(
 	const struct renderer_info *info);
 static void renderer_COMPACT_FLAG_RENDERER_WITH_COMBINED_AUX(
@@ -65,7 +65,7 @@ static void renderer_COMPACT_FLAG_RENDERER_WITH_COMBINED_AUX(
 	const int *auxvals,
 	int n,
 	const struct ui_entry_details *details,
-	const struct renderer_info* info
+	const struct renderer_info *info
 );
 static int valuewidth_COMPACT_FLAG_RENDERER_WITH_COMBINED_AUX(
 	const struct renderer_info *info);
@@ -76,7 +76,7 @@ static void renderer_NUMERIC_AS_SIGN_RENDERER_WITH_COMBINED_AUX(
 	const int *auxvals,
 	int n,
 	const struct ui_entry_details *details,
-	const struct renderer_info* info);
+	const struct renderer_info *info);
 static int valuewidth_NUMERIC_AS_SIGN_RENDERER_WITH_COMBINED_AUX(
 	const struct renderer_info *info);
 static void renderer_NUMERIC_RENDERER_WITH_COMBINED_AUX(
@@ -86,7 +86,7 @@ static void renderer_NUMERIC_RENDERER_WITH_COMBINED_AUX(
 	const int *auxvals,
 	int n,
 	const struct ui_entry_details *details,
-	const struct renderer_info* info);
+	const struct renderer_info *info);
 static int valuewidth_NUMERIC_RENDERER_WITH_COMBINED_AUX(
 	const struct renderer_info *info);
 static void renderer_NUMERIC_RENDERER_WITH_BOOL_AUX(
@@ -96,7 +96,7 @@ static void renderer_NUMERIC_RENDERER_WITH_BOOL_AUX(
 	const int *auxvals,
 	int n,
 	const struct ui_entry_details *details,
-	const struct renderer_info* info);
+	const struct renderer_info *info);
 static int valuewidth_NUMERIC_RENDERER_WITH_BOOL_AUX(
 	const struct renderer_info *info);
 
@@ -237,7 +237,7 @@ int ui_entry_renderer_query_value_width(int ind)
  */
 void ui_entry_renderer_apply(int ind, const wchar_t *label, int nlabel,
 	const int *vals, const int *auxvals, int n,
-	const struct ui_entry_details* details)
+	const struct ui_entry_details *details)
 {
 	if (ind <= 0 || ind > renderer_count || !renderers[ind - 1].backend) {
 		return;
@@ -255,7 +255,7 @@ void ui_entry_renderer_apply(int ind, const wchar_t *label, int nlabel,
  * of the values to change.
  */
 int ui_entry_renderer_customize(int ind, const char *colors,
-	const char *label_colors, const char* symbols)
+	const char *label_colors, const char *symbols)
 {
 	size_t length;
 
@@ -300,7 +300,7 @@ int ui_entry_renderer_customize(int ind, const char *colors,
  * setting for the palette of colors.  That string should be released with
  * string_free().  Otherwise, returns NULL.
  */
-char* ui_entry_renderer_get_colors(int ind)
+char *ui_entry_renderer_get_colors(int ind)
 {
 	if (ind < 1 || ind > renderer_count) {
 		return NULL;
@@ -315,7 +315,7 @@ char* ui_entry_renderer_get_colors(int ind)
  * setting for the palette of label colors.  That string should be released
  * with string_free().  Otherwise, returns NULL.
  */
-char* ui_entry_renderer_get_label_colors(int ind)
+char *ui_entry_renderer_get_label_colors(int ind)
 {
 	if (ind < 1 || ind > renderer_count) {
 		return NULL;
@@ -330,7 +330,7 @@ char* ui_entry_renderer_get_label_colors(int ind)
  * setting for the palette of symbols.  That string should be released
  * with string_free().  Otherwise, returns NULL.
  */
-char* ui_entry_renderer_get_symbols(int ind)
+char *ui_entry_renderer_get_symbols(int ind)
 {
 	if (ind < 1 || ind > renderer_count) {
 		return NULL;
@@ -410,8 +410,8 @@ static void renderer_COMPACT_RESIST_RENDERER_WITH_COMBINED_AUX(
 	const int *vals,
 	const int *auxvals,
 	int n,
-	const struct ui_entry_details* details,
-	const struct renderer_info* info)
+	const struct ui_entry_details *details,
+	const struct renderer_info *info)
 {
 	bool immune = false;
 	bool resist = false;
@@ -519,8 +519,8 @@ static void renderer_COMPACT_FLAG_RENDERER_WITH_COMBINED_AUX(
 	const int *vals,
 	const int *auxvals,
 	int n,
-	const struct ui_entry_details* details,
-	const struct renderer_info* info)
+	const struct ui_entry_details *details,
+	const struct renderer_info *info)
 {
 	bool any_on = false;
 	bool any_timed_on = false;
@@ -596,8 +596,8 @@ static void renderer_NUMERIC_AS_SIGN_RENDERER_WITH_COMBINED_AUX(
 	const int *vals,
 	const int *auxvals,
 	int n,
-	const struct ui_entry_details* details,
-	const struct renderer_info* info)
+	const struct ui_entry_details *details,
+	const struct renderer_info *info)
 {
 	long sum = 0;
 	long sum_timed = 0;
@@ -705,8 +705,8 @@ static void renderer_NUMERIC_RENDERER_WITH_COMBINED_AUX(
 	const int *vals,
 	const int *auxvals,
 	int n,
-	const struct ui_entry_details* details,
-	const struct renderer_info* info)
+	const struct ui_entry_details *details,
+	const struct renderer_info *info)
 {
 	long sum = 0;
 	long sum_timed = 0;
@@ -873,8 +873,8 @@ static void renderer_NUMERIC_RENDERER_WITH_BOOL_AUX(
 	const int *vals,
 	const int *auxvals,
 	int n,
-	const struct ui_entry_details* details,
-	const struct renderer_info* info)
+	const struct ui_entry_details *details,
+	const struct renderer_info *info)
 {
 	long sum = 0;
 	int aux_combined = 0;

--- a/src/ui-entry-renderers.c
+++ b/src/ui-entry-renderers.c
@@ -1,0 +1,1390 @@
+/**
+ * \file ui-entry-renderers.c
+ * \brief Define backend handling for some parts of the second character screen
+ *
+ * This work is free software; you can redistribute it and/or modify it
+ * under the terms of either:
+ *
+ * a) the GNU General Public License as published by the Free Software
+ *    Foundation, version 2, or
+ *
+ * b) the "Angband licence":
+ *    This software may be copied and distributed for educational, research,
+ *    and not for profit purposes provided that this copyright and statement
+ *    are included in all such copies.  Other copyrights may also apply.
+ */
+
+#include "ui-entry-init.h"
+#include "ui-entry-renderers.h"
+#include "ui-term.h"
+#include "z-color.h"
+#include "z-util.h"
+#include "z-virt.h"
+
+/*
+ * This is the maximum number of symbols/colors used by any renderer.  Used to
+ * limit what's extracted from the configuration file.
+ */
+#define MAX_PALETTE (64)
+
+/*
+ * This is the maximum number of characters to use for any units label.  Used
+ * to limit what's extracted from the configuration file.
+ */
+#define MAX_UNITS_LABEL (24)
+
+struct renderer_info;
+typedef void (*renderer_func)(
+	const wchar_t *label,
+	int nlabel,
+	const int *vals,
+	const int *auxvals,
+	int n,
+	const struct ui_entry_details *details,
+	const struct renderer_info* info);
+typedef int (*valuewidth_func)(const struct renderer_info *info);
+
+static void format_int(int i, bool add_one, wchar_t zero, wchar_t overflow,
+	bool nonneg, bool use_sign, int nbuf, wchar_t *buf);
+
+/* Implemented backends. */
+static void renderer_COMPACT_RESIST_RENDERER_WITH_COMBINED_AUX(
+	const wchar_t *label,
+	int nlabel,
+	const int *vals,
+	const int *auxvals,
+	int n,
+	const struct ui_entry_details *details,
+	const struct renderer_info* info);
+static int valuewidth_COMPACT_RESIST_RENDERER_WITH_COMBINED_AUX(
+	const struct renderer_info *info);
+static void renderer_COMPACT_FLAG_RENDERER_WITH_COMBINED_AUX(
+	const wchar_t *label,
+	int nlabel,
+	const int *vals,
+	const int *auxvals,
+	int n,
+	const struct ui_entry_details *details,
+	const struct renderer_info* info
+);
+static int valuewidth_COMPACT_FLAG_RENDERER_WITH_COMBINED_AUX(
+	const struct renderer_info *info);
+static void renderer_NUMERIC_AS_SIGN_RENDERER_WITH_COMBINED_AUX(
+	const wchar_t *label,
+	int nlabel,
+	const int *vals,
+	const int *auxvals,
+	int n,
+	const struct ui_entry_details *details,
+	const struct renderer_info* info);
+static int valuewidth_NUMERIC_AS_SIGN_RENDERER_WITH_COMBINED_AUX(
+	const struct renderer_info *info);
+static void renderer_NUMERIC_RENDERER_WITH_COMBINED_AUX(
+	const wchar_t *label,
+	int nlabel,
+	const int *vals,
+	const int *auxvals,
+	int n,
+	const struct ui_entry_details *details,
+	const struct renderer_info* info);
+static int valuewidth_NUMERIC_RENDERER_WITH_COMBINED_AUX(
+	const struct renderer_info *info);
+static void renderer_NUMERIC_RENDERER_WITH_BOOL_AUX(
+	const wchar_t *label,
+	int nlabel,
+	const int *vals,
+	const int *auxvals,
+	int n,
+	const struct ui_entry_details *details,
+	const struct renderer_info* info);
+static int valuewidth_NUMERIC_RENDERER_WITH_BOOL_AUX(
+	const struct renderer_info *info);
+
+struct backend_info {
+	renderer_func func;
+	valuewidth_func vw_func;
+	const char *default_colors;
+	const char *default_labelcolors;
+	const char *default_symbols;
+	int default_ndigit;
+	int default_sign;
+};
+
+enum {
+	UI_ENTRY_NO_SIGN,
+	UI_ENTRY_ALWAYS_SIGN,
+	UI_ENTRY_NEGATIVE_SIGN,
+	UI_ENTRY_SIGN_DEFAULT = INT_MIN
+};
+
+static const struct backend_info backends[] =
+{
+	#define F(x) renderer_##x
+	#define FWIDTH(x) valuewidth_##x
+	#define UI_ENTRY_RENDERER(x, c, lc, s, n, sg) { F(x), FWIDTH(x), c, lc, s, n, UI_ENTRY_##sg},
+	#include "list-ui-entry-renderers.h"
+	#undef UI_ENTRY_RENDERER
+	#undef F
+	#undef FWIDTH
+};
+
+static const char *backend_names[] = {
+	#define UI_ENTRY_RENDERER(x, c, lc, s, n, sg) #x,
+	#include "list-ui-entry-renderers.h"
+	#undef UI_ENTRY_RENDERER
+	NULL
+};
+
+static char *convert_attrs_to_chars(const int *attr, int n);
+static void convert_chars_to_attrs(const char *colors, int n, int *attr);
+
+struct renderer_info {
+	char *name;
+	int *colors;
+	int *label_colors;
+	wchar_t *symbols;
+	wchar_t *units_label;
+	const struct backend_info *backend;
+	int ncolors;
+	int nlabcolors;
+	int nsym;
+	int ndigit;
+	int sign;
+	int units_nlabel;
+};
+
+static int renderer_count = 0;
+static int renderer_allocated = 0;
+static struct renderer_info *renderers = 0;
+
+
+/**
+ * Return the first valid index accepted by ui_entry_renderer_apply()
+ * and the other functions expecting a renderer index.  Any index whose
+ * value is greater than or equal to ui_entry_get_min_index() and less than
+ * ui_entry_get_index_limit() is valid.
+ */
+int ui_entry_renderer_get_min_index(void)
+{
+	return 1;
+}
+
+
+/**
+ * Return the upper bound for indices accepted by ui_entry_renderer_apply()
+ * and the other functions expecting a renderer index.  Any index whose
+ * value is greater than or equal to ui_entry_get_min_index() and less than
+ * ui_entry_get_index_limit() is valid.
+ */
+int ui_entry_renderer_get_index_limit(void)
+{
+	return renderer_count + 1;
+}
+
+
+/**
+ * Returns the name for the renderer as configured in ui_entry_renderers.txt.
+ * The returned value will be NULL if ind is out of bounds.
+ */
+const char *ui_entry_renderer_get_name(int ind)
+{
+	return (ind >= 1 && ind <= renderer_count) ?
+		renderers[ind - 1].name : NULL;
+}
+
+/**
+ * Look up a renderer by name.  If the name is not one of those configured in
+ * ui_entry_renderers.txt, returns zero.  Otherwise returns the index for
+ * the renderer.
+ */
+int ui_entry_renderer_lookup(const char *name)
+{
+	int i = 0;
+
+	while (i < renderer_count) {
+		if (streq(name, renderers[i].name)) {
+			return i + 1;
+		}
+		++i;
+	}
+	return 0;
+}
+
+
+/**
+ * Query a renderer for the number of characters used to draw a value.  ind
+ * is the index for the renderer; use ui_entry_renderer_lookup to get it.
+ * Will return -1 if the renderer is not valid or does not have an implemented
+ * backend.
+ */
+int ui_entry_renderer_query_value_width(int ind)
+{
+	if (ind <= 0 || ind > renderer_count || !renderers[ind - 1].backend) {
+		return -1;
+	}
+	return (*renderers[ind - 1].backend->vw_func)(renderers + ind - 1);
+}
+
+
+/**
+ * Use a renderer to draw a set of values and their label.  ind is the
+ * index for the renderer; use ui_entry_renderer_lookup to get it.
+ * label and nlabel specify the label to draw.  If nlabel is 0, no label will
+ * drawn.  vals, auxvals, and n set the values to draw.  vals and auxvals
+ * each refer to n values.  details controls certain aspects of the rendering
+ * including positions.  The comments for it in ui-entry-renderers.h describe
+ * it in more detail.
+ */
+void ui_entry_renderer_apply(int ind, const wchar_t *label, int nlabel,
+	const int *vals, const int *auxvals, int n,
+	const struct ui_entry_details* details)
+{
+	if (ind <= 0 || ind > renderer_count || !renderers[ind - 1].backend) {
+		return;
+	}
+	(*renderers[ind - 1].backend->func)(
+		label, nlabel, vals, auxvals, n, details, renderers + ind - 1);
+}
+
+
+/*
+ * Change the colors, label colors, or symbols used by a renderer.  Any of
+ * the three may be a null pointer which leaves the current setting for that
+ * unchanged.  Returns zero if successful.  Returns a nonzero value if the
+ * renderer index is invalid or it was not possible to convert one or more
+ * of the values to change.
+ */
+int ui_entry_renderer_customize(int ind, const char *colors,
+	const char *label_colors, const char* symbols)
+{
+	size_t length;
+
+	if (ind <= 0 || ind > renderer_count) {
+		return 1;
+	}
+	if (colors != 0) {
+		length = strlen(colors);
+		convert_chars_to_attrs(colors,
+			(length < (size_t) renderers[ind - 1].ncolors) ?
+			(int) length : renderers[ind - 1].ncolors,
+			renderers[ind - 1].colors);
+	}
+	if (label_colors != 0) {
+		length = strlen(label_colors);
+		convert_chars_to_attrs(label_colors,
+			(length < (size_t) renderers[ind - 1].ncolors) ?
+			(int) length : renderers[ind - 1].ncolors,
+			renderers[ind - 1].label_colors);
+	}
+	if (symbols != 0) {
+		wchar_t *tmp = mem_alloc((renderers[ind - 1].nsym + 1) *
+			sizeof(*tmp));
+
+		length = text_mbstowcs(tmp, symbols,
+			renderers[ind - 1].nsym + 1);
+		if (length == (size_t)-1) {
+			return 1;
+		}
+		(void) memcpy(renderers[ind - 1].symbols, tmp,
+			(((int)length < renderers[ind - 1].nsym) ?
+			(int)length : renderers[ind - 1].nsym) *
+			sizeof(*renderers[ind - 1].symbols));
+		mem_free(tmp);
+	}
+	return 0;
+}
+
+
+/*
+ * If ind is valid, returns a dynamically allocated string with the current
+ * setting for the palette of colors.  That string should be released with
+ * string_free().  Otherwise, returns NULL.
+ */
+char* ui_entry_renderer_get_colors(int ind)
+{
+	if (ind < 1 || ind > renderer_count) {
+		return NULL;
+	}
+	return convert_attrs_to_chars(renderers[ind - 1].colors,
+		renderers[ind - 1].ncolors);
+}
+
+
+/*
+ * If ind is valid, returns a dynamically allocated string with the current
+ * setting for the palette of label colors.  That string should be released
+ * with string_free().  Otherwise, returns NULL.
+ */
+char* ui_entry_renderer_get_label_colors(int ind)
+{
+	if (ind < 1 || ind > renderer_count) {
+		return NULL;
+	}
+	return convert_attrs_to_chars(renderers[ind - 1].label_colors,
+		renderers[ind - 1].nlabcolors);
+}
+
+
+/*
+ * If ind is valid, returns a dynamically allocated string with the current
+ * setting for the palette of symbols.  That string should be released
+ * with string_free().  Otherwise, returns NULL.
+ */
+char* ui_entry_renderer_get_symbols(int ind)
+{
+	if (ind < 1 || ind > renderer_count) {
+		return NULL;
+	}
+	return string_make(format("%ls", renderers[ind - 1].symbols));
+}
+
+
+static void format_int(int i, bool add_one, wchar_t zero, wchar_t overflow,
+	bool nonneg, bool use_sign, int nbuf, wchar_t *buf)
+{
+	static bool first_call = true;
+	static wchar_t wdigits[14];
+	const char *digits = "0123456789+- ";
+	int j = nbuf - 1;
+	div_t parts;
+
+	if (first_call) {
+		if (text_mbstowcs(wdigits, digits, 14) == (size_t)-1) {
+			quit("Invalid encoding for digits");
+		}
+		first_call = false;
+	}
+
+	/* Special handling for first digit. */
+	assert(nbuf > 0);
+	if (i == 0 && !add_one) {
+		parts.quot = 0;
+		parts.rem = 0;
+		buf[j] = zero;
+	} else {
+		parts = div(i, 10);
+		if (add_one) {
+			++parts.rem;
+			if (parts.rem == 10) {
+				parts.rem = 0;
+				++parts.quot;
+			}
+		}
+		buf[j] = wdigits[parts.rem];
+	}
+	--j;
+
+	while (parts.quot > 0 && j >= 0) {
+		parts = div(parts.quot, 10);
+		buf[j] = wdigits[parts.rem];
+		--j;
+	}
+
+	if (parts.quot > 0 || (use_sign && j == -1)) {
+		if (use_sign) {
+			buf[0] = (nonneg) ? wdigits[10] : wdigits[11];
+			j = 1;
+		} else {
+			j = 0;
+		}
+		while (j < nbuf) {
+			buf[j] = overflow;
+			++j;
+		}
+	} else {
+		 if (use_sign && (i != 0 || add_one || zero == wdigits[0])) {
+			buf[j] = (nonneg) ? wdigits[10] : wdigits[11];
+			--j;
+		}
+		while (j >= 0) {
+			buf[j] = wdigits[12];
+			--j;
+		}
+	}
+}
+
+
+static void renderer_COMPACT_RESIST_RENDERER_WITH_COMBINED_AUX(
+	const wchar_t *label,
+	int nlabel,
+	const int *vals,
+	const int *auxvals,
+	int n,
+	const struct ui_entry_details* details,
+	const struct renderer_info* info)
+{
+	bool immune = false;
+	bool resist = false;
+	bool vulnerable = false;
+	bool timed_immune = false;
+	bool timed_resist = false;
+	bool timed_vulnerable = false;
+	struct loc p = details->value_position;
+	int color_offset = (details->alternate_color_first) ? 9 : 0;
+	int i;
+
+	/* Check for defaults that are too short in list-ui-entry-renders.h. */
+	assert(info->ncolors >= 9 && info->nlabcolors >= 8 && info->nsym >= 9);
+
+	for (i = 0; i < n; ++i) {
+		int palette_index = 2;
+
+		if (vals[i] == UI_ENTRY_UNKNOWN_VALUE) {
+			palette_index = 0;
+		} else if (vals[i] == UI_ENTRY_VALUE_NOT_PRESENT) {
+			palette_index = 1;
+		} else if (vals[i] >= 3) {
+			immune = true;
+			palette_index = 5;
+		} else if (vals[i] >= 1) {
+			resist = true;
+			palette_index = 3;
+		} else if (vals[i] < 0) {
+			vulnerable = true;
+			palette_index = 4;
+		}
+		if (auxvals[i] >= 3 && auxvals[i] != UI_ENTRY_UNKNOWN_VALUE &&
+			auxvals[i] != UI_ENTRY_VALUE_NOT_PRESENT) {
+			timed_immune = true;
+			if (vals[i] == 0) {
+				palette_index = 8;
+			}
+		} else if (auxvals[i] >= 1 &&
+			auxvals[i] != UI_ENTRY_UNKNOWN_VALUE &&
+			auxvals[i] != UI_ENTRY_VALUE_NOT_PRESENT) {
+			timed_resist = true;
+			if (vals[i] == 0) {
+				palette_index = 6;
+			}
+		} else if (auxvals[i] < 0 &&
+			auxvals[i] != UI_ENTRY_UNKNOWN_VALUE &&
+			auxvals[i] != UI_ENTRY_VALUE_NOT_PRESENT) {
+			timed_vulnerable = true;
+			if (vals[i] == 0) {
+				palette_index = 7;
+			}
+		}
+		Term_putch(p.x, p.y,
+			info->colors[palette_index + color_offset],
+			info->symbols[palette_index]);
+		p = loc_sum(p, details->position_step);
+		color_offset ^= 9;
+	}
+
+	if (nlabel > 0) {
+		int palette_index = 1;
+
+		if (! details->known_rune) {
+			palette_index = 0;
+		} else if (immune) {
+			palette_index = 4;
+		} else if (resist) {
+			palette_index = 2;
+		} else if (vulnerable) {
+			palette_index = 3;
+		} else if (timed_immune) {
+			palette_index = 7;
+		} else if (timed_resist) {
+			palette_index = 5;
+		} else if (timed_vulnerable) {
+			palette_index = 6;
+		}
+		if (details->vertical_label) {
+			p = details->label_position;
+			for (i = 0; i < nlabel; ++i) {
+				Term_putch(p.x, p.y,
+					info->label_colors[palette_index],
+					label[i]);
+				p.y += 1;
+			}
+		} else {
+			Term_queue_chars(details->label_position.x,
+				details->label_position.y, nlabel,
+				info->label_colors[palette_index], label);
+		}
+	}
+}
+
+
+static int valuewidth_COMPACT_RESIST_RENDERER_WITH_COMBINED_AUX(
+	const struct renderer_info *info)
+{
+	return 1;
+}
+
+
+static void renderer_COMPACT_FLAG_RENDERER_WITH_COMBINED_AUX(
+	const wchar_t *label,
+	int nlabel,
+	const int *vals,
+	const int *auxvals,
+	int n,
+	const struct ui_entry_details* details,
+	const struct renderer_info* info)
+{
+	bool any_on = false;
+	bool any_timed_on = false;
+	struct loc p = details->value_position;
+	int color_offset = (details->alternate_color_first) ? 5 : 0;
+	int i;
+
+	/* Check for defaults that are too short in list-ui-entry-renders.h. */
+	assert(info->ncolors >= 5 && info->nlabcolors >= 4 && info->nsym >= 5);
+
+	for (i = 0; i < n; ++i) {
+		int palette_index = 2;
+
+		if (vals[i] == UI_ENTRY_UNKNOWN_VALUE) {
+			palette_index = 0;
+		} else if (vals[i] == UI_ENTRY_VALUE_NOT_PRESENT) {
+			palette_index = 1;
+		} else if (vals[i]) {
+			any_on = true;
+			palette_index = 3;
+		}
+		if (auxvals[i] && auxvals[i] != UI_ENTRY_UNKNOWN_VALUE &&
+			auxvals[i] != UI_ENTRY_VALUE_NOT_PRESENT) {
+			any_timed_on = true;
+			if (vals[i] == 0) {
+				palette_index = 4;
+			}
+		}
+		Term_putch(p.x, p.y,
+			info->colors[palette_index + color_offset],
+			info->symbols[palette_index]);
+		p = loc_sum(p, details->position_step);
+		color_offset ^= 5;
+	}
+
+	if (nlabel > 0) {
+		int palette_index = 1;
+
+		if (! details->known_rune) {
+			palette_index = 0;
+		} else if (any_on) {
+			palette_index = 2;
+		} else if (any_timed_on) {
+			palette_index = 3;
+		}
+		if (details->vertical_label) {
+			p = details->label_position;
+			for (i = 0; i < nlabel; ++i) {
+				Term_putch(p.x, p.y,
+					info->label_colors[palette_index],
+					label[i]);
+				p.y += 1;
+			}
+		} else {
+			Term_queue_chars(details->label_position.x,
+				details->label_position.y, nlabel,
+				info->label_colors[palette_index], label);
+		}
+	}
+}
+
+
+static int valuewidth_COMPACT_FLAG_RENDERER_WITH_COMBINED_AUX(
+	const struct renderer_info *info)
+{
+	return 1;
+}
+
+
+static void renderer_NUMERIC_AS_SIGN_RENDERER_WITH_COMBINED_AUX(
+	const wchar_t *label,
+	int nlabel,
+	const int *vals,
+	const int *auxvals,
+	int n,
+	const struct ui_entry_details* details,
+	const struct renderer_info* info)
+{
+	long sum = 0;
+	long sum_timed = 0;
+	struct loc p = details->value_position;
+	int color_offset = (details->alternate_color_first) ? 7 : 0;
+	int i;
+
+	/* Check for defaults that are too short in list-ui-entry-renders.h. */
+	assert(info->ncolors >= 7 && info->nlabcolors >= 6 && info->nsym >= 7);
+
+	for (i = 0; i < n; ++i) {
+		int palette_index = 2;
+
+		if (vals[i] == UI_ENTRY_UNKNOWN_VALUE || (vals[i] == 0 &&
+			auxvals[i] == UI_ENTRY_UNKNOWN_VALUE)) {
+			palette_index = 0;
+		} else if (vals[i] == UI_ENTRY_VALUE_NOT_PRESENT) {
+			palette_index = 1;
+		} else if (vals[i] > 0) {
+			if (sum < LONG_MAX - vals[i]) {
+				sum += vals[i];
+			} else {
+				sum = LONG_MAX;
+			}
+			palette_index = 3;
+		} else if (vals[i] < 0) {
+			if (sum > LONG_MIN - vals[i]) {
+				sum += vals[i];
+			} else {
+				sum = LONG_MIN;
+			}
+			palette_index = 4;
+		}
+		if (auxvals[i] > 0 && auxvals[i] != UI_ENTRY_UNKNOWN_VALUE &&
+			auxvals[i] != UI_ENTRY_VALUE_NOT_PRESENT) {
+			if (sum_timed < LONG_MAX - auxvals[i]) {
+				sum_timed += auxvals[i];
+			} else {
+				sum_timed = LONG_MAX;
+			}
+			if (vals[i] == 0) {
+				palette_index = 5;
+			}
+		} else if (auxvals[i] < 0 &&
+			auxvals[i] != UI_ENTRY_UNKNOWN_VALUE &&
+			auxvals[i] != UI_ENTRY_VALUE_NOT_PRESENT) {
+			if (sum_timed > LONG_MIN - auxvals[i]) {
+				sum_timed += auxvals[i];
+			} else {
+				sum_timed = LONG_MIN;
+			}
+			sum_timed += auxvals[i];
+			if (vals[i] == 0) {
+				palette_index = 6;
+			}
+		}
+		Term_putch(p.x, p.y,
+			info->colors[palette_index + color_offset],
+			info->symbols[palette_index]);
+		p = loc_sum(p, details->position_step);
+		color_offset ^= 7;
+	}
+
+	if (nlabel > 0) {
+		int palette_index = 1;
+
+		if (! details->known_rune) {
+			palette_index = 0;
+		} else if (sum > 0) {
+			palette_index = 2;
+		} else if (sum < 0) {
+			palette_index = 3;
+		} else if (sum_timed > 0) {
+			palette_index = 4;
+		} else if (sum_timed < 0) {
+			palette_index = 5;
+		}
+		if (details->vertical_label) {
+			p = details->label_position;
+			for (i = 0; i < nlabel; ++i) {
+				Term_putch(p.x, p.y,
+					info->label_colors[palette_index],
+					label[i]);
+				p.y += 1;
+			}
+		} else {
+			Term_queue_chars(details->label_position.x,
+				details->label_position.y, nlabel,
+				info->label_colors[palette_index], label);
+		}
+	}
+}
+
+
+static int valuewidth_NUMERIC_AS_SIGN_RENDERER_WITH_COMBINED_AUX(
+	const struct renderer_info *info)
+{
+	return 1;
+}
+
+
+static void renderer_NUMERIC_RENDERER_WITH_COMBINED_AUX(
+	const wchar_t *label,
+	int nlabel,
+	const int *vals,
+	const int *auxvals,
+	int n,
+	const struct ui_entry_details* details,
+	const struct renderer_info* info)
+{
+	long sum = 0;
+	long sum_timed = 0;
+	struct loc p = details->value_position;
+	int color_offset = (details->alternate_color_first) ? 7 : 0;
+	int nbuf = info->ndigit + ((info->sign == UI_ENTRY_NO_SIGN) ? 0 : 1);
+	wchar_t *buffer = mem_alloc(nbuf * sizeof(*buffer));
+	int i;
+
+	/* Check for defaults that are too short in list-ui-entry-renders.h. */
+	assert(info->ncolors >= 7 && info->nlabcolors >= 6 && info->nsym >= 7);
+
+	for (i = 0; i < n; ++i) {
+		int palette_index;
+
+		if (vals[i] == UI_ENTRY_UNKNOWN_VALUE || (vals[i] == 0 &&
+			auxvals[i] == UI_ENTRY_UNKNOWN_VALUE)) {
+			int j;
+
+			palette_index = 0;
+			for (j = 0; j < nbuf; ++j) {
+				buffer[j] = info->symbols[0];
+			}
+		} else if (vals[i] == UI_ENTRY_VALUE_NOT_PRESENT) {
+			int j;
+
+			palette_index = 1;
+			for (j = 0; j < nbuf; ++j) {
+				buffer[j] = info->symbols[1];
+			}
+		} else if (vals[i] > 0) {
+			if (sum < LONG_MAX - vals[i]) {
+				sum += vals[i];
+			} else {
+				sum = LONG_MAX;
+			}
+			palette_index = 3;
+			format_int(vals[i], false, info->symbols[2],
+				info->symbols[3], true,
+				info->sign == UI_ENTRY_ALWAYS_SIGN,
+				nbuf, buffer);
+		} else if (vals[i] < 0) {
+			int v;
+			bool o;
+
+			if (sum > LONG_MIN - vals[i]) {
+				sum += vals[i];
+			} else {
+				sum = LONG_MIN;
+			}
+			palette_index = 4;
+			if (vals[i] == INT_MIN) {
+				v = -(INT_MIN + 1);
+				o = true;
+			} else {
+				v = -vals[i];
+				o = false;
+			}
+			format_int(v, o, info->symbols[2], info->symbols[4],
+				false, info->sign != UI_ENTRY_NO_SIGN,
+				nbuf, buffer);
+		}
+		if (auxvals[i] > 0 && auxvals[i] != UI_ENTRY_UNKNOWN_VALUE &&
+			auxvals[i] != UI_ENTRY_VALUE_NOT_PRESENT) {
+			if (sum_timed < LONG_MAX - auxvals[i]) {
+				sum_timed += auxvals[i];
+			} else {
+				sum_timed = LONG_MAX;
+			}
+			if (vals[i] == 0) {
+				palette_index = 5;
+				format_int(auxvals[i], false, info->symbols[2],
+					info->symbols[5], true,
+					info->sign == UI_ENTRY_ALWAYS_SIGN,
+					nbuf, buffer);
+			}
+		} else if (auxvals[i] < 0 &&
+			auxvals[i] != UI_ENTRY_UNKNOWN_VALUE &&
+			auxvals[i] != UI_ENTRY_VALUE_NOT_PRESENT) {
+			if (sum_timed > LONG_MIN - auxvals[i]) {
+				sum_timed += auxvals[i];
+			} else {
+				sum_timed = LONG_MIN;
+			}
+			if (vals[i] == 0) {
+				int v;
+				bool o;
+
+				palette_index = 6;
+				if (auxvals[i] == INT_MIN) {
+					v = -(INT_MIN + 1);
+					o = true;
+				} else {
+					v = -vals[i];
+					o = false;
+				}
+				format_int(v, o, info->symbols[2],
+					info->symbols[6], false,
+					info->sign != UI_ENTRY_NO_SIGN,
+					nbuf, buffer);
+			}
+		} else if (vals[i] == 0) {
+			palette_index = 2;
+			format_int(0, false, info->symbols[2],
+				info->symbols[3], true,
+				info->sign == UI_ENTRY_ALWAYS_SIGN,
+				nbuf, buffer);
+		}
+		Term_queue_chars(p.x, p.y, nbuf,
+			info->colors[palette_index + color_offset], buffer);
+		if (info->units_nlabel != 0) {
+			Term_queue_chars(p.x + nbuf, p.y, info->units_nlabel,
+				info->colors[palette_index + color_offset],
+				info->units_label);
+		}
+		p = loc_sum(p, details->position_step);
+		color_offset ^= 7;
+	}
+
+	mem_free(buffer);
+
+	if (nlabel > 0) {
+		int palette_index = 1;
+
+		if (! details->known_rune) {
+			palette_index = 0;
+		} else if (sum > 0) {
+			palette_index = 2;
+		} else if (sum < 0) {
+			palette_index = 3;
+		} else if (sum_timed > 0) {
+			palette_index = 4;
+		} else if (sum_timed < 0) {
+			palette_index = 5;
+		}
+		if (details->vertical_label) {
+			p = details->label_position;
+			for (i = 0; i < nlabel; ++i) {
+				Term_putch(p.x, p.y,
+					info->label_colors[palette_index],
+					label[i]);
+				p.y += 1;
+			}
+		} else {
+			Term_queue_chars(details->label_position.x,
+				details->label_position.y, nlabel,
+				info->label_colors[palette_index], label);
+		}
+	}
+}
+
+
+static int valuewidth_NUMERIC_RENDERER_WITH_COMBINED_AUX(
+	const struct renderer_info *info)
+{
+	return info->ndigit + ((info->sign == UI_ENTRY_NO_SIGN) ? 0 : 1) +
+		info->units_nlabel;
+}
+
+
+static void renderer_NUMERIC_RENDERER_WITH_BOOL_AUX(
+	const wchar_t *label,
+	int nlabel,
+	const int *vals,
+	const int *auxvals,
+	int n,
+	const struct ui_entry_details* details,
+	const struct renderer_info* info)
+{
+	long sum = 0;
+	int aux_combined = 0;
+	struct loc p = details->value_position;
+	int color_offset = (details->alternate_color_first) ? 8 : 0;
+	int nbuf = info->ndigit + ((info->sign == UI_ENTRY_NO_SIGN) ? 0 : 1);
+	wchar_t *buffer = mem_alloc(nbuf * sizeof(*buffer));
+	int i;
+
+	/* Check for defaults that are too short in list-ui-entry-renders.h. */
+	assert(info->ncolors >= 8 && info->nlabcolors >= 7 && info->nsym >= 6);
+
+	for (i = 0; i < n; ++i) {
+		int palette_index;
+
+		if (vals[i] == UI_ENTRY_UNKNOWN_VALUE || (vals[i] == 0 &&
+			auxvals[i] == UI_ENTRY_UNKNOWN_VALUE)) {
+			int j;
+
+			palette_index = 0;
+			for (j = 0; j < nbuf; ++j) {
+				buffer[j] = info->symbols[0];
+			}
+		} else if (vals[i] == UI_ENTRY_VALUE_NOT_PRESENT) {
+			int j;
+
+			palette_index = 1;
+			for (j = 0; j < nbuf; ++j) {
+				buffer[j] = info->symbols[1];
+			}
+		} else if (vals[i] > 0) {
+			if (sum < LONG_MAX - vals[i]) {
+				sum += vals[i];
+			} else {
+				sum = LONG_MAX;
+			}
+			if (auxvals[i] != 0 &&
+				auxvals[i] != UI_ENTRY_UNKNOWN_VALUE &&
+				auxvals[i] != UI_ENTRY_VALUE_NOT_PRESENT) {
+				aux_combined = 1;
+				palette_index = 5;
+			} else {
+				palette_index = 4;
+			}
+			format_int(vals[i], false, info->symbols[2],
+				info->symbols[4], true,
+				info->sign == UI_ENTRY_ALWAYS_SIGN,
+				nbuf, buffer);
+		} else if (vals[i] < 0) {
+			int v;
+			bool o;
+
+			if (sum > LONG_MIN - vals[i]) {
+				sum += vals[i];
+			} else {
+				sum = LONG_MIN;
+			}
+			if (auxvals[i] != 0 &&
+				auxvals[i] != UI_ENTRY_UNKNOWN_VALUE &&
+				auxvals[i] != UI_ENTRY_VALUE_NOT_PRESENT) {
+				aux_combined = 1;
+				palette_index = 7;
+			} else {
+				palette_index = 6;
+			}
+			if (vals[i] == INT_MIN) {
+				v = -(INT_MIN + 1);
+				o = true;
+			} else {
+				v = -vals[i];
+				o = false;
+			}
+			format_int(v, o, info->symbols[2], info->symbols[5],
+				false, info->sign != UI_ENTRY_NO_SIGN,
+				nbuf, buffer);
+		} else {
+			int zerosym;
+
+			if (auxvals[i] != 0 &&
+				auxvals[i] != UI_ENTRY_UNKNOWN_VALUE &&
+				auxvals[i] != UI_ENTRY_VALUE_NOT_PRESENT) {
+				aux_combined = 1;
+				palette_index = 3;
+				zerosym = 3;
+			} else {
+				palette_index = 2;
+				zerosym = 2;
+			}
+			format_int(0, false, info->symbols[zerosym],
+				info->symbols[4], true,
+				info->sign == UI_ENTRY_ALWAYS_SIGN,
+				nbuf, buffer);
+		}
+		Term_queue_chars(p.x, p.y, nbuf,
+			info->colors[palette_index + color_offset], buffer);
+		if (info->units_nlabel != 0) {
+			Term_queue_chars(p.x + nbuf, p.y, info->units_nlabel,
+				info->colors[palette_index + color_offset],
+				info->units_label);
+		}
+		p = loc_sum(p, details->position_step);
+		color_offset ^= 8;
+	}
+
+	mem_free(buffer);
+
+	if (nlabel > 0) {
+		int palette_index = 1;
+
+		if (! details->known_rune) {
+			palette_index = 0;
+		} else if (sum > 0) {
+			palette_index = (aux_combined) ? 2 : 1;
+		} else if (sum < 0) {
+			palette_index = (aux_combined) ? 4 : 3;
+		} else {
+			palette_index = (aux_combined) ? 6 : 5;
+		}
+		if (details->vertical_label) {
+			p = details->label_position;
+			for (i = 0; i < nlabel; ++i) {
+				Term_putch(p.x, p.y,
+					info->label_colors[palette_index],
+					label[i]);
+				p.y += 1;
+			}
+		} else {
+			Term_queue_chars(details->label_position.x,
+				details->label_position.y, nlabel,
+				info->label_colors[palette_index], label);
+		}
+	}
+}
+
+
+static int valuewidth_NUMERIC_RENDERER_WITH_BOOL_AUX(
+	const struct renderer_info *info)
+{
+	return info->ndigit + ((info->sign == UI_ENTRY_NO_SIGN) ? 0 : 1) +
+		info->units_nlabel;
+}
+
+
+static int lookup_backend_by_name(const char *name)
+{
+	int n = N_ELEMENTS(backend_names);
+	int i = 0;
+
+	while (i < n) {
+		if (streq(backend_names[i], name)) {
+			return i + 1;
+		}
+		++i;
+	}
+	return 0;
+}
+
+
+static char *convert_attrs_to_chars(const int *attr, int n)
+{
+	char buf[9];
+	int nbuf = N_ELEMENTS(buf) - 1;
+	char *result = NULL;
+	int i = 0, j = 0;
+
+	while (1) {
+		if (i == nbuf || j >= n) {
+			buf[i] = '\0';
+			result = string_append(result, buf);
+			if (j >= n) {
+				return result;
+			}
+			i = 0;
+		}
+		if (attr[j] >= 0 && attr[j] < BASIC_COLORS) {
+			buf[i] = color_table[attr[j]].index_char;
+		} else {
+			buf[i] = 'w';
+		}
+		++i;
+		++j;
+	}
+}
+
+
+static void convert_chars_to_attrs(const char *colors, int n, int *attr)
+{
+	int i;
+
+	for (i = 0; i < n; ++i) {
+		attr[i] = color_char_to_attr(colors[i]);
+	}
+}
+
+
+static void augment_colors(const char *colors, int **attr, int *nattr)
+{
+	int n = (int) strlen(colors);
+
+	if (*nattr < n) {
+		int *newattr = mem_alloc(sizeof(*newattr) * n);
+
+		if (*nattr > 0) {
+			(void) memcpy(newattr, *attr, *nattr *
+				sizeof(*newattr));
+		}
+		mem_free(*attr);
+		convert_chars_to_attrs(colors + *nattr, n - *nattr,
+			newattr + *nattr);
+		*attr = newattr;
+		*nattr = n;
+	}
+}
+
+
+static void augment_symbols(const char *symbols, wchar_t **s, int *n)
+{
+	wchar_t defsym[MAX_PALETTE];
+	size_t nd = text_mbstowcs(defsym, symbols, MAX_PALETTE);
+	
+	if (nd == (size_t)-1) {
+		quit("Invalid encoding for default symbols");
+	}
+	if (*n < (int) nd) {
+		wchar_t *newsym = mem_alloc((nd + 1) * sizeof(*newsym));
+
+		if (*n > 0) {
+			(void) memcpy(newsym, *s, *n * sizeof(*newsym));
+		}
+		mem_free(*s);
+		(void) memcpy(newsym + *n, defsym + *n,
+			((int) nd - *n) * sizeof(*newsym));
+		/* Ensure null termination. */
+		if (text_mbstowcs(newsym + nd, "", 1) == (size_t)-1) {
+			quit("Couldn't terminate null character string");
+		}
+		*n = (int) nd;
+		*s = newsym;
+	}
+}
+
+
+static enum parser_error parse_renderer_name(struct parser *p)
+{
+	const char *name = parser_getstr(p, "name");
+	int ind = ui_entry_renderer_lookup(name);
+	struct renderer_info *renderer;
+
+	if (ind == 0) {
+		if (renderer_count >= renderer_allocated) {
+			if (renderer_allocated > INT_MAX / 2) {
+				return PARSE_ERROR_TOO_MANY_ENTRIES;
+			}
+			renderer_allocated = (renderer_allocated == 0) ?
+				4 : renderer_allocated * 2;
+			renderers = mem_realloc(renderers,
+				renderer_allocated * sizeof(*renderers));
+		}
+		renderer = renderers + renderer_count;
+		++renderer_count;
+		renderer->name = string_make(name);
+		renderer->colors = NULL;
+		renderer->label_colors = NULL;
+		renderer->symbols = NULL;
+		renderer->units_label = NULL;
+		renderer->backend = NULL;
+		renderer->ncolors = 0;
+		renderer->nlabcolors = 0;
+		renderer->nsym = 0;
+		renderer->ndigit = INT_MIN;
+		renderer->sign = UI_ENTRY_SIGN_DEFAULT;
+		renderer->units_nlabel = 0;
+	} else {
+		renderer = renderers + ind - 1;
+	}
+	parser_setpriv(p, renderer);
+	return PARSE_ERROR_NONE;
+}
+
+
+static enum parser_error parse_renderer_code(struct parser *p)
+{
+	struct renderer_info *renderer = parser_priv(p);
+	const char *code;
+	int ind;
+
+	if (!renderer) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	code = parser_getstr(p, "code");
+	ind = lookup_backend_by_name(code);
+	if (ind == 0) {
+		return PARSE_ERROR_INVALID_VALUE;
+	}
+	renderer->backend = backends + ind - 1;
+	return PARSE_ERROR_NONE;
+}
+
+
+static enum parser_error parse_renderer_colors(struct parser *p)
+{
+	struct renderer_info *renderer = parser_priv(p);
+	const char *colors;
+	size_t n;
+
+	if (!renderer) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	colors = parser_getstr(p, "colors");
+	mem_free(renderer->colors);
+	n = strlen(colors);
+	renderer->ncolors = (n < MAX_PALETTE) ? (int) n : MAX_PALETTE;
+	renderer->colors = mem_alloc(renderer->ncolors *
+		sizeof(*renderer->colors));
+	convert_chars_to_attrs(colors, renderer->ncolors, renderer->colors);
+	return PARSE_ERROR_NONE;
+}
+
+
+static enum parser_error parse_renderer_labelcolors(struct parser *p)
+{
+	struct renderer_info *renderer = parser_priv(p);
+	const char *colors;
+	size_t n;
+
+	if (!renderer) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	colors = parser_getstr(p, "colors");
+	mem_free(renderer->label_colors);
+	n = strlen(colors);
+	renderer->nlabcolors = (n < MAX_PALETTE) ? (int) n : MAX_PALETTE;
+	renderer->label_colors = mem_alloc(renderer->nlabcolors *
+		sizeof(*renderer->label_colors));
+	convert_chars_to_attrs(colors, renderer->nlabcolors,
+		renderer->label_colors);
+	return PARSE_ERROR_NONE;
+}
+
+
+static enum parser_error parse_renderer_symbols(struct parser *p)
+{
+	struct renderer_info *renderer = parser_priv(p);
+	const char *symbols;
+	size_t n;
+
+	if (!renderer) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	symbols = parser_getstr(p, "symbols");
+	mem_free(renderer->symbols);
+	renderer->symbols = mem_alloc((MAX_PALETTE + 1) *
+		sizeof(*renderer->symbols));
+	n = text_mbstowcs(renderer->symbols, symbols, MAX_PALETTE);
+	if (n == (size_t)-1) {
+		return PARSE_ERROR_INVALID_VALUE;
+	}
+	/* Make sure there's a null terminator. */
+	if (text_mbstowcs(renderer->symbols + n, "", 1) == (size_t)-1) {
+		return PARSE_ERROR_INVALID_VALUE;
+	}
+	renderer->nsym = n;
+	return PARSE_ERROR_NONE;
+}
+
+
+static enum parser_error parse_renderer_ndigit(struct parser *p)
+{
+	struct renderer_info *renderer = parser_priv(p);
+	int ndigit;
+
+	if (!renderer) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	ndigit = parser_getint(p, "ndigit");
+	if (ndigit < 1) {
+		return PARSE_ERROR_INVALID_VALUE;
+	}
+	renderer->ndigit = ndigit;
+	return PARSE_ERROR_NONE;
+}
+
+
+static enum parser_error parse_renderer_sign(struct parser *p)
+{
+	struct renderer_info *renderer = parser_priv(p);
+	const char *sign;
+
+	if (!renderer) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	sign = parser_getstr(p, "sign");
+	if (streq(sign, "NO_SIGN")) {
+		renderer->sign = UI_ENTRY_NO_SIGN;
+	} else if (streq(sign, "ALWAYS_SIGN")) {
+		renderer->sign = UI_ENTRY_ALWAYS_SIGN;
+	} else if (streq(sign, "NEGATIVE_SIGN")) {
+		renderer->sign = UI_ENTRY_NEGATIVE_SIGN;
+	} else {
+		return PARSE_ERROR_INVALID_VALUE;
+	}
+	return PARSE_ERROR_NONE;
+}
+
+
+static enum parser_error parse_renderer_units(struct parser *p)
+{
+	struct renderer_info *renderer = parser_priv(p);
+	const char *units;
+	size_t n, n2;
+
+	if (!renderer) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	mem_free(renderer->units_label);
+	renderer->units_label = mem_alloc((MAX_UNITS_LABEL + 1) *
+		sizeof(*renderer->units_label));
+	units = parser_getstr(p, "units");
+	n = text_mbstowcs(renderer->units_label, units, MAX_UNITS_LABEL);
+	if (n == (size_t)-1) {
+		return PARSE_ERROR_INVALID_VALUE;
+	}
+	/* Ensure null termination. */
+	n2 = text_mbstowcs(renderer->units_label + n, "", 1);
+	if (n2 == (size_t)-1) {
+		return PARSE_ERROR_INVALID_VALUE;
+	}
+	renderer->units_nlabel = n;
+	return PARSE_ERROR_NONE;
+}
+
+
+static struct parser *init_parse_ui_entry_renderer(void)
+{
+	struct parser *p = parser_new();
+
+	parser_setpriv(p, NULL);
+	parser_reg(p, "name str name", parse_renderer_name);
+	parser_reg(p, "code str code", parse_renderer_code);
+	parser_reg(p, "colors str colors", parse_renderer_colors);
+	parser_reg(p, "labelcolors str colors", parse_renderer_labelcolors);
+	parser_reg(p, "symbols str symbols", parse_renderer_symbols);
+	parser_reg(p, "ndigit int ndigit", parse_renderer_ndigit);
+	parser_reg(p, "sign str sign", parse_renderer_sign);
+	parser_reg(p, "units str units", parse_renderer_units);
+	return p;
+}
+
+
+static errr run_parse_ui_entry_renderer(struct parser *p)
+{
+	return parse_file(p, "ui_entry_renderer");
+}
+
+
+static errr finish_parse_ui_entry_renderer(struct parser *p)
+{
+	int i;
+
+	for (i = 0; i < renderer_count; ++i) {
+		if (!renderers[i].backend) {
+			continue;
+		}
+
+		/*
+		 * If have fewer colors or symbols than the defaults for the
+		 * backend, augment what was set with the default values.
+		 */
+		augment_colors(renderers[i].backend->default_colors,
+			&renderers[i].colors, &renderers[i].ncolors);
+		augment_colors(renderers[i].backend->default_labelcolors,
+			&renderers[i].label_colors, &renderers[i].nlabcolors);
+		augment_symbols(renderers[i].backend->default_symbols,
+			&renderers[i].symbols, &renderers[i].nsym);
+
+		if (renderers[i].ndigit == INT_MIN) {
+			renderers[i].ndigit =
+				renderers[i].backend->default_ndigit;
+		}
+		if (renderers[i].sign == UI_ENTRY_SIGN_DEFAULT) {
+			renderers[i].sign =
+				renderers[i].backend->default_sign;
+		}
+	}
+	parser_destroy(p);
+	return 0;
+}
+
+
+static void cleanup_parse_ui_entry_renderer(void)
+{
+	int i;
+
+	for (i = 0; i < renderer_count; i++) {
+		mem_free(renderers[i].symbols);
+		mem_free(renderers[i].label_colors);
+		mem_free(renderers[i].colors);
+		string_free(renderers[i].name);
+	}
+	mem_free(renderers);
+	renderers = NULL;
+	renderer_count = 0;
+	renderer_allocated = 0;
+}
+
+
+struct file_parser ui_entry_renderer_parser = {
+	"ui_entry_renderer",
+	init_parse_ui_entry_renderer,
+	run_parse_ui_entry_renderer,
+	finish_parse_ui_entry_renderer,
+	cleanup_parse_ui_entry_renderer
+};

--- a/src/ui-entry-renderers.h
+++ b/src/ui-entry-renderers.h
@@ -61,8 +61,8 @@ void ui_entry_renderer_apply(int ind, const wchar_t *label, int nlabel,
 	const struct ui_entry_details *details);
 /* Handling for user-configurable parts */
 int ui_entry_renderer_customize(int ind, const char *colors,
-	const char *label_colors, const char* symbols);
-char* ui_entry_renderer_get_colors(int ind);
-char* ui_entry_renderer_get_label_colors(int ind);
-char* ui_entry_renderer_get_symbols(int ind);
+	const char *label_colors, const char *symbols);
+char *ui_entry_renderer_get_colors(int ind);
+char *ui_entry_renderer_get_label_colors(int ind);
+char *ui_entry_renderer_get_symbols(int ind);
 #endif /* INCLUDED_UI_ENTRY_RENDERERS_H */

--- a/src/ui-entry-renderers.h
+++ b/src/ui-entry-renderers.h
@@ -1,0 +1,68 @@
+/**
+ * \file ui-entry-renderers.h
+ * \brief Declare backend handling for parts of the second character screen
+ *
+ * This work is free software; you can redistribute it and/or modify it
+ * under the terms of either:
+ *
+ * a) the GNU General Public License as published by the Free Software
+ *    Foundation, version 2, or
+ *
+ * b) the "Angband licence":
+ *    This software may be copied and distributed for educational, research,
+ *    and not for profit purposes provided that this copyright and statement
+ *    are included in all such copies.  Other copyrights may also apply.
+ */
+#ifndef INCLUDED_UI_ENTRY_RENDERERS_H
+#define INCLUDED_UI_ENTRY_RENDERERS_H
+
+#include "z-type.h"
+
+struct ui_entry_details {
+	/* This is the position for the first character in the label. */
+	struct loc label_position;
+	/* This is the position for the rendering of the first value. */
+	struct loc value_position;
+	/* This is the step size to use between values. */
+	struct loc position_step;
+	/* If true the characters of the label will be spaced vertically. */
+	bool vertical_label;
+	/*
+	 * The rendering may alternate the colors for every other value shown.
+	 * If this is true, the first value is shown with the alternate color.
+	 */
+	bool alternate_color_first;
+	/*
+	 * If true, the rune associated with the values is known to the
+	 * player.
+	 */
+	bool known_rune;
+};
+
+/*
+ * This is the value to use in vals or aux_vals array when the real value is
+ * unknown to the player.
+ */
+#define UI_ENTRY_UNKNOWN_VALUE (INT_MAX)
+
+/*
+ * This is the value to use in vals or aux_vals array when the value is to
+ * be treated as not present.
+ */
+#define UI_ENTRY_VALUE_NOT_PRESENT (INT_MAX - 1)
+
+int ui_entry_renderer_get_min_index(void);
+int ui_entry_renderer_get_index_limit(void);
+const char *ui_entry_renderer_get_name(int ind);
+int ui_entry_renderer_lookup(const char *name);
+int ui_entry_renderer_query_value_width(int ind);
+void ui_entry_renderer_apply(int ind, const wchar_t *label, int nlabel,
+	const int *vals, const int *auxvals, int n,
+	const struct ui_entry_details *details);
+/* Handling for user-configurable parts */
+int ui_entry_renderer_customize(int ind, const char *colors,
+	const char *label_colors, const char* symbols);
+char* ui_entry_renderer_get_colors(int ind);
+char* ui_entry_renderer_get_label_colors(int ind);
+char* ui_entry_renderer_get_symbols(int ind);
+#endif /* INCLUDED_UI_ENTRY_RENDERERS_H */

--- a/src/ui-entry.c
+++ b/src/ui-entry.c
@@ -1,0 +1,2457 @@
+/**
+ * \file ui-entry.c
+ * \brief Definitions to link object/player properties to 2nd character screen
+ *
+ * This work is free software; you can redistribute it and/or modify it
+ * under the terms of either:
+ *
+ * a) the GNU General Public License as published by the Free Software
+ *    Foundation, version 2, or
+ *
+ * b) the "Angband licence":
+ *    This software may be copied and distributed for educational, research,
+ *    and not for profit purposes provided that this copyright and statement
+ *    are included in all such copies.  Other copyrights may also apply.
+ */
+
+#include "init.h"
+#include "object.h"
+#include "obj-curse.h"
+#include "obj-gear.h"
+#include "obj-knowledge.h"
+#include "obj-util.h"
+#include "player.h"
+#include "player-timed.h"
+#include "ui-entry.h"
+#include "ui-entry-init.h"
+#include "ui-entry-renderers.h"
+#include "z-util.h"
+#include "z-virt.h"
+
+/*
+ * This is the maximum number of characters stored for a label.  Used to
+ * limit what's extracted from the configuration file.
+ */
+#define MAX_ENTRY_LABEL (80)
+
+struct ui_entry_iterator {
+	struct ui_entry** entries;
+	int n, i;
+};
+
+struct cached_object_data {
+	bitflag f[OF_SIZE];
+};
+
+struct cached_player_data {
+	bitflag untimed[OF_SIZE];
+	bitflag timed[OF_SIZE];
+};
+
+struct category_reference {
+	const char* name;
+	int priority;
+        bool priority_set;
+};
+
+struct bound_object_property {
+	int type;
+	int index;
+	int value;
+	bool have_value;
+	bool isaux;
+};
+
+struct bound_player_ability {
+	struct player_ability *ability;
+	int value;
+	bool have_value;
+	bool isaux;
+};
+
+
+struct combining_algorithm_state {
+	void *v;
+	int accum;
+	int accum_aux;
+};
+
+struct combining_algorithm {
+	const char *name;
+	void (*init_func)(int v, int a, struct combining_algorithm_state *st);
+	void (*accum_func)(int v, int a, struct combining_algorithm_state *st);
+	void (*finish_func)(struct combining_algorithm_state *st);
+};
+
+static void simple_combine_init(int v, int a,
+	struct combining_algorithm_state *st);
+static void dummy_combine_accum(int v, int a,
+	struct combining_algorithm_state *st);
+static void dummy_combine_finish(struct combining_algorithm_state *st);
+static void add_combine_accum(int v, int a,
+	struct combining_algorithm_state *st);
+static void bitwise_or_combine_accum(int v, int a,
+	struct combining_algorithm_state *st);
+static void largest_combine_accum(int v, int a,
+	struct combining_algorithm_state *st);
+static void last_combine_accum(int v, int a, 
+	struct combining_algorithm_state *st);
+static void logical_combine_init(int v, int a,
+	struct combining_algorithm_state *st);
+static void logical_or_combine_accum(int v, int a,
+	struct combining_algorithm_state *st);
+static void resist_0_combine_init(int v, int a,
+	struct combining_algorithm_state *st);
+static void resist_0_combine_accum(int v, int a,
+	struct combining_algorithm_state *st);
+static void resist_0_combine_finish(struct combining_algorithm_state *st);
+static void smallest_combine_accum(int v, int a,
+	struct combining_algorithm_state *st);
+
+/* Sorted alphabetically by name to facilitate lookup. */
+static struct combining_algorithm combiners[] = {
+	{ "ADD", simple_combine_init, add_combine_accum,
+		dummy_combine_finish },
+	{ "BITWISE_OR", simple_combine_init, bitwise_or_combine_accum,
+		dummy_combine_finish },
+	{ "FIRST", simple_combine_init, dummy_combine_accum,
+		dummy_combine_finish },
+	{ "LARGEST", simple_combine_init, largest_combine_accum,
+		dummy_combine_finish },
+	{ "LAST", simple_combine_init, last_combine_accum,
+		dummy_combine_finish },
+	{ "LOGICAL_OR", logical_combine_init, logical_or_combine_accum,
+		dummy_combine_finish },
+	{ "RESIST_0", resist_0_combine_init, resist_0_combine_accum,
+		resist_0_combine_finish },
+	{ "SMALLEST", simple_combine_init, smallest_combine_accum,
+		dummy_combine_finish }
+};
+
+
+enum {
+	ENTRY_FLAG_TIMED_AUX = 1,
+	/* Used internally; not set from within the configuration files. */
+	ENTRY_FLAG_TEMPLATE_ONLY = (1 << 20)
+};
+struct entry_flag {
+	const char* name;
+	int value;
+};
+static struct entry_flag entry_flags[] = {
+	{ "TIMED_AS_AUX", ENTRY_FLAG_TIMED_AUX },
+};
+
+/*
+ * Set the maximum number of shortened versions of the label that will be
+ * accepted.  The shortened versions will have lengths of one to MAX_SHORTENED
+ * characters, not including the terminating null.
+ */
+#define MAX_SHORTENED (10)
+struct ui_entry {
+	char *name;
+	struct category_reference *categories;
+	struct bound_object_property *obj_props;
+	struct bound_player_ability *p_abilities;
+	wchar_t *label;
+	wchar_t* shortened_labels[MAX_SHORTENED];
+	wchar_t shortened_buffer[MAX_SHORTENED + (MAX_SHORTENED * (MAX_SHORTENED + 1)) / 2];
+	int nshortened[MAX_SHORTENED];
+	int nlabel;
+	int renderer_index;
+	int combiner_index;
+	int default_priority;
+	int param_index;
+	int flags;
+	int n_category;
+	int nalloc_category;
+	int n_obj_prop;
+	int nalloc_obj_prop;
+	int n_p_ability;
+	int nalloc_p_ability;
+};
+
+static int ui_entry_search(const char *name, int *ind);
+static int ui_entry_search_categories(const struct ui_entry *entry,
+	const char *name, int *ind);
+static void modifier_to_skill(int modind, int *skillind, int *skill2mod_num,
+	int *skill2mod_den
+);
+static int get_timed_element_effect(const struct player *p, int ind);
+static int get_timed_modifier_effect(const struct player *p, int ind);
+
+struct ui_entry_name_parameter {
+	const char *name;
+	int (*count_func)(void);
+	const char *(*ith_name_func)(int i);
+};
+
+static int get_dummy_param_count(void);
+static const char *get_dummy_param_name(int i);
+static int get_element_count(void);
+static const char *get_element_name(int i);
+static int get_stat_count(void);
+static const char *get_stat_name(int i);
+
+static struct ui_entry_name_parameter name_parameters[] = {
+	{ "", get_dummy_param_count, get_dummy_param_name },
+	{ "element", get_element_count, get_element_name },
+	{ "stat", get_stat_count, get_stat_name },
+};
+
+struct ui_entry_priority_scheme {
+	const char* name;
+	int (*priority)(int i);
+};
+
+static int get_dummy_priority(int i);
+static int get_priority_from_index(int i);
+static int get_priority_from_negative_index(int i);
+
+static struct ui_entry_priority_scheme priority_schemes[] = {
+	{ "", get_dummy_priority },
+	{ "index", get_priority_from_index },
+	{ "negative_index", get_priority_from_negative_index },
+};
+
+struct embryonic_category_reference {
+	const char* name;
+	int psource_index;
+	int priority;
+	bool priority_set;
+};
+
+struct embryonic_ui_entry {
+	struct ui_entry *entry;
+	struct embryonic_category_reference *categories;
+	int param_index;
+	int psource_index;
+	int last_category_index;
+	bool exists;
+};
+
+static int n_category = 0;
+static int nalloc_category = 0;
+static char **categories = NULL;
+
+static int n_entry = 0;
+static int nalloc_entry = 0;
+static struct ui_entry **entries = NULL;
+
+
+/**
+ * Binds an object property, given by type and index, to a user interface
+ * entry configured in ui_entry.txt.  If name isn't configured in that file
+ * returns a nonzero value.  Otherwise returns zero after binding the property.
+ * Currently, this is only used for some parts of the second character screen.
+ */
+int bind_object_property_to_ui_entry_by_name(const char* name, int type,
+	int index, int value, bool have_value, bool isaux)
+{
+	int ind;
+
+	if (! ui_entry_search(name, &ind)) {
+		return 1;
+	}
+	if (entries[ind]->n_obj_prop == entries[ind]->nalloc_obj_prop) {
+		struct bound_object_property *nblk;
+
+		if (entries[ind]->nalloc_obj_prop > INT_MAX / 2) {
+			return 2;
+		}
+		entries[ind]->nalloc_obj_prop =
+			(entries[ind]->nalloc_obj_prop == 0) ?
+			4 : 2 * entries[ind]->nalloc_obj_prop;
+		nblk = mem_alloc(entries[ind]->nalloc_obj_prop *
+			sizeof(*nblk));
+		if (entries[ind]->n_obj_prop > 0) {
+			(void) memcpy(nblk, entries[ind]->obj_props,
+				entries[ind]->n_obj_prop * sizeof(*nblk));
+		}
+		mem_free(entries[ind]->obj_props);
+		entries[ind]->obj_props = nblk;
+	}
+	entries[ind]->obj_props[entries[ind]->n_obj_prop].type = type;
+	entries[ind]->obj_props[entries[ind]->n_obj_prop].index = index;
+	entries[ind]->obj_props[entries[ind]->n_obj_prop].value = value;
+	entries[ind]->obj_props[entries[ind]->n_obj_prop].have_value =
+		have_value;
+	entries[ind]->obj_props[entries[ind]->n_obj_prop].isaux = isaux;
+	++entries[ind]->n_obj_prop;
+	return 0;
+}
+
+
+/**
+ * Binds a player ability to to a user interface entry configured in ui_entry.
+ * If name isn't configured in that file returns a nonzero value.  Otherwise
+ * returns zero after binding the ability.  Currently, this is only used for
+ * some parts of the second character screen.
+ */
+int bind_player_ability_to_ui_entry_by_name(const char* name,
+	struct player_ability *ability, int value, bool have_value, bool isaux)
+{
+	int ind;
+
+	if (! ui_entry_search(name, &ind)) {
+		return 1;
+	}
+	if (entries[ind]->n_p_ability ==
+		entries[ind]->nalloc_p_ability) {
+		struct bound_player_ability *abilities;
+
+		if (entries[ind]->nalloc_p_ability > INT_MAX / 2) {
+			return 2;
+		}
+		entries[ind]->nalloc_p_ability =
+			(entries[ind]->nalloc_p_ability == 0) ?
+			4 : 2 * entries[ind]->nalloc_p_ability;
+		abilities = mem_alloc(entries[ind]->nalloc_p_ability *
+			sizeof(*abilities));
+		if (entries[ind]->n_p_ability > 0) {
+			(void) memcpy(abilities, entries[ind]->p_abilities,
+				entries[ind]->n_p_ability *
+				sizeof(*abilities));
+		}
+		mem_free(entries[ind]->p_abilities);
+		entries[ind]->p_abilities = abilities;
+	}
+	entries[ind]->p_abilities[entries[ind]->n_p_ability].ability = ability;
+	entries[ind]->p_abilities[entries[ind]->n_p_ability].value = value;
+	entries[ind]->p_abilities[entries[ind]->n_p_ability].have_value =
+		have_value;
+	entries[ind]->p_abilities[entries[ind]->n_p_ability].isaux = isaux;
+	++entries[ind]->n_p_ability;
+	return 0;
+}
+
+
+/**
+ * Returns true if the given user interface entry was configured in
+ * ui_entry.txt to be part of the category with the given name.  Otherwise,
+ * returns false.
+ */
+bool ui_entry_has_category(const struct ui_entry *entry, const char *name)
+{
+	int ind;
+
+	return ui_entry_search_categories(entry, name, &ind) != 0;
+}
+
+
+/**
+ * Fills label with length characters, including a terminating null, of a
+ * label for a user interface entry configured in ui_entry.txt.  If the label
+ * is naturally shorter than the specified length, the label will be padded
+ * with spaces, either on the left if pad_left is true, or on the right if
+ * pad_left is false.
+ */
+void get_ui_entry_label(const struct ui_entry *entry, int length,
+	bool pad_left, wchar_t *label)
+{
+	static bool first_call = true;
+	static wchar_t spc[2];
+	const wchar_t *src;
+	int n;
+
+	if (first_call) {
+		size_t nw = text_mbstowcs(spc, " ", 2);
+
+		assert(nw != (size_t)-1);
+		first_call = false;
+	}
+
+	if (length <= 0) {
+		return;
+	}
+	if (length == 1) {
+		label[0] = spc[1];
+		return;
+	}
+	if (length <= MAX_SHORTENED + 1) {
+		src = entry->shortened_labels[length - 2];
+		n = entry->nshortened[length - 2];
+	} else {
+		src = entry->label;
+		n = entry->nlabel;
+	}
+	if (n < length - 1) {
+		int i;
+
+		if (pad_left) {
+			for (i = 0; i < length - 1 - n; ++i) {
+				label[i] = spc[0];
+			}
+			(void) memcpy(label + length - 1 - n, src,
+				n * sizeof(*label));
+		} else {
+			(void) memcpy(label, src, n * sizeof(*label));
+			for (i = n; i < length - 1; ++i) {
+				label[i] = spc[0];
+			}
+		}
+	} else {
+		(void) memcpy(label, src, (length - 1) * sizeof(*label));
+	}
+	label[length - 1] = spc[1];
+}
+
+
+static const char* category_for_cmp_desc_prio = NULL;
+static int cmp_desc_prio(const void *left, const void *right)
+{
+	const struct ui_entry *eleft =
+		*((const struct ui_entry* const *) left);
+	const struct ui_entry *eright =
+		*((const struct ui_entry* const *) right);
+	int left_ind = -1, right_ind = -1;
+	int result;
+
+	if (category_for_cmp_desc_prio) {
+		int ind;
+
+		if (ui_entry_search_categories(eleft,
+			category_for_cmp_desc_prio, &ind)) {
+			left_ind = ind;
+		}
+		if (ui_entry_search_categories(eright,
+			category_for_cmp_desc_prio, &ind)) {
+			right_ind = ind;
+		}
+	}
+	if (left_ind >= 0) {
+		if (right_ind >= 0) {
+			if (eleft->categories[left_ind].priority >
+				eright->categories[right_ind].priority) {
+				result = -1;
+			} else if (eleft->categories[left_ind].priority <
+				   eright->categories[right_ind].priority) {
+				result = 1;
+			} else {
+				result = strcmp(eleft->name, eright->name);
+			}
+		} else {
+			/*
+			 * right is not in the sort category so it should be
+			 * pushed toward the end.
+			 */
+			result = -1;
+		}
+	} else if (right_ind >= 0) {
+		/*
+		 * left is not in the sort category so it should be pushed
+		 * towards the end.
+		 */
+		result = 1;
+	} else {
+		result = strcmp(eleft->name, eright->name);
+	}
+	return result;
+}
+
+
+/**
+ * Constructs an iterator to enumerate all the user interface elements for
+ * which the given predicate returns true.  The iterator will present those
+ * elements in descending order of priority where the priority is that
+ * configured for the element in the category named sortcategory.
+ */
+struct ui_entry_iterator *initialize_ui_entry_iterator(
+	ui_entry_predicate predicate, void *closure, const char *sortcategory)
+{
+	struct ui_entry_iterator *result = mem_alloc(sizeof(*result));
+	int i;
+
+	result->entries = mem_alloc(n_entry * sizeof(*result->entries));
+	result->n = 0;
+	result->i = 0;
+	for (i = 0; i < n_entry; ++i) {
+		if (! (entries[i]->flags & ENTRY_FLAG_TEMPLATE_ONLY) &&
+			(*predicate)(entries[i], closure)) {
+			result->entries[result->n] = entries[i];
+			++result->n;
+		}
+	}
+	category_for_cmp_desc_prio = sortcategory;
+	sort(result->entries, result->n, sizeof(*result->entries),
+		cmp_desc_prio);
+	return result;
+}
+
+
+/**
+ * Releases the resources allocated by a prior call to
+ * initialize_ui_entry_iterator.
+ */
+void release_ui_entry_iterator(struct ui_entry_iterator *i)
+{
+	mem_free(i->entries);
+	mem_free(i);
+}
+
+
+/**
+ * Resets the given iterator to the position it ahd when returned by
+ * initialize_ui_entry_iterator.
+ */
+void reset_ui_entry_iterator(struct ui_entry_iterator *i)
+{
+	i->i = 0;
+}
+
+
+/**
+ * Returns the number of elements remaining to be iterated for the given
+ * iterator.
+ */
+int count_ui_entry_iterator(struct ui_entry_iterator *i)
+{
+	return i->n - i->i;
+}
+
+
+/**
+ * Returns the user interface entry currently pointed to by the iterator and
+ * advances the iterator.
+ */
+struct ui_entry *advance_ui_entry_iterator(struct ui_entry_iterator *i)
+{
+	struct ui_entry *result = i->entries[i->i];
+	++i->i;
+	return result;
+}
+
+
+/**
+ * Returns the renderer index, suitable as the first argument to
+ * ui_entry_renderer_apply(), for the given user interface element.
+ */
+int get_ui_entry_renderer_index(const struct ui_entry *entry)
+{
+	return entry->renderer_index;
+}
+
+
+/**
+ * Returns true if the properties/abilities bound to a user interface entry
+ * correspond to a known rune.  Otherwise, returns false.
+ */
+bool is_ui_entry_for_known_rune(const struct ui_entry *entry,
+	const struct player *p)
+{
+	bool result = true;
+	int i;
+
+	/*
+	 * Mark it as known if all of the properties/abilities bound to the
+	 * entry are known.
+	 */
+	for (i = 0; i < entry->n_obj_prop && result; ++i) {
+		int ind = entry->obj_props[i].index;
+
+		switch (entry->obj_props[i].type) {
+		case OBJ_PROPERTY_STAT:
+		case OBJ_PROPERTY_MOD:
+			if (p->obj_k->modifiers[ind] == 0) {
+				result = false;
+			}
+			break;
+
+		case OBJ_PROPERTY_FLAG:
+			if (! of_has(p->obj_k->flags, ind)) {
+				result = false;
+			}
+			break;
+
+		case OBJ_PROPERTY_IGNORE:
+		case OBJ_PROPERTY_RESIST:
+		case OBJ_PROPERTY_VULN:
+		case OBJ_PROPERTY_IMM:
+			if (p->obj_k->el_info[ind].res_level == 0) {
+				result = false;
+			}
+			break;
+
+		default:
+			result = false;
+			break;
+		}
+	}
+	for (i = 0; i < entry->n_p_ability && result; ++i) {
+		int ind = entry->p_abilities[i].ability->index;
+
+		if (streq(entry->p_abilities[i].ability->type, "player")) {
+			/*
+			 * Not so easy to associate with a rune so don't let
+			 * it change the result.
+			 */
+			continue;
+		} else if (streq(entry->p_abilities[i].ability->type,
+			"object")) {
+			if (! of_has(p->obj_k->flags, ind)) {
+				result = false;
+			}
+		} else if (streq(entry->p_abilities[i].ability->type,
+			"element")) {
+			if (p->obj_k->el_info[ind].res_level == 0) {
+				result = false;
+			}
+		} else {
+			result = false;
+		}
+	}
+	return result;
+}
+
+
+void compute_ui_entry_values_for_object(const struct ui_entry *entry,
+	const struct object *obj, const struct player *p,
+	struct cached_object_data **cache, int *val, int *auxval)
+{
+	struct combining_algorithm_state cst = { 0, 0, 0 };
+	const struct combining_algorithm* combiner;
+	const struct curse_data *curse;
+	struct cached_object_data *cache2;
+	bool first, all_unknown, all_aux_unknown, any_aux, all_aux;
+	int curse_ind;
+
+	if (!obj || !entry->n_obj_prop) {
+		*val = UI_ENTRY_VALUE_NOT_PRESENT;
+		*auxval = UI_ENTRY_VALUE_NOT_PRESENT;
+		return;
+	}
+	if (*cache == NULL) {
+		*cache = mem_alloc(sizeof(**cache));
+		of_wipe((*cache)->f);
+		object_flags_known(obj, (*cache)->f);
+	}
+	first = true;
+	all_unknown = true;
+	all_aux_unknown = true;
+	any_aux = false;
+	all_aux = true;
+	combiner = combiners + entry->combiner_index - 1;
+	cache2 = *cache;
+	curse = obj->curses;
+	curse_ind = 0;
+	while (obj) {
+		int i;
+
+		for (i = 0; i < entry->n_obj_prop; ++i) {
+			int ind = entry->obj_props[i].index;
+
+			if (entry->obj_props[i].isaux) {
+				if (entry->flags & ENTRY_FLAG_TIMED_AUX) {
+					continue;
+				}
+				any_aux = true;
+			} else {
+				all_aux = false;
+			}
+
+			switch (entry->obj_props[i].type) {
+			case OBJ_PROPERTY_STAT:
+			case OBJ_PROPERTY_MOD:
+				if (p->obj_k->modifiers[ind] != 0 ||
+					obj->modifiers[ind] == 0) {
+					int v = obj->modifiers[ind];
+					int a = 0;
+
+					if (v && entry->obj_props[i].have_value) {
+						v = entry->obj_props[i].value;
+					}
+					if (entry->obj_props[i].isaux) {
+						int t = a;
+
+						a = v;
+						v = t;
+						all_aux_unknown = false;
+					} else {
+						all_unknown = false;
+					}
+					if (first) {
+						(*combiner->init_func)(v, a, &cst);
+						first = false;
+					} else {
+						(*combiner->accum_func)(v, a, &cst);
+					}
+				}
+				break;
+
+			case OBJ_PROPERTY_FLAG:
+				if (object_flag_is_known(obj, ind)) {
+					int v = of_has(cache2->f, ind) ? 1 : 0;
+					int a = 0;
+
+					if (v && entry->obj_props[i].have_value) {
+						v = entry->obj_props[i].value;
+					}
+					if (entry->obj_props[i].isaux) {
+						int t = a;
+
+						a = v;
+						v = t;
+						all_aux_unknown = false;
+					} else {
+						all_unknown = false;
+					}
+					if (first) {
+						(*combiner->init_func)(v, a, &cst);
+						first = false;
+					} else {
+						(*combiner->accum_func)(v, a, &cst);
+					}
+				}
+				break;
+
+			case OBJ_PROPERTY_IGNORE:
+				if (object_element_is_known(obj, ind)) {
+					int v = (obj->el_info[ind].flags &
+						EL_INFO_IGNORE) ? 1 : 0;
+					int a = 0;
+
+					if (v && entry->obj_props[i].have_value) {
+						v = entry->obj_props[i].value;
+					}
+					if (entry->obj_props[i].isaux) {
+						int t = a;
+
+						a = v;
+						v = t;
+						all_aux_unknown = false;
+					} else {
+						all_unknown = false;
+					}
+					if (first) {
+						(*combiner->init_func)(v, a, &cst);
+						first = false;
+					} else {
+						(*combiner->accum_func)(v, a, &cst);
+					}
+				}
+				break;
+
+			case OBJ_PROPERTY_RESIST:
+			case OBJ_PROPERTY_VULN:
+			case OBJ_PROPERTY_IMM:
+				if (object_element_is_known(obj, ind)) {
+					int v = obj->el_info[ind].res_level;
+					int a = 0;
+
+					if (v && entry->obj_props[i].have_value) {
+						v = entry->obj_props[i].value;
+					}
+					if (entry->obj_props[i].isaux) {
+						int t = a;
+
+						a = v;
+						v = t;
+						all_aux_unknown = false;
+					} else {
+						all_unknown = false;
+					}
+					if (first) {
+						(*combiner->init_func)(v, a, &cst);
+						first = false;
+					} else {
+						(*combiner->accum_func)(v, a, &cst);
+					}
+				}
+				break;
+
+			default:
+				break;
+			}
+		}
+
+		if (curse) {
+			/*
+			 * Proceed to the next unprocessed curse object.
+			 * Don't overwrite the cached data for the base.
+			 */
+			obj = NULL;
+			if (curse_ind == 0) {
+				cache2 = mem_alloc(sizeof(*cache2));
+			}
+			++curse_ind;
+			while (1) {
+				if (curse_ind >= z_info->curse_max) {
+					mem_free(cache2);
+					break;
+				}
+				if (curse[curse_ind].power) {
+					obj = curses[curse_ind].obj;
+					of_wipe(cache2->f);
+					object_flags_known(obj, cache2->f);
+					break;
+				}
+				++curse_ind;
+			}
+		} else {
+			obj = NULL;
+		}
+	}
+	if (all_unknown && all_aux_unknown) {
+		*val = (all_aux) ? 0 : UI_ENTRY_UNKNOWN_VALUE;
+		*auxval = (any_aux) ? UI_ENTRY_UNKNOWN_VALUE : 0;
+	} else {
+		(*combiner->finish_func)(&cst);
+		if (all_unknown) {
+			*val = (all_aux) ? 0 : UI_ENTRY_UNKNOWN_VALUE;
+		} else {
+			*val = cst.accum;
+		}
+		if (all_aux_unknown) {
+			*auxval = (any_aux) ? UI_ENTRY_UNKNOWN_VALUE : 0;
+		} else {
+			*auxval = cst.accum_aux;
+		}
+	}
+}
+
+
+void compute_ui_entry_values_for_player(const struct ui_entry *entry,
+	struct player *p, struct cached_player_data **cache, int *val,
+	int *auxval)
+{
+	struct combining_algorithm_state cst = { 0, 0, 0 };
+	const struct combining_algorithm* combiner;
+	bool first;
+	int i;
+
+	if (!p) {
+		*val = UI_ENTRY_VALUE_NOT_PRESENT;
+		*auxval = UI_ENTRY_VALUE_NOT_PRESENT;
+		return;
+	}
+	if (*cache == NULL) {
+		*cache = mem_alloc(sizeof(**cache));
+		player_flags(p, (*cache)->untimed);
+		of_wipe((*cache)->timed);
+		player_flags_timed(p, (*cache)->timed);
+		if (p->timed[TMD_TRAPSAFE]) {
+			of_on((*cache)->timed, OF_TRAP_IMMUNE);
+		}
+	}
+	first = true;
+	combiner = combiners + entry->combiner_index - 1;
+	for (i = 0; i < entry->n_p_ability; ++i) {
+		int ind = entry->p_abilities[i].ability->index;
+
+		if ((entry->flags & ENTRY_FLAG_TIMED_AUX) &&
+			entry->p_abilities[i].isaux) {
+			continue;
+		}
+		if (streq(entry->p_abilities[i].ability->type, "player")) {
+			if (! player_has(p, ind)) {
+				continue;
+			}
+			if (entry->p_abilities[i].have_value) {
+				int v = entry->p_abilities[i].value;
+				int a = 0;
+
+				if (entry->p_abilities[i].isaux) {
+					int t = v;
+
+					v = a;
+					a = t;
+				}
+				if (first) {
+					(*combiner->init_func)(v, a, &cst);
+					first = false;
+				} else {
+					(*combiner->accum_func)(v, a, &cst);
+				}
+			} else {
+				int v, a;
+				struct object *launcher;
+
+				/*
+				 * Handle player abilities that did not bind a
+				 * value to the user interface element as
+				 * special cases.
+				 */
+				switch (ind) {
+				case PF_FAST_SHOT:
+					launcher = equipped_item_by_slot_name(
+						p, "shooting");
+					if (kf_has(launcher->kind->kind_flags,
+						KF_SHOOTS_ARROWS)) {
+						v = p->lev / 3;
+						a = 0;
+					} else {
+						v = 0;
+						a = 0;
+					}
+					if (entry->p_abilities[i].isaux) {
+						int t = v;
+
+						v = a;
+						a = t;
+					}
+					if (first) {
+						(*combiner->init_func)(v, a, &cst);
+						first = false;
+					} else {
+						(*combiner->accum_func)(v, a, &cst);
+					}
+					break;
+
+				case PF_BRAVERY_30:
+					/*
+					 * player_flags() accounts for
+					 * PF_BRAVERY_30 so this is only
+					 * necessary in cases where
+					 * OF_PROT_FEAR isn't also bound to
+					 * the element.
+					 */
+					v = (p->lev >= 30) ? 1 : 0;
+					a = 0;
+					if (entry->p_abilities[i].isaux) {
+						int t = v;
+
+						v = a;
+						a = t;
+					}
+					if (first) {
+						(*combiner->init_func)(v, a, &cst);
+						first = false;
+					} else {
+						(*combiner->accum_func)(v, a, &cst);
+					}
+					break;
+				}
+			}
+		} else if (streq(entry->p_abilities[i].ability->type,
+			"object")) {
+			int v = of_has((*cache)->untimed, ind) ? 1 : 0;
+			int a;
+
+			if (entry->flags & ENTRY_FLAG_TIMED_AUX) {
+				a = of_has((*cache)->timed, ind) ? 1 : 0;
+			} else {
+				a = 0;
+			}
+			if (entry->p_abilities[i].isaux) {
+				int t = v;
+
+				v = a;
+				a = t;
+			}
+			if (first) {
+				(*combiner->init_func)(v, a, &cst);
+				first = false;
+			} else {
+				(*combiner->accum_func)(v, a, &cst);
+			}
+
+			v = of_has(p->shape->flags, ind) ? 1 : 0;
+			a = 0;
+			if (v && of_has(p->obj_k->flags, ind)) {
+				if (entry->p_abilities[i].isaux) {
+					int t = v;
+
+					v = a;
+					a = t;
+				}
+				(*combiner->accum_func)(v, a, &cst);
+			}
+		} else if (streq(entry->p_abilities[i].ability->type,
+			"element")) {
+			int v = p->race->el_info[ind].res_level;
+			int a;
+
+			if (entry->flags & ENTRY_FLAG_TIMED_AUX) {
+				a = get_timed_element_effect(p, ind);
+			} else {
+				a = 0;
+			}
+			if (entry->p_abilities[i].isaux) {
+				int t = v;
+
+				v = a;
+				a = t;
+			}
+			if (first) {
+				(*combiner->init_func)(v, a, &cst);
+				first = false;
+			} else {
+				(*combiner->accum_func)(v, a, &cst);
+			}
+			v = p->shape->el_info[ind].res_level;
+			a = 0;
+			if (v != 0 && p->obj_k->el_info[ind].res_level) {
+				if (entry->p_abilities[i].isaux) {
+					int t = v;
+
+					v = a;
+					a = t;
+				}
+				(*combiner->accum_func)(v, a, &cst);
+			}
+		}
+	}
+	/*
+	 * Since stats and modifiers aren't stored in the ability list, check
+	 * if any object properties for those are bound to this element.
+	 * Then lookup the player's intrinsic values for those.
+	 */
+	for (i = 0; i < entry->n_obj_prop; ++i) {
+		int ind = entry->obj_props[i].index;
+		int skill_ind, skill_cnv_num, skill_cnv_den;
+		int v, a;
+
+		if (entry->obj_props[i].isaux &&
+			(entry->flags & ENTRY_FLAG_TIMED_AUX)) {
+			continue;
+		}
+		switch (entry->obj_props[i].type) {
+		case OBJ_PROPERTY_STAT:
+		case OBJ_PROPERTY_MOD:
+			v = p->shape->modifiers[ind];
+			if (entry->flags & ENTRY_FLAG_TIMED_AUX) {
+				a = get_timed_modifier_effect(p, ind);
+			} else {
+				a = 0;
+			}
+			if (entry->obj_props[i].isaux) {
+				int t = v;
+
+				v = a;
+				a = t;
+			}
+			if (first) {
+				(*combiner->init_func)(v, a, &cst);
+				first = false;
+			} else {
+				(*combiner->accum_func)(v, a, &cst);
+			}
+			/*
+			 * Racial information doesn't store modifiers but does
+			 * store skills.  If applicable, extract the relevant
+			 * value and convert.
+			 */
+			modifier_to_skill(ind, &skill_ind, &skill_cnv_num,
+				&skill_cnv_den);
+			if (skill_ind >= 0) {
+				v = (p->race->r_skills[skill_ind] *
+					skill_cnv_num) / skill_cnv_den;
+				a = 0;
+				if (entry->obj_props[i].isaux) {
+					int t = v;
+
+					v = a;
+					a = t;
+				}
+				(*combiner->accum_func)(v, a, &cst);
+			}
+			/*
+			 * Uggh, the player race handles infravision
+			 * separately.
+			 */
+			if (ind == OBJ_MOD_INFRA) {
+				v = p->race->infra;
+				a = 0;
+				if (entry->obj_props[i].isaux) {
+					int t = v;
+
+					v = a;
+					a = t;
+				}
+				(*combiner->accum_func)(v, a, &cst);
+			}
+			break;
+		}
+	}
+	if (first) {
+		*val = 0;
+		*auxval = 0;
+	} else {
+		(*combiner->finish_func)(&cst);
+		*val = cst.accum;
+		*auxval = cst.accum_aux;
+	}
+}
+
+
+void release_cached_object_data(struct cached_object_data *cache)
+{
+	mem_free(cache);
+}
+
+
+void release_cached_player_data(struct cached_player_data *cache)
+{
+	mem_free(cache);
+}
+
+
+/**
+ * Lookup the entry by name.  Return a nonzero value if present and set *ind to
+ * its index.  Otherwise return zero and set *ind to where it should be
+ * inserted.
+ */
+static int ui_entry_search(const char *name, int *ind)
+{
+	/* They're sorted by name so use a binary search. */
+	int ilow = 0, ihigh = n_entry;
+
+	while (1) {
+		int imid, cmp;
+
+		if (ilow == ihigh) {
+			*ind = ilow;
+			return 0;
+		}
+		imid = (ilow + ihigh) / 2;
+		cmp = strcmp(entries[imid]->name, name);
+		if (cmp == 0) {
+			*ind = imid;
+			return 1;
+		}
+		if (cmp < 0) {
+			ilow = imid + 1;
+		} else {
+			ihigh = imid;
+		}
+	}
+}
+
+
+/**
+ * Lookup the entry by name.  If present return its index + 1.  Otherwise,
+ * return 0.
+ */
+static int ui_entry_lookup(const char *name)
+{
+	int ind;
+
+	return ui_entry_search(name, &ind) ? ind + 1 : 0;
+}
+
+
+/**
+ * Insert the entry.
+ */
+static void ui_entry_insert(struct ui_entry *entry)
+{
+	int ind;
+
+	if (ui_entry_search(entry->name, &ind)) {
+		quit("Attempted to insert ui_entry with same name");
+	}
+
+	if (n_entry == nalloc_entry) {
+		struct ui_entry **extended;
+
+		if (nalloc_entry > INT_MAX / 2) {
+			quit("Too many ui_entry");
+		}
+		nalloc_entry = (nalloc_entry == 0) ? 8 : 2 * nalloc_entry;
+		extended = mem_alloc(nalloc_entry * sizeof(*extended));
+		if (ind > 0) {
+			(void) memcpy(extended, entries,
+				ind * sizeof(*entries));
+		}
+		extended[ind] = entry;
+		if (ind < n_entry) {
+			(void) memcpy(extended + ind + 1, entries + ind,
+				(n_entry - ind) * sizeof(*entries));
+		}
+		mem_free(entries);
+		entries = extended;
+	} else {
+		int i;
+
+		for (i = n_entry; i > ind; --i) {
+			entries[i] = entries[i - 1];
+		}
+		entries[ind] = entry;
+	}
+	++n_entry;
+}
+
+
+/**
+ * Search for name in the categories associated with ui_entry.  Return a
+ * nonzero value if present and set *ind to its index.  Otherwise, return zero
+ * and set *ind to where it should be inserted.
+ */
+static int ui_entry_search_categories(const struct ui_entry *entry,
+	const char *name, int *ind)
+{
+	/* They're sorted by name so use a binary search. */
+	int ilow = 0, ihigh = entry->n_category;
+
+	while (1) {
+		int imid, cmp;
+
+		if (ilow == ihigh) {
+			*ind = ilow;
+			return 0;
+		}
+		imid = (ilow + ihigh) / 2;
+		cmp = strcmp(entry->categories[imid].name, name);
+		if (cmp == 0) {
+			*ind = imid;
+			return 1;
+		}
+		if (cmp < 0) {
+			ilow = imid + 1;
+		} else {
+			ihigh = imid;
+		}
+	}
+}
+
+
+static void modifier_to_skill(int modind, int *skillind, int *skill2mod_num,
+	int *skill2mod_den
+)
+{
+	switch (modind) {
+	case OBJ_MOD_TUNNEL:
+		*skillind = SKILL_DIGGING;
+		*skill2mod_num = 1;
+		*skill2mod_den = 20;
+		break;
+
+	/*
+	 * Stealth and searching also have skills, but the calculations
+	 * formerly in ui-player.c didn't include the racial contribution from
+	 * those in what was shown in the second player screen.  If that's
+	 * desirable, these are the conversion factors used in player-calcs.c
+	 */
+#if 0
+	case OBJ_MOD_STEALTH:
+		*skillind = SKILL_STEALTH;
+		*skill2mod_num = 1;
+		*skill2mod_den = 1;
+		break;
+
+	case OBJ_MOD_SEARCH:
+		*skillind = SKILL_SEARCH;
+		*skill2mod_num = 1;
+		*skill2mod_den = 5;
+		break;
+#endif
+
+	default:
+		*skillind = -1;
+		*skill2mod_num = 1;
+		*skill2mod_den = 1;
+		break;
+	}
+}
+
+
+static int get_timed_element_effect(const struct player *p, int ind)
+{
+	int result;
+
+	switch (ind) {
+	case ELEM_ACID:
+		result = p->timed[TMD_OPP_ACID] ? 1 : 0;
+		break;
+
+	case ELEM_ELEC:
+		result = p->timed[TMD_OPP_ELEC] ? 1 : 0;
+		break;
+
+	case ELEM_FIRE:
+		result = p->timed[TMD_OPP_FIRE] ? 1 : 0;
+		break;
+
+	case ELEM_COLD:
+		result = p->timed[TMD_OPP_COLD] ? 1 : 0;
+		break;
+
+	case ELEM_POIS:
+		result = p->timed[TMD_OPP_POIS] ? 1 : 0;
+		break;
+
+	default:
+		result = 0;
+		break;
+	}
+	return result;
+}
+
+
+static int get_timed_modifier_effect(const struct player *p, int ind)
+{
+	int result;
+
+	/* Mimics calculations made in player-calcs.c. */
+	switch (ind) {
+	case OBJ_MOD_BLOWS:
+		result = (p->timed[TMD_BLOODLUST]) ?
+			p->timed[TMD_BLOODLUST] / 20 : 0;
+		break;
+
+	case OBJ_MOD_INFRA:
+		result = (p->timed[TMD_SINFRA]) ? 5 : 0;
+		break;
+
+	case OBJ_MOD_SPEED:
+		result = (p->timed[TMD_FAST] || p->timed[TMD_SPRINT]) ? 10 : 0;
+		if (p->timed[TMD_STONESKIN]) {
+			result -= 5;
+		}
+		if (p->timed[TMD_SLOW]) {
+			result -= 10;
+		}
+		if (p->timed[TMD_TERROR]) {
+			result += 10;
+		}
+		break;
+
+	case OBJ_MOD_STEALTH:
+		result = (p->timed[TMD_STEALTH]) ? 10 : 0;
+		break;
+
+	default:
+		result = 0;
+		break;
+	}
+	return result;
+}
+
+
+/**
+ * Search for name in the categories associated with ui_entry being parsed.
+ * Return a nonzero value if present and set *ind to its index.  Otherwise,
+ * return zero and set *ind to where it should be inserted.
+ */
+static int search_embryo_categories(const struct embryonic_ui_entry *embryo,
+	const char *name, int *ind)
+{
+	int ilow, ihigh;
+
+	if (embryo->exists) {
+		return ui_entry_search_categories(embryo->entry, name, ind);
+	}
+
+	/* They're sorted by name so use a binary search. */
+	ilow = 0;
+	ihigh = embryo->entry->n_category;
+	while (1) {
+		int imid, cmp;
+
+		if (ilow == ihigh) {
+			*ind = ilow;
+			return 0;
+		}
+		imid = (ilow + ihigh) / 2;
+		cmp = strcmp(embryo->categories[imid].name, name);
+		if (cmp == 0) {
+			*ind = imid;
+			return 1;
+		}
+		if (cmp < 0) {
+			ilow = imid + 1;
+		} else {
+			ihigh = imid;
+		}
+	}
+}
+
+
+/**
+ * Search the list of all categories seen so far for a name.  Return a
+ * nonzero value if found and set *ind to its index.  Otherwise, return zero
+ * and set *ind to where it should be inserted.
+ */
+static int search_categories(const char* name, int *ind)
+{
+	int ilow = 0, ihigh = n_category;
+
+	while (1) {
+		int imid, cmp;
+
+		if (ilow == ihigh) {
+			*ind = ilow;
+			return 0;
+		}
+		imid = (ilow + ihigh) / 2;
+		cmp = strcmp(categories[imid], name);
+		if (cmp == 0) {
+			*ind = imid;
+			return 1;
+		}
+		if (cmp < 0) {
+			ilow = imid + 1;
+		} else {
+			ihigh = imid;
+		}
+	}
+}
+
+
+/**
+ * Insert a category with (name, priority) into the ui_entry being parsed.
+ * Use ind as the insertion point.
+ */
+static void insert_embryo_category(struct embryonic_ui_entry *embryo,
+	const char *name, int psource_index, int priority, bool priority_set,
+	int ind)
+{
+	int cind;
+
+	if (! search_categories(name, &cind)) {
+		if (n_category == nalloc_category) {
+			char **extended;
+
+			if (n_category > INT_MAX / 2) {
+				quit("Too many categories");
+			}
+			nalloc_category = (nalloc_category == 0) ?
+				8 : nalloc_category * 2;
+			extended = mem_alloc(nalloc_category *
+				sizeof(*extended));
+			if (cind > 0) {
+				memcpy(extended, categories,
+					cind * sizeof(*extended));
+			}
+			extended[cind] = string_make(name);
+			if (cind < n_category) {
+				memcpy(extended + cind + 1, categories + cind,
+					(n_category - cind) *
+					sizeof(*extended));
+			}
+			mem_free(categories);
+			categories = extended;
+		} else {
+			int i;
+
+			for (i = n_category; i > cind; --i) {
+				categories[i] = categories[i - 1];
+			}
+			categories[cind] = string_make(name);
+		}
+		++n_category;
+	}
+	if (embryo->entry->n_category == embryo->entry->nalloc_category) {
+		if (embryo->entry->nalloc_category > INT_MAX / 2) {
+			quit("Too many categories for an ui_entry");
+		}
+		embryo->entry->nalloc_category =
+			(embryo->entry->nalloc_category == 0) ?
+			4 : 2 * embryo->entry->nalloc_category;
+		if (embryo->exists) {
+			struct category_reference *extended =
+				mem_alloc(embryo->entry->nalloc_category *
+				sizeof(*extended));
+
+			if (ind > 0) {
+				(void) memcpy(extended,
+					embryo->entry->categories,
+					ind * sizeof(*extended));
+			}
+			extended[ind].name = categories[cind];
+			extended[ind].priority = priority;
+			extended[ind].priority_set = priority_set;
+			if (ind < embryo->entry->n_category) {
+				(void) memcpy(extended + ind + 1,
+					embryo->entry->categories + ind,
+					(embryo->entry->n_category - ind) *
+					sizeof(*extended));
+			}
+			mem_free(embryo->entry->categories);
+			embryo->entry->categories = extended;
+		} else {
+			struct embryonic_category_reference *extended =
+				mem_alloc(embryo->entry->nalloc_category *
+				sizeof(*extended));
+
+			if (ind > 0) {
+				(void) memcpy(extended,
+					embryo->categories,
+					ind * sizeof(*extended));
+			}
+			extended[ind].name = categories[cind];
+			extended[ind].psource_index = psource_index;
+			extended[ind].priority = priority;
+			extended[ind].priority_set = priority_set;
+			if (ind < embryo->entry->n_category) {
+				(void) memcpy(extended + ind + 1,
+					embryo->categories + ind,
+					(embryo->entry->n_category - ind) *
+					sizeof(*extended));
+			}
+			mem_free(embryo->categories);
+			embryo->categories = extended;
+		}
+	} else {
+		int i;
+
+		if (embryo->exists) {
+			for (i = embryo->entry->n_category; i > ind; --i) {
+				embryo->entry->categories[i] =
+					embryo->entry->categories[i - 1];
+			}
+			embryo->entry->categories[ind].name = categories[cind];
+			embryo->entry->categories[ind].priority = priority;
+			embryo->entry->categories[ind].priority_set =
+				priority_set;
+		} else {
+			for (i = embryo->entry->n_category; i > ind; --i) {
+				embryo->categories[i] =
+					embryo->categories[i - 1];
+			}
+			embryo->categories[ind].name = categories[cind];
+			embryo->categories[ind].psource_index = psource_index;
+			embryo->categories[ind].priority = priority;
+			embryo->categories[ind].priority_set = priority_set;
+		}
+	}
+	++embryo->entry->n_category;
+}
+
+
+/*
+ * Implement combining several modifiers or flags into one value for display.
+ */
+static int lookup_combiner(const char *name)
+{
+	/* Sorted alphabetically so use a binary search. */
+	int ilow = 0, ihigh = N_ELEMENTS(combiners);
+
+	while (1) {
+		int imid, cmp;
+
+		if (ilow == ihigh) {
+			return 0;
+		}
+		imid = (ilow + ihigh) / 2;
+		cmp = strcmp(combiners[imid].name, name);
+		if (cmp == 0) {
+			return imid + 1;
+		}
+		if (cmp < 0) {
+			ilow = imid + 1;
+		} else {
+			ihigh = imid;
+		}
+	}
+}
+
+
+static void simple_combine_init(int v, int a,
+	struct combining_algorithm_state *st)
+{
+	st->v = 0;
+	st->accum = v;
+	st->accum_aux = a;
+}
+
+
+static void dummy_combine_accum(int v, int a,
+	struct combining_algorithm_state *st)
+{
+	/* Do nothing. */
+}
+
+
+static void dummy_combine_finish(struct combining_algorithm_state *st)
+{
+	/* Do nothing. */
+}
+
+
+static void add_combine_accum(int v, int a,
+	struct combining_algorithm_state *st)
+{
+	/* Just in case, guard against overflow or underflow */
+	if (v > 0) {
+		if (st->accum <= INT_MAX - v) {
+			st->accum += v;
+		} else {
+			st->accum = INT_MAX;
+		}
+	} else if (v < 0) {
+		if (st->accum >= INT_MIN - v) {
+			st->accum += v;
+		} else {
+			st->accum = INT_MIN;
+		}
+	}
+	if (a > 0) {
+		if (st->accum_aux <= INT_MAX - a) {
+			st->accum_aux += a;
+		} else {
+			st->accum_aux = INT_MAX;
+		}
+	} else if (a < 0) {
+		if (st->accum_aux >= INT_MIN - a) {
+			st->accum_aux += a;
+		} else {
+			st->accum_aux = INT_MIN;
+		}
+	}
+}
+
+
+static void bitwise_or_combine_accum(int v, int a,
+	struct combining_algorithm_state *st)
+{
+	st->accum |= v;
+	st->accum_aux |= a;
+}
+
+
+static void largest_combine_accum(int v, int a,
+	struct combining_algorithm_state *st)
+{
+	if (st->accum < v) {
+		st->accum = v;
+	}
+	if (st->accum_aux < a) {
+		st->accum_aux = a;
+	}
+}
+
+
+static void last_combine_accum(int v, int a,
+	struct combining_algorithm_state *st)
+{
+	st->accum = v;
+	st->accum_aux = a;
+}
+
+
+static void logical_combine_init(int v, int a,
+	struct combining_algorithm_state *st)
+{
+	st->v = 0;
+	st->accum = (v != 0);
+	st->accum_aux = (a != 0);
+}
+
+
+static void logical_or_combine_accum(int v, int a,
+	struct combining_algorithm_state *st)
+{
+	st->accum = st->accum || (v != 0);
+	st->accum_aux = st->accum_aux || (a != 0);
+}
+
+
+static void resist_0_combine_init(int v, int a,
+	struct combining_algorithm_state *st)
+{
+	/*
+	 * Use the accum values in st for the most positive.  Allocate working
+	 * space to store the most negative.
+	 */
+	int* work = mem_alloc(2 * sizeof(*work));
+
+	st->v = work;
+	if (v > 0) {
+		st->accum = v;
+		work[0] = 0;
+	} else {
+		st->accum = 0;
+		work[0] = v;
+	}
+	if (a > 0) {
+		st->accum_aux = a;
+		work[1] = 0;
+	} else {
+		st->accum_aux = 0;
+		work[1] = a;
+	}
+}
+
+
+static void resist_0_combine_accum(int v, int a,
+	struct combining_algorithm_state *st)
+{
+	int *work = st->v;
+
+	if (v > 0) {
+		if (st->accum < v) {
+			st->accum = v;
+		}
+	} else if (work[0] > v) {
+		work[0] = v;
+	}
+	if (a > 0) {
+		if (st->accum_aux < a) {
+			st->accum_aux = a;
+		}
+	} else if (work[1] > a) {
+		work[1] = a;
+	}
+}
+
+
+static void resist_0_combine_finish(struct combining_algorithm_state *st)
+{
+	int *work = st->v;
+
+	if (! st->accum) {
+		st->accum = work[0];
+	}
+	if (! st->accum_aux) {
+		st->accum_aux = work[1];
+	}
+	mem_free(work);
+	st->v = 0;
+}
+
+
+static void smallest_combine_accum(int v, int a,
+	struct combining_algorithm_state *st)
+{
+	if (st->accum > v) {
+		st->accum = v;
+	}
+	if (st->accum_aux > a) {
+		st->accum_aux = a;
+	}
+}
+
+/* These are for handling unparameterized entry names. */
+static int get_dummy_param_count(void)
+{
+	return 1;
+}
+
+
+static const char *get_dummy_param_name(int i)
+{
+	assert(i == 0);
+	return "";
+}
+
+
+/* These are for handling of entries parameterized by the element name. */
+static const char *element_names[] = {
+	#define ELEM(x) #x,
+	#include "list-elements.h"
+	#undef ELEM
+};
+
+
+static int get_element_count(void)
+{
+	return N_ELEMENTS(element_names);
+}
+
+
+static const char *get_element_name(int i)
+{
+	assert(i >= 0 && i < get_element_count());
+	return element_names[i];
+}
+
+
+/* These are for handling of entries parameterized by the stat name. */
+static const char *stat_names[] = {
+	#define STAT(x) #x,
+	#include "list-stats.h"
+	#undef STAT
+};
+
+
+static int get_stat_count(void)
+{
+	return N_ELEMENTS(stat_names);
+}
+
+
+static const char *get_stat_name(int i)
+{
+	assert(i >= 0 && i < get_stat_count());
+	return stat_names[i];
+}
+
+
+/*
+ * For handling of automatically setting the priority based on the parameter
+ * indexing.
+ */
+static int get_dummy_priority(int i)
+{
+	return 0;
+}
+
+
+static int get_priority_from_index(int i)
+{
+	return i;
+}
+
+
+static int get_priority_from_negative_index(int i)
+{
+	return -i;
+}
+
+
+/* Convert list of categories in the embryo to its final form. */
+static void parameterize_category_list(
+	const struct embryonic_category_reference *categories, int n, int ind,
+	struct ui_entry *entry)
+{
+	int i;
+
+	entry->categories = mem_alloc(n * sizeof(*entry->categories));
+	entry->n_category = n;
+	entry->nalloc_category = n;
+
+	for (i = 0; i < n; ++i) {
+		entry->categories[i].name = categories[i].name;
+		if (categories[i].priority_set) {
+			entry->categories[i].priority =
+				(categories[i].psource_index > 0) ?
+				(*priority_schemes[categories[i].psource_index].priority)(ind) :
+				categories[i].priority;
+			entry->categories[i].priority_set = true;
+		} else {
+			entry->categories[i].priority = 0;
+			entry->categories[i].priority_set = false;
+		}
+	}
+}
+
+
+static void initialize_shortened(struct ui_entry *entry)
+{
+	int i;
+
+	assert(MAX_SHORTENED > 0);
+	entry->shortened_labels[0] = entry->shortened_buffer;
+	for (i = 1; i < MAX_SHORTENED; ++i) {
+		entry->shortened_labels[i] =
+			entry->shortened_labels[i - 1] + i + 1;
+	}
+	for (i = 0; i < MAX_SHORTENED; ++i) {
+		entry->nshortened[i] = 0;
+	}
+}
+
+
+static void copy_shortened_labels(struct ui_entry *dest,
+	const struct ui_entry *src)
+{
+	int i;
+
+	for (i = 0; i < MAX_SHORTENED; ++i) {
+		dest->shortened_labels[i] = (i == 0) ? dest->shortened_buffer :
+			dest->shortened_labels[i - 1] + i + 1;
+		dest->nshortened[i] = src->nshortened[i];
+		if (src->nshortened[i] > 0) {
+			(void) memcpy(dest->shortened_labels[i],
+				src->shortened_labels[i],
+				(src->nshortened[i] + 1) *
+				sizeof(*dest->shortened_labels[i]));
+		}
+	}
+}
+
+
+static void fill_out_shortened(struct ui_entry *entry)
+{
+	int i;
+
+	for (i = 0; i < MAX_SHORTENED; ++i) {
+		if (entry->nshortened[i] != 0) {
+			continue;
+		}
+		entry->nshortened[i] = (entry->nlabel < i + 1) ?
+			entry->nlabel : i + 1;
+		(void) memcpy(entry->shortened_labels[i], entry->label,
+			(entry->nshortened[i] + 1) *
+			sizeof(*entry->shortened_labels[i]));
+	}
+}
+
+
+static int hatch_embryo(struct embryonic_ui_entry *embryo)
+{
+	/* If was editing an existing entry, do not have to recommit it. */
+	if (! embryo->exists) {
+		int n, i;
+
+		/* Check that required fields are valid. */
+		if (embryo->entry->combiner_index == 0) {
+			string_free(embryo->entry->name);
+			mem_free(embryo->entry->label);
+			mem_free(embryo->entry);
+			mem_free(embryo->categories);
+			return 1;
+		}
+
+		/* Parameterize the name generating multiple entries. */
+		n = (*name_parameters[embryo->param_index].count_func)();
+		for (i = 0; i < n - 1; ++i) {
+			struct ui_entry *entry = mem_alloc(sizeof(*entry));
+
+			entry->name = string_make(
+				format("%s<%s>", embryo->entry->name,
+				(*name_parameters[embryo->param_index].ith_name_func)(i)));
+			if (embryo->psource_index != 0) {
+				entry->default_priority =
+					(*priority_schemes[embryo->psource_index].priority)(i);
+			} else {
+				entry->default_priority =
+					embryo->entry->default_priority;
+			}
+			parameterize_category_list(
+				embryo->categories, embryo->entry->n_category,
+				i, entry);
+			entry->obj_props = NULL;
+			entry->p_abilities = NULL;
+			if (embryo->entry->nlabel > 0) {
+				size_t sz = embryo->entry->nlabel *
+					sizeof(*entry->label);
+
+				entry->label = mem_alloc(sz);
+				(void) memcpy(entry->label,
+					embryo->entry->label, sz);
+				entry->nlabel = embryo->entry->nlabel;
+			} else {
+				entry->label = NULL;
+				entry->nlabel = 0;
+			}
+			copy_shortened_labels(entry, embryo->entry);
+			entry->renderer_index = embryo->entry->renderer_index;
+			entry->combiner_index = embryo->entry->combiner_index;
+			entry->param_index = i;
+			entry->flags = embryo->entry->flags;
+			entry->n_obj_prop = 0;
+			entry->nalloc_obj_prop = 0;
+			entry->n_p_ability = 0;
+			entry->nalloc_p_ability = 0;
+			ui_entry_insert(entry);
+		}
+		/*
+		 * For the last one, reuse the structure stored in the embryo
+		 * to save a bit of effort.
+		 */
+		if (embryo->param_index == 0) {
+			/* Not parameterized */
+			embryo->entry->param_index = -1;
+		} else {
+			char *newname = string_make(
+				format("%s<%s>", embryo->entry->name,
+				(*name_parameters[embryo->param_index].ith_name_func)(n - 1)));
+
+			string_free(embryo->entry->name);
+			embryo->entry->name = newname;
+			embryo->entry->param_index = n - 1;
+			if (embryo->psource_index != 0) {
+				embryo->entry->default_priority =
+					(*priority_schemes[embryo->psource_index].priority)(n - 1);
+			}
+		}
+		parameterize_category_list(embryo->categories,
+			embryo->entry->n_category, n - 1, embryo->entry);
+		ui_entry_insert(embryo->entry);
+	}
+	mem_free(embryo->categories);
+	return 0;
+}
+
+
+static int hatch_last_embryo(struct parser *p)
+{
+	struct embryonic_ui_entry *embryo = parser_priv(p);
+	int result = 0;
+
+	if (embryo) {
+		if (hatch_embryo(embryo)) {
+			result = 1;
+		}
+		mem_free(embryo);
+		parser_setpriv(p, NULL);
+	}
+	return result;
+}
+
+
+static enum parser_error parse_entry_name(struct parser *p)
+{
+	const char* name = parser_getstr(p, "name");
+	struct embryonic_ui_entry *embryo = parser_priv(p);
+	int ind;
+
+	if (embryo) {
+		if (streq(name, embryo->entry->name)) {
+			/*
+			 * Strange case since the last record is the same as
+			 * the this one.  Simply proceeed to modify the
+			 * previous record without a warning.
+			 */
+			return PARSE_ERROR_NONE;
+		}
+		if (hatch_embryo(embryo)) {
+			mem_free(embryo);
+			parser_setpriv(p, NULL);
+			return PARSE_ERROR_INVALID_VALUE;
+		}
+	} else {
+		embryo = mem_alloc(sizeof(*embryo));
+	}
+	
+	parser_setpriv(p, embryo);
+	ind = ui_entry_lookup(name);
+	if (ind > 0) {
+		/*
+		 * Modify an already existing record.  Recall it, convert it
+		 * back to embryonic form, and mark it as already existing.
+		 */
+		embryo->entry = entries[ind - 1];
+		embryo->exists = true;
+	} else {
+		/* Make a completely new entry. */
+		embryo->entry = mem_alloc(sizeof(*embryo->entry));
+		embryo->entry->name = string_make(name);
+		embryo->entry->categories = NULL;
+		embryo->entry->obj_props = NULL;
+		embryo->entry->p_abilities = NULL;
+		embryo->entry->label = NULL;
+		initialize_shortened(embryo->entry);
+		embryo->entry->nlabel = 0;
+		embryo->entry->renderer_index = 0;
+		embryo->entry->combiner_index = 0;
+		embryo->entry->default_priority = 0;
+		embryo->entry->flags = 0;
+		embryo->entry->n_category = 0;
+		embryo->entry->nalloc_category = 0;
+		embryo->entry->n_obj_prop = 0;
+		embryo->entry->nalloc_obj_prop = 0;
+		embryo->entry->n_p_ability = 0;
+		embryo->entry->nalloc_p_ability = 0;
+		embryo->exists = false;
+	}
+	embryo->categories = NULL;
+	embryo->param_index = 0;
+	embryo->psource_index = 0;
+	embryo->last_category_index = -1;
+
+	return PARSE_ERROR_NONE;
+}
+
+
+static enum parser_error parse_entry_template(struct parser *p)
+{
+	struct embryonic_ui_entry *embryo = parser_priv(p);
+	const char *name;
+	const struct ui_entry *tentry;
+	int template_ind, i;
+
+	if (!embryo) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	name = parser_getstr(p, "template");
+	template_ind = ui_entry_lookup(name);
+	if (template_ind == 0) {
+		return PARSE_ERROR_INVALID_VALUE;
+	}
+	tentry = entries[template_ind - 1];
+	/* Replace simple fields with what's in the template. */
+	embryo->entry->renderer_index = tentry->renderer_index;
+	embryo->entry->combiner_index = tentry->combiner_index;
+	embryo->entry->default_priority = tentry->default_priority;
+	embryo->entry->flags = tentry->flags & ~ENTRY_FLAG_TEMPLATE_ONLY;
+	/* Add in categories not already present. */
+	for (i = 0; i < tentry->n_category; ++i) {
+		int ind;
+
+		if (! search_embryo_categories(embryo,
+			tentry->categories[i].name, &ind)) {
+			insert_embryo_category(embryo,
+				tentry->categories[i].name, 0,
+				tentry->categories[i].priority,
+				tentry->categories[i].priority_set, ind);
+		}
+	}
+	return PARSE_ERROR_NONE;
+}
+
+
+static enum parser_error parse_entry_parameter(struct parser *p)
+{
+	struct embryonic_ui_entry *embryo = parser_priv(p);
+	const char *name;
+	int n = N_ELEMENTS(name_parameters);
+	int i;
+
+	if (!embryo) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	/*
+	 * Don't allow parameterization when editing an already existing entry.
+	 */
+	if (embryo->exists) {
+		return PARSE_ERROR_INVALID_OPTION;
+	}
+	name = parser_getstr(p, "parameter");
+	i = 0;
+	while (1) {
+		if (i >= n) {
+			return PARSE_ERROR_INVALID_VALUE;
+		}
+		if (streq(name, name_parameters[i].name)) {
+			embryo->param_index = i;
+			break;
+		}
+		++i;
+	}
+	return PARSE_ERROR_NONE;
+}
+
+
+static enum parser_error parse_entry_renderer(struct parser *p)
+{
+	struct embryonic_ui_entry *embryo = parser_priv(p);
+	const char *name;
+
+	if (!embryo) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	name = parser_getstr(p, "renderer");
+	embryo->entry->renderer_index = ui_entry_renderer_lookup(name);
+	return (embryo->entry->renderer_index) ?
+		PARSE_ERROR_NONE : PARSE_ERROR_INVALID_VALUE;
+}
+
+
+static enum parser_error parse_entry_combine(struct parser *p)
+{
+	struct embryonic_ui_entry *embryo = parser_priv(p);
+	const char *name;
+
+	if (!embryo) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	name = parser_getstr(p, "combine");
+	embryo->entry->combiner_index = lookup_combiner(name);
+	return (embryo->entry->combiner_index) ?
+		PARSE_ERROR_NONE : PARSE_ERROR_INVALID_VALUE;
+}
+
+
+static enum parser_error parse_entry_label(struct parser *p)
+{
+	struct embryonic_ui_entry *embryo = parser_priv(p);
+	const char *name;
+	size_t nw;
+
+	if (!embryo) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	name = parser_getstr(p, "label");
+	embryo->entry->label = mem_alloc((MAX_ENTRY_LABEL + 1) *
+		sizeof(*embryo->entry->label));
+	nw = text_mbstowcs(embryo->entry->label, name, MAX_ENTRY_LABEL);
+	if (nw != (size_t)-1) {
+		/* Ensure null termination. */
+		size_t nw2 = text_mbstowcs(embryo->entry->label + nw, "", 1);
+
+		if (nw2 != (size_t)-1) {
+			embryo->entry->nlabel = nw;
+		} else {
+			return PARSE_ERROR_INVALID_VALUE;
+		}
+	} else {
+		return PARSE_ERROR_INVALID_VALUE;
+	}
+	return PARSE_ERROR_NONE;
+}
+
+
+static enum parser_error parse_entry_shortened_label(struct parser *p)
+{
+	struct embryonic_ui_entry *embryo = parser_priv(p);
+	int n = 1;
+	const char *name;
+	size_t nw;
+
+	if (!embryo) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	while (1) {
+		if (n > MAX_SHORTENED) {
+			return PARSE_ERROR_INTERNAL;
+		}
+		if (parser_hasval(p, format("label%d", n))) {
+			break;
+		}
+		++n;
+	}
+	name = parser_getstr(p, format("label%d", n));
+	nw = text_mbstowcs(embryo->entry->shortened_labels[n - 1], name, n);
+	if (nw != (size_t) -1) {
+		/* Ensure null termination. */
+		size_t nw2 = text_mbstowcs(
+			embryo->entry->shortened_labels[n - 1] +
+			((int)nw < n ? (int)nw : n), "", 1);
+
+		if (nw2 != (size_t)-1) {
+			embryo->entry->nshortened[n - 1] = nw;
+		} else {
+			return PARSE_ERROR_INVALID_VALUE;
+		}
+	} else {
+		return PARSE_ERROR_INVALID_VALUE;
+	}
+	return PARSE_ERROR_NONE;
+}
+
+
+static enum parser_error parse_entry_category(struct parser *p)
+{
+	struct embryonic_ui_entry *embryo = parser_priv(p);
+	const char *name;
+	int ind;
+
+	if (!embryo) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	name = parser_getstr(p, "category");
+	if (! search_embryo_categories(embryo, name, &ind)) {
+		insert_embryo_category(embryo, name, embryo->psource_index,
+			embryo->entry->default_priority, false, ind);
+	}
+	embryo->last_category_index = ind;
+	return PARSE_ERROR_NONE;
+}
+
+
+static enum parser_error parse_entry_priority(struct parser *p)
+{
+	struct embryonic_ui_entry *embryo = parser_priv(p);
+	const char *name;
+	int psource_index = 0;
+	int priority = 0;
+	int n = N_ELEMENTS(priority_schemes);
+	int i;
+
+	if (!embryo) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	name = parser_getstr(p, "priority");
+	i = 1;
+	while (1) {
+		if (i >= n) {
+			char* end;
+			long v;
+
+			v = strtol(name, &end, 10);
+			if (! *name || *end) {
+				return PARSE_ERROR_NOT_NUMBER;
+			}
+			priority = (v <= INT_MAX) ?
+				((v >= INT_MIN) ? v : INT_MIN) : INT_MAX;
+			break;
+		}
+		if (streq(name, priority_schemes[i].name)) {
+			if (embryo->exists) {
+				priority = (*priority_schemes[i].priority)(
+					embryo->entry->param_index);
+			} else {
+				psource_index = i;
+			}
+			break;
+		}
+		++i;
+	}
+	if (embryo->last_category_index == -1) {
+		embryo->psource_index = psource_index;
+		embryo->entry->default_priority = priority;
+	} else {
+		if (embryo->exists) {
+			embryo->entry->categories[embryo->last_category_index].priority = priority;
+			embryo->entry->categories[embryo->last_category_index].priority_set = true;
+		} else {
+			embryo->categories[embryo->last_category_index].psource_index = psource_index;
+			embryo->categories[embryo->last_category_index].priority = priority;
+			embryo->categories[embryo->last_category_index].priority_set = true;
+		}
+	}
+	return PARSE_ERROR_NONE;
+}
+
+
+static enum parser_error parse_entry_flags(struct parser *p)
+{
+	struct embryonic_ui_entry *embryo = parser_priv(p);
+	char *flags;
+	char *s;
+	int n;
+
+	if (!embryo) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	if (!parser_hasval(p, "flags")) {
+		return PARSE_ERROR_NONE;
+	}
+	flags = string_make(parser_getstr(p, "flags"));
+	n = N_ELEMENTS(entry_flags);
+	s = strtok(flags, " |");
+	while (s) {
+		int i = 0;
+
+		while (1) {
+			if (i >= n) {
+				string_free(flags);
+				return PARSE_ERROR_INVALID_FLAG;
+			}
+			if (streq(s, entry_flags[i].name)) {
+				embryo->entry->flags |= entry_flags[i].value;
+				break;
+			}
+			++i;
+		}
+		s = strtok(NULL, " |");
+	}
+	string_free(flags);
+	return PARSE_ERROR_NONE;
+}
+
+
+static enum parser_error parse_entry_desc(struct parser *p)
+{
+	struct embryonic_ui_entry *embryo = parser_priv(p);
+
+	if (!embryo) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	/* Don't bother to store the description. */
+	return PARSE_ERROR_NONE;
+}
+
+
+static struct parser *init_parse_ui_entry(void)
+{
+	struct parser *p = parser_new();
+	int i;
+
+	parser_setpriv(p, NULL);
+	parser_reg(p, "name str name", parse_entry_name);
+	parser_reg(p, "template str template", parse_entry_template);
+	parser_reg(p, "parameter str parameter", parse_entry_parameter);
+	parser_reg(p, "renderer str renderer", parse_entry_renderer);
+	parser_reg(p, "combine str combine", parse_entry_combine);
+	parser_reg(p, "label str label", parse_entry_label);
+	for (i = 1; i <= MAX_SHORTENED; ++i) {
+		parser_reg(p, format("label%d str label%d", i, i),
+			parse_entry_shortened_label);
+	}
+	parser_reg(p, "category str category", parse_entry_category);
+	parser_reg(p, "priority str priority", parse_entry_priority);
+	parser_reg(p, "flags ?str flags", parse_entry_flags);
+	parser_reg(p, "desc str desc", parse_entry_desc);
+	return p;
+}
+
+
+static errr run_parse_ui_entry(struct parser *p)
+{
+	errr result = parse_file(p, "ui_entry_base");
+	int i;
+
+	if (result != 0) {
+		return result;
+	}
+	if (hatch_last_embryo(p)) {
+		return 1;
+	}
+	/*
+	 * Mark those as templates only so they'll never be directly displayed.
+	 */
+	for (i = 0; i < n_entry; ++i) {
+		entries[i]->flags |= ENTRY_FLAG_TEMPLATE_ONLY;
+	}
+	return parse_file(p, "ui_entry");
+}
+
+
+static errr finish_parse_ui_entry(struct parser *p)
+{
+	errr result = 0;
+	int i;
+
+	if (hatch_last_embryo(p)) {
+		result = 1;
+	}
+	for (i = 0; i < n_entry; ++i) {
+		int j;
+
+		/* Set labels not already configured. */
+		if (entries[i]->nlabel == 0) {
+			size_t n;
+
+			entries[i]->label = mem_alloc((MAX_ENTRY_LABEL + 1) *
+				sizeof(*entries[i]->label));
+			n = text_mbstowcs(entries[i]->label, entries[i]->name,
+				MAX_ENTRY_LABEL);
+			if (n != (size_t)-1) {
+			 	/* Ensure null termination. */
+				size_t n2 = text_mbstowcs(
+					entries[i]->label + n, "", 1);
+
+				if (n2 != (size_t)-1) {
+					entries[i]->nlabel = n;
+				} else {
+					result = 1;
+				}
+			} else {
+				result = 1;
+			}
+		}
+		fill_out_shortened(entries[i]);
+
+		/* Set priorities not already configured. */
+		for (j = 0; j < entries[i]->n_category; ++j) {
+			if (! entries[i]->categories[j].priority_set) {
+				entries[i]->categories[j].priority =
+					entries[i]->default_priority;
+				entries[i]->categories[j].priority_set = true;
+			}
+		}
+	}
+
+	parser_destroy(p);
+	return result;
+}
+
+
+static void cleanup_parse_ui_entry(void)
+{
+	int i;
+
+	for (i = 0; i < n_entry; ++i) {
+		string_free(entries[i]->name);
+		mem_free(entries[i]->categories);
+		mem_free(entries[i]->obj_props);
+		mem_free(entries[i]->p_abilities);
+		mem_free(entries[i]->label);
+		mem_free(entries[i]);
+	}
+	mem_free(entries);
+	n_entry = 0;
+	nalloc_entry = 0;
+	entries = NULL;
+
+	for (i = 0; i < n_category; ++i) {
+		string_free(categories[i]);
+	}
+	mem_free(categories);
+	n_category = 0;
+	nalloc_category = 0;
+	categories = NULL;
+}
+
+
+struct file_parser ui_entry_parser = {
+	"ui_entry",
+	init_parse_ui_entry,
+	run_parse_ui_entry,
+	finish_parse_ui_entry,
+	cleanup_parse_ui_entry
+};

--- a/src/ui-entry.c
+++ b/src/ui-entry.c
@@ -1904,7 +1904,7 @@ static int hatch_embryo(struct embryonic_ui_entry *embryo)
 			entry->obj_props = NULL;
 			entry->p_abilities = NULL;
 			if (embryo->entry->nlabel > 0) {
-				size_t sz = embryo->entry->nlabel *
+				size_t sz = (embryo->entry->nlabel + 1) *
 					sizeof(*entry->label);
 
 				entry->label = mem_alloc(sz);

--- a/src/ui-entry.c
+++ b/src/ui-entry.c
@@ -35,7 +35,7 @@
 #define MAX_ENTRY_LABEL (80)
 
 struct ui_entry_iterator {
-	struct ui_entry** entries;
+	struct ui_entry **entries;
 	int n, i;
 };
 
@@ -49,7 +49,7 @@ struct cached_player_data {
 };
 
 struct category_reference {
-	const char* name;
+	const char *name;
 	int priority;
         bool priority_set;
 };
@@ -135,7 +135,7 @@ enum {
 	ENTRY_FLAG_TEMPLATE_ONLY = (1 << 20)
 };
 struct entry_flag {
-	const char* name;
+	const char *name;
 	int value;
 };
 static struct entry_flag entry_flags[] = {
@@ -154,7 +154,7 @@ struct ui_entry {
 	struct bound_object_property *obj_props;
 	struct bound_player_ability *p_abilities;
 	wchar_t *label;
-	wchar_t* shortened_labels[MAX_SHORTENED];
+	wchar_t *shortened_labels[MAX_SHORTENED];
 	wchar_t shortened_buffer[MAX_SHORTENED + (MAX_SHORTENED * (MAX_SHORTENED + 1)) / 2];
 	int nshortened[MAX_SHORTENED];
 	int nlabel;
@@ -200,7 +200,7 @@ static struct ui_entry_name_parameter name_parameters[] = {
 };
 
 struct ui_entry_priority_scheme {
-	const char* name;
+	const char *name;
 	int (*priority)(int i);
 };
 
@@ -215,7 +215,7 @@ static struct ui_entry_priority_scheme priority_schemes[] = {
 };
 
 struct embryonic_category_reference {
-	const char* name;
+	const char *name;
 	int psource_index;
 	int priority;
 	bool priority_set;
@@ -245,7 +245,7 @@ static struct ui_entry **entries = NULL;
  * returns a nonzero value.  Otherwise returns zero after binding the property.
  * Currently, this is only used for some parts of the second character screen.
  */
-int bind_object_property_to_ui_entry_by_name(const char* name, int type,
+int bind_object_property_to_ui_entry_by_name(const char *name, int type,
 	int index, int value, bool have_value, bool isaux)
 {
 	int ind;
@@ -288,7 +288,7 @@ int bind_object_property_to_ui_entry_by_name(const char* name, int type,
  * returns zero after binding the ability.  Currently, this is only used for
  * some parts of the second character screen.
  */
-int bind_player_ability_to_ui_entry_by_name(const char* name,
+int bind_player_ability_to_ui_entry_by_name(const char *name,
 	struct player_ability *ability, int value, bool have_value, bool isaux)
 {
 	int ind;
@@ -397,7 +397,7 @@ void get_ui_entry_label(const struct ui_entry *entry, int length,
 }
 
 
-static const char* category_for_cmp_desc_prio = NULL;
+static const char *category_for_cmp_desc_prio = NULL;
 static int cmp_desc_prio(const void *left, const void *right)
 {
 	const struct ui_entry *eleft =
@@ -609,7 +609,7 @@ void compute_ui_entry_values_for_object(const struct ui_entry *entry,
 	struct cached_object_data **cache, int *val, int *auxval)
 {
 	struct combining_algorithm_state cst = { 0, 0, 0 };
-	const struct combining_algorithm* combiner;
+	const struct combining_algorithm *combiner;
 	const struct curse_data *curse;
 	struct cached_object_data *cache2;
 	bool first, all_unknown, all_aux_unknown, any_aux, all_aux;
@@ -815,7 +815,7 @@ void compute_ui_entry_values_for_player(const struct ui_entry *entry,
 	int *auxval)
 {
 	struct combining_algorithm_state cst = { 0, 0, 0 };
-	const struct combining_algorithm* combiner;
+	const struct combining_algorithm *combiner;
 	bool first;
 	int i;
 
@@ -1362,7 +1362,7 @@ static int search_embryo_categories(const struct embryonic_ui_entry *embryo,
  * nonzero value if found and set *ind to its index.  Otherwise, return zero
  * and set *ind to where it should be inserted.
  */
-static int search_categories(const char* name, int *ind)
+static int search_categories(const char *name, int *ind)
 {
 	int ilow = 0, ihigh = n_category;
 
@@ -1644,7 +1644,7 @@ static void resist_0_combine_init(int v, int a,
 	 * Use the accum values in st for the most positive.  Allocate working
 	 * space to store the most negative.
 	 */
-	int* work = mem_alloc(2 * sizeof(*work));
+	int *work = mem_alloc(2 * sizeof(*work));
 
 	st->v = work;
 	if (v > 0) {
@@ -1997,7 +1997,7 @@ static int hatch_last_embryo(struct parser *p)
 
 static enum parser_error parse_entry_name(struct parser *p)
 {
-	const char* name = parser_getstr(p, "name");
+	const char *name = parser_getstr(p, "name");
 	struct embryonic_ui_entry *embryo = parser_priv(p);
 	int ind;
 
@@ -2262,7 +2262,7 @@ static enum parser_error parse_entry_priority(struct parser *p)
 	i = 1;
 	while (1) {
 		if (i >= n) {
-			char* end;
+			char *end;
 			long v;
 
 			v = strtol(name, &end, 10);

--- a/src/ui-entry.c
+++ b/src/ui-entry.c
@@ -2145,6 +2145,7 @@ static enum parser_error parse_entry_label(struct parser *p)
 		return PARSE_ERROR_MISSING_RECORD_HEADER;
 	}
 	name = parser_getstr(p, "label");
+	mem_free(embryo->entry->label);
 	embryo->entry->label = mem_alloc((MAX_ENTRY_LABEL + 1) *
 		sizeof(*embryo->entry->label));
 	nw = text_mbstowcs(embryo->entry->label, name, MAX_ENTRY_LABEL);

--- a/src/ui-entry.h
+++ b/src/ui-entry.h
@@ -23,14 +23,14 @@ struct object;
 struct player;
 
 struct ui_entry;
-typedef bool (*ui_entry_predicate)(const struct ui_entry* entry, void* closure);
+typedef bool (*ui_entry_predicate)(const struct ui_entry *entry, void *closure);
 struct ui_entry_iterator;
 struct cached_object_data;
 struct cached_player_data;
 
-int bind_object_property_to_ui_entry_by_name(const char* name, int type,
+int bind_object_property_to_ui_entry_by_name(const char *name, int type,
 	int index, int value, bool have_value, bool isaux);
-int bind_player_ability_to_ui_entry_by_name(const char* name,
+int bind_player_ability_to_ui_entry_by_name(const char *name,
 	struct player_ability *ability, int value, bool have_value,
 	bool isaux);
 

--- a/src/ui-entry.h
+++ b/src/ui-entry.h
@@ -1,0 +1,59 @@
+/**
+ * \file ui-entry.h
+ * \brief Declarations to link object/player properties to 2nd character screen
+ *
+ * This work is free software; you can redistribute it and/or modify it
+ * under the terms of either:
+ *
+ * a) the GNU General Public License as published by the Free Software
+ *    Foundation, version 2, or
+ *
+ * b) the "Angband licence":
+ *    This software may be copied and distributed for educational, research,
+ *    and not for profit purposes provided that this copyright and statement
+ *    are included in all such copies.  Other copyrights may also apply.
+ */
+#ifndef INCLUDED_UI_ENTRY_H
+#define INCLUDED_UI_ENTRY_H
+
+#include "h-basic.h"
+
+struct player_ability;
+struct object;
+struct player;
+
+struct ui_entry;
+typedef bool (*ui_entry_predicate)(const struct ui_entry* entry, void* closure);
+struct ui_entry_iterator;
+struct cached_object_data;
+struct cached_player_data;
+
+int bind_object_property_to_ui_entry_by_name(const char* name, int type,
+	int index, int value, bool have_value, bool isaux);
+int bind_player_ability_to_ui_entry_by_name(const char* name,
+	struct player_ability *ability, int value, bool have_value,
+	bool isaux);
+
+struct ui_entry_iterator *initialize_ui_entry_iterator(
+	ui_entry_predicate predicate, void *closure, const char *sortcategory);
+void release_ui_entry_iterator(struct ui_entry_iterator *i);
+void reset_ui_entry_iterator(struct ui_entry_iterator *i);
+int count_ui_entry_iterator(struct ui_entry_iterator *i);
+struct ui_entry *advance_ui_entry_iterator(struct ui_entry_iterator *i);
+
+bool ui_entry_has_category(const struct ui_entry *entry, const char *name);
+void get_ui_entry_label(const struct ui_entry *entry, int length,
+	bool pad_left, wchar_t *label);
+int get_ui_entry_renderer_index(const struct ui_entry *entry);
+bool is_ui_entry_for_known_rune(const struct ui_entry *entry,
+	const struct player *p);
+void compute_ui_entry_values_for_object(const struct ui_entry *entry,
+	const struct object *obj, const struct player *p,
+	struct cached_object_data **cache,  int *val, int *auxval);
+void compute_ui_entry_values_for_player(const struct ui_entry *entry,
+	struct player *p, struct cached_player_data **cache, int *val,
+	int *auxval);
+void release_cached_object_data(struct cached_object_data *cache);
+void release_cached_player_data(struct cached_player_data *cache);
+
+#endif /* INCLUDED_UI_ENTRY_H */

--- a/src/ui-options.c
+++ b/src/ui-options.c
@@ -1044,6 +1044,13 @@ static void do_dump_autoinsc(const char *title, int row) {
 }
 
 /**
+ * Write character screen customizations to a file.
+ */
+static void do_dump_charscreen_opt(const char *title, int row) {
+	dump_pref_file(dump_ui_entry_renderers, "Dump char screen options", 20);
+}
+
+/**
  * Load a pref file.
  */
 static void options_load_pref_file(const char *n, int row)
@@ -1816,6 +1823,7 @@ static menu_action option_actions[] =
 	{ 0, 0, NULL, NULL },
 	{ 0, 's', "Save subwindow setup to pref file", do_dump_options },
 	{ 0, 't', "Save autoinscriptions to pref file", do_dump_autoinsc },
+	{ 0, 'u', "Save char screen options to pref file", do_dump_charscreen_opt },
 	{ 0, 0, NULL, NULL },
 	{ 0, 'l', "Load a user pref file", options_load_pref_file },
 	{ 0, 'k', "Edit keymaps (advanced)", do_cmd_keymaps },

--- a/src/ui-prefs.c
+++ b/src/ui-prefs.c
@@ -32,6 +32,7 @@
 #include "player.h"
 #include "trap.h"
 #include "ui-display.h"
+#include "ui-entry-renderers.h"
 #include "ui-keymap.h"
 #include "ui-prefs.h"
 #include "ui-term.h"
@@ -309,6 +310,36 @@ void dump_colors(ang_file *fff)
 
 		file_putf(fff, "# Color: %s\n", name);
 		file_putf(fff, "color:%d:%d:%d:%d:%d\n\n", i, kv, rv, gv, bv);
+	}
+}
+
+
+/**
+ * Dump the customizable attributes for renderers used in the character
+ * screen.
+ */
+void dump_ui_entry_renderers(ang_file *fff)
+{
+	int n = ui_entry_renderer_get_index_limit(), i;
+
+	file_putf(fff, "# Renderers for parts of the character screen.\n");
+	file_putf(fff, "# Format entry-renderer:name:colors:label_colors:symbols\n");
+	file_putf(fff, "# Use * for colors or label_colors to leave those unchanged\n");
+	file_putf(fff, "# Leave off symbols and the colon before it to leave those unchanged\n");
+	file_putf(fff, "# Look at lib/gamedata/ui_entry_renderers.txt for more information\n");
+	file_putf(fff, "# about how colors, label_colors, and symbols are used\n");
+
+	for (i = ui_entry_renderer_get_min_index(); i < n; i++) {
+		char* colors = ui_entry_renderer_get_colors(i);
+		char* labcolors = ui_entry_renderer_get_label_colors(i);
+		char* symbols = ui_entry_renderer_get_symbols(i);
+
+		file_putf(fff, "entry-renderer:%s:%s:%s:%s\n",
+			ui_entry_renderer_get_name(i), colors, labcolors,
+			symbols);
+		string_free(symbols);
+		string_free(labcolors);
+		string_free(colors);
 	}
 }
 
@@ -1033,6 +1064,45 @@ static enum parser_error parse_prefs_window(struct parser *p)
 	return PARSE_ERROR_NONE;
 }
 
+static enum parser_error parse_prefs_entry_renderer(struct parser *p)
+{
+	const char* name = parser_getsym(p, "name");
+	const char* colors;
+	const char* label_colors;
+	const char* symbols;
+	int index;
+
+	index = ui_entry_renderer_lookup(name);
+	if (index == 0) {
+		return PARSE_ERROR_INVALID_VALUE;
+	}
+	if (parser_hasval(p, "colors")) {
+		colors = parser_getsym(p, "colors");
+		if (streq(colors, "*")) {
+			colors = NULL;
+		}
+	} else {
+		colors = NULL;
+	}
+	if (parser_hasval(p, "labelcolors")) {
+		label_colors = parser_getsym(p, "labelcolors");
+		if (streq(label_colors, "*")) {
+			label_colors = NULL;
+		}
+	} else {
+		label_colors = NULL;
+	}
+	if (parser_hasval(p, "symbols")) {
+		symbols = parser_getsym(p, "symbols");
+	} else {
+		symbols = NULL;
+	}
+	if (ui_entry_renderer_customize(index, colors, label_colors, symbols)) {
+		return PARSE_ERROR_INVALID_VALUE;
+	}
+	return PARSE_ERROR_NONE;
+}
+
 enum parser_error parse_prefs_dummy(struct parser *p)
 {
 	return PARSE_ERROR_NONE;
@@ -1065,6 +1135,7 @@ static struct parser *init_parse_prefs(bool user)
 	parser_reg(p, "message sym type sym attr", parse_prefs_message);
 	parser_reg(p, "color uint idx int k int r int g int b", parse_prefs_color);
 	parser_reg(p, "window int window uint flag uint value", parse_prefs_window);
+	parser_reg(p, "entry-renderer sym name ?sym colors ?sym labelcolors ?sym symbols", parse_prefs_entry_renderer);
 	register_sound_pref_parser(p);
 
 	return p;

--- a/src/ui-prefs.h
+++ b/src/ui-prefs.h
@@ -64,6 +64,7 @@ void dump_autoinscriptions(ang_file *f);
 void dump_features(ang_file *fff);
 void dump_flavors(ang_file *fff);
 void dump_colors(ang_file *fff);
+void dump_ui_entry_renderers(ang_file *fff);
 void option_dump(ang_file *fff);
 bool prefs_save(const char *path, void (*dump)(ang_file *), const char *title);
 errr process_pref_file_command(const char *buf);


### PR DESCRIPTION
Added infrastructure to drive the resistance panel and object stat/sustain information in the character screen from the configuration files. ui_entry_renderer.txt configures types of formatting. The backend code is in list-ui-entry-renderers.h, ui-entry-renderers.h, and ui-entry-renderers.c. ui_entry.txt (with templates from ui_entry_base.txt) configures the links between object or player properties and those formatters. It also sets some details of the character screen (labels, category, order within category). The backend code is in ui-entry.h and ui-entry.c. ui-entry-init.h exposes the bits needed by init.c for initialization and cleanup. ui-player.c for the resistance panel and stat/sustain object information now largely just does placement and iteration over the elements. The data collection and computation is handled in ui-entry.c, and the formatting and display in ui-entry-renderers.c.

Part of the intent is that a "resistance grid for home" could also use this.
