### PR TITLE
Set combat minimums for missiles of backbiting so ego_apply_minima() …

### DIFF
--- a/lib/gamedata/ego_item.txt
+++ b/lib/gamedata/ego_item.txt
@@ -649,6 +649,7 @@ name:of Backbiting
 info:0:0
 alloc:0:10 to 80
 combat:-26+d25:-26+d25:0
+min-combat:255:255:0
 type:shot
 type:arrow
 type:bolt


### PR DESCRIPTION
…does not reset the penalties to zero.  Related to issue #4449 and https://github.com/NickMcConnell/FirstAgeAngband/issues/43 .