### PR TITLE
Change prototype for teardown_test() in unit-test.c

### DIFF
--- a/src/tests/artifact/name.c
+++ b/src/tests/artifact/name.c
@@ -15,7 +15,7 @@ int setup_tests(void **state) {
 	return 0;
 }
 
-int teardown_tests(void **state) {
+int teardown_tests(void *state) {
 	mem_free(k_info);
 	mem_free(z_info);
 	return 0;

--- a/src/tests/game/basic.c
+++ b/src/tests/game/basic.c
@@ -38,7 +38,7 @@ int setup_tests(void **state) {
 	return 0;
 }
 
-int teardown_tests(void **state) {
+int teardown_tests(void *state) {
 	file_delete("Test1");
 	cleanup_angband();
 	return 0;

--- a/src/tests/game/mage.c
+++ b/src/tests/game/mage.c
@@ -39,7 +39,7 @@ int setup_tests(void **state) {
 	return 0;
 }
 
-int teardown_tests(void **state) {
+int teardown_tests(void *state) {
 	file_delete("Test1");
 	wipe_mon_list(cave, player);
 	cleanup_angband();

--- a/src/tests/object/util.c
+++ b/src/tests/object/util.c
@@ -21,7 +21,7 @@ int setup_tests(void **state) {
     return 0;
 }
 
-int teardown_tests(void **state) {
+int teardown_tests(void *state) {
 	quarks_free();
 	mem_free(z_info);
 	return 0;

--- a/src/tests/unit-test.c
+++ b/src/tests/unit-test.c
@@ -14,7 +14,7 @@ int verbose = 0;
 extern const char *suite_name;
 extern struct test tests[];
 extern int setup_tests(void **data);
-extern int teardown_tests(void **data);
+extern int teardown_tests(void *data);
 
 int main(int argc, char *argv[]) {
 	void *state;


### PR DESCRIPTION
Brings it into agreement with the README and the usage in unit-tests.c's main().  Some of the unit tests also declare teardown_test() that way.  Change them as well.  Since none use the argument only the declaration changes.