### PR TITLE
Don't allow the number of an artifact to be boosted even if its kind …

### DIFF
--- a/src/obj-make.c
+++ b/src/obj-make.c
@@ -1212,7 +1212,7 @@ struct object *make_object(struct chunk *c, int lev, bool good, bool great,
 	apply_magic(new_obj, lev, true, good, great, extra_roll);
 
 	/* Generate multiple items */
-	if (kind->gen_mult_prob >= randint1(100))
+	if (! new_obj->artifact && kind->gen_mult_prob >= randint1(100))
 		new_obj->number = randcalc(kind->stack_size, lev, RANDOMISE);
 
 	if (new_obj->number > new_obj->kind->base->max_stack)


### PR DESCRIPTION
…can be generated in piles.  Should resolve https://github.com/NickMcConnell/FirstAgeAngband/issues/56 .  Will not fix this http://angband.oook.cz/forum/showpost.php?p=147171&postcount=88 .