### PR TITLE
Changed to allow a confused monster to move into dangerous terrain or…

### DIFF
--- a/lib/gamedata/terrain.txt
+++ b/lib/gamedata/terrain.txt
@@ -35,6 +35,7 @@
 # run-msg: warning message - running
 # hurt-msg: damage message
 # die-msg: death message
+# confused-msg: message for confused monster move into non-passable terrain
 # resist-flag: monster race flag for resist
 
 # 'name' indicates the beginning of an entry. The serial number must
@@ -73,6 +74,9 @@
 
 # 'die-msg' is the description if damaging terrain kills the player
 
+# 'confused-msg' is the description of an attempt for a monster to move into
+# non-passable terrain due to confusion
+
 # 'resist-flag' is the race flag a monster must have to be able to enter
 # damaging terrain
 
@@ -93,6 +97,7 @@ graphics:+:U
 priority:17
 flags:DOOR_ANY | DOOR_CLOSED | INTERESTING
 info:0:5
+confused-msg:bangs into a door
 desc:Doors may be locked; getting through them may not be easy.  Your 
 desc:disarming skill makes all the difference to your ability to handle locks, 
 desc:but you can also take a pickaxe to them, or blast them open 
@@ -192,6 +197,7 @@ graphics:#:w
 priority:10
 mimic:granite wall
 flags:WALL | ROCK | DOOR_ANY | GRANITE | TORCH
+confused-msg:bashes into a wall
 desc:A door that appears like a granite wall to untrained eyes.
 
 name:pile of rubble
@@ -199,6 +205,7 @@ graphics:::W
 priority:13
 flags:ROCK | NO_SCENT | NO_FLOW | INTERESTING | TORCH
 info:0:1
+confused-msg:bumps into some rocks
 desc:Ends LOS, stops missiles, bolts, and beams.  May dissolve or be tunnelled 
 desc:to normal floor.
 
@@ -207,6 +214,7 @@ graphics:%:D
 priority:12
 flags:WALL | ROCK | NO_SCENT | NO_FLOW | MAGMA | TORCH
 info:0:2
+confused-msg:bashes into a wall
 desc:A seam of soft rock.  It can be removed by digging or magic, and passed 
 desc:through by immaterial monsters.  It stops any spells, missiles or line of 
 desc:sight.
@@ -216,6 +224,7 @@ graphics:%:s
 priority:11
 flags:WALL | ROCK | NO_SCENT | NO_FLOW | QUARTZ | TORCH
 info:0:3
+confused-msg:bashes into a wall
 desc:A seam of hardish rock.  It can be removed by digging or magic, and passed 
 desc:through by immaterial monsters.  It stops any spells, missiles or line of 
 desc:sight.
@@ -225,6 +234,7 @@ graphics:*:o
 priority:19
 flags:WALL | ROCK | INTERESTING | NO_SCENT | NO_FLOW | GOLD | MAGMA
 info:0:2
+confused-msg:bashes into a wall
 desc:A seam of soft rock.  It can be removed by digging or magic, and passed 
 desc:through by immaterial monsters.  It stops any spells, missiles or line of 
 desc:sight.  It contains visible treasure.
@@ -234,6 +244,7 @@ graphics:*:y
 priority:19
 flags:WALL | ROCK | INTERESTING | NO_SCENT | NO_FLOW | GOLD | QUARTZ
 info:0:3
+confused-msg:bashes into a wall
 desc:A seam of hardish rock.  It can be removed by digging or magic, and passed 
 desc:through by immaterial monsters.  It stops any spells, missiles or line of 
 desc:sight.  It contains visible treasure.
@@ -243,6 +254,7 @@ graphics:#:W
 priority:10
 flags:WALL | ROCK | GRANITE | NO_SCENT | NO_FLOW | TORCH
 info:0:4
+confused-msg:bashes into a wall
 desc:A seam of hard rock.  It can be removed by digging or magic, and passed 
 desc:through by immaterial monsters.  It stops any spells, missiles or line of 
 desc:sight. 
@@ -251,6 +263,7 @@ name:permanent wall
 graphics:#:z
 priority:10
 flags:WALL | ROCK | PERMANENT | NO_SCENT | NO_FLOW
+confused-msg:bashes into a wall
 desc:You can dig through most walls but these are impenetrable.  The dungeon is 
 desc:surrounded by these kinds of walls and some special rooms are made of them.
 

--- a/src/cave.h
+++ b/src/cave.h
@@ -128,6 +128,7 @@ struct feature {
 	char *run_msg;	/**< Message on running into feature */
 	char *hurt_msg;	/**< Message on being hurt by feature */
 	char *die_msg;	/**< Message on dying to feature */
+	char *confused_msg; /**< Message on confused monster move into feature */
 	int resist_flag;/**< Monster resist flag for entering feature */
 };
 

--- a/src/init.c
+++ b/src/init.c
@@ -1781,6 +1781,15 @@ static enum parser_error parse_feat_die_msg(struct parser *p) {
     return PARSE_ERROR_NONE;
 }
 
+static enum parser_error parse_feat_confused_msg(struct parser *p) {
+	struct feature *f = parser_priv(p);
+	assert(f);
+
+	f->confused_msg =
+		string_append(f->confused_msg, parser_getstr(p, "text"));
+	return PARSE_ERROR_NONE;
+}
+
 static enum parser_error parse_feat_resist_flag(struct parser *p) {
 	int flag;
     struct feature *f = parser_priv(p);
@@ -1811,6 +1820,7 @@ struct parser *init_parse_feat(void) {
     parser_reg(p, "run-msg str text", parse_feat_run_msg);
     parser_reg(p, "hurt-msg str text", parse_feat_hurt_msg);
     parser_reg(p, "die-msg str text", parse_feat_die_msg);
+	parser_reg(p, "confused-msg str text", parse_feat_confused_msg);
 	parser_reg(p, "resist-flag sym flag", parse_feat_resist_flag);
 	return p;
 }

--- a/src/mon-move.c
+++ b/src/mon-move.c
@@ -1011,10 +1011,12 @@ static bool monster_turn_multiply(struct chunk *c, struct monster *mon)
  * Always stagger when confused, but also deal with random movement for
  * RAND_25 and RAND_50 monsters.
  */
-static bool monster_turn_should_stagger(struct monster *mon)
+enum monster_stagger {
+	 NO_STAGGER = 0, CONFUSED_STAGGER = 1, INNATE_STAGGER = 2 };
+static enum monster_stagger monster_turn_should_stagger(struct monster *mon)
 {
 	struct monster_lore *lore = get_lore(mon->race);
-	int chance = 0;
+	int chance = 0, confused_chance, roll;
 
 	/* Increase chance of being erratic for every level of confusion */
 	int conf_level = monster_effect_level(mon, MON_TMD_CONF);
@@ -1025,6 +1027,7 @@ static bool monster_turn_should_stagger(struct monster *mon)
 		chance = 100 - accuracy;
 		conf_level--;
 	}
+	confused_chance = chance;
 
 	/* RAND_25 and RAND_50 are cumulative */
 	if (rf_has(mon->race->flags, RF_RAND_25)) {
@@ -1039,7 +1042,37 @@ static bool monster_turn_should_stagger(struct monster *mon)
 			rf_on(lore->flags, RF_RAND_50);
 	}
 
-	return randint0(100) < chance;
+	roll = randint0(100);
+	return (roll < confused_chance) ?
+		 CONFUSED_STAGGER :
+		 ((roll < chance) ? INNATE_STAGGER : NO_STAGGER);
+}
+
+
+/**
+ * Helper function for monster_turn_can_move() to display a message for a
+ * confused move into non-passable terrain.
+ */
+static void monster_display_confused_move_msg(struct monster *mon,
+	const char *m_name, struct chunk *c, struct loc new)
+{
+	if (monster_is_visible(mon) && monster_is_in_view(mon)) {
+		const char *m = square_feat(c, new)->confused_msg;
+
+		msg("%s %s.", m_name, (m) ? m : "stumbles");
+	}
+}
+
+
+/**
+ * Helper function for monster_turn_can_move() to slightly stun a monster
+ * on occasion due to bumbling into something.
+ */
+static void monster_slightly_stun_by_move(struct monster *mon)
+{
+	if (mon->m_timed[MON_TMD_STUN] < 5 && one_in_(3)) {
+		mon_inc_timed(mon, MON_TMD_STUN, 3, 0);
+	}
 }
 
 
@@ -1050,12 +1083,13 @@ static bool monster_turn_should_stagger(struct monster *mon)
  * Returns true if the monster is able to move through the grid.
  */
 static bool monster_turn_can_move(struct chunk *c, struct monster *mon,
-		const char *m_name, struct loc new, bool *did_something)
+		const char *m_name, struct loc new, bool confused,
+		bool *did_something)
 {
 	struct monster_lore *lore = get_lore(mon->race);
 
 	/* Dangerous terrain in the way */
-	if (monster_hates_grid(c, mon, new)) {
+	if (!confused && monster_hates_grid(c, mon, new)) {
 		return false;
 	}
 
@@ -1066,6 +1100,11 @@ static bool monster_turn_can_move(struct chunk *c, struct monster *mon,
 
 	/* Permanent wall in the way */
 	if (square_iswall(c, new) && square_isperm(c, new)) {
+		if (confused) {
+			*did_something = true;
+			monster_display_confused_move_msg(mon, m_name, c, new);
+			monster_slightly_stun_by_move(mon);
+		}
 		return false;
 	}
 
@@ -1100,15 +1139,19 @@ static bool monster_turn_can_move(struct chunk *c, struct monster *mon,
 
 		return true;
 	} else if (square_iscloseddoor(c, new) || square_issecretdoor(c, new)) {
-		bool can_open = rf_has(mon->race->flags, RF_OPEN_DOOR);
-		bool can_bash = rf_has(mon->race->flags, RF_BASH_DOOR);
+		/* Don't allow a confused move to open a door. */
+		bool can_open = rf_has(mon->race->flags, RF_OPEN_DOOR) &&
+			!confused;
+		/* During a confused move, a monster only bashes sometimes. */
+		bool can_bash = rf_has(mon->race->flags, RF_BASH_DOOR) &&
+			(!confused || one_in_(3));
 		bool will_bash = false;
 
 		/* Take a turn */
-		*did_something = true;
+		if (can_open || can_bash) *did_something = true;
 
 		/* Learn about door abilities */
-		if (monster_is_visible(mon)) {
+		if (!confused && monster_is_visible(mon)) {
 			rf_on(lore->flags, RF_OPEN_DOOR);
 			rf_on(lore->flags, RF_BASH_DOOR);
 		}
@@ -1124,6 +1167,11 @@ static bool monster_turn_can_move(struct chunk *c, struct monster *mon,
 			will_bash = true;
 		} else {
 			/* Door is an insurmountable obstacle */
+			if (confused) {
+				*did_something = true;
+				monster_display_confused_move_msg(mon, m_name, c, new);
+				monster_slightly_stun_by_move(mon);
+			}
 			return false;
 		}
 
@@ -1141,6 +1189,14 @@ static bool monster_turn_can_move(struct chunk *c, struct monster *mon,
 				/* Reduce the power of the door by one */
 				square_set_door_lock(c, new, k - 1);
 			}
+			if (confused) {
+				/* Didn't learn above; apply now since attempted to bash. */
+				if (monster_is_visible(mon)) {
+					rf_on(lore->flags, RF_BASH_DOOR);
+				}
+				/* When confused, can stun itself while bashing. */
+				monster_slightly_stun_by_move(mon);
+			}
 		} else {
 			/* Closed or secret door -- always open or bash */
 			if (square_isview(c, new))
@@ -1152,12 +1208,25 @@ static bool monster_turn_can_move(struct chunk *c, struct monster *mon,
 				msg("You hear a door burst open!");
 				disturb(player);
 
+				if (confused) {
+					/* Didn't learn above; apply since bashed the door. */
+					if (monster_is_visible(mon)) {
+						rf_on(lore->flags, RF_BASH_DOOR);
+					}
+					/* When confused, can stun itself while bashing. */
+					monster_slightly_stun_by_move(mon);
+				}
+
 				/* Fall into doorway */
 				return true;
 			} else {
 				square_open_door(c, new);
 			}
 		}
+	} else if (confused) {
+		*did_something = true;
+		monster_display_confused_move_msg(mon, m_name, c, new);
+		monster_slightly_stun_by_move(mon);
 	}
 
 	return false;
@@ -1374,7 +1443,7 @@ static void monster_turn(struct chunk *c, struct monster *mon)
 
 	int i;
 	int dir = 0;
-	bool stagger = false;
+	enum monster_stagger stagger;
 	bool tracking = false;
 	char m_name[80];
 
@@ -1425,9 +1494,8 @@ static void monster_turn(struct chunk *c, struct monster *mon)
 	if (make_ranged_attack(mon)) return;
 
 	/* Work out what kind of movement to use - random movement or AI */
-	if (monster_turn_should_stagger(mon)) {
-		stagger = true;
-	} else {
+	stagger = monster_turn_should_stagger(mon);
+	if (stagger == NO_STAGGER) {
 		/* If there's no sensible move, we're done */
 		if (!get_move(c, mon, &dir, &tracking)) return;
 	}
@@ -1438,18 +1506,18 @@ static void monster_turn(struct chunk *c, struct monster *mon)
 	 * can't move in their chosen direction. */
 	for (i = 0; i < 5 && !did_something; i++) {
 		/* Get the direction (or stagger) */
-		int d = (stagger ? ddd[randint0(8)] : side_dirs[dir][i]);
+		int d = (stagger != NO_STAGGER) ? ddd[randint0(8)] : side_dirs[dir][i];
 
 		/* Get the grid to step to or attack */
 		struct loc new = loc_sum(mon->grid, ddgrid[d]);
 
 		/* Tracking monsters have their best direction, don't change */
-		if ((i > 0) && !stagger && !square_isview(c, mon->grid) && tracking) {
+		if ((i > 0) && stagger != NO_STAGGER && !square_isview(c, mon->grid) && tracking) {
 			break;
 		}
 
 		/* Check if we can move */
-		if (!monster_turn_can_move(c, mon, m_name, new, &did_something))
+		if (!monster_turn_can_move(c, mon, m_name, new, stagger == CONFUSED_STAGGER, &did_something))
 			continue;
 
 		/* Try to break the glyph if there is one.  This can happen multiple


### PR DESCRIPTION
… to waste a turn (before testing all 5 attempted move directions) by attempting to move into impassable terrain.  This is an attempt to resolve https://github.com/NickMcConnell/FirstAgeAngband/issues/32 .

As a side effect, for non-confused monsters that can't open or bash a door, does allow them to try the remaining move directions.  I left the comments about fixation on doors in place since that change likely isn't enough for the monster to find an alternate path around a door.

Distinguishes between innate erratic behavior and induced confusion.  The former won't, by itself, cause moves into dangerous terrain.  Perhaps it would be desirable to allow some monsters (like singing happy drunks) to cause self harm by their innate erratic behavior.  Should that be a separate flag?

Like FAAngband 1.4, a confused monster that tries to blunder into impassable terrain can be stunned.  The amount of stunning and maximum amount that can be acquired may need to be adjusted:  I mimicked the values in FAAngband without knowing if they're really equivalent to how stunning is used in Vanilla.

Unlike FAAngband 1.4, there's no chance to blunder into a tree and pick up a stun since trees are passable terrain.