### PR TITLE
Fix logic error introduced in confused move change

### DIFF
--- a/src/mon-move.c
+++ b/src/mon-move.c
@@ -1523,7 +1523,7 @@ static void monster_turn(struct chunk *c, struct monster *mon)
 		struct loc new = loc_sum(mon->grid, ddgrid[d]);
 
 		/* Tracking monsters have their best direction, don't change */
-		if ((i > 0) && stagger != NO_STAGGER && !square_isview(c, mon->grid) && tracking) {
+		if ((i > 0) && stagger == NO_STAGGER && !square_isview(c, mon->grid) && tracking) {
 			break;
 		}
 


### PR DESCRIPTION
The '!stagger' from before the change is equivalent to 'stagger == NO_STAGGER', but the revision had the negation of that.