### PR TITLE
Plug memory leak if object_find_unknown_rune() returns early.

### DIFF
--- a/src/obj-knowledge.c
+++ b/src/obj-knowledge.c
@@ -1648,11 +1648,12 @@ bool object_curses_find_element(struct player *p, struct object *obj, int elem)
 int object_find_unknown_rune(struct player *p, struct object *obj)
 {
 	size_t i, num = 0;
-	int *poss_runes = mem_zalloc(rune_max * sizeof(int));
+	int *poss_runes;
 	int chosen = -1;
 
 	if (object_runes_known(obj)) return -1;
 
+	poss_runes = mem_zalloc(rune_max * sizeof(int));
 	for (i = 0; i < rune_max; i++)
 		if (object_has_rune(obj, i) && !player_knows_rune(p, i))
 			poss_runes[num++] = i;


### PR DESCRIPTION
Currently object_find_unknown_rune() is only called on an object with some unknown property so the leak  (even without this change) can't be triggered with the current version of Angband.