### PR TITLE
Use a white asterisk rather than an orange asterisk for detected gold on the floor

### DIFF
--- a/lib/gamedata/object.txt
+++ b/lib/gamedata/object.txt
@@ -154,7 +154,7 @@ graphics:*:r
 
 name:<unknown treasure>
 type:none
-graphics:*:o
+graphics:*:w
 
 name:<curse object>
 type:none


### PR DESCRIPTION
That distinguishes it from orange asterisks used for magma veins with treasure and is one way to resolve https://github.com/angband/angband/issues/4441 .