### PR TITLE
Makefiles for compiling with ncurse and sdl2 on Windows msys2 shell

### DIFF
--- a/docs/hacking/compiling.rst
+++ b/docs/hacking/compiling.rst
@@ -124,24 +124,40 @@ If you want to build the Unix version of Angband that uses X11 or
 Curses and run it under Cygwin, then follow the native build
 instructions (./autogen.sh; ./configure; make; make install).
 
-Using MSYS2 (with MinGW64) to build with ncurse 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Using MSYS2 (with MinGW64) 
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Install the dependencies by::
 
 	pacman -S make mingw-w64-x86_64-toolchain mingw-w64-x86_64-ncurses
+
+Additional dependencies for SDL2 client::
+
+	pacman -S mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_gfx \
+		  mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-SDL2_ttf
 
 Then run the following to compile with ncurse::
 
 	cd src
 	make -f Makefile.msys2
 
-To start Angband, either double click the angband.exe at the source root, 
-or run the following in the msys2 shell::
+For SDL2, do::
+
+	cd src
+	make -f Makefile.msys2.sdl2
+
+Go to the root of the source directory and start angband by::
+
+	./angband.exe -uPLAYER
+
+The ncurse client may not be able to start properly from msys2 shell, try::
 
 	start bash
+
+and run::
+
 	export TERM=
-	./angband.exe
+	./angband.exe -uPLAYER
 
 Using eclipse (Indigo) on Windows (with MinGW)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/hacking/compiling.rst
+++ b/docs/hacking/compiling.rst
@@ -102,7 +102,6 @@ Following build, to get the program to run, you need to copy the executable
 from the src directory into the top-level dir, and copy 2 DLLs (libpng12.dll
 and zlib1.dll) from src/win/dll to the top-level dir
 
-
 Using Cygwin (with MinGW)
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -125,6 +124,24 @@ If you want to build the Unix version of Angband that uses X11 or
 Curses and run it under Cygwin, then follow the native build
 instructions (./autogen.sh; ./configure; make; make install).
 
+Using MSYS2 (with MinGW64) to build with ncurse 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Install the dependencies by::
+
+	pacman -S make mingw-w64-x86_64-toolchain mingw-w64-x86_64-ncurses
+
+Then run the following to compile with ncurse::
+
+	cd src
+	make -f Makefile.msys2
+
+To start Angband, either double click the angband.exe at the source root, 
+or run the following in the msys2 shell::
+
+	start bash
+	export TERM=
+	./angband.exe
 
 Using eclipse (Indigo) on Windows (with MinGW)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/Makefile.msys2
+++ b/src/Makefile.msys2
@@ -1,0 +1,73 @@
+# File: Makefile.msys2
+# Makefile for compiling Angband with ncurse using the msys2 shell in Windows
+#
+# Requirements: make, mingw-w64-x86_64-gcc, mingw-w64-x86_64-ncurses
+#
+# Run the following to compile:
+#
+# cd src
+# make -f Makefile.msys2
+#
+# angband.exe is copied to the project root automatically
+# You can double click it to run angband
+# 
+# Issue when opening ncurse application in msys2 shell:
+# https://sourceforge.net/p/msys2/discussion/general/thread/f81f0b97/
+#
+# Even with "export TERM=xterm" and "export TERMINFO=/mingw64/share/terminfo",
+# the input is not working
+#
+# To run angband from msys2 shell:
+# start bash
+# export TERM=
+# ./angband.exe 
+#
+
+# Executable name and default target
+EXE = angband.exe
+all: ../$(EXE)
+
+# Include list of object files and add system-specific ones
+include Makefile.inc
+AINFILES="$(WINMAINFILES)"
+
+CFLAGS = -DUSE_GCU -DWIN32_CONSOLE_MODE -DUSE_NCURSES -I$(NCURSES_INC) -static
+LIBS = -s $(NCURSES_LIB)
+IOBJS = $(BASEOBJS) main-gcu.o main.o
+
+NCURSES_INC = /mingw64/include/ncurses
+NCURSES_LIB = /mingw64/lib/libncurses.a
+
+CC = gcc
+WRES = windres
+WARNINGS = -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers
+CFLAGS += $(WARNINGS) -std=c99 -DUSE_PRIVATE_PATHS -O2 -I.
+
+# This is an issue on mingw32 on linux
+CFLAGS += -D_stdcall=
+
+OBJS = $(IOBJS)
+
+#
+# Targets
+#
+
+../$(EXE): $(EXE)
+	cp $(EXE) ..
+
+$(EXE): $(OBJS)
+	$(CC) $(CFLAGS) -o $(EXE) $(OBJS) $(LIBS)
+
+clean:
+	rm -f ../$(EXE) $(EXE) $(OBJS)
+
+
+#
+# Rules
+#
+
+win/$(PROGNAME).res: win/$(PROGNAME).rc
+	$(WRES) $< -O coff -o $@
+
+$(OBJDIR)%.o: %.c $(INCS)
+	$(CC) $(CFLAGS) -c -o $@ $<

--- a/src/Makefile.msys2.sdl2
+++ b/src/Makefile.msys2.sdl2
@@ -1,0 +1,132 @@
+# File: Makefile.sdl2
+# Makefile for compiling Angband with SDL2.
+#
+# This makefile requires GNU make.
+#
+# This makefile is intended for use with Unix machines that have SDL2 library.
+# The video subsystem requires libsdl2, libsdl2-ttf and libsdl2-image.
+# The sound subsystem requires libsdl2 and libsdl2-mixer.
+#
+# If you want only video (but not sound), use it like this:
+# (from angband directory)
+#
+# cd src
+# make -f Makefile.msys2.sdl
+#
+# TODO: sound is not working for windows build
+#
+
+# By default, copy the executable to ../ so that
+# you don't find yourself debugging a stale copy.
+.PHONY: default
+default: install
+
+# Support SDL2 frontend, link all dependencies statically
+# freetype and harfbuzz has Circular dependency
+VIDEO_sdl2 := -DUSE_SDL2 \
+	$(shell sdl2-config --cflags) \
+	$(shell sdl2-config --static-libs) \
+	-lSDL2_ttf -lSDL2_image \
+	-ltiff \
+	-lzstd \
+	-llzma \
+	-lwebp \
+	-lfreetype \
+	-lharfbuzz \
+	-lfreetype \
+	-lbrotlidec-static \
+	-lbrotlicommon-static \
+	-lgraphite2 \
+	-lpng \
+	-ljpeg \
+	-lbz2 \
+	-lintl \
+	-lrpcrt4 \
+	-lz \
+	-lVersion \
+	-lstdc++ \
+	-lImm32 \
+	-lhid \
+	-lsetupapi \
+	-lole32 \
+	-loleaut32 \
+	-lwinmm \
+
+## Support SDL_mixer for sound, doesn't work yet
+#SOUND_sdl2 := -DSOUND_SDL -DSOUND \
+#	$(shell sdl2-config --cflags) \
+#	$(shell sdl2-config --libs) -lSDL2_mixer
+
+# Compiler to use
+CC := gcc
+
+# Flags to use in compilation
+CFLAGS := -std=c99 \
+	-g \
+	-O2 \
+	-W -Wall -Wextra -Wno-unused-parameter -pedantic \
+	-static \
+	-DUSE_PRIVATE_PATHS \
+	-DHAVE_DIRENT_H \
+
+# Linker flags
+LDFLAGS := -lm
+
+# Frontends to compile
+MODULES := $(VIDEO_sdl2)
+
+#ifdef SOUND
+#	MODULES += $(SOUND_sdl2)
+#endif
+
+# Extract CFLAGS and LDFLAGS from the module definitions
+CFLAGS += $(patsubst -l%,,$(MODULES))
+LDFLAGS += $(patsubst -D%,,$(patsubst -I%,, $(MODULES)))
+
+# Makefile.inc contains an up-to-date set of object files to compile
+include Makefile.inc
+
+#### Targets and objects #####
+
+# Program name (PROGNAME comes from Makefile.src via Makefile.inc)
+EXE := $(PROGNAME)
+
+# Object definitions (BASEOBJS come from Makefile.inc)
+OBJS := main.o main-sdl2.o $(BASEOBJS)
+
+ifdef SOUND
+	OBJS += snd-sdl.o
+endif
+
+# Build the "Angband" program
+$(EXE): $(OBJS)
+	@printf "%10s %-20s\n" LINK $@
+	@$(CC) -o $(EXE) $(OBJS) $(CFLAGS) $(LDFLAGS)
+
+# Install the game.
+.PHONY: install
+install: ../$(EXE)
+
+../$(EXE): $(EXE)
+	cp $(EXE) ..
+
+# Clean up old junk
+.PHONY: clean
+clean:
+	-rm -f $(OBJS) $(EXE) snd-sdl.o
+
+# Verify module arguments
+.PHONY: args
+args:
+	@echo CFLAGS = $(CFLAGS)
+	@echo "---"
+	@echo LDFLAGS = $(LDFLAGS)
+	@echo "---"
+	@echo MODULES = $(MODULES)
+	@echo "---"
+	@echo INCLUDES = $(INCLUDES)
+
+# Some file dependencies
+%.o: %.c
+	@printf "%10s %-20s\n" CC $<
+	@$(CC) -o $@ -c $< $(CFLAGS)

--- a/src/main-win.c
+++ b/src/main-win.c
@@ -81,7 +81,7 @@
 
 #define uint unsigned int
 
-#if (defined(WINDOWS) && !defined(USE_SDL))
+#if (defined(WINDOWS) && !defined(USE_SDL)) && !defined(USE_SDL2)
 
 #include "sound.h"
 #include "snd-win.h"

--- a/src/main.c
+++ b/src/main.c
@@ -35,14 +35,17 @@
  * locale junk
  */
 #include "locale.h"
+
+#if !defined(WINDOWS)
 #include "langinfo.h"
+#endif
 
 /**
  * Some machines have a "main()" function in their "main-xxx.c" file,
  * all the others use this file for their "main()" function.
  */
 
-#if defined(WIN32_CONSOLE_MODE) || !defined(WINDOWS) || defined(USE_SDL)
+#if defined(WIN32_CONSOLE_MODE) || !defined(WINDOWS) || defined(USE_SDL) 
 
 #include "main.h"
 
@@ -469,12 +472,13 @@ int main(int argc, char *argv[])
 	/* If we were told which mode to use, then use it */
 	if (mstr)
 		ANGBAND_SYS = mstr;
-
+#if !defined(WINDOWS)
 	if (setlocale(LC_CTYPE, "")) {
 		/* Require UTF-8 */
 		if (strcmp(nl_langinfo(CODESET), "UTF-8") != 0)
 			quit("Angband requires UTF-8 support");
 	}
+#endif
 
 	/* Try the modules in the order specified by modules[] */
 	for (i = 0; i < (int)N_ELEMENTS(modules); i++) {

--- a/src/main.c
+++ b/src/main.c
@@ -45,7 +45,7 @@
  * all the others use this file for their "main()" function.
  */
 
-#if defined(WIN32_CONSOLE_MODE) || !defined(WINDOWS) || defined(USE_SDL) 
+#if defined(WIN32_CONSOLE_MODE) || !defined(WINDOWS) || defined(USE_SDL) || defined(USE_SDL2)
 
 #include "main.h"
 

--- a/src/sound-core.c
+++ b/src/sound-core.c
@@ -24,7 +24,7 @@
 #include "snd-sdl.h"
 #endif
 
-#if (!defined(WIN32_CONSOLE_MODE) && defined(WINDOWS) && !defined(USE_SDL))
+#if (!defined(WIN32_CONSOLE_MODE) && defined(WINDOWS) && !defined(USE_SDL) && !defined(USE_SDL2))
 #include "snd-win.h"
 #endif
 
@@ -58,7 +58,7 @@ static const struct sound_module sound_modules[] =
 #ifdef SOUND_SDL
 	{ "sdl", "SDL_mixer sound module", init_sound_sdl },
 #endif /* SOUND_SDL */
-#if (!defined(WIN32_CONSOLE_MODE) && defined(WINDOWS) && !defined(USE_SDL))
+#if (!defined(WIN32_CONSOLE_MODE) && defined(WINDOWS) && !defined(USE_SDL) && !defined(USE_SDL2)) 
 	{ "win", "Windows sound module", init_sound_win },
 #endif
 

--- a/src/sound-core.c
+++ b/src/sound-core.c
@@ -24,7 +24,7 @@
 #include "snd-sdl.h"
 #endif
 
-#if (defined(WINDOWS) && !defined(USE_SDL))
+#if (!defined(WIN32_CONSOLE_MODE) && defined(WINDOWS) && !defined(USE_SDL))
 #include "snd-win.h"
 #endif
 
@@ -58,7 +58,7 @@ static const struct sound_module sound_modules[] =
 #ifdef SOUND_SDL
 	{ "sdl", "SDL_mixer sound module", init_sound_sdl },
 #endif /* SOUND_SDL */
-#if (defined(WINDOWS) && !defined(USE_SDL))
+#if (!defined(WIN32_CONSOLE_MODE) && defined(WINDOWS) && !defined(USE_SDL))
 	{ "win", "Windows sound module", init_sound_win },
 #endif
 

--- a/src/z-file.c
+++ b/src/z-file.c
@@ -723,7 +723,7 @@ bool dir_create(const char *path) { return false; }
  * For information on what these are meant to do, please read the header file.
  */
 
-#ifdef WINDOWS
+#if defined(WINDOWS) && !defined(HAVE_DIRENT_H)
 
 
 /* System-specific struct */
@@ -802,7 +802,7 @@ void my_dclose(ang_dir *dir)
 	mem_free(dir);
 }
 
-#else /* WINDOWS */
+#else /* defined(WINDOWS) && !defined(HAVE_DIRENT_H) */
 
 #ifdef HAVE_DIRENT_H
 


### PR DESCRIPTION
Msys2 is useful to manage dependencies on Windows, but it is not straightforward to build Angband with that. This adds two makefiles:

1. Makefile.msys2 : build ncurse client
2. Makefile.msys2.sdl2 : build sdl2 client

What's working:
* run angband with `./angband.exe -uPLAYER`

What's not working:
* load saved game without the `-uPLAYER` arguments
* sound in sdl2 client
* the display in sdl2 client can be bugged after resize, you have to change the font in the menu to force redraw the whole thing. And the redraw shortcut `^R` is missing in sdl2 client?

I think this can be merged for further testing and for others to work on the relevant code. For example, I don't understand autotools so I don't know how to / if I should integrate this with autotools.