### PR TITLE
Increase player's melee/missile/thrown damage if brand hits vulnerability

### DIFF
--- a/lib/gamedata/brand.txt
+++ b/lib/gamedata/brand.txt
@@ -7,7 +7,7 @@
 # power: weighting in object power calculations (100 is neutral)
 # verb: verb used when a susceptible monster is hit
 # resist-flag: monster race flag for resist to the brand element
-
+# vuln-flag: monster race flag for special vulnerability to the brand element
 # This file encodes the brands that can appear on object.
 
 code:ACID_3

--- a/lib/gamedata/brand.txt
+++ b/lib/gamedata/brand.txt
@@ -33,6 +33,7 @@ multiplier:3
 o-multiplier:25
 power:113
 resist-flag:IM_FIRE
+vuln-flag:HURT_FIRE
 
 code:COLD_3
 name:cold
@@ -41,6 +42,7 @@ multiplier:3
 o-multiplier:25
 power:119
 resist-flag:IM_COLD
+vuln-flag:HURT_COLD
 
 code:POIS_3
 name:poison
@@ -73,6 +75,7 @@ multiplier:2
 o-multiplier:15
 power:107
 resist-flag:IM_FIRE
+vuln-flag:HURT_FIRE
 
 code:COLD_2
 name:cold
@@ -81,6 +84,7 @@ multiplier:2
 o-multiplier:15
 power:109
 resist-flag:IM_COLD
+vuln-flag:HURT_COLD
 
 code:POIS_2
 name:poison

--- a/src/obj-init.c
+++ b/src/obj-init.c
@@ -878,6 +878,23 @@ static enum parser_error parse_brand_resist_flag(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
+static enum parser_error parse_brand_vuln_flag(struct parser *p) {
+	int flag;
+	struct brand *brand = parser_priv(p);
+	if (!brand)
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+
+	flag = lookup_flag(mon_race_flags, parser_getsym(p, "flag"));
+
+	if (flag == FLAG_END) {
+		return PARSE_ERROR_INVALID_FLAG;
+	} else {
+		brand->vuln_flag = flag;
+	}
+
+	return PARSE_ERROR_NONE;
+}
+
 struct parser *init_parse_brand(void) {
 	struct parser *p = parser_new();
 	parser_setpriv(p, NULL);
@@ -888,6 +905,7 @@ struct parser *init_parse_brand(void) {
 	parser_reg(p, "o-multiplier uint multiplier", parse_brand_o_multiplier);
 	parser_reg(p, "power uint power", parse_brand_power);
 	parser_reg(p, "resist-flag sym flag", parse_brand_resist_flag);
+	parser_reg(p, "vuln-flag sym flag", parse_brand_vuln_flag);
 	return p;
 }
 

--- a/src/obj-slays.c
+++ b/src/obj-slays.c
@@ -307,6 +307,31 @@ bool player_has_temporary_slay(int idx)
 }
 
 /**
+ * Return the multiplicative factor for a brand hitting a given monster.
+ * Account for any elemental vulnerabilities but not for resistances.
+ */
+int get_monster_brand_multiplier(const struct monster *mon, const struct brand *b)
+{
+	bool is_o_combat = OPT(player, birth_percent_damage);
+	int mult;
+
+	mult = (is_o_combat) ? b->o_multiplier : b->multiplier;
+	if (rf_has(mon->race->flags, b->vuln_flag)) {
+		/*
+		 * If especially vulnerable, apply a factor of two to the
+		 * extra damage from the brand.
+		 */
+		if (is_o_combat) {
+			mult = 2 * (mult - 10) + 10;
+		} else {
+			mult *= 2;
+		}
+	}
+
+	return mult;
+}
+
+/**
  * Extract the multiplier from a given object hitting a given monster.
  *
  * \param obj is the object being used to attack
@@ -327,11 +352,7 @@ void improve_attack_modifier(struct object *obj, const struct monster *mon,
 	/* Set the current best multiplier */
 	if (*brand_used) {
 		struct brand *b = &brands[*brand_used];
-		if (!OPT(player, birth_percent_damage)) {
-			best_mult = MAX(best_mult, b->multiplier);
-		} else {
-			best_mult = MAX(best_mult, b->o_multiplier);
-		}
+		best_mult = MAX(best_mult, get_monster_brand_multiplier(mon, b));
 	} else if (*slay_used) {
 		struct slay *s = &slays[*slay_used];
 		if (!OPT(player, birth_percent_damage)) {
@@ -354,8 +375,7 @@ void improve_attack_modifier(struct object *obj, const struct monster *mon,
  
 		/* Is the monster is vulnerable? */
 		if (!rf_has(mon->race->flags, b->resist_flag)) {
-			int mult = OPT(player, birth_percent_damage) ?
-				b->o_multiplier : b->multiplier;
+			int mult = get_monster_brand_multiplier(mon, b);
 
 			/* Record the best multiplier */
 			if (best_mult < mult) {
@@ -373,11 +393,14 @@ void improve_attack_modifier(struct object *obj, const struct monster *mon,
 			/* Learn about the monster */
 			if (monster_is_visible(mon)) {
 				rf_on(lore->flags, b->resist_flag);
+				rf_on(lore->flags, b->vuln_flag);
 			}
 		} else if (player_knows_brand(player, i)) {
-			/* Learn about resistant monsters */
-			if (monster_is_visible(mon))
+			/* Learn about resistant and vulnerable monsters */
+			if (monster_is_visible(mon)) {
 				rf_on(lore->flags, b->resist_flag);
+				rf_on(lore->flags, b->vuln_flag);
+			}
 		}
 	}
 

--- a/src/obj-slays.c
+++ b/src/obj-slays.c
@@ -316,7 +316,7 @@ int get_monster_brand_multiplier(const struct monster *mon, const struct brand *
 	int mult;
 
 	mult = (is_o_combat) ? b->o_multiplier : b->multiplier;
-	if (rf_has(mon->race->flags, b->vuln_flag)) {
+	if (b->vuln_flag && rf_has(mon->race->flags, b->vuln_flag)) {
 		/*
 		 * If especially vulnerable, apply a factor of two to the
 		 * extra damage from the brand.
@@ -393,13 +393,17 @@ void improve_attack_modifier(struct object *obj, const struct monster *mon,
 			/* Learn about the monster */
 			if (monster_is_visible(mon)) {
 				rf_on(lore->flags, b->resist_flag);
-				rf_on(lore->flags, b->vuln_flag);
+				if (b->vuln_flag) {
+					rf_on(lore->flags, b->vuln_flag);
+				}
 			}
 		} else if (player_knows_brand(player, i)) {
 			/* Learn about resistant and vulnerable monsters */
 			if (monster_is_visible(mon)) {
 				rf_on(lore->flags, b->resist_flag);
-				rf_on(lore->flags, b->vuln_flag);
+				if (b->vuln_flag) {
+					rf_on(lore->flags, b->vuln_flag);
+				}
 			}
 		}
 	}

--- a/src/obj-slays.h
+++ b/src/obj-slays.h
@@ -33,6 +33,7 @@ int brand_count(bool *brands);
 int slay_count(bool *slays);
 bool player_has_temporary_brand(int idx);
 bool player_has_temporary_slay(int idx);
+int get_monster_brand_multiplier(const struct monster *mon, const struct brand *b);
 void improve_attack_modifier(struct object *obj, const struct monster *mon, 
 							 int *brand_used, int *slay_used, char *verb,
 							 bool range);

--- a/src/object.h
+++ b/src/object.h
@@ -85,6 +85,7 @@ struct brand {
 	char *name;
 	char *verb;
 	int resist_flag;
+	int vuln_flag;
 	int multiplier;
 	int o_multiplier;
 	int power;


### PR DESCRIPTION
Resolves #4198 .

I used two as the multiplier for the extra damage since that's the multiplicative factor in project-mon.c and man-blows.c.  So a weak fire/cold brand would add 40% to the damage dice against a HURT_FIRE/HURT_COLD monster in standard combat and a strong fire/cold brand would add 60% to the damage dice in the same situation.  For O-combat, the modifier is set to (config_mod-10)*2+10 when a brand hits an especially vulnerable monster.  Is that the right thing to do?