### PR TITLE
Use UI_ENTRY_VALUE_NOT_PRESENT in initializations for player property values

### DIFF
--- a/src/ui-entry.c
+++ b/src/ui-entry.c
@@ -804,7 +804,7 @@ void compute_ui_entry_values_for_player(const struct ui_entry *entry,
 			}
 			if (entry->p_abilities[i].have_value) {
 				int v = entry->p_abilities[i].value;
-				int a = 0;
+				int a = UI_ENTRY_VALUE_NOT_PRESENT;
 
 				if (entry->p_abilities[i].isaux) {
 					int t = v;
@@ -1020,8 +1020,8 @@ void compute_ui_entry_values_for_player(const struct ui_entry *entry,
 		}
 	}
 	if (first) {
-		*val = 0;
-		*auxval = 0;
+		*val = UI_ENTRY_VALUE_NOT_PRESENT;
+		*auxval = UI_ENTRY_VALUE_NOT_PRESENT;
 	} else {
 		(*combiner.finish_func)(&cst);
 		*val = cst.accum;


### PR DESCRIPTION
That works better than zero when the semantics of the underlying property are not known.  Should not have an effect on Vanilla but better handles FirstAgeAngband's resistance system.