### PR TITLE
Changed calculation of average thrown damage to match what's in ...

### DIFF
--- a/src/obj-info.c
+++ b/src/obj-info.c
@@ -831,7 +831,7 @@ static bool obj_known_damage(const struct object *obj, int *normal_damage,
 								&crit_add, &crit_div);
 
 		dam += (obj->known->to_d * 10);
-		dam *= 1 + player->lev / 12;
+		dam *= 2 + obj->weight / 12;
 	}
 
 	if (ammo) multiplier = player->state.ammo_mult;
@@ -1002,7 +1002,7 @@ static bool o_obj_known_damage(const struct object *obj, int *normal_damage,
 		dice += o_calculate_missile_crits(player->state, obj, bow);
 	} else {
 		dice += o_calculate_missile_crits(player->state, obj, NULL);
-		dice *= 2 + player->lev / 12;
+		dice *= 2 + obj->weight / 12;
 	}
 
 	if (ammo) multiplier = player->state.ammo_mult;


### PR DESCRIPTION
ranged_damage() and o_ranged_damage().  Address [this report](http://angband.oook.cz/forum/showpost.php?p=147203&postcount=97) of a mismatch between the thrown damage in practice and the damage displayed in the information for a weapon.