### PR TITLE
For items dropped or created by the player, remove the penalty for ...

### DIFF
--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -1587,7 +1587,7 @@ void do_cmd_mon_command(struct command *cmd)
 			if (!obj) break;
 			obj->held_m_idx = 0;
 			pile_excise(&mon->held_obj, obj);
-			drop_near(cave, &obj, 0, mon->grid, true);
+			drop_near(cave, &obj, 0, mon->grid, true, false);
 			object_desc(o_name, sizeof(o_name), obj, ODESC_PREFIX | ODESC_FULL);
 			if (!ignore_item_ok(obj)) {
 				msg("%s drops %s.", m_name, o_name);

--- a/src/cmd-obj.c
+++ b/src/cmd-obj.c
@@ -550,7 +550,7 @@ static void use_aux(struct command *cmd, struct object *obj, enum use use,
 					object_copy(dropped->known, work_obj->known);
 				}
 				if (from_floor) {
-					drop_near(cave, &dropped, 0, player->grid, true);
+					drop_near(cave, &dropped, 0, player->grid, true, true);
 				} else {
 					inven_carry(player, dropped, true, true);
 				}
@@ -915,7 +915,7 @@ static void refill_lamp(struct object *lamp, struct object *obj)
 			if (object_is_carried(player, obj))
 				inven_carry(player, used, true, true);
 			else
-				drop_near(cave, &used, 0, player->grid, false);
+				drop_near(cave, &used, 0, player->grid, false, true);
 		} else
 			/* Empty a single lantern */
 			obj->timeout = 0;

--- a/src/effects.c
+++ b/src/effects.c
@@ -4662,7 +4662,7 @@ bool effect_handler_CREATE_ARROWS(effect_handler_context_t *context)
 
 	/* Make some arrows */
 	arrows = make_object(cave, player->lev, good, great, false, NULL, TV_ARROW);
-	drop_near(cave, &arrows, 0, player->grid, true);
+	drop_near(cave, &arrows, 0, player->grid, true, true);
 
 	return true;
 }

--- a/src/mon-util.c
+++ b/src/mon-util.c
@@ -907,7 +907,7 @@ void monster_death(struct monster *mon, bool stats)
 		if (!visible && !stats)
 			obj->origin = ORIGIN_DROP_UNKNOWN;
 
-		drop_near(cave, &obj, 0, mon->grid, true);
+		drop_near(cave, &obj, 0, mon->grid, true, false);
 		obj = next;
 	}
 
@@ -1408,7 +1408,7 @@ void steal_monster_item(struct monster *mon, int midx)
 					char o_name[80];
 					object_desc(o_name, sizeof(o_name), obj,
 								ODESC_PREFIX | ODESC_FULL);
-					drop_near(cave, &obj, 0, player->grid, true);
+					drop_near(cave, &obj, 0, player->grid, true, true);
 					msg("You drop %s.", o_name);
 				} else {
 					inven_carry(player, obj, true, true);

--- a/src/obj-chest.c
+++ b/src/obj-chest.c
@@ -537,7 +537,7 @@ static void chest_death(struct loc grid, struct object *chest)
 
 		treasure->origin = ORIGIN_CHEST;
 		treasure->origin_depth = chest->origin_depth;
-		drop_near(cave, &treasure, 0, grid, true);
+		drop_near(cave, &treasure, 0, grid, true, false);
 		number--;
 	}
 

--- a/src/obj-gear.c
+++ b/src/obj-gear.c
@@ -888,7 +888,7 @@ void inven_drop(struct object *obj, int amt)
 	}
 
 	/* Drop it near the player */
-	drop_near(cave, &dropped, 0, player->grid, false);
+	drop_near(cave, &dropped, 0, player->grid, false, true);
 
 	/* Sound for quiver objects */
 	if (quiver)
@@ -1037,7 +1037,7 @@ void pack_overflow(struct object *obj)
 
 	/* Excise the object and drop it (carefully) near the player */
 	gear_excise_object(obj);
-	drop_near(cave, &obj, 0, player->grid, false);
+	drop_near(cave, &obj, 0, player->grid, false, true);
 
 	/* Describe */
 	if (artifact)

--- a/src/obj-make.c
+++ b/src/obj-make.c
@@ -1196,7 +1196,7 @@ void acquirement(struct loc grid, int level, int num, bool great)
 		nice_obj->origin_depth = player->depth;
 
 		/* Drop the object */
-		drop_near(cave, &nice_obj, 0, grid, true);
+		drop_near(cave, &nice_obj, 0, grid, true, false);
 	}
 }
 

--- a/src/obj-pile.h
+++ b/src/obj-pile.h
@@ -75,7 +75,7 @@ struct object *floor_object_for_use(struct object *obj, int num, bool message,
 bool floor_carry(struct chunk *c, struct loc grid, struct object *drop,
 				 bool *note);
 void drop_near(struct chunk *c, struct object **dropped, int chance,
-			   struct loc grid, bool verbose);
+			   struct loc grid, bool verbose, bool prefer_pile);
 void push_object(struct loc grid);
 void floor_item_charges(struct object *obj);
 int scan_floor(struct object **items, int max_size, object_floor_t mode,

--- a/src/player-attack.c
+++ b/src/player-attack.c
@@ -1099,7 +1099,7 @@ static void ranged_helper(struct player *p,	struct object *obj, int dir,
 	}
 
 	/* Drop (or break) near that location */
-	drop_near(cave, &missile, breakage_chance(missile, hit_target), grid, true);
+	drop_near(cave, &missile, breakage_chance(missile, hit_target), grid, true, false);
 }
 
 

--- a/src/wiz-debug.c
+++ b/src/wiz-debug.c
@@ -603,7 +603,7 @@ static void wiz_create_item_drop_object(struct object *obj)
 	obj->origin_depth = player->depth;
 
 	/* Drop the object from heaven */
-	drop_near(cave, &obj, 0, player->grid, true);
+	drop_near(cave, &obj, 0, player->grid, true, true);
 }
 
 /**
@@ -1908,7 +1908,7 @@ static void wiz_test_kind(int tval)
 		obj->known = known_obj;
 
 		/* Drop the object from heaven */
-		drop_near(cave, &obj, 0, player->grid, true);
+		drop_near(cave, &obj, 0, player->grid, true, true);
 	}
 
 	msg("Done.");


### PR DESCRIPTION
stacking items of different types in the same square so they will prefer to drop at the player's feet if they can't be combined with a stack of nearby identical items. Other drops retain the old behavior (including those from chests and scrolls of acquirement). The change addresses #3249.