### PR TITLE
Fix various compilation problems for MSVC

### DIFF
--- a/src/obj-make.c
+++ b/src/obj-make.c
@@ -1121,7 +1121,7 @@ struct object *make_object(struct chunk *c, int lev, bool good, bool great,
 						   bool extra_roll, s32b *value, int tval)
 {
 	int base, tries = 3;
-	struct object_kind *kind;
+	struct object_kind *kind = NULL;
 	struct object *new_obj;
 
 	/* Try to make a special artifact */

--- a/src/player-util.c
+++ b/src/player-util.c
@@ -424,9 +424,9 @@ void player_adjust_hp_precise(struct player *p, s32b hp_gain)
 	/* Check for overflow */
 	/*     {new_chp = LONG_MIN;} DAVIDTODO*/
 	if ((new_chp < 0) && (old_chp > 0) && (hp_gain > 0)) {
-		new_chp = 2147483647;
+		new_chp = INT32_MAX;
 	} else if ((new_chp > 0) && (old_chp < 0) && (hp_gain < 0)) {
-		new_chp = -2147483648;
+		new_chp = INT32_MIN;
 	}
 
 	/* Break it back down*/
@@ -468,10 +468,10 @@ s32b player_adjust_mana_precise(struct player *p, s32b sp_gain)
 
 	/* new_csp = LONG_MAX LONG_MIN;} DAVIDTODO produces warning*/
 	if ((new_csp_long < 0) && (old_csp_long > 0) && (sp_gain > 0)) {
-		new_csp_long = 2147483647;
+		new_csp_long = INT32_MAX;
 		sp_gain = 0;
 	} else if ((new_csp_long > 0) && (old_csp_long < 0) && (sp_gain < 0)) {
-		new_csp_long = -2147483648;
+		new_csp_long = INT32_MIN;
 		sp_gain = 0;
 	}
 

--- a/src/z-form.c
+++ b/src/z-form.c
@@ -585,7 +585,7 @@ char *vformat(const char *fmt, va_list vp)
 		size_t len;
 
 		/* Build the string */
-		VA_COPY(args, vp);
+		va_copy(args, vp);
 		len = vstrnfmt(format_buf, format_len, fmt, args);
 		va_end(args);
 

--- a/src/z-form.h
+++ b/src/z-form.h
@@ -31,15 +31,6 @@
  * This file makes use of both "z-util.c" and "z-virt.c"
  */
 
-/* MSVC doesn't have va_copy (which is C99) or an alternative, so we'll just
- * copy the SRC pointer. In other cases we'll use va_copy() as we should. */
-#ifdef _MSC_VER
-#define VA_COPY(DST, SRC) (DST) = (SRC)
-#else
-#define VA_COPY(DST, SRC) va_copy(DST, SRC)
-#endif
-
-
 /**** Available Functions ****/
 
 /**

--- a/src/z-textblock.c
+++ b/src/z-textblock.c
@@ -98,7 +98,7 @@ static void textblock_vappend_c(textblock *tb, byte attr, const char *fmt,
 		va_list args;
 		size_t len;
 
-		VA_COPY(args, vp);
+		va_copy(args, vp);
 		len = vstrnfmt(temp_space, temp_len, fmt, args);
 		va_end(args);
 		if (len < temp_len - 1) {


### PR DESCRIPTION
This pull request contains the following changes.
- Use INT32_MIN for -2147483648 and INT32_MAX for 2147483647
- Initialize a pointer variable with NULL 
- Remove va_copy() workaround for MSVC

See each commit massages for detail.
