### PR TITLE
Performance: Avoid copying when accessing a square in a cave

### DIFF
--- a/src/cave-map.c
+++ b/src/cave-map.c
@@ -93,13 +93,13 @@ void map_info(struct loc grid, struct grid_data *g)
 	g->unseen_money = false;
 
 	/* Use real feature (remove later) */
-	g->f_idx = square(cave, grid).feat;
+	g->f_idx = square(cave, grid)->feat;
 	if (f_info[g->f_idx].mimic)
 		g->f_idx = lookup_feat(f_info[g->f_idx].mimic);
 
 	g->in_view = (square_isseen(cave, grid)) ? true : false;
-	g->is_player = (square(cave, grid).mon < 0) ? true : false;
-	g->m_idx = (g->is_player) ? 0 : square(cave, grid).mon;
+	g->is_player = (square(cave, grid)->mon < 0) ? true : false;
+	g->m_idx = (g->is_player) ? 0 : square(cave, grid)->mon;
 	g->hallucinate = player->timed[TMD_IMAGE] ? true : false;
 
 	if (g->in_view) {
@@ -139,13 +139,13 @@ void map_info(struct loc grid, struct grid_data *g)
 	}
 
 	/* Use known feature */
-	g->f_idx = square(player->cave, grid).feat;
+	g->f_idx = square(player->cave, grid)->feat;
 	if (f_info[g->f_idx].mimic)
 		g->f_idx = lookup_feat(f_info[g->f_idx].mimic);
 
 	/* There is a known trap in this square */
 	if (square_trap(player->cave, grid) && square_isknown(cave, grid)) {
-		struct trap *trap = square(cave, grid).trap;
+		struct trap *trap = square(cave, grid)->trap;
 
 		/* Scan the square trap list */
 		while (trap) {
@@ -291,7 +291,7 @@ static void cave_light(struct point_set *ps)
 	/* Apply flag changes */
 	for (i = 0; i < ps->n; i++)	{
 		/* Perma-Light */
-		sqinfo_on(square(cave, ps->pts[i]).info, SQUARE_GLOW);
+		sqinfo_on(square(cave, ps->pts[i])->info, SQUARE_GLOW);
 	}
 
 	/* Process the grids */
@@ -300,7 +300,7 @@ static void cave_light(struct point_set *ps)
 		square_light_spot(cave, ps->pts[i]);
 
 		/* Process affected monsters */
-		if (square(cave, ps->pts[i]).mon > 0) {
+		if (square(cave, ps->pts[i])->mon > 0) {
 			int chance = 25;
 
 			struct monster *mon = square_monster(cave, ps->pts[i]);
@@ -338,7 +338,7 @@ static void cave_unlight(struct point_set *ps)
 
 		/* Darken the grid... */
 		if (!square_isbright(cave, ps->pts[i])) {
-			sqinfo_off(square(cave, ps->pts[i]).info, SQUARE_GLOW);
+			sqinfo_off(square(cave, ps->pts[i])->info, SQUARE_GLOW);
 		}
 
 		/* ...but dark-loving characters remember them */
@@ -442,7 +442,7 @@ void wiz_light(struct chunk *c, struct player *p, bool full)
 					struct loc a_grid = loc_sum(grid, ddgrid_ddd[i]);
 
 					/* Perma-light the grid */
-					sqinfo_on(square(c, a_grid).info, SQUARE_GLOW);
+					sqinfo_on(square(c, a_grid)->info, SQUARE_GLOW);
 
 					/* Memorize normal features */
 					if (!square_isfloor(c, a_grid) || 
@@ -508,7 +508,7 @@ void wiz_dark(struct chunk *c, struct player *p, bool full)
 					struct loc a_grid = loc_sum(grid, ddgrid_ddd[i]);
 
 					/* Perma-darken the grid */
-					sqinfo_off(square(cave, a_grid).info, SQUARE_GLOW);
+					sqinfo_off(square(cave, a_grid)->info, SQUARE_GLOW);
 
 					/* Memorize normal features */
 					if (!square_isfloor(c, a_grid) || 
@@ -578,10 +578,10 @@ void cave_illuminate(struct chunk *c, bool daytime)
 
 			/* Only interesting grids at night */
 			if (daytime || !square_isfloor(c, grid)) {
-				sqinfo_on(square(c, grid).info, SQUARE_GLOW);
+				sqinfo_on(square(c, grid)->info, SQUARE_GLOW);
 				if(light) square_memorize(c, grid);
 			} else if (!square_isbright(c, grid)) {
-				sqinfo_off(square(c, grid).info, SQUARE_GLOW);
+				sqinfo_off(square(c, grid)->info, SQUARE_GLOW);
 				square_forget(c, grid);
 			}
 		}
@@ -596,7 +596,7 @@ void cave_illuminate(struct chunk *c, bool daytime)
 				continue;
 			for (i = 0; i < 8; i++) {
 				struct loc a_grid = loc_sum(grid, ddgrid_ddd[i]);
-				sqinfo_on(square(c, a_grid).info, SQUARE_GLOW);
+				sqinfo_on(square(c, a_grid)->info, SQUARE_GLOW);
 				square_memorize(c, a_grid);
 			}
 		}
@@ -635,7 +635,7 @@ void cave_known(struct player *p)
 
 			/* Internal walls not known */
 			if (count < 8) {
-				p->cave->squares[y][x].feat = square(cave, grid).feat;
+				p->cave->squares[y][x].feat = square(cave, grid)->feat;
 			}
 		}
 	}

--- a/src/cave-square.c
+++ b/src/cave-square.c
@@ -186,7 +186,7 @@ bool feat_is_smooth(int feat)
  *
  * These functions are used to figure out what kind of square something is,
  * via c->squares[y][x].feat (preferably accessed via square(c, grid)).
- * All direct testing of square(c, grid).feat should be rewritten
+ * All direct testing of square(c, grid)->feat should be rewritten
  * in terms of these functions.
  *
  * It's often better to use square behavior predicates (written in terms of
@@ -202,7 +202,7 @@ bool feat_is_smooth(int feat)
  */
 bool square_isfloor(struct chunk *c, struct loc grid)
 {
-	return feat_is_floor(square(c, grid).feat);
+	return feat_is_floor(square(c, grid)->feat);
 }
 
 /**
@@ -210,7 +210,7 @@ bool square_isfloor(struct chunk *c, struct loc grid)
  */
 bool square_istrappable(struct chunk *c, struct loc grid)
 {
-	return feat_is_trap_holding(square(c, grid).feat);
+	return feat_is_trap_holding(square(c, grid)->feat);
 }
 
 /**
@@ -218,7 +218,7 @@ bool square_istrappable(struct chunk *c, struct loc grid)
  */
 bool square_isobjectholding(struct chunk *c, struct loc grid)
 {
-	return feat_is_object_holding(square(c, grid).feat);
+	return feat_is_object_holding(square(c, grid)->feat);
 }
 
 /**
@@ -226,8 +226,8 @@ bool square_isobjectholding(struct chunk *c, struct loc grid)
  */
 bool square_isrock(struct chunk *c, struct loc grid)
 {
-	return (tf_has(f_info[square(c, grid).feat].flags, TF_GRANITE) &&
-			!tf_has(f_info[square(c, grid).feat].flags, TF_DOOR_ANY));
+	return (tf_has(f_info[square(c, grid)->feat].flags, TF_GRANITE) &&
+			!tf_has(f_info[square(c, grid)->feat].flags, TF_DOOR_ANY));
 }
 
 /**
@@ -235,7 +235,7 @@ bool square_isrock(struct chunk *c, struct loc grid)
  */
 bool square_isgranite(struct chunk *c, struct loc grid)
 {
-	return feat_is_granite(square(c, grid).feat);
+	return feat_is_granite(square(c, grid)->feat);
 }
 
 /**
@@ -243,8 +243,8 @@ bool square_isgranite(struct chunk *c, struct loc grid)
  */
 bool square_isperm(struct chunk *c, struct loc grid)
 {
-	return (tf_has(f_info[square(c, grid).feat].flags, TF_PERMANENT) &&
-			tf_has(f_info[square(c, grid).feat].flags, TF_ROCK));
+	return (tf_has(f_info[square(c, grid)->feat].flags, TF_PERMANENT) &&
+			tf_has(f_info[square(c, grid)->feat].flags, TF_ROCK));
 }
 
 /**
@@ -252,7 +252,7 @@ bool square_isperm(struct chunk *c, struct loc grid)
  */
 bool square_ismagma(struct chunk *c, struct loc grid)
 {
-	return feat_is_magma(square(c, grid).feat);
+	return feat_is_magma(square(c, grid)->feat);
 }
 
 /**
@@ -260,7 +260,7 @@ bool square_ismagma(struct chunk *c, struct loc grid)
  */
 bool square_isquartz(struct chunk *c, struct loc grid)
 {
-	return feat_is_quartz(square(c, grid).feat);
+	return feat_is_quartz(square(c, grid)->feat);
 }
 
 /**
@@ -274,7 +274,7 @@ bool square_ismineral(struct chunk *c, struct loc grid)
 
 bool square_hasgoldvein(struct chunk *c, struct loc grid)
 {
-	return tf_has(f_info[square(c, grid).feat].flags, TF_GOLD);
+	return tf_has(f_info[square(c, grid)->feat].flags, TF_GOLD);
 }
 
 /**
@@ -282,8 +282,8 @@ bool square_hasgoldvein(struct chunk *c, struct loc grid)
  */
 bool square_isrubble(struct chunk *c, struct loc grid)
 {
-    return (!tf_has(f_info[square(c, grid).feat].flags, TF_WALL) &&
-			tf_has(f_info[square(c, grid).feat].flags, TF_ROCK));
+    return (!tf_has(f_info[square(c, grid)->feat].flags, TF_WALL) &&
+			tf_has(f_info[square(c, grid)->feat].flags, TF_ROCK));
 }
 
 /**
@@ -294,8 +294,8 @@ bool square_isrubble(struct chunk *c, struct loc grid)
  */
 bool square_issecretdoor(struct chunk *c, struct loc grid)
 {
-    return (tf_has(f_info[square(c, grid).feat].flags, TF_DOOR_ANY) &&
-			tf_has(f_info[square(c, grid).feat].flags, TF_ROCK));
+    return (tf_has(f_info[square(c, grid)->feat].flags, TF_DOOR_ANY) &&
+			tf_has(f_info[square(c, grid)->feat].flags, TF_ROCK));
 }
 
 /**
@@ -303,7 +303,7 @@ bool square_issecretdoor(struct chunk *c, struct loc grid)
  */
 bool square_isopendoor(struct chunk *c, struct loc grid)
 {
-    return (tf_has(f_info[square(c, grid).feat].flags, TF_CLOSABLE));
+    return (tf_has(f_info[square(c, grid)->feat].flags, TF_CLOSABLE));
 }
 
 /**
@@ -311,13 +311,13 @@ bool square_isopendoor(struct chunk *c, struct loc grid)
  */
 bool square_iscloseddoor(struct chunk *c, struct loc grid)
 {
-	int feat = square(c, grid).feat;
+	int feat = square(c, grid)->feat;
 	return tf_has(f_info[feat].flags, TF_DOOR_CLOSED);
 }
 
 bool square_isbrokendoor(struct chunk *c, struct loc grid)
 {
-	int feat = square(c, grid).feat;
+	int feat = square(c, grid)->feat;
     return (tf_has(f_info[feat].flags, TF_DOOR_ANY) &&
 			tf_has(f_info[feat].flags, TF_PASSABLE) &&
 			!tf_has(f_info[feat].flags, TF_CLOSABLE));
@@ -330,7 +330,7 @@ bool square_isbrokendoor(struct chunk *c, struct loc grid)
  */
 bool square_isdoor(struct chunk *c, struct loc grid)
 {
-	int feat = square(c, grid).feat;
+	int feat = square(c, grid)->feat;
 	return tf_has(f_info[feat].flags, TF_DOOR_ANY);
 }
 
@@ -339,7 +339,7 @@ bool square_isdoor(struct chunk *c, struct loc grid)
  */
 bool square_isstairs(struct chunk *c, struct loc grid)
 {
-	int feat = square(c, grid).feat;
+	int feat = square(c, grid)->feat;
 	return tf_has(f_info[feat].flags, TF_STAIR);
 }
 
@@ -348,7 +348,7 @@ bool square_isstairs(struct chunk *c, struct loc grid)
  */
 bool square_isupstairs(struct chunk*c, struct loc grid)
 {
-	int feat = square(c, grid).feat;
+	int feat = square(c, grid)->feat;
 	return tf_has(f_info[feat].flags, TF_UPSTAIR);
 }
 
@@ -357,7 +357,7 @@ bool square_isupstairs(struct chunk*c, struct loc grid)
  */
 bool square_isdownstairs(struct chunk *c, struct loc grid)
 {
-	int feat = square(c, grid).feat;
+	int feat = square(c, grid)->feat;
 	return tf_has(f_info[feat].flags, TF_DOWNSTAIR);
 }
 
@@ -366,21 +366,21 @@ bool square_isdownstairs(struct chunk *c, struct loc grid)
  */
 bool square_isshop(struct chunk *c, struct loc grid)
 {
-	return feat_is_shop(square(c, grid).feat);
+	return feat_is_shop(square(c, grid)->feat);
 }
 
 /**
  * True if the square contains the player
  */
 bool square_isplayer(struct chunk *c, struct loc grid) {
-	return square(c, grid).mon < 0 ? true : false;
+	return square(c, grid)->mon < 0 ? true : false;
 }
 
 /**
  * True if the square contains the player or a monster
  */
 bool square_isoccupied(struct chunk *c, struct loc grid) {
-	return square(c, grid).mon != 0 ? true : false;
+	return square(c, grid)->mon != 0 ? true : false;
 }
 
 /**
@@ -389,7 +389,7 @@ bool square_isoccupied(struct chunk *c, struct loc grid) {
 bool square_isknown(struct chunk *c, struct loc grid) {
 	if (c != cave) return false;
 	if (player->cave == NULL) return false;
-	return square(player->cave, grid).feat == FEAT_NONE ? false : true;
+	return square(player->cave, grid)->feat == FEAT_NONE ? false : true;
 }
 
 /**
@@ -399,7 +399,7 @@ bool square_isknown(struct chunk *c, struct loc grid) {
 bool square_isnotknown(struct chunk *c, struct loc grid) {
 	if (c != cave) return false;
 	if (player->cave == NULL) return true;
-	return square(player->cave, grid).feat != square(c, grid).feat;
+	return square(player->cave, grid)->feat != square(c, grid)->feat;
 }
 
 /**
@@ -415,7 +415,7 @@ bool square_isnotknown(struct chunk *c, struct loc grid) {
  */
 bool square_ismark(struct chunk *c, struct loc grid) {
 	assert(square_in_bounds(c, grid));
-	return sqinfo_has(square(c, grid).info, SQUARE_MARK);
+	return sqinfo_has(square(c, grid)->info, SQUARE_MARK);
 }
 
 /**
@@ -423,7 +423,7 @@ bool square_ismark(struct chunk *c, struct loc grid) {
  */
 bool square_isglow(struct chunk *c, struct loc grid) {
 	assert(square_in_bounds(c, grid));
-	return sqinfo_has(square(c, grid).info, SQUARE_GLOW);
+	return sqinfo_has(square(c, grid)->info, SQUARE_GLOW);
 }
 
 /**
@@ -433,7 +433,7 @@ bool square_isglow(struct chunk *c, struct loc grid) {
  */
 bool square_isvault(struct chunk *c, struct loc grid) {
 	assert(square_in_bounds(c, grid));
-	return sqinfo_has(square(c, grid).info, SQUARE_VAULT);
+	return sqinfo_has(square(c, grid)->info, SQUARE_VAULT);
 }
 
 /**
@@ -441,7 +441,7 @@ bool square_isvault(struct chunk *c, struct loc grid) {
  */
 bool square_isroom(struct chunk *c, struct loc grid) {
 	assert(square_in_bounds(c, grid));
-	return sqinfo_has(square(c, grid).info, SQUARE_ROOM);
+	return sqinfo_has(square(c, grid)->info, SQUARE_ROOM);
 }
 
 /**
@@ -449,7 +449,7 @@ bool square_isroom(struct chunk *c, struct loc grid) {
  */
 bool square_isseen(struct chunk *c, struct loc grid) {
 	assert(square_in_bounds(c, grid));
-	return sqinfo_has(square(c, grid).info, SQUARE_SEEN);
+	return sqinfo_has(square(c, grid)->info, SQUARE_SEEN);
 }
 
 /**
@@ -457,7 +457,7 @@ bool square_isseen(struct chunk *c, struct loc grid) {
  */
 bool square_isview(struct chunk *c, struct loc grid) {
 	assert(square_in_bounds(c, grid));
-	return sqinfo_has(square(c, grid).info, SQUARE_VIEW);
+	return sqinfo_has(square(c, grid)->info, SQUARE_VIEW);
 }
 
 /**
@@ -465,7 +465,7 @@ bool square_isview(struct chunk *c, struct loc grid) {
  */
 bool square_wasseen(struct chunk *c, struct loc grid) {
 	assert(square_in_bounds(c, grid));
-	return sqinfo_has(square(c, grid).info, SQUARE_WASSEEN);
+	return sqinfo_has(square(c, grid)->info, SQUARE_WASSEEN);
 }
 
 /**
@@ -473,7 +473,7 @@ bool square_wasseen(struct chunk *c, struct loc grid) {
  */
 bool square_isfeel(struct chunk *c, struct loc grid) {
 	assert(square_in_bounds(c, grid));
-	return sqinfo_has(square(c, grid).info, SQUARE_FEEL);
+	return sqinfo_has(square(c, grid)->info, SQUARE_FEEL);
 }
 
 /**
@@ -481,7 +481,7 @@ bool square_isfeel(struct chunk *c, struct loc grid) {
  */
 bool square_istrap(struct chunk *c, struct loc grid) {
 	assert(square_in_bounds(c, grid));
-	return sqinfo_has(square(c, grid).info, SQUARE_TRAP);
+	return sqinfo_has(square(c, grid)->info, SQUARE_TRAP);
 }
 
 /**
@@ -489,7 +489,7 @@ bool square_istrap(struct chunk *c, struct loc grid) {
  */
 bool square_isinvis(struct chunk *c, struct loc grid) {
 	assert(square_in_bounds(c, grid));
-	return sqinfo_has(square(c, grid).info, SQUARE_INVIS);
+	return sqinfo_has(square(c, grid)->info, SQUARE_INVIS);
 }
 
 /**
@@ -497,7 +497,7 @@ bool square_isinvis(struct chunk *c, struct loc grid) {
  */
 bool square_iswall_inner(struct chunk *c, struct loc grid) {
 	assert(square_in_bounds(c, grid));
-	return sqinfo_has(square(c, grid).info, SQUARE_WALL_INNER);
+	return sqinfo_has(square(c, grid)->info, SQUARE_WALL_INNER);
 }
 
 /**
@@ -505,7 +505,7 @@ bool square_iswall_inner(struct chunk *c, struct loc grid) {
  */
 bool square_iswall_outer(struct chunk *c, struct loc grid) {
 	assert(square_in_bounds(c, grid));
-	return sqinfo_has(square(c, grid).info, SQUARE_WALL_OUTER);
+	return sqinfo_has(square(c, grid)->info, SQUARE_WALL_OUTER);
 }
 
 /**
@@ -513,7 +513,7 @@ bool square_iswall_outer(struct chunk *c, struct loc grid) {
  */
 bool square_iswall_solid(struct chunk *c, struct loc grid) {
 	assert(square_in_bounds(c, grid));
-	return sqinfo_has(square(c, grid).info, SQUARE_WALL_SOLID);
+	return sqinfo_has(square(c, grid)->info, SQUARE_WALL_SOLID);
 }
 
 /**
@@ -521,7 +521,7 @@ bool square_iswall_solid(struct chunk *c, struct loc grid) {
  */
 bool square_ismon_restrict(struct chunk *c, struct loc grid) {
 	assert(square_in_bounds(c, grid));
-	return sqinfo_has(square(c, grid).info, SQUARE_MON_RESTRICT);
+	return sqinfo_has(square(c, grid)->info, SQUARE_MON_RESTRICT);
 }
 
 /**
@@ -529,7 +529,7 @@ bool square_ismon_restrict(struct chunk *c, struct loc grid) {
  */
 bool square_isno_teleport(struct chunk *c, struct loc grid) {
 	assert(square_in_bounds(c, grid));
-	return sqinfo_has(square(c, grid).info, SQUARE_NO_TELEPORT);
+	return sqinfo_has(square(c, grid)->info, SQUARE_NO_TELEPORT);
 }
 
 /**
@@ -537,7 +537,7 @@ bool square_isno_teleport(struct chunk *c, struct loc grid) {
  */
 bool square_isno_map(struct chunk *c, struct loc grid) {
 	assert(square_in_bounds(c, grid));
-	return sqinfo_has(square(c, grid).info, SQUARE_NO_MAP);
+	return sqinfo_has(square(c, grid)->info, SQUARE_NO_MAP);
 }
 
 /**
@@ -545,7 +545,7 @@ bool square_isno_map(struct chunk *c, struct loc grid) {
  */
 bool square_isno_esp(struct chunk *c, struct loc grid) {
 	assert(square_in_bounds(c, grid));
-	return sqinfo_has(square(c, grid).info, SQUARE_NO_ESP);
+	return sqinfo_has(square(c, grid)->info, SQUARE_NO_ESP);
 }
 
 /**
@@ -553,7 +553,7 @@ bool square_isno_esp(struct chunk *c, struct loc grid) {
  */
 bool square_isproject(struct chunk *c, struct loc grid) {
 	assert(square_in_bounds(c, grid));
-	return sqinfo_has(square(c, grid).info, SQUARE_PROJECT);
+	return sqinfo_has(square(c, grid)->info, SQUARE_PROJECT);
 }
 
 /**
@@ -561,7 +561,7 @@ bool square_isproject(struct chunk *c, struct loc grid) {
  */
 bool square_isdtrap(struct chunk *c, struct loc grid) {
 	assert(square_in_bounds(c, grid));
-	return sqinfo_has(square(c, grid).info, SQUARE_DTRAP);
+	return sqinfo_has(square(c, grid)->info, SQUARE_DTRAP);
 }
 
 /**
@@ -569,7 +569,7 @@ bool square_isdtrap(struct chunk *c, struct loc grid) {
  */
 bool square_isno_stairs(struct chunk *c, struct loc grid) {
 	assert(square_in_bounds(c, grid));
-	return sqinfo_has(square(c, grid).info, SQUARE_NO_STAIRS);
+	return sqinfo_has(square(c, grid)->info, SQUARE_NO_STAIRS);
 }
 
 
@@ -587,7 +587,7 @@ bool square_isno_stairs(struct chunk *c, struct loc grid) {
  * True if the square is open (a floor square not occupied by a monster).
  */
 bool square_isopen(struct chunk *c, struct loc grid) {
-	return square_isfloor(c, grid) && !square(c, grid).mon;
+	return square_isfloor(c, grid) && !square(c, grid)->mon;
 }
 
 /**
@@ -603,7 +603,7 @@ bool square_isempty(struct chunk *c, struct loc grid) {
  * True if the square is empty (an open square without any items).
  */
 bool square_isarrivable(struct chunk *c, struct loc grid) {
-	if (square(c, grid).mon) return false;
+	if (square(c, grid)->mon) return false;
 	if (square_isplayertrap(c, grid)) return false;
 	if (square_iswebbed(c, grid)) return false;
 	if (square_isfloor(c, grid)) return true;
@@ -647,7 +647,7 @@ bool square_iswebbable(struct chunk *c, struct loc grid) {
 bool square_is_monster_walkable(struct chunk *c, struct loc grid)
 {
 	assert(square_in_bounds(c, grid));
-	return feat_is_monster_walkable(square(c, grid).feat);
+	return feat_is_monster_walkable(square(c, grid)->feat);
 }
 
 /**
@@ -655,7 +655,7 @@ bool square_is_monster_walkable(struct chunk *c, struct loc grid)
  */
 bool square_ispassable(struct chunk *c, struct loc grid) {
 	assert(square_in_bounds(c, grid));
-	return feat_is_passable(square(c, grid).feat);
+	return feat_is_passable(square(c, grid)->feat);
 }
 
 /**
@@ -665,7 +665,7 @@ bool square_ispassable(struct chunk *c, struct loc grid) {
  */
 bool square_isprojectable(struct chunk *c, struct loc grid) {
 	if (!square_in_bounds(c, grid)) return false;
-	return feat_is_projectable(square(c, grid).feat);
+	return feat_is_projectable(square(c, grid)->feat);
 }
 
 /**
@@ -694,7 +694,7 @@ bool square_isstrongwall(struct chunk *c, struct loc grid) {
  */
 bool square_isbright(struct chunk *c, struct loc grid) {
 	assert(square_in_bounds(c, grid));
-	return feat_is_bright(square(c, grid).feat);
+	return feat_is_bright(square(c, grid)->feat);
 }
 
 /**
@@ -702,7 +702,7 @@ bool square_isbright(struct chunk *c, struct loc grid) {
  */
 bool square_isfiery(struct chunk *c, struct loc grid) {
 	assert(square_in_bounds(c, grid));
-	return feat_is_fiery(square(c, grid).feat);
+	return feat_is_fiery(square(c, grid)->feat);
 }
 
 /**
@@ -737,7 +737,7 @@ bool square_islitwall(struct chunk *c, struct loc grid) {
  */
 bool square_isdamaging(struct chunk *c, struct loc grid) {
 	assert(square_in_bounds(c, grid));
-	return feat_is_fiery(square(c, grid).feat);
+	return feat_is_fiery(square(c, grid)->feat);
 }
 
 /**
@@ -745,7 +745,7 @@ bool square_isdamaging(struct chunk *c, struct loc grid) {
  */
 bool square_isnoflow(struct chunk *c, struct loc grid) {
 	assert(square_in_bounds(c, grid));
-	return feat_is_no_flow(square(c, grid).feat);
+	return feat_is_no_flow(square(c, grid)->feat);
 }
 
 /**
@@ -753,7 +753,7 @@ bool square_isnoflow(struct chunk *c, struct loc grid) {
  */
 bool square_isnoscent(struct chunk *c, struct loc grid) {
 	assert(square_in_bounds(c, grid));
-	return feat_is_no_scent(square(c, grid).feat);
+	return feat_is_no_scent(square(c, grid)->feat);
 }
 
 bool square_iswarded(struct chunk *c, struct loc grid)
@@ -776,12 +776,12 @@ bool square_iswebbed(struct chunk *c, struct loc grid)
 
 bool square_seemslikewall(struct chunk *c, struct loc grid)
 {
-	return tf_has(f_info[square(c, grid).feat].flags, TF_ROCK);
+	return tf_has(f_info[square(c, grid)->feat].flags, TF_ROCK);
 }
 
 bool square_isinteresting(struct chunk *c, struct loc grid)
 {
-	int f = square(c, grid).feat;
+	int f = square(c, grid)->feat;
 	return tf_has(f_info[f].flags, TF_INTERESTING);
 }
 
@@ -939,22 +939,22 @@ bool square_suits_stairs_ok(struct chunk *c, struct loc grid)
  * Below are various square-specific functions which are not predicates
  */
 
-struct square square(struct chunk *c, struct loc grid)
+const struct square *square(struct chunk *c, struct loc grid)
 {
 	assert(square_in_bounds(c, grid));
-	return c->squares[grid.y][grid.x];
+	return &c->squares[grid.y][grid.x];
 }
 
 struct feature *square_feat(struct chunk *c, struct loc grid)
 {
 	assert(square_in_bounds(c, grid));
-	return &f_info[square(c, grid).feat];
+	return &f_info[square(c, grid)->feat];
 }
 
 int square_light(struct chunk *c, struct loc grid)
 {
 	assert(square_in_bounds(c, grid));
-	return square(c, grid).light;
+	return square(c, grid)->light;
 }
 
 /**
@@ -963,8 +963,8 @@ int square_light(struct chunk *c, struct loc grid)
 struct monster *square_monster(struct chunk *c, struct loc grid)
 {
 	if (!square_in_bounds(c, grid)) return NULL;
-	if (square(c, grid).mon > 0) {
-		struct monster *mon = cave_monster(c, square(c, grid).mon);
+	if (square(c, grid)->mon > 0) {
+		struct monster *mon = cave_monster(c, square(c, grid)->mon);
 		return mon && mon->race ? mon : NULL;
 	}
 
@@ -976,7 +976,7 @@ struct monster *square_monster(struct chunk *c, struct loc grid)
  */
 struct object *square_object(struct chunk *c, struct loc grid) {
 	if (!square_in_bounds(c, grid)) return NULL;
-	return square(c, grid).obj;
+	return square(c, grid)->obj;
 }
 
 /**
@@ -985,7 +985,7 @@ struct object *square_object(struct chunk *c, struct loc grid) {
 struct trap *square_trap(struct chunk *c, struct loc grid)
 {
 	if (!square_in_bounds(c, grid)) return NULL;
-    return square(c, grid).trap;
+    return square(c, grid)->trap;
 }
 
 /**
@@ -1107,10 +1107,10 @@ int square_num_walls_adjacent(struct chunk *c, struct loc grid)
     int k = 0;
     assert(square_in_bounds(c, grid));
 
-    if (feat_is_wall(square(c, next_grid(grid, DIR_S)).feat)) k++;
-	if (feat_is_wall(square(c, next_grid(grid, DIR_N)).feat)) k++;
-    if (feat_is_wall(square(c, next_grid(grid, DIR_E)).feat)) k++;
-    if (feat_is_wall(square(c, next_grid(grid, DIR_W)).feat)) k++;
+    if (feat_is_wall(square(c, next_grid(grid, DIR_S))->feat)) k++;
+	if (feat_is_wall(square(c, next_grid(grid, DIR_N))->feat)) k++;
+    if (feat_is_wall(square(c, next_grid(grid, DIR_E))->feat)) k++;
+    if (feat_is_wall(square(c, next_grid(grid, DIR_W))->feat)) k++;
 
     return k;
 }
@@ -1127,10 +1127,10 @@ int square_num_walls_diagonal(struct chunk *c, struct loc grid)
     int k = 0;
     assert(square_in_bounds(c, grid));
 
-    if (feat_is_wall(square(c, next_grid(grid, DIR_SE)).feat)) k++;
-    if (feat_is_wall(square(c, next_grid(grid, DIR_NW)).feat)) k++;
-    if (feat_is_wall(square(c, next_grid(grid, DIR_NE)).feat)) k++;
-    if (feat_is_wall(square(c, next_grid(grid, DIR_SW)).feat)) k++;
+    if (feat_is_wall(square(c, next_grid(grid, DIR_SE))->feat)) k++;
+    if (feat_is_wall(square(c, next_grid(grid, DIR_NW))->feat)) k++;
+    if (feat_is_wall(square(c, next_grid(grid, DIR_NE))->feat)) k++;
+    if (feat_is_wall(square(c, next_grid(grid, DIR_SW))->feat)) k++;
 
     return k;
 }
@@ -1147,7 +1147,7 @@ void square_set_feat(struct chunk *c, struct loc grid, int feat)
 	int current_feat;
 
 	assert(square_in_bounds(c, grid));
-	current_feat = square(c, grid).feat;
+	current_feat = square(c, grid)->feat;
 
 	/* Track changes */
 	if (current_feat) c->feat_count[current_feat]--;
@@ -1158,7 +1158,7 @@ void square_set_feat(struct chunk *c, struct loc grid, int feat)
 
 	/* Light bright terrain */
 	if (feat_is_bright(feat)) {
-		sqinfo_on(square(c, grid).info, SQUARE_GLOW);
+		sqinfo_on(square(c, grid)->info, SQUARE_GLOW);
 	}
 
 	/* Make the new terrain feel at home */
@@ -1171,9 +1171,9 @@ void square_set_feat(struct chunk *c, struct loc grid, int feat)
 		square_light_spot(c, grid);
 	} else {
 		/* Make sure no incorrect wall flags set for dungeon generation */
-		sqinfo_off(square(c, grid).info, SQUARE_WALL_INNER);
-		sqinfo_off(square(c, grid).info, SQUARE_WALL_OUTER);
-		sqinfo_off(square(c, grid).info, SQUARE_WALL_SOLID);
+		sqinfo_off(square(c, grid)->info, SQUARE_WALL_INNER);
+		sqinfo_off(square(c, grid)->info, SQUARE_WALL_OUTER);
+		sqinfo_off(square(c, grid)->info, SQUARE_WALL_SOLID);
 	}
 }
 
@@ -1379,9 +1379,9 @@ void square_earthquake(struct chunk *c, struct loc grid) {
  */
 void square_upgrade_mineral(struct chunk *c, struct loc grid)
 {
-	if (square(c, grid).feat == FEAT_MAGMA)
+	if (square(c, grid)->feat == FEAT_MAGMA)
 		square_set_feat(c, grid, FEAT_MAGMA_K);
-	if (square(c, grid).feat == FEAT_QUARTZ)
+	if (square(c, grid)->feat == FEAT_QUARTZ)
 		square_set_feat(c, grid, FEAT_QUARTZ_K);
 }
 
@@ -1397,18 +1397,18 @@ void square_force_floor(struct chunk *c, struct loc grid) {
 /* Note that this returns the STORE_ index, which is one less than shopnum */
 int square_shopnum(struct chunk *c, struct loc grid) {
 	if (square_isshop(c, grid))
-		return f_info[square(c, grid).feat].shopnum - 1;
+		return f_info[square(c, grid)->feat].shopnum - 1;
 	return -1;
 }
 
 int square_digging(struct chunk *c, struct loc grid) {
 	if (square_isdiggable(c, grid))
-		return f_info[square(c, grid).feat].dig;
+		return f_info[square(c, grid)->feat].dig;
 	return 0;
 }
 
 const char *square_apparent_name(struct chunk *c, struct player *p, struct loc grid) {
-	int actual = square(player->cave, grid).feat;
+	int actual = square(player->cave, grid)->feat;
 	char *mimic_name = f_info[actual].mimic;
 	int f = mimic_name ? lookup_feat(mimic_name) : actual;
 	return f_info[f].name;
@@ -1417,7 +1417,7 @@ const char *square_apparent_name(struct chunk *c, struct player *p, struct loc g
 /* Memorize the terrain */
 void square_memorize(struct chunk *c, struct loc grid) {
 	if (c != cave) return;
-	square_set_known_feat(c, grid, square(c, grid).feat);
+	square_set_known_feat(c, grid, square(c, grid)->feat);
 }
 
 /* Forget the terrain */
@@ -1427,9 +1427,9 @@ void square_forget(struct chunk *c, struct loc grid) {
 }
 
 void square_mark(struct chunk *c, struct loc grid) {
-	sqinfo_on(square(c, grid).info, SQUARE_MARK);
+	sqinfo_on(square(c, grid)->info, SQUARE_MARK);
 }
 
 void square_unmark(struct chunk *c, struct loc grid) {
-	sqinfo_off(square(c, grid).info, SQUARE_MARK);
+	sqinfo_off(square(c, grid)->info, SQUARE_MARK);
 }

--- a/src/cave-view.c
+++ b/src/cave-view.c
@@ -437,9 +437,9 @@ static void mark_wasseen(struct chunk *c)
 		for (x = 0; x < c->width; x++) {
 			struct loc grid = loc(x, y);
 			if (square_isseen(c, grid))
-				sqinfo_on(square(c, grid).info, SQUARE_WASSEEN);
-			sqinfo_off(square(c, grid).info, SQUARE_VIEW);
-			sqinfo_off(square(c, grid).info, SQUARE_SEEN);
+				sqinfo_on(square(c, grid)->info, SQUARE_WASSEEN);
+			sqinfo_off(square(c, grid)->info, SQUARE_VIEW);
+			sqinfo_off(square(c, grid)->info, SQUARE_SEEN);
 		}
 	}
 }
@@ -549,9 +549,9 @@ static void become_viewable(struct chunk *c, struct loc grid, struct player *p,
 	if (square_isview(c, grid)) return;
 
 	/* Add the grid to the view, make seen if it's close enough to the player */
-	sqinfo_on(square(c, grid).info, SQUARE_VIEW);
+	sqinfo_on(square(c, grid)->info, SQUARE_VIEW);
 	if (close)
-		sqinfo_on(square(c, grid).info, SQUARE_SEEN);
+		sqinfo_on(square(c, grid)->info, SQUARE_SEEN);
 
 	/* Mark lit grids, and walls near to them, as seen */
 	if (square_islit(c, grid)) {
@@ -560,10 +560,10 @@ static void become_viewable(struct chunk *c, struct loc grid, struct player *p,
 			int xc = (x < p->grid.x) ? (x + 1) : (x > p->grid.x) ? (x - 1) : x;
 			int yc = (y < p->grid.y) ? (y + 1) : (y > p->grid.y) ? (y - 1) : y;
 			if (square_islit(c, loc(xc, yc))) {
-				sqinfo_on(square(c, grid).info, SQUARE_SEEN);
+				sqinfo_on(square(c, grid)->info, SQUARE_SEEN);
 			}
 		} else {
-			sqinfo_on(square(c, grid).info, SQUARE_SEEN);
+			sqinfo_on(square(c, grid)->info, SQUARE_SEEN);
 		}
 	}
 }
@@ -645,7 +645,7 @@ static void update_one(struct chunk *c, struct loc grid, int blind)
 {
 	/* Remove view if blind, check visible squares for traps */
 	if (blind) {
-		sqinfo_off(square(c, grid).info, SQUARE_SEEN);
+		sqinfo_off(square(c, grid)->info, SQUARE_SEEN);
 	} else if (square_isseen(c, grid)) {
 		square_reveal_trap(c, grid, false, true);
 	}
@@ -654,7 +654,7 @@ static void update_one(struct chunk *c, struct loc grid, int blind)
 	if (square_isseen(c, grid) && !square_wasseen(c, grid)) {
 		if (square_isfeel(c, grid)) {
 			c->feeling_squares++;
-			sqinfo_off(square(c, grid).info, SQUARE_FEEL);
+			sqinfo_off(square(c, grid)->info, SQUARE_FEEL);
 			/* Don't display feeling if it will display for the new level */
 			if ((c->feeling_squares == z_info->feeling_need) &&
 				!player->upkeep->only_partial) {
@@ -671,7 +671,7 @@ static void update_one(struct chunk *c, struct loc grid, int blind)
 	if (!square_isseen(c, grid) && square_wasseen(c, grid))
 		square_light_spot(c, grid);
 
-	sqinfo_off(square(c, grid).info, SQUARE_WASSEEN);
+	sqinfo_off(square(c, grid)->info, SQUARE_WASSEEN);
 }
 
 /**
@@ -685,10 +685,10 @@ void update_view(struct chunk *c, struct player *p)
 	mark_wasseen(c);
 
 	/* Assume we can view the player grid */
-	sqinfo_on(square(c, p->grid).info, SQUARE_VIEW);
+	sqinfo_on(square(c, p->grid)->info, SQUARE_VIEW);
 	if (p->state.cur_light > 0 || square_isglow(c, p->grid) ||
 		player_has(p, PF_UNLIGHT)) {
-		sqinfo_on(square(c, p->grid).info, SQUARE_SEEN);
+		sqinfo_on(square(c, p->grid)->info, SQUARE_SEEN);
 	}
 
 	/* Calculate light levels */

--- a/src/cave.h
+++ b/src/cave.h
@@ -381,7 +381,7 @@ bool square_suits_stairs_well(struct chunk *c, struct loc grid);
 bool square_suits_stairs_ok(struct chunk *c, struct loc grid);
 
 
-struct square square(struct chunk *c, struct loc grid);
+const struct square *square(struct chunk *c, struct loc grid);
 struct feature *square_feat(struct chunk *c, struct loc grid);
 int square_light(struct chunk *c, struct loc grid);
 struct monster *square_monster(struct chunk *c, struct loc grid);

--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -417,7 +417,7 @@ void do_cmd_close(struct command *cmd)
 	}
 
 	/* Monster - alert, then attack */
-	if (square(cave, grid).mon > 0) {
+	if (square(cave, grid)->mon > 0) {
 		msg("There is a monster in the way!");
 		py_attack(player, grid);
 	} else
@@ -613,7 +613,7 @@ void do_cmd_tunnel(struct command *cmd)
 	}
 
 	/* Attack any monster we run into */
-	if (square(cave, grid).mon > 0) {
+	if (square(cave, grid)->mon > 0) {
 		msg("There is a monster in the way!");
 		py_attack(player, grid);
 	} else {
@@ -717,7 +717,7 @@ static bool do_cmd_lock_door(struct loc grid)
 static bool do_cmd_disarm_aux(struct loc grid)
 {
 	int skill, power, chance;
-    struct trap *trap = square(cave, grid).trap;
+    struct trap *trap = square(cave, grid)->trap;
 	bool more = false;
 
 	/* Verify legality */
@@ -837,7 +837,7 @@ void do_cmd_disarm(struct command *cmd)
 
 
 	/* Monster */
-	if (square(cave, grid).mon > 0) {
+	if (square(cave, grid)->mon > 0) {
 		msg("There is a monster in the way!");
 		py_attack(player, grid);
 	} else if (obj)
@@ -891,7 +891,7 @@ void do_cmd_alter_aux(int dir)
 	o_chest_trapped = chest_check(grid, CHEST_TRAPPED);
 
 	/* Action depends on what's there */
-	if (square(cave, grid).mon > 0) {
+	if (square(cave, grid)->mon > 0) {
 		/* Attack monster */
 		py_attack(player, grid);
 	} else if (square_isdiggable(cave, grid)) {
@@ -947,7 +947,7 @@ void do_cmd_steal_aux(int dir)
 	}
 
 	/* Attack or steal from monsters */
-	if ((square(cave, grid).mon > 0) && player_has(player, PF_STEAL)) {
+	if ((square(cave, grid)->mon > 0) && player_has(player, PF_STEAL)) {
 		steal_monster_item(square_monster(cave, grid), -1);
 	} else {
 		/* Oops */
@@ -978,7 +978,7 @@ void move_player(int dir, bool disarm)
 {
 	struct loc grid = loc_sum(player->grid, ddgrid[dir]);
 
-	int m_idx = square(cave, grid).mon;
+	int m_idx = square(cave, grid)->mon;
 	struct monster *mon = cave_monster(cave, m_idx);
 	bool trapsafe = player_is_trapsafe(player);
 	bool trap = square_isdisarmabletrap(cave, grid);
@@ -1122,7 +1122,7 @@ void move_player(int dir, bool disarm)
  */
 static bool do_cmd_walk_test(struct loc grid)
 {
-	int m_idx = square(cave, grid).mon;
+	int m_idx = square(cave, grid)->mon;
 	struct monster *mon = cave_monster(cave, m_idx);
 
 	/* Allow attack on visible monsters if unafraid */

--- a/src/effects.c
+++ b/src/effects.c
@@ -1714,7 +1714,7 @@ bool effect_handler_DETECT_TRAPS(effect_handler_context_t *context)
 				}
 			}
 			/* Mark as trap-detected */
-			sqinfo_on(square(cave, loc(x, y)).info, SQUARE_DTRAP);
+			sqinfo_on(square(cave, loc(x, y))->info, SQUARE_DTRAP);
 		}
 	}
 
@@ -2988,7 +2988,7 @@ bool effect_handler_TELEPORT(effect_handler_context_t *context)
 	monster_swap(start, spots->grid);
 
 	/* Clear any projection marker to prevent double processing */
-	sqinfo_off(square(cave, spots->grid).info, SQUARE_PROJECT);
+	sqinfo_off(square(cave, spots->grid)->info, SQUARE_PROJECT);
 
 	/* Clear monster target if it's no longer visible */
 	if (!target_able(target_get_monster())) {
@@ -3118,7 +3118,7 @@ bool effect_handler_TELEPORT_TO(effect_handler_context_t *context)
 	monster_swap(start, land);
 
 	/* Clear any projection marker to prevent double processing */
-	sqinfo_off(square(cave, land).info, SQUARE_PROJECT);
+	sqinfo_off(square(cave, land)->info, SQUARE_PROJECT);
 
 	/* Lots of updates after monster_swap */
 	handle_stuff(player);
@@ -3320,14 +3320,14 @@ bool effect_handler_DESTRUCTION(effect_handler_context_t *context)
 			if (k > r) continue;
 
 			/* Lose room and vault */
-			sqinfo_off(square(cave, grid).info, SQUARE_ROOM);
-			sqinfo_off(square(cave, grid).info, SQUARE_VAULT);
+			sqinfo_off(square(cave, grid)->info, SQUARE_ROOM);
+			sqinfo_off(square(cave, grid)->info, SQUARE_VAULT);
 
 			/* Forget completely */
 			if (!square_isbright(cave, grid)) {
-				sqinfo_off(square(cave, grid).info, SQUARE_GLOW);
+				sqinfo_off(square(cave, grid)->info, SQUARE_GLOW);
 			}
-			sqinfo_off(square(cave, grid).info, SQUARE_SEEN);
+			sqinfo_off(square(cave, grid)->info, SQUARE_SEEN);
 			square_forget(cave, grid);
 			square_light_spot(cave, grid);
 
@@ -3459,14 +3459,14 @@ bool effect_handler_EARTHQUAKE(effect_handler_context_t *context)
 			if (distance(centre, grid) > r) continue;
 
 			/* Lose room and vault */
-			sqinfo_off(square(cave, grid).info, SQUARE_ROOM);
-			sqinfo_off(square(cave, grid).info, SQUARE_VAULT);
+			sqinfo_off(square(cave, grid)->info, SQUARE_ROOM);
+			sqinfo_off(square(cave, grid)->info, SQUARE_VAULT);
 
 			/* Forget completely */
 			if (!square_isbright(cave, grid)) {
-				sqinfo_off(square(cave, grid).info, SQUARE_GLOW);
+				sqinfo_off(square(cave, grid)->info, SQUARE_GLOW);
 			}
-			sqinfo_off(square(cave, grid).info, SQUARE_SEEN);
+			sqinfo_off(square(cave, grid)->info, SQUARE_SEEN);
 			square_forget(cave, grid);
 			square_light_spot(cave, grid);
 
@@ -3573,7 +3573,7 @@ bool effect_handler_EARTHQUAKE(effect_handler_context_t *context)
 			if (!map[16 + grid.y - centre.y][16 + grid.x - centre.x]) continue;
 
 			/* Process monsters */
-			if (square(cave, grid).mon > 0) {
+			if (square(cave, grid)->mon > 0) {
 				struct monster *mon = square_monster(cave, grid);
 
 				/* Most monsters cannot co-exist with rock */

--- a/src/game-world.c
+++ b/src/game-world.c
@@ -737,7 +737,7 @@ void process_world(struct chunk *c)
 	for (y = 0; y < c->height; y++) {
 		for (x = 0; x < c->width; x++) {
 			struct loc grid = loc(x, y);
-			struct trap *trap = square(c, grid).trap;
+			struct trap *trap = square(c, grid)->trap;
 			while (trap) {
 				if (trap->timeout) {
 					trap->timeout--;

--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -86,8 +86,8 @@
 static bool square_is_granite_with_flag(struct chunk *c, struct loc grid,
 										int flag)
 {
-	if (square(c, grid).feat != FEAT_GRANITE) return false;
-	if (!sqinfo_has(square(c, grid).info, flag)) return false;
+	if (square(c, grid)->feat != FEAT_GRANITE) return false;
+	if (!sqinfo_has(square(c, grid)->info, flag)) return false;
 
 	return true;
 }
@@ -723,7 +723,7 @@ struct chunk *labyrinth_chunk(int depth, int h, int w, bool lit, bool soft)
 			struct loc diag = next_grid(grid, DIR_SE);
 			sets[k_local] = k_local;
 			square_set_feat(c, diag, FEAT_FLOOR);
-			if (lit) sqinfo_on(square(c, diag).info, SQUARE_GLOW);
+			if (lit) sqinfo_on(square(c, diag)->info, SQUARE_GLOW);
 		}
     }
 
@@ -754,7 +754,7 @@ struct chunk *labyrinth_chunk(int depth, int h, int w, bool lit, bool soft)
 			int sb = sets[b];
 			square_set_feat(c, next_grid(grid, DIR_SE), FEAT_FLOOR);
 			if (lit) {
-				sqinfo_on(square(c, next_grid(grid, DIR_SE)).info, SQUARE_GLOW);
+				sqinfo_on(square(c, next_grid(grid, DIR_SE))->info, SQUARE_GLOW);
 			}
 			for (k = 0; k < n; k++) {
 				if (sets[k] == sb) sets[k] = sa;
@@ -937,7 +937,7 @@ static void mutate_cavern(struct chunk *c) {
 			else if (count < 4)
 				temp[grid_to_i(grid, w)] = FEAT_FLOOR;
 			else
-				temp[grid_to_i(grid, w)] = square(c, grid).feat;
+				temp[grid_to_i(grid, w)] = square(c, grid)->feat;
 		}
     }
 
@@ -1467,7 +1467,7 @@ bool lot_has_shop(struct chunk *c, struct loc xroads, struct loc lot,
 
 	for (probe.x = nw_corner.x; probe.x <= se_corner.x; probe.x++) {
 		for (probe.y = nw_corner.y; probe.y <= se_corner.y; probe.y++) {
-			if (feat_is_shop(square(c, probe).feat)) {
+			if (feat_is_shop(square(c, probe)->feat)) {
 				return true;
 			}
 		}
@@ -1719,7 +1719,7 @@ static void town_gen_layout(struct chunk *c, struct player *p)
 		for (grid.y = 1; grid.y < c->height - 1; grid.y++) {
 			for (grid.x = 1; grid.x < c->width - 1; grid.x++) {
 				if (square_isfloor(c, grid))
-					sqinfo_off(square(c, grid).info, SQUARE_ROOM);
+					sqinfo_off(square(c, grid)->info, SQUARE_ROOM);
 			}
 		}
 

--- a/src/gen-chunk.c
+++ b/src/gen-chunk.c
@@ -53,8 +53,8 @@ struct chunk *chunk_write(struct chunk *c)
 	for (y = 0; y < new->height; y++) {
 		for (x = 0; x < new->width; x++) {
 			/* Terrain */
-			new->squares[y][x].feat = square(c, loc(x, y)).feat;
-			sqinfo_copy(square(new, loc(x, y)).info, square(c, loc(x, y)).info);
+			new->squares[y][x].feat = square(c, loc(x, y))->feat;
+			sqinfo_copy(square(new, loc(x, y))->info, square(c, loc(x, y))->info);
 		}
 	}
 
@@ -226,9 +226,9 @@ bool chunk_copy(struct chunk *dest, struct chunk *source, int y0, int x0,
 
 			/* Terrain */
 			dest->squares[dest_grid.y][dest_grid.x].feat =
-				square(source, grid).feat;
-			sqinfo_copy(square(dest, dest_grid).info,
-						square(source, grid).info);
+				square(source, grid)->feat;
+			sqinfo_copy(square(dest, dest_grid)->info,
+						square(source, grid)->info);
 
 			/* Dungeon objects */
 			if (square_object(source, grid)) {
@@ -244,8 +244,8 @@ bool chunk_copy(struct chunk *dest, struct chunk *source, int y0, int x0,
 			}
 
 			/* Traps */
-			if (square(source, grid).trap) {
-				struct trap *trap = square(source, grid).trap;
+			if (square(source, grid)->trap) {
+				struct trap *trap = square(source, grid)->trap;
 				dest->squares[dest_grid.y][dest_grid.x].trap = trap;
 
 				/* Traverse the trap list */
@@ -258,7 +258,7 @@ bool chunk_copy(struct chunk *dest, struct chunk *source, int y0, int x0,
 			}
 
 			/* Player */
-			if (square(source, grid).mon == -1) 
+			if (square(source, grid)->mon == -1)
 				dest->squares[dest_grid.y][dest_grid.x].mon = -1;
 		}
 	}
@@ -368,7 +368,7 @@ void chunk_validate_objects(struct chunk *c) {
 			struct loc grid = loc(x, y);
 			for (obj = square_object(c, grid); obj; obj = obj->next)
 				assert(obj->tval != 0);
-			if (square(c, grid).mon > 0) {
+			if (square(c, grid)->mon > 0) {
 				struct monster *mon = square_monster(c, grid);
 				if (mon->held_obj)
 					for (obj = mon->held_obj; obj; obj = obj->next)

--- a/src/gen-room.c
+++ b/src/gen-room.c
@@ -110,9 +110,9 @@ static void generate_room(struct chunk *c, int y1, int x1, int y2, int x2,
 	struct loc grid;
 	for (grid.y = y1; grid.y <= y2; grid.y++)
 		for (grid.x = x1; grid.x <= x2; grid.x++) {
-			sqinfo_on(square(c, grid).info, SQUARE_ROOM);
+			sqinfo_on(square(c, grid)->info, SQUARE_ROOM);
 			if (light)
-				sqinfo_on(square(c, grid).info, SQUARE_GLOW);
+				sqinfo_on(square(c, grid)->info, SQUARE_GLOW);
 		}
 }
 
@@ -130,7 +130,7 @@ void generate_mark(struct chunk *c, int y1, int x1, int y2, int x2, int flag)
 	struct loc grid;
 	for (grid.y = y1; grid.y <= y2; grid.y++) {
 		for (grid.x = x1; grid.x <= x2; grid.x++) {
-			sqinfo_on(square(c, grid).info, flag);
+			sqinfo_on(square(c, grid)->info, flag);
 		}
 	}
 }
@@ -205,10 +205,10 @@ static void fill_xrange(struct chunk *c, int y, int x1, int x2, int feat,
 	for (x = x1; x <= x2; x++) {
 		struct loc grid = loc(x, y);
 		square_set_feat(c, grid, feat);
-		sqinfo_on(square(c, grid).info, SQUARE_ROOM);
-		if (flag) sqinfo_on(square(c, grid).info, flag);
+		sqinfo_on(square(c, grid)->info, SQUARE_ROOM);
+		if (flag) sqinfo_on(square(c, grid)->info, flag);
 		if (light)
-			sqinfo_on(square(c, grid).info, SQUARE_GLOW);
+			sqinfo_on(square(c, grid)->info, SQUARE_GLOW);
 	}
 }
 
@@ -229,10 +229,10 @@ static void fill_yrange(struct chunk *c, int x, int y1, int y2, int feat,
 	for (y = y1; y <= y2; y++) {
 		struct loc grid = loc(x, y);
 		square_set_feat(c, grid, feat);
-		sqinfo_on(square(c, grid).info, SQUARE_ROOM);
-		if (flag) sqinfo_on(square(c, grid).info, flag);
+		sqinfo_on(square(c, grid)->info, SQUARE_ROOM);
+		if (flag) sqinfo_on(square(c, grid)->info, flag);
 		if (light)
-			sqinfo_on(square(c, grid).info, SQUARE_GLOW);
+			sqinfo_on(square(c, grid)->info, SQUARE_GLOW);
 	}
 }
 
@@ -651,15 +651,15 @@ extern bool generate_starburst_room(struct chunk *c, int y1, int x1, int y2,
 							square_set_feat(c, grid, feat);
 
 							if (feat_is_floor(feat)) {
-								sqinfo_on(square(c, grid).info, SQUARE_ROOM);
+								sqinfo_on(square(c, grid)->info, SQUARE_ROOM);
 							} else {
-								sqinfo_off(square(c, grid).info, SQUARE_ROOM);
+								sqinfo_off(square(c, grid)->info, SQUARE_ROOM);
 							}
 
 							if (light) {
-								sqinfo_on(square(c, grid).info, SQUARE_GLOW);
+								sqinfo_on(square(c, grid)->info, SQUARE_GLOW);
 							} else if (!square_isbright(c, grid)) {
-								sqinfo_off(square(c, grid).info, SQUARE_GLOW);
+								sqinfo_off(square(c, grid)->info, SQUARE_GLOW);
 							}
 						}
 
@@ -679,7 +679,7 @@ extern bool generate_starburst_room(struct chunk *c, int y1, int x1, int y2,
 
 							/* Light grid. */
 							if (light)
-								sqinfo_on(square(c, grid).info, SQUARE_GLOW);
+								sqinfo_on(square(c, grid)->info, SQUARE_GLOW);
 						}
 					}
 
@@ -707,15 +707,15 @@ extern bool generate_starburst_room(struct chunk *c, int y1, int x1, int y2,
 						struct loc grid1 = loc_sum(grid, ddgrid_ddd[d]);
 
 						/* Join to room, forbid stairs */
-						sqinfo_on(square(c, grid1).info, SQUARE_ROOM);
-						sqinfo_on(square(c, grid1).info, SQUARE_NO_STAIRS);
+						sqinfo_on(square(c, grid1)->info, SQUARE_ROOM);
+						sqinfo_on(square(c, grid1)->info, SQUARE_NO_STAIRS);
 
 						/* Illuminate if requested. */
 						if (light)
-							sqinfo_on(square(c, grid1).info, SQUARE_GLOW);
+							sqinfo_on(square(c, grid1)->info, SQUARE_GLOW);
 
 						/* Look for dungeon granite. */
-						if (square(c, grid1).feat == FEAT_GRANITE) {
+						if (square(c, grid1)->feat == FEAT_GRANITE) {
 							/* Mark as outer wall. */
 							set_marked_granite(c, grid1, SQUARE_WALL_OUTER);
 						}
@@ -1093,9 +1093,9 @@ static bool build_room_template(struct chunk *c, struct loc centre, int ymax,
 			}
 
 			/* Part of a room */
-			sqinfo_on(square(c, grid).info, SQUARE_ROOM);
+			sqinfo_on(square(c, grid)->info, SQUARE_ROOM);
 			if (light)
-				sqinfo_on(square(c, grid).info, SQUARE_GLOW);
+				sqinfo_on(square(c, grid)->info, SQUARE_GLOW);
 		}
 	}
 
@@ -1239,8 +1239,8 @@ bool build_vault(struct chunk *c, struct loc centre, struct vault *v)
 			}
 
 			/* Part of a vault */
-			sqinfo_on(square(c, grid).info, SQUARE_ROOM);
-			if (icky) sqinfo_on(square(c, grid).info, SQUARE_VAULT);
+			sqinfo_on(square(c, grid)->info, SQUARE_ROOM);
+			if (icky) sqinfo_on(square(c, grid)->info, SQUARE_VAULT);
 		}
 	}
 
@@ -1433,8 +1433,8 @@ static bool build_vault_type(struct chunk *c, struct loc centre,
 static void make_inner_chamber_wall(struct chunk *c, int y, int x)
 {
 	struct loc grid = loc(x, y);
-	if ((square(c, grid).feat != FEAT_GRANITE) &&
-		(square(c, grid).feat != FEAT_MAGMA))
+	if ((square(c, grid)->feat != FEAT_GRANITE) &&
+		(square(c, grid)->feat != FEAT_MAGMA))
 		return;
 	if (square_iswall_outer(c, grid)) return;
 	if (square_iswall_solid(c, grid)) return;
@@ -1508,7 +1508,7 @@ static void make_chamber(struct chunk *c, int y1, int x1, int y2, int x2)
 			int xx = x + ddx_ddd[d];
 
 			/* No doors beside doors. */
-			if (square(c, loc(xx, yy)).feat == FEAT_OPEN)
+			if (square(c, loc(xx, yy))->feat == FEAT_OPEN)
 				break;
 
 			/* Count the inner walls. */
@@ -1547,14 +1547,14 @@ static void hollow_out_room(struct chunk *c, struct loc grid)
 		struct loc grid1 = loc_sum(grid, ddgrid_ddd[d]);
 
 		/* Change magma to floor. */
-		if (square(c, grid1).feat == FEAT_MAGMA) {
+		if (square(c, grid1)->feat == FEAT_MAGMA) {
 			square_set_feat(c, grid1, FEAT_FLOOR);
 
 			/* Hollow out the room. */
 			hollow_out_room(c, grid1);
 		}
 		/* Change open door to broken door. */
-		else if (square(c, grid1).feat == FEAT_OPEN) {
+		else if (square(c, grid1)->feat == FEAT_OPEN) {
 			square_set_feat(c, grid1, FEAT_BROKEN);
 
 			/* Hollow out the (new) room. */
@@ -2805,14 +2805,14 @@ bool build_room_of_chambers(struct chunk *c, struct loc centre, int rating)
 				struct loc grid1 = loc_sum(grid, ddgrid_ddd[d]);
 
 				/* Count the walls and dungeon granite. */
-				if ((square(c, grid1).feat == FEAT_GRANITE) &&
+				if ((square(c, grid1)->feat == FEAT_GRANITE) &&
 					(!square_iswall_outer(c, grid1)) &&
 					(!square_iswall_solid(c, grid1)))
 					count++;
 			}
 
 			/* Five adjacent walls: Change non-chamber to wall. */
-			if ((count == 5) && (square(c, grid).feat != FEAT_MAGMA))
+			if ((count == 5) && (square(c, grid)->feat != FEAT_MAGMA))
 				set_marked_granite(c, grid, SQUARE_WALL_INNER);
 
 			/* More than five adjacent walls: Change anything to wall. */
@@ -2825,7 +2825,7 @@ bool build_room_of_chambers(struct chunk *c, struct loc centre, int rating)
 	for (i = 0; i < 50; i++) {
 		grid = loc(x1 + ABS(x2 - x1) / 4 + randint0(ABS(x2 - x1) / 2),
 				   y1 + ABS(y2 - y1) / 4 + randint0(ABS(y2 - y1) / 2));
-		if (square(c, grid).feat == FEAT_MAGMA)
+		if (square(c, grid)->feat == FEAT_MAGMA)
 			break;
 	}
 
@@ -2842,7 +2842,7 @@ bool build_room_of_chambers(struct chunk *c, struct loc centre, int rating)
 		for (grid.y = y1; grid.y < y2; grid.y++) {
 			for (grid.x = x1; grid.x < x2; grid.x++) {
 				/* Current grid must be magma. */
-				if (square(c, grid).feat != FEAT_MAGMA) continue;
+				if (square(c, grid)->feat != FEAT_MAGMA) continue;
 
 				/* Stay legal. */
 				if (!square_in_bounds_fully(c, grid)) continue;
@@ -2863,7 +2863,7 @@ bool build_room_of_chambers(struct chunk *c, struct loc centre, int rating)
 					if (!square_in_bounds(c, grid2)) continue;
 
 					/* If we find open floor, place a door. */
-					if (square(c, grid2).feat == FEAT_FLOOR) {
+					if (square(c, grid2)->feat == FEAT_FLOOR) {
 						joy = true;
 
 						/* Make a broken door in the wall grid. */
@@ -2883,7 +2883,7 @@ bool build_room_of_chambers(struct chunk *c, struct loc centre, int rating)
 						if (!square_in_bounds(c, grid3)) continue;
 
 						/* If we /now/ find floor, make a tunnel. */
-						if (square(c, grid3).feat == FEAT_FLOOR) {
+						if (square(c, grid3)->feat == FEAT_FLOOR) {
 							joy = true;
 
 							/* Turn both wall grids into floor. */
@@ -2909,9 +2909,9 @@ bool build_room_of_chambers(struct chunk *c, struct loc centre, int rating)
 	/* Turn broken doors into a random kind of door, remove open doors. */
 	for (grid.y = y1; grid.y <= y2; grid.y++) {
 		for (grid.x = x1; grid.x <= x2; grid.x++) {
-			if (square(c, grid).feat == FEAT_OPEN)
+			if (square(c, grid)->feat == FEAT_OPEN)
 				set_marked_granite(c, grid, SQUARE_WALL_INNER);
-			else if (square(c, grid).feat == FEAT_BROKEN)
+			else if (square(c, grid)->feat == FEAT_BROKEN)
 				place_random_door(c, grid);
 		}
 	}
@@ -2925,7 +2925,7 @@ bool build_room_of_chambers(struct chunk *c, struct loc centre, int rating)
 			 grid.x < (x2 + 2 < c->width ? x2 + 2 : c->width); grid.x++) {
 
 			if (square_iswall_inner(c, grid)
-				|| (square(c, grid).feat == FEAT_MAGMA)) {
+				|| (square(c, grid)->feat == FEAT_MAGMA)) {
 				for (d = 0; d < 9; d++) {
 					/* Extract adjacent location */
 					struct loc grid1 = loc_sum(grid, ddgrid_ddd[d]);
@@ -2934,7 +2934,7 @@ bool build_room_of_chambers(struct chunk *c, struct loc centre, int rating)
 					if (!square_in_bounds(c, grid1)) continue;
 
 					/* No floors allowed */
-					if (square(c, grid1).feat == FEAT_FLOOR) break;
+					if (square(c, grid1)->feat == FEAT_FLOOR) break;
 
 					/* Turn me into dungeon granite. */
 					if (d == 8)
@@ -2950,11 +2950,11 @@ bool build_room_of_chambers(struct chunk *c, struct loc centre, int rating)
 					if (!square_in_bounds(c, grid1)) continue;
 
 					/* Turn into room, forbid stairs. */
-					sqinfo_on(square(c, grid1).info, SQUARE_ROOM);
-					sqinfo_on(square(c, grid1).info, SQUARE_NO_STAIRS);
+					sqinfo_on(square(c, grid1)->info, SQUARE_ROOM);
+					sqinfo_on(square(c, grid1)->info, SQUARE_NO_STAIRS);
 
 					/* Illuminate if requested. */
-					if (light) sqinfo_on(square(c, grid1).info, SQUARE_GLOW);
+					if (light) sqinfo_on(square(c, grid1)->info, SQUARE_GLOW);
 				}
 			}
 		}
@@ -2976,7 +2976,7 @@ bool build_room_of_chambers(struct chunk *c, struct loc centre, int rating)
 					struct loc grid1 = loc_sum(grid, ddgrid_ddd[d]);
 
 					/* Look for dungeon granite */
-					if ((square(c, grid1).feat == FEAT_GRANITE) && 
+					if ((square(c, grid1)->feat == FEAT_GRANITE) && 
 						(!square_iswall_inner(c, grid)) &&
 						(!square_iswall_outer(c, grid)) &&
 						(!square_iswall_solid(c, grid)))

--- a/src/generate.c
+++ b/src/generate.c
@@ -659,7 +659,7 @@ static void place_feeling(struct chunk *c)
 				continue;
 
 			/* Set the cave square appropriately */
-			sqinfo_on(square(c, grid).info, SQUARE_FEEL);
+			sqinfo_on(square(c, grid)->info, SQUARE_FEEL);
 			
 			break;
 		}
@@ -1037,10 +1037,10 @@ static struct chunk *cave_generate(struct player *p, int height, int width)
 			for (x = 0; x < chunk->width; x++) {
 				struct loc grid = loc(x, y);
 
-				sqinfo_off(square(chunk, grid).info, SQUARE_WALL_INNER);
-				sqinfo_off(square(chunk, grid).info, SQUARE_WALL_OUTER);
-				sqinfo_off(square(chunk, grid).info, SQUARE_WALL_SOLID);
-				sqinfo_off(square(chunk, grid).info, SQUARE_MON_RESTRICT);
+				sqinfo_off(square(chunk, grid)->info, SQUARE_WALL_INNER);
+				sqinfo_off(square(chunk, grid)->info, SQUARE_WALL_OUTER);
+				sqinfo_off(square(chunk, grid)->info, SQUARE_WALL_SOLID);
+				sqinfo_off(square(chunk, grid)->info, SQUARE_MON_RESTRICT);
 
 				if (square_isstairs(chunk, grid)) {
 					size_t n;
@@ -1049,7 +1049,7 @@ static struct chunk *cave_generate(struct player *p, int height, int width)
 					new->feat = square_feat(chunk, grid)->fidx;
 					new->info = mem_zalloc(SQUARE_SIZE * sizeof(bitflag));
 					for (n = 0; n < SQUARE_SIZE; n++) {
-						new->info[n] = square(chunk, grid).info[n];
+						new->info[n] = square(chunk, grid)->info[n];
 					}
 					new->next = chunk->join;
 					chunk->join = new;
@@ -1289,7 +1289,7 @@ void prepare_next_level(struct chunk **c, struct player *p)
 				for (y = 0; y < (*c)->height; y++) {
 					for (x = 0; x < (*c)->width; x++) {
 						struct loc grid = loc(x, y);
-						if (square(*c, grid).mon == -1) {
+						if (square(*c, grid)->mon == -1) {
 							p->grid = grid;
 							found = true;
 							break;

--- a/src/mon-make.c
+++ b/src/mon-make.c
@@ -392,8 +392,8 @@ void delete_monster(struct loc grid)
 	assert(square_in_bounds(cave, grid));
 
 	/* Delete the monster (if any) */
-	if (square(cave, grid).mon > 0)
-		delete_monster_idx(square(cave, grid).mon);
+	if (square(cave, grid)->mon > 0)
+		delete_monster_idx(square(cave, grid)->mon);
 }
 
 

--- a/src/mon-move.c
+++ b/src/mon-move.c
@@ -980,7 +980,7 @@ static bool monster_turn_multiply(struct chunk *c, struct monster *mon)
 	/* Count the adjacent monsters */
 	for (y = mon->grid.y - 1; y <= mon->grid.y + 1; y++)
 		for (x = mon->grid.x - 1; x <= mon->grid.x + 1; x++)
-			if (square(c, loc(x, y)).mon > 0) k++;
+			if (square(c, loc(x, y))->mon > 0) k++;
 
 	/* Multiply slower in crowded areas */
 	if ((k < 4) && (k == 0 || one_in_(k * z_info->repro_monster_rate))) {

--- a/src/mon-util.c
+++ b/src/mon-util.c
@@ -224,7 +224,7 @@ static void path_analyse(struct chunk *c, struct loc grid)
 	for (i = 0; i < path_n - 1; ++i) {
 		/* Forget grids which would block los */
 		if (square_iswall(player->cave, path_g[i])) {
-			sqinfo_off(square(c, path_g[i]).info, SQUARE_SEEN);
+			sqinfo_off(square(c, path_g[i])->info, SQUARE_SEEN);
 			square_forget(c, path_g[i]);
 			square_light_spot(c, path_g[i]);
 		}

--- a/src/obj-pile.c
+++ b/src/obj-pile.c
@@ -1068,7 +1068,7 @@ void drop_near(struct chunk *c, struct object **dropped, int chance,
 	drop_find_grid(*dropped, prefer_pile, &best);
 	if (floor_carry(c, best, *dropped, &dont_ignore)) {
 		sound(MSG_DROP);
-		if (dont_ignore && (square(c, best).mon < 0)) {
+		if (dont_ignore && (square(c, best)->mon < 0)) {
 			msg("You feel something roll beneath your feet.");
 		}
 	} else {

--- a/src/player-path.c
+++ b/src/player-path.c
@@ -150,7 +150,7 @@ static bool set_up_path_distances(struct loc grid)
 	/* Check bounds */
 	if ((grid.x >= top_left.x) && (grid.x < bottom_right.x) &&
 		(grid.y >= top_left.y) && (grid.y < bottom_right.y)) {
-		if ((square(cave, grid).mon > 0) &&
+		if ((square(cave, grid)->mon > 0) &&
 			monster_is_visible(square_monster(cave, grid))) {
 			set_path_dist(grid, MAX_PF_LENGTH);
 		}
@@ -594,7 +594,7 @@ static bool run_test(void)
 		grid = loc_sum(player->grid, ddgrid[new_dir]);
 
 		/* Visible monsters abort running */
-		if (square(cave, grid).mon > 0) {
+		if (square(cave, grid)->mon > 0) {
 			struct monster *mon = square_monster(cave, grid);
 			if (monster_is_visible(mon)) {
 				return true;
@@ -676,7 +676,7 @@ static bool run_test(void)
 		if (!square_in_bounds(cave, grid)) continue;
 
 		/* Obvious monsters abort running */
-		if (square(cave, grid).mon > 0) {
+		if (square(cave, grid)->mon > 0) {
 			struct monster *mon = square_monster(cave, grid);
 			if (monster_is_obvious(mon))
 				return true;
@@ -821,7 +821,7 @@ void run_step(int dir)
 				}
 
 				/* Visible monsters abort running */
-				if (square(cave, grid).mon > 0) {
+				if (square(cave, grid)->mon > 0) {
 					struct monster *mon = square_monster(cave, grid);
 
 					/* Visible monster */

--- a/src/project-feat.c
+++ b/src/project-feat.c
@@ -49,7 +49,7 @@ static void project_feature_handler_LIGHT_WEAK(project_feature_handler_context_t
 	const struct loc grid = context->grid;
 
 	/* Turn on the light */
-	sqinfo_on(square(cave, grid).info, SQUARE_GLOW);
+	sqinfo_on(square(cave, grid)->info, SQUARE_GLOW);
 
 	/* Grid is in line of sight */
 	if (square_isview(cave, grid)) {
@@ -70,7 +70,7 @@ static void project_feature_handler_DARK_WEAK(project_feature_handler_context_t 
 
 	if ((player->depth != 0 || !is_daytime()) && !square_isbright(cave, grid)) {
 		/* Turn off the light */
-		sqinfo_off(square(cave, grid).info, SQUARE_GLOW);
+		sqinfo_off(square(cave, grid)->info, SQUARE_GLOW);
 	}
 
 	/* Grid is in line of sight */

--- a/src/project-mon.c
+++ b/src/project-mon.c
@@ -142,11 +142,11 @@ void thrust_away(struct loc centre, struct loc target, int grids_away)
 			next = loc_sum(grid, ddgrid_ddd[d % 8]);
 
 			/* There's someone there, try to switch places. */
-			if (square(cave, next).mon != 0) {
+			if (square(cave, next)->mon != 0) {
 				/* A monster is trying to pass. */
-				if (square(cave, grid).mon > 0) {
+				if (square(cave, grid)->mon > 0) {
 					struct monster *mon = square_monster(cave, grid);
-					if (square(cave, next).mon > 0) {
+					if (square(cave, next)->mon > 0) {
 						struct monster *mon1 = square_monster(cave, next);
 
 						/* Monsters cannot pass by stronger monsters. */
@@ -160,8 +160,8 @@ void thrust_away(struct loc centre, struct loc target, int grids_away)
 				}
 
 				/* The player is trying to pass. */
-				if (square(cave, grid).mon < 0) {
-					if (square(cave, next).mon > 0) {
+				if (square(cave, grid)->mon < 0) {
+					if (square(cave, next)->mon > 0) {
 						struct monster *mon1 = square_monster(cave, next);
 
 						/* Players cannot pass by stronger monsters. */
@@ -191,7 +191,7 @@ void thrust_away(struct loc centre, struct loc target, int grids_away)
 				/* If there are walls everywhere, stop here. */
 				else if (d == (8 + first_d - 1)) {
 					/* Message for player. */
-					if (square(cave, grid).mon < 0)
+					if (square(cave, grid)->mon < 0)
 						msg("You come to rest next to a wall.");
 					i = grids_away;
 				}
@@ -210,16 +210,16 @@ void thrust_away(struct loc centre, struct loc target, int grids_away)
 
 	/* Some special messages or effects for player or monster. */
 	if (square_isfiery(cave, grid)) {
-		if (square(cave, grid).mon < 0) {
+		if (square(cave, grid)->mon < 0) {
 			msg("You are thrown into molten lava!");
-		} else if (square(cave, grid).mon > 0) {
+		} else if (square(cave, grid)->mon > 0) {
 			struct monster *mon = square_monster(cave, grid);
 			monster_take_terrain_damage(mon);
 		}
 	}
 
 	/* Clear the projection mark. */
-	sqinfo_off(square(cave, grid).info, SQUARE_PROJECT);
+	sqinfo_off(square(cave, grid)->info, SQUARE_PROJECT);
 }
 
 /**
@@ -1294,7 +1294,7 @@ void project_m(struct source origin, int r, struct loc grid, int dam, int typ,
 	bool charm = (origin.what == SRC_PLAYER) ?
 		player_has(player, PF_CHARM) : false;
 
-	int m_idx = square(cave, grid).mon;
+	int m_idx = square(cave, grid)->mon;
 
 	project_monster_handler_f monster_handler = monster_handlers[typ];
 	project_monster_handler_context_t context = {

--- a/src/project.c
+++ b/src/project.c
@@ -214,7 +214,7 @@ int project_path(struct loc *gp, int range, struct loc grid1, struct loc grid2,
 
 			/* Sometimes stop at non-initial monsters/players, decoys */
 			if (flg & (PROJECT_STOP)) {
-				if ((n > 0) && (square(cave, loc(x, y)).mon != 0)) break;
+				if ((n > 0) && (square(cave, loc(x, y))->mon != 0)) break;
 				if (loc_eq(loc(x, y), decoy)) break;
 			}
 
@@ -279,7 +279,7 @@ int project_path(struct loc *gp, int range, struct loc grid1, struct loc grid2,
 
 			/* Sometimes stop at non-initial monsters/players, decoys */
 			if (flg & (PROJECT_STOP)) {
-				if ((n > 0) && (square(cave, loc(x, y)).mon != 0)) break;
+				if ((n > 0) && (square(cave, loc(x, y))->mon != 0)) break;
 				if (loc_eq(loc(x, y), decoy)) break;
 			}
 
@@ -338,7 +338,7 @@ int project_path(struct loc *gp, int range, struct loc grid1, struct loc grid2,
 
 			/* Sometimes stop at non-initial monsters/players, decoys */
 			if (flg & (PROJECT_STOP)) {
-				if ((n > 0) && (square(cave, loc(x, y)).mon != 0)) break;
+				if ((n > 0) && (square(cave, loc(x, y))->mon != 0)) break;
 				if (loc_eq(loc(x, y), decoy)) break;
 			}
 
@@ -662,7 +662,7 @@ bool project(struct source origin, int rad, struct loc finish,
 		blast_grid[num_grids] =  finish;
 		centre = finish;
 		distance_to_grid[num_grids] = 0;
-		sqinfo_on(square(cave, finish).info, SQUARE_PROJECT);
+		sqinfo_on(square(cave, finish)->info, SQUARE_PROJECT);
 		num_grids++;
 	} else {
 		/* Start from caster */
@@ -706,13 +706,13 @@ bool project(struct source origin, int rad, struct loc finish,
 					blast_grid[num_grids].y = y;
 					blast_grid[num_grids].x = x;
 					distance_to_grid[num_grids] = 0;
-					sqinfo_on(square(cave, loc(x, y)).info, SQUARE_PROJECT);
+					sqinfo_on(square(cave, loc(x, y))->info, SQUARE_PROJECT);
 					num_grids++;
 				} else if (i == num_path_grids - 1) {
 					blast_grid[num_grids].y = y;
 					blast_grid[num_grids].x = x;
 					distance_to_grid[num_grids] = 0;
-					sqinfo_on(square(cave, loc(x, y)).info, SQUARE_PROJECT);
+					sqinfo_on(square(cave, loc(x, y))->info, SQUARE_PROJECT);
 					num_grids++;
 				}
 
@@ -763,7 +763,7 @@ bool project(struct source origin, int rad, struct loc finish,
 		if (num_grids == 0) {
 			blast_grid[num_grids] = centre;
 			distance_to_grid[num_grids] = 0;
-			sqinfo_on(square(cave, centre).info, SQUARE_PROJECT);
+			sqinfo_on(square(cave, centre)->info, SQUARE_PROJECT);
 			num_grids++;
 		}
 
@@ -847,7 +847,7 @@ bool project(struct source origin, int rad, struct loc finish,
 					blast_grid[num_grids].y = y;
 					blast_grid[num_grids].x = x;
 					distance_to_grid[num_grids] = dist_from_centre;
-					sqinfo_on(square(cave, grid).info, SQUARE_PROJECT);
+					sqinfo_on(square(cave, grid)->info, SQUARE_PROJECT);
 					num_grids++;
 				}
 			}
@@ -967,7 +967,7 @@ bool project(struct source origin, int rad, struct loc finish,
 			int y = last_hit_grid.y;
 
 			/* Track if possible */
-			if (square(cave, loc(x, y)).mon > 0) {
+			if (square(cave, loc(x, y))->mon > 0) {
 				struct monster *mon = square_monster(cave, loc(x, y));
 
 				/* Recall and track */
@@ -1018,7 +1018,7 @@ bool project(struct source origin, int rad, struct loc finish,
 	/* Clear all the processing marks. */
 	for (i = 0; i < num_grids; i++) {
 		/* Clear the mark */
-		sqinfo_off(square(cave, blast_grid[i]).info, SQUARE_PROJECT);
+		sqinfo_off(square(cave, blast_grid[i])->info, SQUARE_PROJECT);
 	}
 
 	/* Update stuff if needed */

--- a/src/save.c
+++ b/src/save.c
@@ -786,7 +786,7 @@ static void wr_dungeon_aux(struct chunk *c)
 		for (y = 0; y < c->height; y++) {
 			for (x = 0; x < c->width; x++) {
 				/* Extract the important c->squares[y][x].info flags */
-				tmp8u = square(c, loc(x, y)).info[i];
+				tmp8u = square(c, loc(x, y))->info[i];
 
 				/* If the run is broken, or too full, flush it */
 				if ((tmp8u != prev_char) || (count == UCHAR_MAX)) {
@@ -814,7 +814,7 @@ static void wr_dungeon_aux(struct chunk *c)
 	for (y = 0; y < c->height; y++) {
 		for (x = 0; x < c->width; x++) {
 			/* Extract a byte */
-			tmp8u = square(c, loc(x, y)).feat;
+			tmp8u = square(c, loc(x, y))->feat;
 
 			/* If the run is broken, or too full, flush it */
 			if ((tmp8u != prev_char) || (count == UCHAR_MAX)) {
@@ -873,7 +873,7 @@ static void wr_objects_aux(struct chunk *c)
 	wr_u16b(c->obj_max);
 	for (y = 0; y < c->height; y++) {
 		for (x = 0; x < c->width; x++) {
-			struct object *obj = square(c, loc(x, y)).obj;
+			struct object *obj = square(c, loc(x, y))->obj;
 			while (obj) {
 				wr_item(obj);
 				obj = obj->next;
@@ -933,7 +933,7 @@ static void wr_traps_aux(struct chunk *c)
 
 	for (y = 0; y < c->height; y++) {
 		for (x = 0; x < c->width; x++) {
-			struct trap *trap = square(c, loc(x, y)).trap;
+			struct trap *trap = square(c, loc(x, y))->trap;
 			while (trap) {
 				wr_trap(trap);
 				trap = trap->next;

--- a/src/target.c
+++ b/src/target.c
@@ -327,13 +327,13 @@ bool target_accept(int y, int x)
 	struct object *obj;
 
 	/* Player grids are always interesting */
-	if (square(cave, grid).mon < 0) return true;
+	if (square(cave, grid)->mon < 0) return true;
 
 	/* Handle hallucination */
 	if (player->timed[TMD_IMAGE]) return false;
 
 	/* Obvious monsters */
-	if (square(cave, grid).mon > 0) {
+	if (square(cave, grid)->mon > 0) {
 		struct monster *mon = square_monster(cave, grid);
 		if (monster_is_obvious(mon)) {
 			return true;

--- a/src/trap.c
+++ b/src/trap.c
@@ -139,7 +139,7 @@ static bool square_verify_trap(struct chunk *c, struct loc grid, int vis)
     /* No traps in this location. */
     if (!trap_exists) {
 		/* No traps */
-		sqinfo_off(square(c, grid).info, SQUARE_TRAP);
+		sqinfo_off(square(c, grid)->info, SQUARE_TRAP);
 
 		/* Take note */
 		square_note_spot(c, grid);
@@ -170,7 +170,7 @@ void square_free_trap(struct chunk *c, struct loc grid)
  */
 bool square_remove_all_traps(struct chunk *c, struct loc grid)
 {
-	struct trap *trap = square(c, grid).trap;
+	struct trap *trap = square(c, grid)->trap;
 	bool were_there_traps = trap == NULL ? false : true;
 
 	assert(square_in_bounds(c, grid));
@@ -203,7 +203,7 @@ bool square_remove_trap(struct chunk *c, struct loc grid, int t_idx_remove)
 
 	/* Look at the traps in this grid */
 	struct trap *prev_trap = NULL;
-	struct trap *trap = square(c, grid).trap;
+	struct trap *trap = square(c, grid)->trap;
 
 	assert(square_in_bounds(c, grid));
 	while (trap) {
@@ -352,7 +352,7 @@ void place_trap(struct chunk *c, struct loc grid, int t_idx, int trap_level)
 		/* Require the correct terrain */
 		if (!square_player_trap_allowed(c, grid)) return;
 
-		t_idx = pick_trap(c, square(c, grid).feat, trap_level);
+		t_idx = pick_trap(c, square(c, grid)->feat, trap_level);
     }
 
     /* Failure */
@@ -371,7 +371,7 @@ void place_trap(struct chunk *c, struct loc grid, int t_idx, int trap_level)
 	trf_copy(new_trap->flags, trap_info[t_idx].flags);
 
 	/* Toggle on the trap marker */
-	sqinfo_on(square(c, grid).info, SQUARE_TRAP);
+	sqinfo_on(square(c, grid)->info, SQUARE_TRAP);
 
 	/* Redraw the grid */
 	square_note_spot(c, grid);
@@ -443,7 +443,7 @@ bool square_reveal_trap(struct chunk *c, struct loc grid, bool always,
  */
 void square_memorize_traps(struct chunk *c, struct loc grid)
 {
-	struct trap *trap = square(c, grid).trap;
+	struct trap *trap = square(c, grid)->trap;
 	struct trap *current = NULL;
 	if (c != cave) return;
 
@@ -602,7 +602,7 @@ bool square_set_trap_timeout(struct chunk *c, struct loc grid, bool domsg,
 	assert(square_in_bounds(c, grid));
 
 	/* Look at the traps in this grid */
-	current_trap = square(c, grid).trap;
+	current_trap = square(c, grid)->trap;
 	while (current_trap) {
 		/* Get the next trap (may be NULL) */
 		struct trap *next_trap = current_trap->next;
@@ -641,7 +641,7 @@ bool square_set_trap_timeout(struct chunk *c, struct loc grid, bool domsg,
  */
 int square_trap_timeout(struct chunk *c, struct loc grid, int t_idx)
 {
-	struct trap *current_trap = square(c, grid).trap;
+	struct trap *current_trap = square(c, grid)->trap;
 	while (current_trap) {
 		/* Get the next trap (may be NULL) */
 		struct trap *next_trap = current_trap->next;

--- a/src/ui-context.c
+++ b/src/ui-context.c
@@ -440,7 +440,7 @@ int context_menu_cave(struct chunk *c, int y, int x, int adjacent, int mx,
 	cmdkey = (mode == KEYMAP_MODE_ORIG) ? 'l' : 'x';
 	menu_dynamic_add_label(m, "Look At", cmdkey, MENU_VALUE_LOOK, labels);
 
-	if (square(c, grid).mon)
+	if (square(c, grid)->mon)
 		/* '/' is used for recall in both keymaps. */
 		menu_dynamic_add_label(m, "Recall Info", '/', MENU_VALUE_RECALL,
 							   labels);
@@ -452,7 +452,7 @@ int context_menu_cave(struct chunk *c, int y, int x, int adjacent, int mx,
 
 	if (adjacent) {
 		struct object *obj = chest_check(grid, CHEST_ANY);
-		ADD_LABEL((square(c, grid).mon) ? "Attack" : "Alter", CMD_ALTER,
+		ADD_LABEL((square(c, grid)->mon) ? "Attack" : "Alter", CMD_ALTER,
 				  MN_ROW_VALID);
 
 		if (obj && !ignore_item_ok(obj)) {
@@ -468,7 +468,7 @@ int context_menu_cave(struct chunk *c, int y, int x, int adjacent, int mx,
 			}
 		}
 
-		if ((square(cave, grid).mon > 0) && player_has(player, PF_STEAL)) {
+		if ((square(cave, grid)->mon > 0) && player_has(player, PF_STEAL)) {
 			ADD_LABEL("Steal", CMD_STEAL, MN_ROW_VALID);
 		}
 
@@ -513,7 +513,7 @@ int context_menu_cave(struct chunk *c, int y, int x, int adjacent, int mx,
 
 	if (player->timed[TMD_IMAGE]) {
 		prt("(Enter to select command, ESC to cancel) You see something strange:", 0, 0);
-	} else if (square(c, grid).mon) {
+	} else if (square(c, grid)->mon) {
 		char m_name[80];
 		struct monster *mon = square_monster(c, grid);
 

--- a/src/ui-target.c
+++ b/src/ui-target.c
@@ -337,7 +337,7 @@ static ui_event target_set_interactive_aux(int y, int x, int mode)
 		}
 
 		/* The player */
-		if (square(cave, loc(x, y)).mon < 0) {
+		if (square(cave, loc(x, y))->mon < 0) {
 			/* Description */
 			s1 = "You are ";
 
@@ -373,7 +373,7 @@ static ui_event target_set_interactive_aux(int y, int x, int mode)
 		}
 
 		/* Actual monsters */
-		if (square(cave, loc(x, y)).mon > 0) {
+		if (square(cave, loc(x, y))->mon > 0) {
 			struct monster *mon = square_monster(cave, loc(x, y));
 			const struct monster_lore *lore = get_lore(mon->race);
 
@@ -409,7 +409,7 @@ static ui_event target_set_interactive_aux(int y, int x, int mode)
 
 						/* Describe the monster */
 						look_mon_desc(buf, sizeof(buf),
-									  square(cave, loc(x, y)).mon);
+									  square(cave, loc(x, y))->mon);
 
 						/* Describe, and prompt for recall */
 						if (player->wizard) {
@@ -524,7 +524,7 @@ static ui_event target_set_interactive_aux(int y, int x, int mode)
 
 		/* A trap */
 		if (square_isvisibletrap(cave, loc(x, y))) {
-			struct trap *trap = square(cave, loc(x, y)).trap;
+			struct trap *trap = square(cave, loc(x, y))->trap;
 
 			/* Not boring */
 			boring = false;
@@ -532,7 +532,7 @@ static ui_event target_set_interactive_aux(int y, int x, int mode)
 			/* Interact */
 			while (1) {
 				/* Change the intro */
-				if (square(cave, loc(x, y)).mon < 0) {
+				if (square(cave, loc(x, y))->mon < 0) {
 					s1 = "You are ";
 					s2 = "on ";
 				} else {

--- a/src/wiz-debug.c
+++ b/src/wiz-debug.c
@@ -1736,7 +1736,7 @@ static void do_cmd_wiz_query(void)
 			if (!square_in_bounds_fully(cave, grid)) continue;
 
 			/* Given flag, show only those grids */
-			if (flag && !sqinfo_has(square(cave, grid).info, flag)) continue;
+			if (flag && !sqinfo_has(square(cave, grid)->info, flag)) continue;
 
 			/* Given no flag, show known grids */
 			if (!flag && (!square_isknown(cave, grid))) continue;
@@ -1846,7 +1846,7 @@ static void do_cmd_wiz_features(void)
 
 			/* Given feature, show only those grids */
 			for (i = 0; i < length; i++)
-				if (square(cave, grid).feat == feat[i]) show = true;
+				if (square(cave, grid)->feat == feat[i]) show = true;
 
 			/* Color */
 			if (square_ispassable(cave, grid)) a = COLOUR_YELLOW;


### PR DESCRIPTION
With the introduction of the square() function, access to a square in a 
cave chunk suffered performance reduction: every time square() is called,
struct square is created and content copied from cave->squares[x][y].

With this pull request, the function instead returns a pointer to the square
in the chunk, removes unnecessary copy operation. To enforce changes to
squares go through square_set_* functions, the pointer is const.

This may improve #4443.
