### PR TITLE
fixing bugs with shapechangers and food counter

### DIFF
--- a/src/mon-make.c
+++ b/src/mon-make.c
@@ -315,7 +315,8 @@ void delete_monster_idx(int m_idx)
 	grid = mon->grid;
 
 	/* Hack -- Reduce the racial counter */
-	mon->race->cur_num--;
+     if (mon->original_race) mon->original_race->cur_num--;
+     else mon->race->cur_num--;
 
 	/* Count the number of "reproducers" */
 	if (rf_has(mon->race->flags, RF_MULTIPLY)) {
@@ -991,7 +992,8 @@ s16b place_monster(struct chunk *c, struct loc grid, struct monster *mon,
 	if (rf_has(new_mon->race->flags, RF_MULTIPLY)) c->num_repro++;
 
 	/* Count racial occurrences */
-	new_mon->race->cur_num++;
+     if (new_mon->original_race) new_mon->original_race->cur_num++; 
+     else new_mon->race->cur_num++;
 
 	/* Create the monster's drop, if any */
 	if (origin)

--- a/src/mon-make.c
+++ b/src/mon-make.c
@@ -582,7 +582,8 @@ void wipe_mon_list(struct chunk *c, struct player *p)
 		}
 
 		/* Reduce the racial counter */
-		mon->race->cur_num--;
+           if (mon->original_race) mon->original_race->cur_num--;
+		else mon->race->cur_num--;
 
 		/* Monster is gone from square */
 		square_set_mon(c, mon->grid, 0);

--- a/src/mon-move.c
+++ b/src/mon-move.c
@@ -126,8 +126,8 @@ static bool monster_can_smell(struct chunk *c, struct monster *mon)
 static int compare_monsters(const struct monster *mon1,
 							const struct monster *mon2)
 {
-	u32b mexp1 = mon1->race->mexp;
-	u32b mexp2 = mon2->race->mexp;
+	u32b mexp1 = (mon1->original_race) ? mon1->original_race->mexp : mon1->race->mexp;
+	u32b mexp2 = (mon2->original_race) ? mon2->original_race->mexp : mon2->race->mexp;
 
 	/* Compare */
 	if (mexp1 < mexp2) return (-1);

--- a/src/player-timed.c
+++ b/src/player-timed.c
@@ -416,7 +416,7 @@ bool player_set_timed(struct player *p, int idx, int v, bool notify)
 	struct object *weapon = equipped_item_by_slot_name(p, "weapon");
 
 	/* Lower bound */
-	v = MAX(v, 0);
+	v = MAX(v, (idx == TMD_FOOD) ? 1 : 0);
 
 	/* No change */
 	if (p->timed[idx] == v) {


### PR DESCRIPTION
- fixed apparent issue with trampling of shape-changed monsters
- fixed bug with food counter that stopped starvation when the counter hit 0 and caused the food indicator to disappear
- fixed bug with tracking of shape-changed monsters on destruction/trampling
- fixed bug with tracking of shape-changed monsters on leaving level
- fixed bug with tracking of shape-changed monsters on game loading, which should also fix a previously reported bug of the same unique being killed more than once