### PR TITLE
Use an alternate method for resolving curse ID issues ( #4190 and #4334 )

### DIFF
--- a/src/obj-init.c
+++ b/src/obj-init.c
@@ -183,6 +183,8 @@ static void write_curse_kinds(void)
 		}
 		curse->obj->known->kind = curse_object_kind;
 		curses[i].obj->known->sval = sval;
+		/* Mark it as touched so it can be fully known. */
+		curse->obj->known->notice |= OBJ_NOTICE_ASSESSED;
 	}
 }
 

--- a/src/obj-knowledge.c
+++ b/src/obj-knowledge.c
@@ -1446,7 +1446,6 @@ void object_curses_find_to_a(struct player *p, struct object *obj)
 				index = rune_index(RUNE_VAR_CURSE, i);
 				if (index >= 0) {
 					player_learn_rune(p, index, true);
-					curses[i].obj->known->to_a = curses[i].obj->to_a;
 				}
 			}
 		}
@@ -1470,7 +1469,6 @@ void object_curses_find_to_h(struct player *p, struct object *obj)
 				index = rune_index(RUNE_VAR_CURSE, i);
 				if (index >= 0) {
 					player_learn_rune(p, index, true);
-					curses[i].obj->known->to_h = curses[i].obj->to_h;
 				}
 			}
 		}
@@ -1494,7 +1492,6 @@ void object_curses_find_to_d(struct player *p, struct object *obj)
 				index = rune_index(RUNE_VAR_CURSE, i);
 				if (index >= 0) {
 					player_learn_rune(p, index, true);
-					curses[i].obj->known->to_d = curses[i].obj->to_d;
 				}
 			}
 		}
@@ -1544,7 +1541,6 @@ bool object_curses_find_flags(struct player *p, struct object *obj,
 				index = rune_index(RUNE_VAR_CURSE, i);
 				if (index >= 0) {
 					player_learn_rune(p, index, true);
-					of_on(curses[i].obj->known->flags, flag);
 				}
 			}
 		}
@@ -1584,7 +1580,6 @@ void object_curses_find_modifiers(struct player *p, struct object *obj)
 					/* Learn the curse */
 					if (index >= 0) {
 						player_learn_rune(p, index, true);
-						curses[i].obj->modifiers[j] = 1;
 					}
 				}
 			}
@@ -1628,8 +1623,6 @@ bool object_curses_find_element(struct player *p, struct object *obj, int elem)
 				/* Learn the curse */
 				if (index >= 0) {
 					player_learn_rune(p, index, true);
-					curses[i].obj->known->el_info[elem].res_level
-						= curses[i].obj->el_info[elem].res_level;
 				}
 				new = true;
 			}

--- a/src/ui-game.c
+++ b/src/ui-game.c
@@ -25,6 +25,7 @@
 #include "init.h"
 #include "mon-lore.h"
 #include "mon-make.h"
+#include "obj-knowledge.h"
 #include "obj-util.h"
 #include "player-attack.h"
 #include "player-calcs.h"
@@ -406,6 +407,12 @@ static void start_game(bool new_game)
 	if (player->is_dead || new_game) {
 		character_generated = false;
 		textui_do_birth();
+	} else {
+		/*
+		 * Bring the stock curse objects up-to-date with what the
+		 * player knows.
+		 */
+		update_player_object_knowledge(player);
 	}
 
 	/* Tell the UI we've started. */


### PR DESCRIPTION
Mark the known versions of the stock curse objects as touched so full knowledge can propagate to them in the normal way.  Backed out the prior change to resolve those since it should now be redundant and had an issue with changing the modifier on a curse.  When resuming from a savefile, call update_player_object_knowledge() so the stock curse objects are up-to-date with the knowledge of the newly loaded character.  That resolves #4377 where immediately looking at the character screen after loading with a cursed item did not show the effects of the curse.