### PR TITLE
Moved call to Term_xtra(TERM_XTRA_REACT, 0) from ui_enter_world() to …

### DIFF
--- a/src/ui-display.c
+++ b/src/ui-display.c
@@ -2366,9 +2366,6 @@ static void ui_enter_world(game_event_type type, game_event_data *data,
 	player->upkeep->redraw |= (PR_INVEN | PR_EQUIP | PR_MONSTER | PR_MESSAGE);
 	redraw_stuff(player);
 
-	/* React to changes */
-	Term_xtra(TERM_XTRA_REACT, 0);
-
 	/* Because of the "flexible" sidebar, all these things trigger
 	   the same function. */
 	event_add_handler_set(player_events, N_ELEMENTS(player_events),

--- a/src/ui-init.c
+++ b/src/ui-init.c
@@ -77,6 +77,9 @@ void textui_init(void)
 
 		/* Hack -- Turn off the cursor */
 		(void)Term_set_cursor(false);
+
+		/* Update terminals for preference changes. */
+		(void) Term_xtra(TERM_XTRA_REACT, 0);
 	}
 
 	/* initialize window options that will be overridden by the savefile */


### PR DESCRIPTION
…textui_init() so changes from loading the preferences in textui_init() are responded to before displaying the birth screen.  That is an attempt to resolve https://github.com/angband/angband/issues/4481 .