### PR TITLE
Add sval validity check in parse_ego_item()

### DIFF
--- a/src/obj-init.c
+++ b/src/obj-init.c
@@ -2117,6 +2117,8 @@ static enum parser_error parse_ego_item(struct parser *p) {
 		return PARSE_ERROR_MISSING_RECORD_HEADER;
 	if (tval < 0)
 		return PARSE_ERROR_UNRECOGNISED_TVAL;
+	if (sval < 0)
+		return PARSE_ERROR_UNRECOGNISED_SVAL;
 
 	poss = mem_zalloc(sizeof(struct poss_item));
 	poss->kidx = lookup_kind(tval, sval)->kidx;


### PR DESCRIPTION
This Addresses #4432.
When lookup_sval() returns a negative value (happens when the object 
specified does not exist), lookup_kind() returns NULL and causes a 
crash due to an improper member access through a NULL pointer.
