### PR TITLE
Possible way to address monsters not attacking (#4444)

### DIFF
--- a/src/mon-group.c
+++ b/src/mon-group.c
@@ -457,7 +457,11 @@ struct monster *group_monster_tracking(struct chunk *c,
 
 	while (entry) {
 		struct monster *tracker = cave_monster(c, entry->midx);
-		if (mflag_has(tracker->mflag, MFLAG_TRACKING)) return tracker;
+		if (tracker != mon &&
+				mflag_has(tracker->mflag, MFLAG_TRACKING) &&
+				mflag_has(tracker->mflag, MFLAG_ACTIVE)) {
+			return tracker;
+		}
 		entry = entry->next;
 	}
 

--- a/src/mon-move.c
+++ b/src/mon-move.c
@@ -827,10 +827,25 @@ static bool get_move(struct chunk *c, struct monster *mon, int *dir, bool *good)
 		struct monster *tracker = group_monster_tracking(c, mon);
 		if (tracker && los(c, mon->grid, tracker->grid)) { /* Need los? */
 			grid = loc_diff(tracker->grid, mon->grid);
+			/* No longer tracking */
+			mflag_off(mon->mflag, MFLAG_TRACKING);
+		} else if (mflag_has(mon->mflag, MFLAG_TRACKING)) {
+			/* Keep heading to the most recent goal. */
+			grid = loc_diff(mon->target.grid, mon->grid);
+			if (loc_is_zero(grid)) {
+				/* Head blindly for the "player"; see below. */
+				grid = loc_diff(target, mon->grid);
+				mflag_off(mon->mflag, MFLAG_TRACKING);
+			}
+		} else {
+			/*
+			 * Head blindly straight for the "player" if there's
+			 * no better idea.  This was the else clause for
+			 * get_move_advance() failing in 4.1.3.
+			 */
+			grid = loc_diff(target, mon->grid);
+			mflag_off(mon->mflag, MFLAG_TRACKING);
 		}
-
-		/* No longer tracking */
-		mflag_off(mon->mflag, MFLAG_TRACKING);
 	}
 
 	/* Monster is taking damage from terrain */


### PR DESCRIPTION
From observations of some creeping coins, since it was the only monster in its group, group_monster_tracking() would return the pointer to the monster looking for someone to follow.  The first commit doesn't allow that anymore and adds a further condition that the tracker has to be active.

The second commit adds logic for when group_monster_tracking() fails.  The basic idea is to restore what was used (prior to the group_monster_tracking() change) as the else clause when get_move_advance() fails.  I added an additional clause - if the monster was tracking on its last active turn then it'll proceed toward the goal it chose then.  Though, that additional clause may not be a good thing if it's been inactive for some time.  It may also not interact well with group_monster_tracking() since keeps MFLAG_TRACKING set as well:  might want an additional flag (breaking save files I presume) to indicate the monster is going towards old information and probably isn't as reliable as one with MFLAG_TRACKING set.

Another idea, not implemented here, would be to move the line-of-sight check with group_monster_tracking() into group_monster_tracking() itself.