### PR TITLE
Add alloc table binary search

### DIFF
--- a/src/obj-make.c
+++ b/src/obj-make.c
@@ -32,12 +32,31 @@
 #include "obj-tval.h"
 #include "obj-util.h"
 
-/** Arrays holding an index of objects to generate for a given level */
-static u32b *obj_total;
-static byte *obj_alloc;
+/**
+ * Stores cumulative probability distribution for objects at each level.  The
+ * value at ilv * (z_info->k_max + 1) + itm is the probablity, out of
+ * obj_alloc[ilv * (z_info->k_max + 1) + z_info->k_max], that an item whose
+ * index is less than itm occurs at level, ilv.
+ */
+static u32b *obj_alloc;
 
-static u32b *obj_total_great;
-static byte *obj_alloc_great;
+/**
+ * Has the same layout and interpretation as obj_alloc, but only items that
+ * are good or better contribute to the cumulative probability distribution.
+ */
+static u32b *obj_alloc_great;
+
+/**
+ * Store the total allocation value for each tval by level.  The value at
+ * ilv * TV_MAX + tval is the total for tval at the level, ilv.
+ */
+static u32b *obj_total_tval;
+
+/**
+ * Same layout and interpretation as obj_total_tval, but only items that are
+ * good or better contribute.
+ */
+static u32b *obj_total_tval_great;
 
 static s16b alloc_ego_size = 0;
 static alloc_entry *alloc_ego_table;
@@ -57,35 +76,43 @@ static void alloc_init_objects(void) {
 	int item, lev;
 	int k_max = z_info->k_max;
 
-	/* Allocate and wipe */
-	obj_alloc = mem_zalloc((z_info->max_obj_depth + 1) * k_max * sizeof(byte));
-	obj_alloc_great = mem_zalloc((z_info->max_obj_depth + 1) * k_max * sizeof(byte));
-	obj_total = mem_zalloc((z_info->max_obj_depth + 1) * sizeof(u32b));
-	obj_total_great = mem_zalloc((z_info->max_obj_depth + 1) * sizeof(u32b));
+	/* Allocate */
+	obj_alloc = mem_alloc((z_info->max_obj_depth + 1) * (k_max + 1) * sizeof(*obj_alloc));
+	obj_alloc_great = mem_alloc((z_info->max_obj_depth + 1) * (k_max + 1) * sizeof(*obj_alloc_great));
+	obj_total_tval = mem_zalloc((z_info->max_obj_depth + 1) * TV_MAX * sizeof(*obj_total_tval));
+	obj_total_tval_great = mem_zalloc((z_info->max_obj_depth + 1) * TV_MAX * sizeof(*obj_total_tval));
 
-	/* Init allocation data */
+	/* The cumulative chance starts at zero for each level. */
+	for (lev = 0; lev <= z_info->max_obj_depth; lev++) {
+		obj_alloc[lev * (k_max + 1)] = 0;
+		obj_alloc_great[lev * (k_max + 1)] = 0;
+	}
+
+	/* Fill the cumulative probability tables */
 	for (item = 0; item < k_max; item++) {
 		const struct object_kind *kind = &k_info[item];
 
 		int min = kind->alloc_min;
 		int max = kind->alloc_max;
 
-		/* If an item doesn't have a rarity, move on */
-		if (!kind->alloc_prob) continue;
-
 		/* Go through all the dungeon levels */
 		for (lev = 0; lev <= z_info->max_obj_depth; lev++) {
 			int rarity = kind->alloc_prob;
 
-			/* Save the probability in the standard table */
+			/* Add to the cumulative prob. in the standard table */
 			if ((lev < min) || (lev > max)) rarity = 0;
-			obj_total[lev] += rarity;
-			obj_alloc[(lev * k_max) + item] = rarity;
+			assert(rarity >= 0 && obj_alloc[(lev * (k_max + 1)) + item] <= (u32b)-1 - rarity);
+			obj_alloc[(lev * (k_max + 1)) + item + 1] =
+				obj_alloc[(lev * (k_max + 1)) + item] + rarity;
 
-			/* Save the probability in the "great" table if relevant */
+			obj_total_tval[lev * TV_MAX + kind->tval] += rarity;
+
+			/* Add to the cumulative prob. in the "great" table */
 			if (!kind_is_good(kind)) rarity = 0;
-			obj_total_great[lev] += rarity;
-			obj_alloc_great[(lev * k_max) + item] = rarity;
+			obj_alloc_great[(lev * (k_max + 1)) + item + 1] =
+				obj_alloc_great[(lev * (k_max + 1)) + item] + rarity;
+
+			obj_total_tval_great[lev * TV_MAX + kind->tval] += rarity;
 		}
 	}
 }
@@ -189,8 +216,8 @@ static void cleanup_obj_make(void) {
 	}
 	mem_free(money_type);
 	mem_free(alloc_ego_table);
-	mem_free(obj_total_great);
-	mem_free(obj_total);
+	mem_free(obj_total_tval_great);
+	mem_free(obj_total_tval);
 	mem_free(obj_alloc_great);
 	mem_free(obj_alloc);
 }
@@ -277,6 +304,33 @@ static int random_high_resist(struct object *obj, int *resist)
 	}
 
 	return false;
+}
+
+
+/**
+ * Return the index, i, into the cumulative probability table, tbl, such that
+ * tbl[i] <= p < tbl[i + 1].  p must be less than tbl[n - 1] and tbl[0] must be
+ * zero.
+ */
+static int binary_search_probtable(const u32b *tbl, int n, u32b p)
+{
+	int ilow = 0, ihigh = n;
+
+	assert(tbl[0] == 0 && tbl[n - 1] > p);
+	while (1) {
+		int imid;
+
+		if (ilow == ihigh - 1) {
+			assert(tbl[ilow] <= p && tbl[ihigh] > p);
+			return ilow;
+		}
+		imid = (ilow + ihigh) / 2;
+		if (tbl[imid] <= p) {
+			ilow = imid;
+		} else {
+			ihigh = imid;
+		}
+	}
 }
 
 
@@ -1023,31 +1077,40 @@ bool kind_is_good(const struct object_kind *kind)
  */
 static struct object_kind *get_obj_num_by_kind(int level, bool good, int tval)
 {
-	/* This is the base index into obj_alloc for this dlev */
-	size_t ind, item;
-	u32b value;
-	int total = 0;
-	byte *objects = good ? obj_alloc_great : obj_alloc;
+	const u32b *objects;
+	u32b total, value;
+	int item;
 
-	/* Pick an object */
-	ind = level * z_info->k_max;
-
-	/* Get new total */
-	for (item = 0; item < z_info->k_max; item++)
-		if (objkind_byid(item)->tval == tval)
-			total += objects[ind + item];
+	assert(level >= 0 && level <= z_info->max_obj_depth);
+	assert(tval >= 0 && tval < TV_MAX);
+	if (good) {
+		objects = obj_alloc_great + level * (z_info->k_max + 1);
+		total = obj_total_tval_great[level * TV_MAX + tval];
+	} else {
+		objects = obj_alloc + level * (z_info->k_max + 1);
+		total = obj_total_tval[level * TV_MAX + tval];
+	}
 
 	/* No appropriate items of that tval */
 	if (!total) return NULL;
-	
-	value = randint0(total);
-	
-	for (item = 0; item < z_info->k_max; item++)
-		if (objkind_byid(item)->tval == tval) {
-			if (value < objects[ind + item]) break;
 
-			value -= objects[ind + item];
+	/* Pick an object */
+	value = randint0(total);
+
+	/*
+	 * Find it.  Having a loop to calculate the cumulative probability
+	 * here with only the tval and applying a binary search was slower
+	 * for a test of getting a TV_SWORD from 4.2's available objects.
+	 * So continue to use the O(N) search.
+	 */
+	for (item = 0; item < z_info->k_max; item++) {
+		if (objkind_byid(item)->tval == tval) {
+			u32b prob = objects[item + 1] - objects[item];
+
+			if (value < prob) break;
+			value -= prob;
 		}
+	}
 
 	/* Return the item index */
 	return objkind_byid(item);
@@ -1060,9 +1123,9 @@ static struct object_kind *get_obj_num_by_kind(int level, bool good, int tval)
  */
 struct object_kind *get_obj_num(int level, bool good, int tval)
 {
-	/* This is the base index into obj_alloc for this dlev */
-	size_t ind, item;
+	const u32b *objects;
 	u32b value;
+	int item;
 
 	/* Occasional level boost */
 	if ((level > 0) && one_in_(z_info->great_obj))
@@ -1073,31 +1136,20 @@ struct object_kind *get_obj_num(int level, bool good, int tval)
 	level = MIN(level, z_info->max_obj_depth);
 	level = MAX(level, 0);
 
-	/* Pick an object */
-	ind = level * z_info->k_max;
-	
 	if (tval)
 		return get_obj_num_by_kind(level, good, tval);
-	
-	if (!good) {
-		value = randint0(obj_total[level]);
-		for (item = 0; item < z_info->k_max; item++) {
-			/* Found it */
-			if (value < obj_alloc[ind + item]) break;
 
-			/* Decrement */
-			value -= obj_alloc[ind + item];
-		}
-	} else {
-		value = randint0(obj_total_great[level]);
-		for (item = 0; item < z_info->k_max; item++) {
-			/* Found it */
-			if (value < obj_alloc_great[ind + item]) break;
+	objects = (good ? obj_alloc_great : obj_alloc) +
+		level * (z_info->k_max + 1);
 
-			/* Decrement */
-			value -= obj_alloc_great[ind + item];
-		}
+	/* Pick an object. */
+	if (! objects[z_info->k_max]) {
+		return NULL;
 	}
+	value = randint0(objects[z_info->k_max]);
+
+	/* Find it with a binary search. */
+	item = binary_search_probtable(objects, z_info->k_max + 1, value);
 
 	/* Return the item index */
 	return objkind_byid(item);

--- a/src/tests/object/alloc.c
+++ b/src/tests/object/alloc.c
@@ -1,0 +1,313 @@
+/* object/alloc */
+
+#include "unit-test.h"
+#include "unit-test-data.h"
+
+#include "init.h"
+#include "object.h"
+#include "obj-make.h"
+#include "obj-properties.h"
+#include <math.h>
+
+struct alloc_test_state {
+	int *histogram;
+	double *expected;
+};
+
+extern struct init_module obj_make_module;
+
+
+int setup_tests(void **state) {
+	struct alloc_test_state *st;
+
+	player = &test_player;
+
+	z_info = mem_zalloc(sizeof(*z_info));
+	z_info->k_max = 5;
+	/* Won't set up any egos for testing. */
+	z_info->e_max = 0;
+	z_info->max_obj_depth = 2;
+	z_info->great_obj = 20;
+
+	/*
+	 * Set up a small number of fake kinds with a mix of the attributes
+	 * get_obj_num() uses.
+	 */
+	k_info = mem_zalloc(sizeof(*k_info) * z_info->k_max);
+	k_info[0].alloc_min = 0;
+	k_info[0].alloc_max = 1;
+	k_info[0].alloc_prob = 80;
+	k_info[0].tval = TV_LIGHT;
+	k_info[1].alloc_min = 0;
+	k_info[1].alloc_max = 6;
+	k_info[1].alloc_prob = 40;
+	k_info[1].tval = TV_POTION;
+	k_info[2].alloc_min = 0;
+	k_info[2].alloc_max = 6;
+	k_info[2].alloc_prob = 20;
+	k_info[2].tval = TV_WAND;
+	k_info[3].alloc_min = 0;
+	k_info[3].alloc_max = 6;
+	k_info[3].alloc_prob = 10;
+	k_info[3].tval = TV_POTION;
+	kf_on(k_info[3].kind_flags, KF_GOOD);
+	k_info[4].alloc_min = 1;
+	k_info[4].alloc_max = 6;
+	k_info[4].alloc_prob = 5;
+	k_info[4].tval = TV_WAND;
+	kf_on(k_info[4].kind_flags, KF_GOOD);
+
+	st = mem_alloc(sizeof(*st));
+	st->histogram = mem_alloc(z_info->k_max * sizeof(*st->histogram));
+	st->expected = mem_alloc(z_info->k_max * sizeof(*st->expected));
+	*state = st;
+
+	(*obj_make_module.init)();
+
+	return 0;
+}
+
+
+int teardown_tests(void *state) {
+	struct alloc_test_state *st = state;
+
+	(*obj_make_module.cleanup)();
+	if (st) {
+		mem_free(st->expected);
+		mem_free(st->histogram);
+		mem_free(st);
+	}
+	mem_free(k_info);
+	mem_free(z_info);
+	return 0;
+}
+
+
+/*
+ * Compute the G-test statistic, https://en.wikipedia.org/wiki/G-test , given
+ * the number of observed occurences, obs, in n different categories with
+ * ntotal observations made and the expected probability, ex, of each of those
+ * categories.  The distribution for the result is expected to be approximately
+ * a chi-squared distribution with the degrees of freedom equal to one less
+ * than the number of nonzero elements in ex.
+ */
+static double compute_gtest_statistic(const int *ob, const double *ex,
+	int n, int ntotal)
+{
+	double result = 0.0;
+	int i;
+
+	for (i = 0; i < n; ++i) {
+		double oprob;
+
+		/* Zero observations don't contribute. */
+		if (!ob[i]) continue;
+
+		/*
+		 * There were nonzero observations in a supposedly impossible
+		 * category.
+		 */
+		if (ex[i] == 0.0) return 1e30;
+
+		oprob = ob[i] / (double) ntotal;
+		result += oprob * log(oprob / ex[i]);
+	}
+
+	return 2.0 * result;
+}
+
+
+/*
+ * Returns true if the chance of drawing a value greater than or equal to v
+ * from a chi-squared distribution with ndof degrees of freedom is less than
+ * .1%
+ */
+static bool satisfies_chisq_criteria(double v, int ndof)
+{
+	const double table[] = {
+		10.82757, 13.81551, 16.26624, 18.46683, 20.51501
+	};
+
+	if (ndof <= 0 || ndof > (int)N_ELEMENTS(table)) {
+		return false;
+	}
+	return v < table[ndof - 1];
+}
+
+
+static int histogram_max(const int* histogram, int nbin)
+{
+	int result = 0;
+	int i;
+
+	for (i = 0; i < nbin; ++i) {
+		if (result < histogram[i]) {
+			result = histogram[i];
+		}
+	}
+	return result;
+}
+
+
+static void compute_obj_num_expected(int level, bool good, int tval,
+	double *ex, int *nnonzero)
+{
+	double pboost = 1.0 / z_info->great_obj;
+	int i, total;
+
+	for (i = 0; i < z_info->k_max; ++i) {
+		ex[i] = 0.0;
+	}
+
+	/*
+	 * Add up the probabilities from being at a boosted level or
+	 * at the specified level.  To reduce round-off error, do the
+	 * boosted levels first since those probabilities are likely to be
+	 * smaller.
+	 */
+	for (i = z_info->max_obj_depth; i >= 0; --i) {
+		double mult;
+		int total = 0, boosted_level, j;
+
+		if (i == 0) {
+			mult = 1.0 - pboost;
+			boosted_level = level;
+		} else {
+			mult = pboost / z_info->max_obj_depth;
+			boosted_level = 1 +
+				(level * z_info->max_obj_depth / i);
+			if (boosted_level > z_info->max_obj_depth) {
+				boosted_level = z_info->max_obj_depth;
+			}
+		}
+
+		for (j = 0; j < z_info->k_max; ++j) {
+			if (good && !kf_has(k_info[j].kind_flags, KF_GOOD)) continue;
+			if (tval != 0 && k_info[j].tval != tval) continue;
+			if (k_info[j].alloc_min > boosted_level ||
+				k_info[j].alloc_max < boosted_level) continue;
+			total += k_info[j].alloc_prob;
+		}
+		if (!total) continue;
+
+		for (j = 0; j < z_info->k_max; ++j) {
+			int rarity = k_info[j].alloc_prob;
+
+			if (good && !kf_has(k_info[j].kind_flags, KF_GOOD)) continue;
+			if (tval != 0 && k_info[j].tval != tval) continue;
+			if (k_info[j].alloc_min > boosted_level ||
+				k_info[j].alloc_max < boosted_level) continue;
+			ex[j] += mult * (double) k_info[j].alloc_prob / total;
+		}
+	}
+
+	*nnonzero = 0;
+	for (i = 0; i < z_info->k_max; ++i) {
+		if (ex[i] > 0.0) {
+			++*nnonzero;
+		}
+	}
+}
+
+
+/*
+ * There is a non-deterministic element to this test.  The threshold for
+ * failure is unlikey to be met (expected to be .1% for each of the 7 tests
+ * below that can get more than one kind of object) but can happen even if
+ * get_obj_num() performs correctly.
+ */
+int test_get_obj_num_basic(void *state) {
+	struct {
+		int level, tval;
+		bool good;
+	} tests[] = {
+		{ 0, 0, false },
+		{ 1, 0, false },
+		{ 2, 0, false },
+		{ 1, 0, true },
+		{ 0, TV_POTION, false },
+		{ 1, TV_POTION, false },
+		{ 2, TV_POTION, false },
+		{ 1, TV_POTION, true }
+	};
+	int ntrials, i;
+	struct alloc_test_state *st = state;
+
+	/* Check for requesting a tval that can't be satisfied. */
+	null(get_obj_num(1, false, TV_CHEST));
+
+	/*
+	 * Set the number of trials so the expected number of times an object
+	 * will appear in the trials is large enough that the assumptions
+	 * for the G-test should be satisfied.
+	 */
+	ntrials = 0;
+	for (i = 0; i < z_info->k_max; ++i) {
+		ntrials += k_info[i].alloc_prob;
+	}
+	ntrials *= 30;
+
+	for (i = 0; i < (int)N_ELEMENTS(tests); ++i) {
+		int j, nnonzero;
+
+		for (j = 0; j < z_info->k_max; ++j) {
+			st->histogram[j] = 0;
+		}
+		for (j = 0; j < ntrials; ++j) {
+			const struct object_kind *kind =
+				get_obj_num(tests[i].level, tests[i].good,
+					tests[i].tval);
+			int k;
+
+			/*
+			 * The tests have been configured so an object kind
+			 * should always be found.
+			 */
+			notnull(kind);
+
+			k = 0;
+			while (1) {
+				require(k < z_info->k_max);
+				if (kind == k_info + k) {
+					/*
+					 * Check that the minimum level is met.
+					 * Do not check the maximum level
+					 * because of the possibility of level
+					 * boosting.
+					 */
+					require(tests[i].level >= kind->alloc_min);
+					if (tests[i].good) {
+						require(kf_has(kind->kind_flags, KF_GOOD));
+					}
+					if (tests[i].tval != 0) {
+						eq(kind->tval, tests[i].tval);
+					}
+					++st->histogram[k];
+					break;
+				}
+				++k;
+			}
+		}
+
+		compute_obj_num_expected(tests[i].level, tests[i].good,
+			tests[i].tval, st->expected, &nnonzero);
+		require(nnonzero >= 1);
+		if (nnonzero == 1) {
+			require(histogram_max(st->histogram, z_info->k_max) == ntrials);
+		} else {
+			double gtest = compute_gtest_statistic(st->histogram,
+				st->expected, z_info->k_max, ntrials);
+
+			require(satisfies_chisq_criteria(gtest, nnonzero - 1));
+		}
+	}
+
+	ok;
+}
+
+
+const char *suite_name = "object/alloc";
+struct test tests[] = {
+	{ "get_obj_num_basic", test_get_obj_num_basic },
+	{ NULL, NULL }
+};

--- a/src/tests/object/suite.mk
+++ b/src/tests/object/suite.mk
@@ -1,1 +1,1 @@
-TESTPROGS += object/attack object/util object/pile
+TESTPROGS += object/alloc object/attack object/util object/pile


### PR DESCRIPTION
Prompted by #2746, this adds a binary search in get_obj_num().  The gains are modest (called in a tight loop, get_obj_num(level, false, 0) takes about .74x of what it did before the change; get_obj_num(level, true, 0) takes about .90x of what it did).  If looking for performance gains in level setup, some current hot spots are ensure_connectedness(), find_empty(), and lookup_kind().  