### PR TITLE
Generalize player_knows_ego() to better handle modifier value ranges including zero

### DIFF
--- a/src/obj-knowledge.h
+++ b/src/obj-knowledge.h
@@ -56,7 +56,8 @@ void rune_set_note(size_t i, const char *inscription);
 bool player_knows_brand(struct player *p, int i);
 bool player_knows_slay(struct player *p, int i);
 bool player_knows_curse(struct player *p, int i);
-bool player_knows_ego(struct player *p, struct ego_item *ego);
+bool player_knows_ego(struct player *p, struct ego_item *ego,
+	const struct object *obj);
 bool object_effect_is_known(const struct object *obj);
 bool object_is_known_artifact(const struct object *obj);
 bool object_is_in_store(const struct object *obj);


### PR DESCRIPTION
Attempts to address some of the concerns raised here for FirstAgeAngband, http://angband.oook.cz/forum/showthread.php?t=10172&page=16 , starting with wobbly's post (number 157) and continuing till drquicksilver's post (number 168).  Has no effect on current Vanilla since the defined egos either have modifier ranges that are strictly zero or don't include zero.