### PR TITLE
Add ability to set birth options during quickstart.  Resolves ...

### DIFF
--- a/src/ui-birth.c
+++ b/src/ui-birth.c
@@ -101,7 +101,7 @@ bool arg_force_name;
 static enum birth_stage textui_birth_quickstart(void)
 //phantom name change changes
 {
-	const char *prompt = "['Y' to use this character, 'N' to start afresh, 'C' to change name or history]";
+	const char *prompt = "['Y': use as is; 'N': redo; 'C': change name/history; '=': set birth options]";
 
 	enum birth_stage next = BIRTH_QUICKSTART;
 
@@ -120,6 +120,8 @@ static enum birth_stage textui_birth_quickstart(void)
 			quit(NULL);
 		} else if ( !arg_force_name && (ke.code == 'C' || ke.code == 'c')) {
 			next = BIRTH_NAME_CHOICE;
+		} else if (ke.code == '=') {
+			do_cmd_options_birth();
 		} else if (ke.code == 'Y' || ke.code == 'y') {
 			cmdq_push(CMD_ACCEPT_CHARACTER);
 			next = BIRTH_COMPLETE;


### PR DESCRIPTION
… https://github.com/angband/angband/issues/3330 .  Since Vanilla's current birth options don't affect the stages for birth prior to do_cmd_accept_character(), the change is easy.  If future changes have the birth options affect those earlier stages, additional logic would be neccessary during quickstart to handle changes in the options.