### PR TITLE
Avoid crash in mon_create_drop() if carry fails

### DIFF
--- a/src/mon-make.c
+++ b/src/mon-make.c
@@ -838,7 +838,9 @@ static bool mon_create_drop(struct chunk *c, struct monster *mon, byte origin)
 		if (monster_carry(c, mon, obj)) {
 			any = true;
 		} else {
-			obj->artifact->created = false;
+			if (obj->artifact) {
+				obj->artifact->created = false;
+			}
 			object_wipe(obj);
 			mem_free(obj);
 		}


### PR DESCRIPTION
obj->artifact would be dereferenced when the carry fails in the "Make some objects" loop.  Added a test for a non-NULL obj->artifact before dereferencing to avoid a crash.

I don't have a case where the crash occurred - just spotted this while trying to look for what might have caused the reported instance of generating the same randart twice in the same game.