### PR TITLE
monster_death() deleted mimicked object but did not update cave's ...

### DIFF
--- a/src/mon-util.c
+++ b/src/mon-util.c
@@ -877,8 +877,10 @@ void monster_death(struct monster *mon, bool stats)
 	bool visible = monster_is_visible(mon) || monster_is_unique(mon);
 
 	/* Delete any mimicked objects */
-	if (mon->mimicked_obj)
-		object_delete(&mon->mimicked_obj);
+	if (mon->mimicked_obj) {
+		square_delete_object(cave, mon->grid, mon->mimicked_obj, true, true);
+		mon->mimicked_obj = NULL;
+	}
 
 	/* Drop objects being carried */
 	while (obj) {


### PR DESCRIPTION
object list.  That left a dangling reference and caused the crash in #4409.  Fixed.