### PR TITLE
Change player_know_object() to also propagate knowledge of effect

### DIFF
--- a/src/cmd-obj.c
+++ b/src/cmd-obj.c
@@ -469,6 +469,7 @@ static void use_aux(struct command *cmd, struct object *obj, enum use use,
 	if (can_use) {
 		int beam = beam_chance(obj->tval);
 		int boost, level, charges = 0;
+		int number = 0;
 		bool ident = false, used;
 		struct object *work_obj;
 
@@ -506,6 +507,8 @@ static void use_aux(struct command *cmd, struct object *obj, enum use use,
 				work_obj = floor_object_for_use(obj, 1, false, &none_left);
 				from_floor = true;
 			}
+			/* Record number for messages after use */
+			number = (none_left) ? 0 : obj->number;
 		} else  {
 			if (use == USE_CHARGE) {
 				charges = obj->pval;
@@ -577,23 +580,21 @@ static void use_aux(struct command *cmd, struct object *obj, enum use use,
 		/* Increase knowledge */
 		if (use == USE_SINGLE) {
 			char name[80];
+			int old_num = work_obj->number;
+
 			/* Single use items are automatically learned */
 			if (!was_aware) {
-				object_learn_on_use(player, obj);
+				object_learn_on_use(player, work_obj);
 			}
 			/* Get a description */
-			if (used && none_left) {
-				obj->number--;
-			}
-			object_desc(name, sizeof(name), obj, ODESC_PREFIX | ODESC_FULL);
+			work_obj->number = number;
+			object_desc(name, sizeof(name), work_obj, ODESC_PREFIX | ODESC_FULL);
+			work_obj->number = old_num;
 			if (from_floor) {
 				/* Print a message */
 				msg("You see %s.", name);
 			} else {
 				msg("You have %s (%c).", name, label);
-			}
-			if (used && none_left) {
-				obj->number++;
 			}
 		} else {
 			/* Wearables may need update, other things become known or tried */

--- a/src/obj-knowledge.c
+++ b/src/obj-knowledge.c
@@ -1101,6 +1101,13 @@ void player_know_object(struct player *p, struct object *obj)
 		object_flavor_aware(obj);
 	}
 
+	/* Ensure effect is known as if object_set_base_known() had been called. */
+	if ((obj->kind->aware && obj->kind->flavor) ||
+		(!tval_is_wearable(obj) && !obj->kind->flavor) ||
+		(tval_is_wearable(obj) && obj->kind->effect && obj->kind->aware)) {
+		obj->known->effect = obj->effect;
+	}
+
 	/* Report on new stuff */
 	if (!seen) {
 		char o_name[80];


### PR DESCRIPTION
Change player_know_object() to also propagate knowledge of effect.  In testing with objects created by the debug commands, that resolves issue #4446 .   Follow up to revisit the recent change in use_aux() (to workaround knowledge propagation for single use objects) so that only the temporary object is accessed after use.