### PR TITLE
Fix two ASAN failures

### DIFF
--- a/src/project-player.c
+++ b/src/project-player.c
@@ -51,7 +51,7 @@ int adjust_dam(struct player *p, int type, int dam, aspect dam_aspect,
 	if (p && p->race) {
 		/* Ice is a special case */
 		int res_type = (type == PROJ_ICE) ? PROJ_COLD: type;
-		resist = p->state.el_info[res_type].res_level;
+		resist = res_type < ELEM_MAX ? p->state.el_info[res_type].res_level : 0;
 
 		/* Notice element stuff */
 		if (actual) {

--- a/src/z-textblock.c
+++ b/src/z-textblock.c
@@ -113,7 +113,7 @@ static void textblock_vappend_c(textblock *tb, byte attr, const char *fmt,
 	/* Get extent of addition in wide chars */
 	new_length = text_mbstowcs(NULL, temp_space, 0);
 	assert(new_length >= 0); /* If this fails, the string was badly formed */
-	textblock_resize_if_needed(tb, new_length);
+	textblock_resize_if_needed(tb, new_length + 1);
 
 	/* Convert to wide chars, into the text block buffer */
 	text_mbstowcs(tb->text + tb->strlen, temp_space, tb->size - tb->strlen);


### PR DESCRIPTION
This pull request contains two commits that fix two ASAN failures.

- Fix an out-of-bounds access to el_info in ajust_dam()
If the `type` is equal to ELEM_MAX (25) or larger, 
e.g. LIGHT_WEAK (25), the access to `p->state.el_info`
is out of bounds.  This fix is similar to the following commit:
  704ff8be982ebfe8ad8c02c5eeb1897085f099aa

- Account terminating '\0' for buffer length calculation in textblock_vappend_c()
This bug causes a textblock to have non-terminated text, leading
to a buffer over-run.  For example, generating a monster spoiler triggers
this and causes ASAN failure termination/windows build to crash.
