### PR TITLE
Search the surroundings (as if normal movement) upon changing a level

### DIFF
--- a/src/game-world.c
+++ b/src/game-world.c
@@ -996,6 +996,9 @@ void on_new_level(void)
 	if (player->depth)
 		display_feeling(false);
 
+	/* Check the surroundings */
+	search(player);
+
 	/* Give player minimum energy to start a new level, but do not reduce
 	 * higher value from savefile for level in progress */
 	if (player->energy < z_info->move_energy)


### PR DESCRIPTION
The placement of the call to search() may not be the best.  It's done after the initial display of the level feeling and won't be done for an arena level.