### PR TITLE
First batch of equipment comparison fixes

### DIFF
--- a/lib/gamedata/ui_entry.txt
+++ b/lib/gamedata/ui_entry.txt
@@ -137,6 +137,7 @@ category:EQUIPCMP_SCREEN
 
 name:resist_ui_compact_0<NEXUS>
 label:Nexus
+label2:Nx
 category:CHAR_SCREEN1
 category:EQUIPCMP_SCREEN
 
@@ -288,6 +289,7 @@ name:sticky_ui_compact_0
 template:other_flag_ui_compact_0
 label:Sticky curse
 label5:Stick
+label2:Sy
 priority:-6
 
 name:fragile_ui_compact_0
@@ -350,6 +352,7 @@ priority:-7
 name:light_ui_compact_0
 template:numeric_as_sign_ui_0
 label:Light
+label2:Lt
 priority:-8
 
 name:damage_reduction_ui_compact_0

--- a/lib/gamedata/ui_entry.txt
+++ b/lib/gamedata/ui_entry.txt
@@ -27,9 +27,10 @@
 # The label defines a label to be shown for the element.  Changing its value
 # can impact usability.  Optionally, shortened versions with
 # label followed by the number of characters as the field name can be
-# provided to override the default of using the first n characters of label
-# when an abbreviated version is needed.  The second character screen currently
-# uses 5 character labels so only label or label5 are relevant.
+# provided to override the default of using the next longest abbreviated label
+# that's available or the first n characters of label when an abbreviated
+# version is needed.  The second character screen currently uses 5 character
+# labels so only label or label5 are relevant.
 # combine controls how the values of the properties linked to the element are
 # combined before display.  Possible values are limited by the code and must
 # be one of ADD, BITWISE_OR, FIRST, LOGICAL_OR, LARGEST, LAST, RESIST_0, or

--- a/lib/gamedata/ui_entry.txt
+++ b/lib/gamedata/ui_entry.txt
@@ -30,7 +30,9 @@
 # provided to override the default of using the next longest abbreviated label
 # that's available or the first n characters of label when an abbreviated
 # version is needed.  The second character screen currently uses 5 character
-# labels so only label or label5 are relevant.
+# labels and the equipment comparison uses 2 (or 3 though only for filter
+# selection) character labels, so only label, label5, label3, and label2 are
+# relevant.
 # combine controls how the values of the properties linked to the element are
 # combined before display.  Possible values are limited by the code and must
 # be one of ADD, BITWISE_OR, FIRST, LOGICAL_OR, LARGEST, LAST, RESIST_0, or

--- a/lib/gamedata/ui_entry.txt
+++ b/lib/gamedata/ui_entry.txt
@@ -166,35 +166,30 @@ name:pfear_ui_compact_0
 template:good_flag_ui_compact_0
 label:Fear resistance
 label5:pFear
-label2:pF
 priority:0
 
 name:pblind_ui_compact_0
 template:good_flag_ui_compact_0
 label:Blindess resistance
 label5:pBlnd
-label2:pB
 priority:-1
 
 name:pconf_ui_compact_0
 template:good_flag_ui_compact_0
 label:Confusion resistance
 label5:pConf
-label2:pC
 priority:-2
 
 name:pstun_ui_compact_0
 template:good_flag_ui_compact_0
 label:Stun resistance
 label5:pStun
-label2:pS
 priority:-3
 
 name:holdlife_ui_compact_0
 template:good_flag_ui_compact_0
 label:Hold life
 label5:HLife
-label2:HL
 priority:-4
 
 name:regen_ui_compact_0
@@ -335,21 +330,18 @@ name:blows_ui_compact_0
 template:numeric_as_sign_ui_0
 label:Attack speed
 label5:Blows
-label2:Bl
 priority:-5
 
 name:shots_ui_compact_0
 template:numeric_as_sign_ui_0
 label:Shooting speed
 label5:Shots
-label2:Sh
 priority:-6
 
 name:shooting_power_ui_compact_0
 template:numeric_as_sign_ui_0
 label:Shooting power
 label5:Might
-label2:Mi
 priority:-7
 
 name:light_ui_compact_0

--- a/src/ui-entry.c
+++ b/src/ui-entry.c
@@ -1610,12 +1610,33 @@ static void fill_out_shortened(struct ui_entry *entry)
 	int i;
 
 	for (i = 0; i < MAX_SHORTENED; ++i) {
+		int j;
+		int n;
+		const wchar_t *src;
+
 		if (entry->nshortened[i] != 0) {
 			continue;
 		}
-		entry->nshortened[i] = (entry->nlabel < i + 1) ?
-			entry->nlabel : i + 1;
-		(void) memcpy(entry->shortened_labels[i], entry->label,
+		/*
+		 * Is there a longer abbreviated label already set?  Use it
+		 * as the basis for this one.  Otherwise, use the full label.
+		 */
+		j = i + 1;
+		while (1) {
+			if (j >= MAX_SHORTENED) {
+				n = entry->nlabel;
+				src = entry->label;
+				break;
+			}
+			if (entry->nshortened[j] != 0) {
+				n = entry->nshortened[j];
+				src = entry->shortened_labels[j];
+				break;
+			}
+			++j;
+		}
+		entry->nshortened[i] = (n < i + 1) ? n : i + 1;
+		(void) memcpy(entry->shortened_labels[i], src,
 			(entry->nshortened[i] + 1) *
 			sizeof(*entry->shortened_labels[i]));
 	}

--- a/src/ui-equip-cmp.c
+++ b/src/ui-equip-cmp.c
@@ -921,10 +921,11 @@ static int prompt_for_easy_filter(struct equipable_summary *s, bool apply_not)
 {
 	static const char *no_matching_attribute_msg =
 		"Did not find attribute with that name; filter unchanged";
-	char c[3] = "";
+	char c[4] = "";
 	int itry;
+	bool threec;
 
-	if (! get_string("Enter two character code and return or return to clear ", c,
+	if (! get_string("Enter 2 or 3 (for stat) character code and return or return to clear ", c,
 		N_ELEMENTS(c))) {
 		return EQUIP_CMP_MENU_NEW_PAGE;
 	}
@@ -949,11 +950,12 @@ static int prompt_for_easy_filter(struct equipable_summary *s, bool apply_not)
 	 * entered string to one of the column labels.
 	 */
 	itry = 0;
+	threec = false;
 	while (1) {
-		char ctry[3];
-		wchar_t wc[3];
+		char ctry[4];
+		wchar_t wc[4];
 
-		if (itry >= 4) {
+		if (itry >= 4 || (threec && itry >= 3)) {
 			s->dlg_trans_msg = no_matching_attribute_msg;
 			break;
 		}
@@ -962,7 +964,13 @@ static int prompt_for_easy_filter(struct equipable_summary *s, bool apply_not)
 			ctry[0] = toupper(c[0]);
 			if (c[1] != '\0') {
 				ctry[1] = tolower(c[1]);
-				ctry[2] = '\0';
+				if (c[2] != '\0') {
+					ctry[2] = tolower(c[2]);
+					ctry[3] = '\0';
+					threec = true;
+				} else {
+					ctry[2] = '\0';
+				}
 			} else {
 				ctry[1] = '\0';
 			}
@@ -972,7 +980,13 @@ static int prompt_for_easy_filter(struct equipable_summary *s, bool apply_not)
 			ctry[0] = toupper(c[0]);
 			if (c[1] != '\0') {
 				ctry[1] = toupper(c[1]);
-				ctry[2] = '\0';
+				if (c[2] != '\0') {
+					ctry[2] = toupper(c[2]);
+					ctry[3] = '\0';
+					threec = true;
+				} else {
+					ctry[2] = '\0';
+				}
 			} else {
 				ctry[1] = '\0';
 			}
@@ -982,7 +996,13 @@ static int prompt_for_easy_filter(struct equipable_summary *s, bool apply_not)
 			ctry[0] = tolower(c[0]);
 			if (c[1] != '\0') {
 				ctry[1] = tolower(c[1]);
-				ctry[2] = '\0';
+				if (c[2] != '\0') {
+					ctry[2] = tolower(c[2]);
+					ctry[3] = '\0';
+					threec = true;
+				} else {
+					ctry[2] = '\0';
+				}
 			} else {
 				ctry[1] = '\0';
 			}
@@ -1006,7 +1026,18 @@ static int prompt_for_easy_filter(struct equipable_summary *s, bool apply_not)
 			while (search) {
 				if (j < (int)N_ELEMENTS(s->propcats)) {
 					if (k < s->propcats[j].n) {
-						if (wc[0] == s->propcats[j].labels[k][0] &&
+						if (threec) {
+							wchar_t wce[4];
+
+							get_ui_entry_label(s->propcats[j].entries[k], 4, false, wce);
+							if (wc[0] == wce[0] &&
+							    wc[1] == wce[1] &&
+							    wc[2] == wce[2]) {
+								search = false;
+							} else {
+								++k;
+							}
+						} else if (wc[0] == s->propcats[j].labels[k][0] &&
 							wc[1] == s->propcats[j].labels[k][1]) {
 							search = false;
 						} else {

--- a/src/ui-equip-cmp.c
+++ b/src/ui-equip-cmp.c
@@ -1890,6 +1890,8 @@ static void compute_player_and_equipment_values(struct player *p,
 	struct equipable_summary *s)
 {
 	struct cached_player_data *pcache;
+	struct ui_entry_combiner_state *cstates;
+	struct ui_entry_combiner_funcs cfuncs;
 	int i;
 
 	if (! s->p_and_eq_vals) {
@@ -1902,25 +1904,29 @@ static void compute_player_and_equipment_values(struct player *p,
 	}
 
 	pcache = NULL;
+	cstates = mem_alloc(s->nprop * sizeof(*cstates));
 	for (i = 0; i < (int)N_ELEMENTS(s->propcats); ++i) {
 		int j;
 
 		for (j = 0; j < s->propcats[i].n; ++j) {
+			const struct ui_entry *entry =
+				s->propcats[i].entries[j];
+			int rendind = get_ui_entry_renderer_index(entry);
+			int combind =
+				ui_entry_renderer_query_combiner(rendind);
+			int v, a;
+
+			assert(combind > 0);
+			(void) ui_entry_combiner_get_funcs(combind, &cfuncs);
 			compute_ui_entry_values_for_player(
-				s->propcats[i].entries[j], p, &pcache,
-				s->p_and_eq_vals + j + s->propcats[i].off,
-				s->p_and_eq_auxvals + j + s->propcats[i].off);
+				entry, p, &pcache, &v, &a);
+			(*cfuncs.init_func)(v, a,
+				cstates + j + s->propcats[i].off);
 		}
 	}
 	release_cached_player_data(pcache);
 
-	/*
-	 * Combine with the values from the equipment.  Should use the
-	 * same combining procedures as used internally in ui-entry.c, but
-	 * those aren't exposed, so choose how to combine based on the
-	 * category (resistances, abilities (i.e. boolean flags), hindrances
-	 * (more boolean flags), and modifiers).
-	 */
+	/* Combine with the values from the equipment. */
 	for (i = 0; i < p->body.count; ++i) {
 		const struct object *obj = slot_object(p, i);
 		struct cached_object_data *cache = NULL;
@@ -1933,81 +1939,47 @@ static void compute_player_and_equipment_values(struct player *p,
 			int k;
 
 			for (k = 0; k < s->propcats[j].n; ++k) {
-				int ind = k + s->propcats[j].off;
+				const struct ui_entry *entry =
+					s->propcats[j].entries[k];
+				int rendind = get_ui_entry_renderer_index(entry);
+				int combind = ui_entry_renderer_query_combiner(rendind);
 				int v, a;
 
+				assert(combind > 0);
+				(void) ui_entry_combiner_get_funcs(
+					combind, &cfuncs);
 				compute_ui_entry_values_for_object(
 					s->propcats[j].entries[k], obj, p,
 					&cache, &v, &a);
-				if (j == 0) {
-					/* For a resistance, use the larger. */
-					if (v == UI_ENTRY_UNKNOWN_VALUE) {
-						if (s->p_and_eq_vals[ind] == 0 ||
-							s->p_and_eq_vals[ind] == UI_ENTRY_VALUE_NOT_PRESENT) {
-							s->p_and_eq_vals[ind] = UI_ENTRY_UNKNOWN_VALUE;
-						}
-					} else if (v != UI_ENTRY_VALUE_NOT_PRESENT) {
-						if (s->p_and_eq_vals[ind] < v) {
-							s->p_and_eq_vals[ind] = v;
-						}
-					}
-					if (a == UI_ENTRY_UNKNOWN_VALUE) {
-						if (s->p_and_eq_auxvals[ind] == 0 ||
-							s->p_and_eq_auxvals[ind] == UI_ENTRY_VALUE_NOT_PRESENT) {
-							s->p_and_eq_auxvals[ind] = UI_ENTRY_UNKNOWN_VALUE;
-						}
-					} else if (a != UI_ENTRY_VALUE_NOT_PRESENT) {
-						if (s->p_and_eq_auxvals[ind] < a) {
-							s->p_and_eq_auxvals[ind] = a;
-						}
-					}
-				} else if (j < 3) {
-					/*
-					 * For a boolean flag, use logical or.
-					 */
-					if (v == UI_ENTRY_UNKNOWN_VALUE) {
-						if (s->p_and_eq_vals[ind] == 0 ||
-							s->p_and_eq_vals[ind] == UI_ENTRY_VALUE_NOT_PRESENT) {
-							s->p_and_eq_vals[ind] = UI_ENTRY_UNKNOWN_VALUE;
-						}
-					} else if (v != UI_ENTRY_VALUE_NOT_PRESENT) {
-						if (v) {
-					 		s->p_and_eq_vals[ind] = 1;
-						}
-					}
-					if (a == UI_ENTRY_UNKNOWN_VALUE) {
-						if (s->p_and_eq_auxvals[ind] == 0 ||
-							s->p_and_eq_auxvals[ind] == UI_ENTRY_VALUE_NOT_PRESENT) {
-							s->p_and_eq_auxvals[ind] = UI_ENTRY_UNKNOWN_VALUE;
-						}
-					} else if (a != UI_ENTRY_VALUE_NOT_PRESENT) {
-						if (a) {
-					 		s->p_and_eq_auxvals[ind] = 1;
-						}
-					}
-				} else {
-					/* For modifiers, add. */
-					if (v == UI_ENTRY_UNKNOWN_VALUE) {
-						if (s->p_and_eq_vals[ind] == 0 ||
-							s->p_and_eq_vals[ind] == UI_ENTRY_VALUE_NOT_PRESENT) {
-							s->p_and_eq_vals[ind] = UI_ENTRY_UNKNOWN_VALUE;
-						}
-					} else if (v != UI_ENTRY_UNKNOWN_VALUE) {
-						s->p_and_eq_vals[ind] += v;
-					}
-					if (a == UI_ENTRY_UNKNOWN_VALUE) {
-						if (s->p_and_eq_auxvals[ind] == 0 ||
-							s->p_and_eq_auxvals[ind] == UI_ENTRY_VALUE_NOT_PRESENT) {
-							s->p_and_eq_auxvals[ind] = UI_ENTRY_UNKNOWN_VALUE;
-						}
-					} else if (a != UI_ENTRY_UNKNOWN_VALUE) {
-						s->p_and_eq_auxvals[ind] += a;
-					}
-				}
+				(*cfuncs.accum_func)(v, a,
+					cstates + k + s->propcats[j].off);
 			}
 		}
 		release_cached_object_data(cache);
 	}
+
+	for (i = 0; i < (int)N_ELEMENTS(s->propcats); ++i) {
+		int j;
+
+		for (j = 0; j < s->propcats[i].n; ++j) {
+			const struct ui_entry *entry =
+				s->propcats[i].entries[j];
+			int rendind = get_ui_entry_renderer_index(entry);
+			int combind =
+				ui_entry_renderer_query_combiner(rendind);
+
+			assert(combind > 0);
+			(void) ui_entry_combiner_get_funcs(combind, &cfuncs);
+			(*cfuncs.finish_func)(
+				cstates + j + s->propcats[i].off);
+			s->p_and_eq_vals[j + s->propcats[i].off] =
+				cstates[j + s->propcats[i].off].accum;
+			s->p_and_eq_auxvals[j + s->propcats[i].off] =
+				cstates[j + s->propcats[i].off].accum_aux;
+		}
+	}
+
+	mem_free(cstates);
 }
 
 

--- a/src/ui-equip-cmp.c
+++ b/src/ui-equip-cmp.c
@@ -2379,8 +2379,10 @@ static int display_page(struct equipable_summary *s, const struct player *p,
 	rdetails.value_position.x = rdetails.label_position.x;
 	rdetails.value_position.y = s->irow_combined_equip;
 	rdetails.position_step = loc(1, 0);
+	rdetails.combined_position = loc(0, 0);
 	rdetails.vertical_label = true;
 	rdetails.alternate_color_first = false;
+	rdetails.show_combined = false;
 	Term_putch(s->icol_name - 4, rdetails.value_position.y, color, '@');
 	for (i = 0; i < (int)N_ELEMENTS(s->propcats); ++i) {
 		int j;

--- a/src/ui-equip-cmp.c
+++ b/src/ui-equip-cmp.c
@@ -946,8 +946,7 @@ static int prompt_for_easy_filter(struct equipable_summary *s, bool apply_not)
 
 	/*
 	 * Try different combinations of capitalization to match the
-	 * entered string to one of the column labels (do not test for
-	 * a match to column, "Lo",  used for the location of the item).
+	 * entered string to one of the column labels.
 	 */
 	itry = 0;
 	while (1) {

--- a/src/ui-equip-cmp.c
+++ b/src/ui-equip-cmp.c
@@ -2223,6 +2223,7 @@ static int initialize_summary(struct player *p,
 	if (count > (*s)->nalloc) {
 		mem_free((*s)->sorted_indices);
 		cleanup_summary_items(*s);
+		mem_free((*s)->items);
 		(*s)->items = mem_zalloc(count * sizeof(*(*s)->items));
 		(*s)->sorted_indices =
 			mem_alloc((count + 1) * sizeof(*(*s)->sorted_indices));

--- a/src/ui-equip-cmp.c
+++ b/src/ui-equip-cmp.c
@@ -1032,11 +1032,11 @@ static int prompt_for_easy_filter(struct equipable_summary *s, bool apply_not)
 					s->stores != EQUIPABLE_YES_STORE)) {
 					s->easy_filt.v[s->easy_filt.nv].c =
 						EQUIP_EXPR_SELECTOR;
-					s->easy_filt.v[s->easy_filt.nv].s.ex.propind =
-						s->propcats[j].off + k;
 					++s->easy_filt.nv;
 				}
 				ind = s->easy_filt.nv - 1;
+				s->easy_filt.v[ind].s.ex.propind =
+					s->propcats[j].off + k;
 				switch (j) {
 				case 0:
 					/* Resistance */


### PR DESCRIPTION
Fixes:
- Some attributes couldn't be selected with the quick filter because of having the same (up to capitalization) two character label.
- Setting a quick filter when another was in place wouldn't switch the property index used and would require clearing the previous filter first.
- Plug memory leak every time the equipment comparison is reopened.

Code cleanup:
- Bring up to date with the changes to allow for display of a total value.
- Update some configuration file and code comments.