### PR TITLE
Removed leading space in name so NO_TELEPORT player property is bound…

### DIFF
--- a/lib/gamedata/player_property.txt
+++ b/lib/gamedata/player_property.txt
@@ -259,7 +259,7 @@ desc:You are afraid of melee, and bad at shooting and casting spells.
 
 type:object
 code:NO_TELEPORT
-bindui: noteleport_ui_compact_0:0:1
+bindui:noteleport_ui_compact_0:0:1
 name:Teleport Ban
 desc:You cannot teleport.
 


### PR DESCRIPTION
… to the corresponding entry in the character sheet.  The bugged binding had no effect in the current Vanilla (the NO_TELEPORT property isn't currently used as an intrinsic player property or as a timed effect).