### PR TITLE
Set complex_input for terminals so that ^H and ^J work under the ...

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -5605,6 +5605,12 @@ static bool cocoa_get_file(const char *suggested_name, char *path, size_t len)
     /* Disable the per-row flush notifications since they are not used. */
     newterm->never_frosh = TRUE;
 
+    /*
+     * Differentiate between BS/^h, Tab/^i, ... so ^h and ^j work under the
+     * roguelike command set.
+     */
+    newterm->complex_input = TRUE;
+
     /* Prepare the init/nuke hooks */
     newterm->init_hook = Term_init_cocoa;
     newterm->nuke_hook = Term_nuke_cocoa;


### PR DESCRIPTION
roguelike command set to alter west and alter south, respectively.  Resolves issue 4452 - a regression introduced by the OS X front-end changes between 4.2.0 and 4.2.1.