### PR TITLE
Change to allow repeat for scrolls that target an item ...

### DIFF
--- a/src/cmd-obj.c
+++ b/src/cmd-obj.c
@@ -535,7 +535,8 @@ static void use_aux(struct command *cmd, struct object *obj, enum use use,
 							was_aware,
 							dir,
 							beam,
-							boost);
+							boost,
+							cmd);
 		target_release();
 
 		if (!used) {
@@ -1047,7 +1048,7 @@ void do_cmd_cast(struct command *cmd)
 
 	/* Cast a spell */
 	target_fix();
-	if (spell_cast(spell_index, dir)) {
+	if (spell_cast(spell_index, dir, cmd)) {
 		if (player->timed[TMD_FASTCAST]) {
 			player->upkeep->energy_use = (z_info->move_energy * 3) / 4;
 		} else {

--- a/src/effects.c
+++ b/src/effects.c
@@ -70,6 +70,7 @@ typedef struct effect_handler_context_s {
 	const int subtype, radius, other, y, x;
 	const char *msg;
 	bool ident;
+	struct command *cmd;
 } effect_handler_context_t;
 
 typedef bool (*effect_handler_f)(effect_handler_context_t *);
@@ -468,7 +469,7 @@ bool enchant(struct object *obj, int n, int eflag)
  * both to_hit and to_dam with the same flag.  This
  * may not be the most desirable behavior (ACB).
  */
-bool enchant_spell(int num_hit, int num_dam, int num_ac)
+bool enchant_spell(int num_hit, int num_dam, int num_ac, struct command *cmd)
 {
 	bool okay = false;
 
@@ -477,13 +478,19 @@ bool enchant_spell(int num_hit, int num_dam, int num_ac)
 	char o_name[80];
 
 	const char *q, *s;
+	int itemmode = (USE_EQUIP | USE_INVEN | USE_QUIVER | USE_FLOOR);
+	item_tester filter = num_ac ?
+		item_tester_hook_armour : item_tester_hook_weapon;
 
 	/* Get an item */
 	q = "Enchant which item? ";
 	s = "You have nothing to enchant.";
-	if (!get_item(&obj, q, s, 0, 
-		num_ac ? item_tester_hook_armour : item_tester_hook_weapon,
-		(USE_EQUIP | USE_INVEN | USE_QUIVER | USE_FLOOR)))
+	if (cmd) {
+		if (cmd_get_item(cmd, "tgtitem", &obj, q, s, filter,
+				itemmode)) {
+			return false;
+		}
+	} else if (!get_item(&obj, q, s, 0, filter, itemmode))
 		return false;
 
 	/* Description */
@@ -1389,18 +1396,22 @@ bool effect_handler_RESTORE_MANA(effect_handler_context_t *context)
  */
 bool effect_handler_REMOVE_CURSE(effect_handler_context_t *context)
 {
+	const char *prompt = "Uncurse which item? ";
+	const char *rejmsg = "You have no curses to remove.";
+	int itemmode = (USE_EQUIP | USE_INVEN | USE_QUIVER | USE_FLOOR);
 	int strength = effect_calculate_value(context, false);
 	struct object *obj = NULL;
 	char dice_string[20];
 
 	context->ident = true;
 
-	if (!get_item(&obj,
-				  "Uncurse which item? ",
-				  "You have no curses to remove.",
-				  0,
-				  item_tester_uncursable,
-				  (USE_EQUIP | USE_INVEN | USE_QUIVER | USE_FLOOR)))
+	if (context->cmd) {
+		if (cmd_get_item(context->cmd, "tgtitem", &obj, prompt,
+				rejmsg, item_tester_uncursable, itemmode)) {
+			return false;
+		}
+	} else if (!get_item(&obj, prompt, rejmsg, 0, item_tester_uncursable,
+			itemmode))
 		return false;
 
 	/* Get the possible dice strings */
@@ -2196,23 +2207,28 @@ bool effect_handler_DETECT_SOUL(effect_handler_context_t *context)
  */
 bool effect_handler_IDENTIFY(effect_handler_context_t *context)
 {
-    struct object *obj;
-    const char *q, *s;
-    bool used = false;
+	struct object *obj;
+	const char *q, *s;
+	int itemmode = (USE_EQUIP | USE_INVEN | USE_QUIVER | USE_FLOOR);
+	bool used = false;
 
-    context->ident = true;
+	context->ident = true;
 
-    /* Get an item */
-    q = "Identify which item? ";
-    s = "You have nothing to identify.";
-    if (!get_item(&obj, q, s, 0, item_tester_unknown,
-                  (USE_EQUIP | USE_INVEN | USE_QUIVER | USE_FLOOR)))
-        return used;
+	/* Get an item */
+	q = "Identify which item? ";
+	s = "You have nothing to identify.";
+	if (context->cmd) {
+		if (cmd_get_item(context->cmd, "tgtitem", &obj, q, s,
+				item_tester_unknown, itemmode)) {
+			return used;
+		}
+	} else if (!get_item(&obj, q, s, 0, item_tester_unknown, itemmode))
+		return used;
 
-    /* Identify the object */
-    object_learn_unknown_rune(player, obj);
+	/* Identify the object */
+	object_learn_unknown_rune(player, obj);
 
-    return true;
+	return true;
 }
 
 
@@ -2343,19 +2359,19 @@ bool effect_handler_ENCHANT(effect_handler_context_t *context)
 	context->ident = true;
 
 	if ((context->subtype & ENCH_TOBOTH) == ENCH_TOBOTH) {
-		if (enchant_spell(value, value, 0))
+		if (enchant_spell(value, value, 0, context->cmd))
 			used = true;
 	}
 	else if (context->subtype & ENCH_TOHIT) {
-		if (enchant_spell(value, 0, 0))
+		if (enchant_spell(value, 0, 0, context->cmd))
 			used = true;
 	}
 	else if (context->subtype & ENCH_TODAM) {
-		if (enchant_spell(0, value, 0))
+		if (enchant_spell(0, value, 0, context->cmd))
 			used = true;
 	}
 	if (context->subtype & ENCH_TOAC) {
-		if (enchant_spell(0, 0, value))
+		if (enchant_spell(0, 0, value, context->cmd))
 			used = true;
 	}
 
@@ -2383,6 +2399,7 @@ bool effect_handler_RECHARGE(effect_handler_context_t *context)
 {
 	int i, t;
 	int strength = context->value.base;
+	int itemmode = (USE_INVEN | USE_FLOOR | SHOW_RECHARGE);
 	struct object *obj;
 	bool used = false;
 	const char *q, *s;
@@ -2396,8 +2413,13 @@ bool effect_handler_RECHARGE(effect_handler_context_t *context)
 	/* Get an item */
 	q = "Recharge which item? ";
 	s = "You have nothing to recharge.";
-	if (!get_item(&obj, q, s, 0, item_tester_hook_recharge,
-				  (USE_INVEN | USE_FLOOR | SHOW_RECHARGE))) {
+	if (context->cmd) {
+		if (cmd_get_item(context->cmd, "tgtitem", &obj, q, s,
+				item_tester_hook_recharge, itemmode)) {
+			return used;
+		}
+	} else if (!get_item(&obj, q, s, 0, item_tester_hook_recharge,
+				  itemmode)) {
 		return (used);
 	}
 
@@ -4572,6 +4594,7 @@ bool effect_handler_BRAND_AMMO(effect_handler_context_t *context)
 {
 	struct object *obj;
 	const char *q, *s;
+	int itemmode = (USE_INVEN | USE_QUIVER | USE_FLOOR);
 	bool used = false;
 
 	/* Select the brand */
@@ -4582,7 +4605,12 @@ bool effect_handler_BRAND_AMMO(effect_handler_context_t *context)
 	/* Get an item */
 	q = "Brand which kind of ammunition? ";
 	s = "You have nothing to brand.";
-	if (!get_item(&obj, q, s, 0, item_tester_hook_ammo, (USE_INVEN | USE_QUIVER | USE_FLOOR)))
+	if (context->cmd) {
+		if (cmd_get_item(context->cmd, "tgtitem", &obj, q, s,
+				item_tester_hook_ammo, itemmode)) {
+			return used;
+		}
+	} else if (!get_item(&obj, q, s, 0, item_tester_hook_ammo, itemmode))
 		return used;
 
 	/* Brand the ammo */
@@ -4599,6 +4627,7 @@ bool effect_handler_BRAND_BOLTS(effect_handler_context_t *context)
 {
 	struct object *obj;
 	const char *q, *s;
+	int itemmode = (USE_INVEN | USE_QUIVER | USE_FLOOR);
 	bool used = false;
 
 	context->ident = true;
@@ -4606,7 +4635,12 @@ bool effect_handler_BRAND_BOLTS(effect_handler_context_t *context)
 	/* Get an item */
 	q = "Brand which bolts? ";
 	s = "You have no bolts to brand.";
-	if (!get_item(&obj, q, s, 0, item_tester_hook_bolt, (USE_INVEN | USE_QUIVER | USE_FLOOR)))
+	if (context->cmd) {
+		if (cmd_get_item(context->cmd, "tgtitem", &obj, q, s,
+				item_tester_hook_bolt, itemmode)) {
+			return used;
+		}
+	} else if (!get_item(&obj, q, s, 0, item_tester_hook_bolt, itemmode))
 		return used;
 
 	/* Brand the bolts */
@@ -4625,14 +4659,20 @@ bool effect_handler_CREATE_ARROWS(effect_handler_context_t *context)
 	int lev;
 	struct object *obj, *staff, *arrows;
 	const char *q, *s;
+	int itemmode = (USE_INVEN | USE_FLOOR);
 	bool good = false, great = false;
 	bool none_left = false;
 
 	/* Get an item */
 	q = "Make arrows from which staff? ";
 	s = "You have no staff to use.";
-	if (!get_item(&obj, q, s, 0, item_tester_hook_staff,
-				  (USE_INVEN | USE_FLOOR))) {
+	if (context->cmd) {
+		if (cmd_get_item(context->cmd, "tgtitem", &obj, q, s,
+				item_tester_hook_staff, itemmode)) {
+			return false;
+		}
+	} else if (!get_item(&obj, q, s, 0, item_tester_hook_staff,
+				  itemmode)) {
 		return false;
 	}
 
@@ -4676,14 +4716,20 @@ bool effect_handler_TAP_DEVICE(effect_handler_context_t *context)
 	int energy = 0;
 	struct object *obj;
 	bool used = false;
+	int itemmode = (USE_INVEN | USE_FLOOR);
 	const char *q, *s;
 	char *item = "";
 
 	/* Get an item */
 	q = "Drain charges from which item? ";
 	s = "You have nothing to drain charges from.";
-	if (!get_item(&obj, q, s, 0, item_tester_hook_recharge,
-				  (USE_INVEN | USE_FLOOR))) {
+	if (context->cmd) {
+		if (cmd_get_item(context->cmd, "tgtitem", &obj, q, s,
+				item_tester_hook_recharge, itemmode)) {
+			return used;
+		}
+	} else if (!get_item(&obj, q, s, 0, item_tester_hook_recharge,
+				  itemmode)) {
 		return (used);
 	}
 
@@ -4799,7 +4845,7 @@ bool effect_handler_SHAPECHANGE(effect_handler_context_t *context)
 	/* Do effect */
 	if (shape->effect) {
 		(void) effect_do(shape->effect, source_player(), NULL, &ident, true,
-						 0, 0, 0);
+						 0, 0, 0, NULL);
 	}
 
 	/* Update */
@@ -5338,7 +5384,8 @@ bool effect_handler_WONDER(effect_handler_context_t *context)
 			value,
 			subtype, radius, other, y, x,
 			NULL,
-			context->ident
+			context->ident,
+			context->cmd
 		};
 
 		return handler(&new_context);
@@ -5615,6 +5662,11 @@ int effect_subtype(int index, const char *type)
  * \param beam   is the base chance out of 100 that a BOLT_OR_BEAM effect will beam
  * \param boost  is the extent to which skill surpasses difficulty, used as % boost. It
  *               ranges from 0 to 138.
+ * \param cmd    If the effect is invoked as part of a command, this is the
+ *               the command structure - used primarily so repeating the
+ *               command can use the same information without prompting the
+ *               player again.  Use NULL for this if not invoked as part of
+ *               a command.
  */
 bool effect_do(struct effect *effect,
 		struct source origin,
@@ -5623,7 +5675,8 @@ bool effect_do(struct effect *effect,
 		bool aware,
 		int dir,
 		int beam,
-		int boost)
+		int boost,
+		struct command *cmd)
 {
 	bool completed = false;
 	effect_handler_f handler;
@@ -5674,6 +5727,7 @@ bool effect_do(struct effect *effect,
 				effect->x,
 				effect->msg,
 				*ident,
+				cmd
 			};
 
 			completed = handler(&context) || completed;
@@ -5731,6 +5785,6 @@ void effect_simple(int index,
 		ident = &dummy_ident;
 	}
 
-	effect_do(&effect, origin, NULL, ident, true, dir, 0, 0);
+	effect_do(&effect, origin, NULL, ident, true, dir, 0, 0, NULL);
 	dice_free(effect.dice);
 }

--- a/src/effects.h
+++ b/src/effects.h
@@ -51,7 +51,8 @@ bool effect_do(struct effect *effect,
 	bool aware,
 	int dir,
 	int beam,
-	int boost);
+	int boost,
+	struct command *cmd);
 void effect_simple(int index,
 	struct source origin,
 	const char *dice_string,

--- a/src/mon-spell.c
+++ b/src/mon-spell.c
@@ -270,7 +270,7 @@ void do_mon_spell(int index, struct monster *mon, bool seen)
 			msg("%s", level->save_message);
 			spell_check_for_fail_rune(spell);
 		} else {
-			effect_do(spell->effect, source_monster(mon->midx), NULL, &ident, true, 0, 0, 0);
+			effect_do(spell->effect, source_monster(mon->midx), NULL, &ident, true, 0, 0, 0, NULL);
 		}
 	}
 }

--- a/src/obj-chest.c
+++ b/src/obj-chest.c
@@ -567,7 +567,7 @@ static void chest_trap(struct object *obj)
 			}
 			if (trap->effect) {
 				effect_do(trap->effect, source_chest_trap(trap), obj, &ident,
-						  false, 0, 0, 0);
+						  false, 0, 0, 0, NULL);
 			}
 			if (trap->destroy) {
 				obj->pval = 0;

--- a/src/obj-curse.c
+++ b/src/obj-curse.c
@@ -319,7 +319,7 @@ bool do_curse_effect(int i, struct object *obj)
 	if (curse->obj->effect_msg) {
 		msgt(MSG_GENERIC, curse->obj->effect_msg);
 	}
-	effect_do(effect, source_object(obj), NULL, &ident, was_aware, dir, 0, 0);
+	effect_do(effect, source_object(obj), NULL, &ident, was_aware, dir, 0, 0, NULL);
 	curse->obj->known->effect = curse->obj->effect;
 	return !was_aware && ident;
 }

--- a/src/player-spell.c
+++ b/src/player-spell.c
@@ -481,7 +481,7 @@ static int beam_chance(void)
 /**
  * Cast the specified spell
  */
-bool spell_cast(int spell_index, int dir)
+bool spell_cast(int spell_index, int dir, struct command *cmd)
 {
 	int chance;
 	bool *ident = mem_zalloc(sizeof(*ident));
@@ -500,7 +500,7 @@ bool spell_cast(int spell_index, int dir)
 	} else {
 		/* Cast the spell */
 		if (!effect_do(spell->effect, source_player(), NULL, ident, true, dir,
-					   beam, 0)) {
+					   beam, 0, cmd)) {
 			mem_free(ident);
 			return false;
 		}

--- a/src/player-spell.h
+++ b/src/player-spell.h
@@ -34,7 +34,7 @@ bool spell_okay_to_study(int spell_index);
 bool spell_okay_to_browse(int spell_index);
 s16b spell_chance(int spell_index);
 void spell_learn(int spell_index);
-bool spell_cast(int spell_index, int dir);
+bool spell_cast(int spell_index, int dir, struct command *cmd);
 
 extern void get_spell_info(int index, char *buf, size_t len);
 extern bool cast_spell(int tval, int index, int dir);

--- a/src/trap.c
+++ b/src/trap.c
@@ -544,7 +544,7 @@ extern void hit_trap(struct loc grid, int delayed)
 			if (trap->kind->msg_bad)
 				msg(trap->kind->msg_bad);
 			effect = trap->kind->effect;
-			effect_do(effect, source_trap(trap), NULL, &ident, false, 0, 0, 0);
+			effect_do(effect, source_trap(trap), NULL, &ident, false, 0, 0, 0, NULL);
 
 			/* Trap may have gone */
 			if (!square_trap(cave, grid)) break;
@@ -555,7 +555,7 @@ extern void hit_trap(struct loc grid, int delayed)
 					msg(trap->kind->msg_xtra);
 				effect = trap->kind->effect_xtra;
 				effect_do(effect, source_trap(trap), NULL, &ident, false,
-						  0, 0, 0);
+						  0, 0, 0, NULL);
 
 				/* Trap may have gone */
 				if (!square_trap(cave, grid)) break;


### PR DESCRIPTION
without having to reselect the target.  Also affects spells which target an item.  Tested with scrolls of Enchant to Hit, Enchant Armor, Identify Rune, Remove Curse, and Recharge and the Recharge, Tap, and Create Arrows spells.  The BRAND_AMMO and BRAND_BOLTS effects were changed to handle repeat as well, but I didn't test those.

Intended to resolve #3040.