### PR TITLE
Account for the weapon's weight in choosing the best digger

### DIFF
--- a/src/player-util.c
+++ b/src/player-util.c
@@ -613,6 +613,10 @@ struct object *player_best_digger(struct player *p, bool forbid_stack)
 		}
 		score += obj->modifiers[OBJ_MOD_TUNNEL]
 			* p->obj_k->modifiers[OBJ_MOD_TUNNEL];
+		/* Convert tunnel modifier to digging skill as in player-calcs.c */
+		score *= 20;
+		/* Add in weapon weight (does not account for heavy wield) */
+		score += obj->weight / 10;
 		if (score > best_score) {
 			best = obj;
 			best_score = score;


### PR DESCRIPTION
Should resolve Sideway's report about FirstAgeAngband here, http://angband.oook.cz/forum/showpost.php?p=147692&postcount=149 , but in cases where there's a difference in the strength modifier or where heavy wield comes into play, it may not choose the best digger.