### PR TITLE
OS X: use VERSION_NAME instead of "Angband"

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -4246,7 +4246,7 @@ static void Term_init_cocoa(term *t)
 	/* Set its title and, for auxiliary terms, tentative size */
 	if (termIdx == 0)
 	{
-	    [window setTitle:@"Angband"];
+	    [window setTitle:@VERSION_NAME];
 	}
 	else
 	{
@@ -6032,7 +6032,7 @@ static bool cocoa_get_file(const char *suggested_name, char *path, size_t len)
 	NSMenu *windowsMenu = [[NSApplication sharedApplication] windowsMenu];
 	[windowsMenu addItem: [NSMenuItem separatorItem]];
 
-	NSMenuItem *angbandItem = [[NSMenuItem alloc] initWithTitle: @"Angband" action: @selector(selectWindow:) keyEquivalent: @"0"];
+	NSMenuItem *angbandItem = [[NSMenuItem alloc] initWithTitle: @VERSION_NAME action: @selector(selectWindow:) keyEquivalent: @"0"];
 	[angbandItem setTarget: self];
 	[angbandItem setTag: AngbandWindowMenuItemTagBase];
 	[windowsMenu addItem: angbandItem];

--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -17,6 +17,7 @@
  */
 
 #include "angband.h"
+#include "buildid.h"
 #include "cmds.h"
 #include "game-world.h"
 #include "grafmode.h"
@@ -57,7 +58,7 @@
 #define kVK_ANSI_KeypadEnter 0x4C
 
 static NSString * const AngbandDirectoryNameLib = @"lib";
-static NSString * const AngbandDirectoryNameBase = @"Angband";
+static NSString * const AngbandDirectoryNameBase = @VERSION_NAME;
 
 static NSString * const AngbandTerminalsDefaultsKey = @"Terminals";
 static NSString * const AngbandTerminalRowsDefaultsKey = @"Rows";


### PR DESCRIPTION
Should have no noticeable effect on Vanilla and reduces the number of changes necessary when porting main-cocoa.m to a variant.  Can have some effect, because of the location of lore.txt, on https://github.com/NickMcConnell/FirstAgeAngband/issues/75 and https://github.com/NickMcConnell/FirstAgeAngband/issues/51 .  Will change the location of save files if adopted by a variant (like FirstAgeAngband) that was using the unchanged main-cocoa.m.