### PR TITLE
Attempt to resolve SDL2 sound configuration (issue 4458)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -324,6 +324,9 @@ fi
 
 dnl SDL2 mixer checking
 if test "$enable_sdl2_mixer" = "yes"; then
+	if test "$enable_sdl_mixer" = "yes"; then
+		AC_MSG_ERROR(both --enable-sdl-mixer and --enable-sdl2-mixer set, 1)
+	fi
 	AC_CHECK_LIB(SDL2_mixer, Mix_OpenAudio, found_sdl2_mixer=yes, found_sdl2_mixer=no)
 
 	if test "$found_sdl2_mixer" = "yes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -337,7 +337,7 @@ if test "$enable_sdl2_mixer" = "yes"; then
 			SDL2_LIBS=`sdl2-config --libs`
 			LIBS="${LIBS} ${SDL2_LIBS} -lSDL2_mixer"
 		fi
-		MAINFILES="${MAINFILES} \$(SNDSDL2FILES)"
+		MAINFILES="${MAINFILES} \$(SNDSDLFILES)"
 	fi
 fi
 

--- a/src/sound-core.c
+++ b/src/sound-core.c
@@ -20,7 +20,7 @@
 #include "sound.h"
 #include "main.h"
 #include "ui-prefs.h"
-#ifdef SOUND_SDL
+#if defined(SOUND_SDL) || defined(SOUND_SDL2)
 #include "snd-sdl.h"
 #endif
 
@@ -55,7 +55,7 @@ static struct msg_snd_data message_sounds[MSG_MAX];
  */
 static const struct sound_module sound_modules[] =
 {
-#ifdef SOUND_SDL
+#if defined(SOUND_SDL) || defined(SOUND_SDL2)
 	{ "sdl", "SDL_mixer sound module", init_sound_sdl },
 #endif /* SOUND_SDL */
 #if (!defined(WIN32_CONSOLE_MODE) && defined(WINDOWS) && !defined(USE_SDL) && !defined(USE_SDL2)) 


### PR DESCRIPTION
The first commit allows "./configure --enable-sdl2-mixer" and then compiling to generate an executable that includes the SDL sound module.  My Linux virtual machine doesn't appear to handle sound so I couldn't test it further than that.

As a result of the first commit, "./configure --enable-sdl2-mixer --enable-sdl-mixer" leads to duplicate symbols when linking so the 2nd commit rejects that with an error during the configuration step.

Those commits are an initial attempt to resolve #issue 4458 .