### PR TITLE
Add terrain configuration items to help phrase messages for looking/targeting

### DIFF
--- a/lib/gamedata/terrain.txt
+++ b/lib/gamedata/terrain.txt
@@ -36,6 +36,8 @@
 # hurt-msg: damage message
 # die-msg: death message
 # confused-msg: message for confused monster move into non-passable terrain
+# look-prefix: used before the name in the result from looking
+# look-in-preposition: preposition used when looking at one's own position
 # resist-flag: monster race flag for resist
 
 # 'name' indicates the beginning of an entry. The serial number must
@@ -77,6 +79,14 @@
 # 'confused-msg' is the description of an attempt for a monster to move into
 # non-passable terrain due to confusion
 
+# 'look-prefix' is printed before the name in the result of looking at the
+# terrain.  If not set, the default is to use 'an' if the name starts with
+# a vowel or 'a' if the name does not start with a vowel.
+
+# 'look-in-preposition' is the preposition that will be used when printing
+# the result for an observer looking at the observer's grid:  'You are
+# <preposition> <prefix> <name>'.  If not set, the default is to use 'on'.
+
 # 'resist-flag' is the race flag a monster must have to be able to enter
 # damaging terrain
 
@@ -108,6 +118,7 @@ name:open door
 graphics:':U
 priority:15
 flags:LOS | PROJECT | PASSABLE | DOOR_ANY | INTERESTING | CLOSABLE | EASY
+look-in-preposition:in
 desc:A door that is already open.  Player, monster, spell and missile can pass 
 desc:through as long as it stays open.
 
@@ -115,6 +126,7 @@ name:broken door
 graphics:':u
 priority:15
 flags:LOS | PROJECT | PASSABLE | DOOR_ANY | INTERESTING | EASY
+look-in-preposition:in
 desc:A door so broken that it cannot be shut.
 
 name:up staircase
@@ -136,6 +148,8 @@ graphics:1:U
 priority:20
 flags:SHOP | PROJECT | PASSABLE | PERMANENT | INTERESTING | EASY
 info:1:0
+look-prefix:the entrance to the
+look-in-preposition:at
 desc:The General Store sells food, ammunition and lighting supplies.
 
 name:Armoury
@@ -143,6 +157,8 @@ graphics:2:s
 priority:20
 flags:SHOP | PROJECT | PASSABLE | PERMANENT | INTERESTING | EASY
 info:2:0
+look-prefix:the entrance to the
+look-in-preposition:at
 desc:The armour sold here will give you some protection against the blows of 
 desc:your enemies.
 
@@ -151,6 +167,8 @@ graphics:3:w
 priority:20
 flags:SHOP | PROJECT | PASSABLE | PERMANENT | INTERESTING | EASY
 info:3:0
+look-prefix:the entrance to the
+look-in-preposition:at
 desc:Weapons for hitting and shooting your enemies are forged in the hot, acrid 
 desc:backroom of this enticing shop.
 
@@ -159,6 +177,8 @@ graphics:4:g
 priority:20
 flags:SHOP | PROJECT | PASSABLE | PERMANENT | INTERESTING | EASY
 info:4:0
+look-prefix:the entrance to the
+look-in-preposition:at
 desc:A quiet, reflective place of refuge, lined with shelves of 
 desc:mystical tomes.
 
@@ -167,6 +187,8 @@ graphics:5:b
 priority:20
 flags:SHOP | PROJECT | PASSABLE | PERMANENT | INTERESTING | EASY
 info:5:0
+look-prefix:the entrance to the
+look-in-preposition:at
 desc:A dim, scented room where potions and scrolls are traded.
 
 name:Magic Shop
@@ -174,6 +196,8 @@ graphics:6:r
 priority:20
 flags:SHOP | PROJECT | PASSABLE | PERMANENT | INTERESTING | EASY
 info:6:0
+look-prefix:the entrance to the
+look-in-preposition:at
 desc:A shop for devices and adornments with magic trapped within.
 
 name:Black Market
@@ -181,6 +205,8 @@ graphics:7:D
 priority:20
 flags:SHOP | PROJECT | PASSABLE | PERMANENT | INTERESTING | EASY
 info:7:0
+look-prefix:the entrance to the
+look-in-preposition:at
 desc:Watch your back and hold onto your purse as you enter this disreputable 
 desc:haunt - and do not expect friendly service or good bargains.
 
@@ -189,6 +215,8 @@ graphics:8:y
 priority:20
 flags:SHOP | PROJECT | PASSABLE | PERMANENT | INTERESTING | EASY
 info:8:0
+look-prefix:the entrance to the
+look-in-preposition:at
 desc:Your safe piece of Middle Earth, and the only place you can store goods 
 desc:apart from on your person.
 
@@ -273,6 +301,7 @@ name:lava
 graphics:#:r
 priority:10
 flags:PROJECT | FIERY | PASSABLE | NO_SCENT | BRIGHT
+look-prefix:some
 desc:A fiery pool of glowing lava.  Step in it at your peril!
 walk-msg:The lava will scald you!  Really step in? 
 run-msg:Lava blocks your path.  Step into it? 

--- a/src/cave-square.c
+++ b/src/cave-square.c
@@ -1414,6 +1414,22 @@ const char *square_apparent_name(struct chunk *c, struct player *p, struct loc g
 	return f_info[f].name;
 }
 
+const char *square_apparent_look_prefix(struct chunk *c, struct player *p, struct loc grid) {
+	int actual = square(player->cave, grid)->feat;
+	char *mimic_name = f_info[actual].mimic;
+	int f = mimic_name ? lookup_feat(mimic_name) : actual;
+	return (f_info[f].look_prefix) ? f_info[f].look_prefix :
+		(is_a_vowel(f_info[f].name[0]) ? "an " : "a ");
+}
+
+const char *square_apparent_look_in_preposition(struct chunk *c, struct player *p, struct loc grid) {
+	int actual = square(player->cave, grid)->feat;
+	char *mimic_name = f_info[actual].mimic;
+	int f = mimic_name ? lookup_feat(mimic_name) : actual;
+	return (f_info[f].look_in_preposition) ?
+		 f_info[f].look_in_preposition : "on ";
+}
+
 /* Memorize the terrain */
 void square_memorize(struct chunk *c, struct loc grid) {
 	if (c != cave) return;

--- a/src/cave.h
+++ b/src/cave.h
@@ -129,6 +129,8 @@ struct feature {
 	char *hurt_msg;	/**< Message on being hurt by feature */
 	char *die_msg;	/**< Message on dying to feature */
 	char *confused_msg; /**< Message on confused monster move into feature */
+	char *look_prefix; /**< Prefix for name in look result */
+	char *look_in_preposition; /**< Preposition in look result when on the terrain */
 	int resist_flag;/**< Monster resist flag for entering feature */
 };
 
@@ -431,6 +433,8 @@ void square_force_floor(struct chunk *c, struct loc grid);
 int square_shopnum(struct chunk *c, struct loc grid);
 int square_digging(struct chunk *c, struct loc grid);
 const char *square_apparent_name(struct chunk *c, struct player *p, struct loc grid);
+const char *square_apparent_look_prefix(struct chunk *c, struct player *p, struct loc grid);
+const char *square_apparent_look_in_preposition(struct chunk *c, struct player *p, struct loc grid);
 
 void square_memorize(struct chunk *c, struct loc grid);
 void square_forget(struct chunk *c, struct loc grid);

--- a/src/init.c
+++ b/src/init.c
@@ -1790,6 +1790,24 @@ static enum parser_error parse_feat_confused_msg(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
+static enum parser_error parse_feat_look_prefix(struct parser *p) {
+	struct feature *f = parser_priv(p);
+	assert(f);
+
+	f->look_prefix =
+		string_append(f->look_prefix, parser_getstr(p, "text"));
+	return PARSE_ERROR_NONE;
+}
+
+static enum parser_error parse_feat_look_in_preposition(struct parser *p) {
+	struct feature *f = parser_priv(p);
+	assert(f);
+
+	f->look_in_preposition =
+		string_append(f->look_in_preposition, parser_getstr(p, "text"));
+	return PARSE_ERROR_NONE;
+}
+
 static enum parser_error parse_feat_resist_flag(struct parser *p) {
 	int flag;
     struct feature *f = parser_priv(p);
@@ -1821,6 +1839,8 @@ struct parser *init_parse_feat(void) {
     parser_reg(p, "hurt-msg str text", parse_feat_hurt_msg);
     parser_reg(p, "die-msg str text", parse_feat_die_msg);
 	parser_reg(p, "confused-msg str text", parse_feat_confused_msg);
+	parser_reg(p, "look-prefix str text", parse_feat_look_prefix);
+	parser_reg(p, "look-in-preposition str text", parse_feat_look_in_preposition);
 	parser_reg(p, "resist-flag sym flag", parse_feat_resist_flag);
 	return p;
 }
@@ -1848,6 +1868,15 @@ static errr finish_parse_feat(struct parser *p) {
 		assert(fidx >= 0);
 
 		memcpy(&f_info[fidx], f, sizeof(*f));
+		/* Add trailing space for ease of use with targeting code. */
+		if (f_info[fidx].look_prefix) {
+			f_info[fidx].look_prefix =
+				string_append(f_info[fidx].look_prefix, " ");
+		}
+		if (f_info[fidx].look_in_preposition) {
+			f_info[fidx].look_in_preposition =
+				string_append(f_info[fidx].look_in_preposition, " ");
+		}
 		f_info[fidx].fidx = fidx;
 		n = f->next;
 		if (fidx < z_info->f_max - 1)

--- a/src/ui-context.c
+++ b/src/ui-context.c
@@ -534,13 +534,9 @@ int context_menu_cave(struct chunk *c, int y, int x, int adjacent, int mx,
 	} else {
 		/* Feature (apply mimic) */
 		const char *name = square_apparent_name(c, player, grid);
+		const char *prefix = square_apparent_look_prefix(c, player, grid);
 
-		/* Hack -- special introduction for store doors */
-		if (square_isshop(cave, grid)) {
-			prt(format("(Enter to select command, ESC to cancel) You see the entrance to the %s:", name), 0, 0);
-		} else {
-			prt(format("(Enter to select command, ESC to cancel) You see %s %s:", (is_a_vowel(name[0])) ? "an" : "a", name), 0, 0);
-		}
+		prt(format("(Enter to select command, ESC to cancel) You see %s%s:", prefix, name), 0, 0);
 	}
 
 	selected = menu_dynamic_select(m);

--- a/src/ui-target.c
+++ b/src/ui-target.c
@@ -684,15 +684,11 @@ static ui_event target_set_interactive_aux(int y, int x, int mode)
 		if (boring || square_isinteresting(cave, loc(x, y))) {
 			/* Hack -- handle unknown grids */
 
-			/* Pick a prefix */
-			if (*s2 && square_isdoor(cave, loc(x, y))) s2 = "in ";
+			/* Pick a preposition if needed */
+			if (*s2) s2 = square_apparent_look_in_preposition(cave, player, loc(x, y));
 
-			/* Pick proper indefinite article */
-			s3 = (is_a_vowel(name[0])) ? "an " : "a ";
-
-			/* Hack -- special introduction for store doors */
-			if (square_isshop(cave, loc(x, y)))
-				s3 = "the entrance to the ";
+			/* Pick prefix for the name */
+			s3 = square_apparent_look_prefix(cave, player, loc(x, y));
 
 			/* Display a message */
 			if (player->wizard) {


### PR DESCRIPTION
The intent is to make it easier to resolve wobbly's report here, http://angband.oook.cz/forum/showpost.php?p=147606&postcount=129 , of cosmetic issues with FirstAgeAngband.  For Vanilla, the user visible changes are that the message for looking at lava will be "You see some lava" rather than "You see a lava", and the message for standing in a shop entrance will be "You are at the entrance to the ..." rather than "You are in the entrance to the ...".