### PR TITLE
Add assertion to check for failed ego search in brand_object()

### DIFF
--- a/src/effects.c
+++ b/src/effects.c
@@ -557,6 +557,8 @@ void brand_object(struct object *obj, const char *name)
 			if (ok) break;
 		}
 
+		assert(ok);
+
 		/* Make it an ego item */
 		obj->ego = &e_info[i];
 		ego_apply_magic(obj, 0);


### PR DESCRIPTION
Should help diagnose the kind of errors like the one that caused this crash, http://angband.oook.cz/forum/showpost.php?p=147607&postcount=130 , reported by wobbly for FirstAgeAngband.