### PR TITLE
Possible idea to resolve monsters failing to attack, #4444

### DIFF
--- a/src/mon-group.c
+++ b/src/mon-group.c
@@ -457,7 +457,11 @@ struct monster *group_monster_tracking(struct chunk *c,
 
 	while (entry) {
 		struct monster *tracker = cave_monster(c, entry->midx);
-		if (mflag_has(tracker->mflag, MFLAG_TRACKING)) return tracker;
+		if (tracker != mon &&
+				mflag_has(tracker->mflag, MFLAG_TRACKING) &&
+				mflag_has(tracker->mflag, MFLAG_ACTIVE)) {
+			return tracker;
+		}
 		entry = entry->next;
 	}
 


### PR DESCRIPTION
Adds checks in group_monster_tracking() so the returned tracker is active and is not the same as the monster looking to follow.

When group_monster_tracking() fails, will either continue to head to the monster's prior goal (if it was tracking at the end of its last active turn) or, when that's not possible, choose a random adjacent grid that is passable and not harmful as the target for the move.