### PR TITLE
Add function to append textblocks

### DIFF
--- a/src/tests/z-textblock/textblock.c
+++ b/src/tests/z-textblock/textblock.c
@@ -81,11 +81,33 @@ int test_length(void *state) {
 	ok;
 }
 
+int test_append_textblock(void *state) {
+	const byte attrs[] = { COLOUR_L_BLUE, COLOUR_L_BLUE, COLOUR_L_BLUE,
+		COLOUR_L_GREEN, COLOUR_L_GREEN, COLOUR_L_GREEN, COLOUR_L_GREEN };
+	textblock *tb1 = textblock_new();
+	textblock *tb2 = textblock_new();
+
+	textblock_append_c(tb1, COLOUR_L_BLUE, "Hey");
+	textblock_append_c(tb2, COLOUR_L_GREEN, " you");
+	textblock_append_textblock(tb1, tb2);
+	require(!wcscmp(textblock_text(tb1), L"Hey you"));
+	require(!memcmp(textblock_attrs(tb1), attrs, sizeof(attrs)));
+	require(!wcscmp(textblock_text(tb2), L" you"));
+	require(!memcmp(textblock_attrs(tb2), attrs + 3,
+		sizeof(attrs) - 3 * sizeof(*attrs)));
+
+	textblock_free(tb2);
+	textblock_free(tb1);
+
+	ok;
+}
+
 const char *suite_name = "z-textblock/textblock";
 struct test tests[] = {
 	{ "alloc", test_alloc },
 	{ "append", test_append },
 	{ "colour", test_colour },
 	{ "length", test_length },
+	{ "append_textblock", test_append_textblock },
 	{ NULL, NULL }
 };

--- a/src/ui-equip-cmp.c
+++ b/src/ui-equip-cmp.c
@@ -1109,12 +1109,12 @@ static void display_object_comparison(const struct equipable_summary *s)
 
 		assert(s->isel1 >= 0 && s->isel1 < s->nitems);
 		textblock_append(tb1, "%s\n", hbuf);
-		textblock_append(tb1, "%ls", textblock_text(tb0));
+		textblock_append_textblock(tb1, tb0);
 		object_desc(hbuf, sizeof(hbuf), s->items[s->isel1].obj,
 			ODESC_PREFIX | ODESC_FULL | ODESC_CAPITAL);
 		textblock_append(tb1, "\n%s\n", hbuf);
 		tb2 = object_info(s->items[s->isel1].obj, OINFO_NONE);
-		textblock_append(tb1, "%ls", textblock_text(tb2));
+		textblock_append_textblock(tb1, tb2);
 		textblock_free(tb2);
 
 		textui_textblock_show(tb1, local_area, "Object comparison");

--- a/src/z-textblock.c
+++ b/src/z-textblock.c
@@ -163,6 +163,22 @@ void textblock_append_utf8(textblock *tb, const char *utf8_string)
 }
 
 /**
+ * Append one textblock to another.
+ *
+ * \param tb is the textblock we are appending to.
+ * \param tba is the textblock to append.
+ */
+void textblock_append_textblock(textblock *tb, const textblock *tba)
+{
+	textblock_resize_if_needed(tb, tba->strlen);
+	(void) memcpy(tb->text + tb->strlen, tba->text,
+		tba->strlen * sizeof(*tb->text));
+	(void) memcpy(tb->attrs + tb->strlen, tba->attrs, tba->strlen);
+	tb->strlen += tba->strlen;
+}
+
+
+/**
  * Add text to a text block, formatted.
  */
 void textblock_append(textblock *tb, const char *fmt, ...)

--- a/src/z-textblock.h
+++ b/src/z-textblock.h
@@ -33,6 +33,7 @@ void textblock_append(textblock *tb, const char *fmt, ...);
 void textblock_append_c(textblock *tb, byte attr, const char *fmt, ...);
 void textblock_append_pict(textblock *tb, byte attr, int c);
 void textblock_append_utf8(textblock *tb, const char *utf8_string);
+void textblock_append_textblock(textblock *tb, const textblock *tba);
 
 const wchar_t *textblock_text(textblock *tb);
 const byte *textblock_attrs(textblock *tb);


### PR DESCRIPTION
In the equipment comparison, using the option to show information on 'Sting' and something else would truncate the description for 'Sting' at the damage to animals because internally it used textblock_append(tb1, "%ls", textblock_text(tb2)) which ran into the limit of the internal buffer in vstrnfmt().

This adds a function, textblock_append_textblock(), to append a textblock to another.  It modifies the equipment comparison to use the new function.