### PR TITLE
Change message.c for failed unit tests

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -117,7 +117,8 @@ void message_add(const char *str, u16b type)
 
 	if (messages->head &&
 	    messages->head->type == type &&
-	    !strcmp(messages->head->str, str)) {
+	    !strcmp(messages->head->str, str) &&
+	    messages->head->count != (u16b)-1) {
 		messages->head->count++;
 		return;
 	}

--- a/src/message.c
+++ b/src/message.c
@@ -313,7 +313,8 @@ int message_lookup_by_sound_name(const char *name)
 	};
 	size_t i;
 
-	for (i = 0; i < N_ELEMENTS(sound_names); i++) {
+	/* Exclude MSG_MAX since it has NULL for the sound's name. */
+	for (i = 0; i < N_ELEMENTS(sound_names) - 1; i++) {
 		if (my_stricmp(name, sound_names[i]) == 0)
 			return (int)i;
 	}


### PR DESCRIPTION
Resolves the test that crashed (message_lookup_by_sound_name() if the name did not match anything) and the other that failed.(counter wraparound in message_add()).