### PR TITLE
Don't zero blows and blow_known pointers in wipe_mon_lore():  other …

### DIFF
--- a/src/mon-lore.c
+++ b/src/mon-lore.c
@@ -372,6 +372,8 @@ void cheat_monster_lore(const struct monster_race *race, struct monster_lore *lo
  */
 void wipe_monster_lore(const struct monster_race *race, struct monster_lore *lore)
 {
+	struct monster_blow *blows;
+	bool *blow_known;
 	assert(race);
 	assert(lore);
 
@@ -379,7 +381,17 @@ void wipe_monster_lore(const struct monster_race *race, struct monster_lore *lor
 	mem_free(lore->friends);
 	mem_free(lore->friends_base);
 	mem_free(lore->mimic_kinds);
+	/*
+	 * Keep the blows and blown_known pointers - other code assumes they
+	 * are not NULL.  Wipe the pointed to memory.
+	 */
+	blows = lore->blows;
+	memset(blows, 0, z_info->mon_blows_max * sizeof(struct monster_blow));
+	blow_known = lore->blow_known;
+	memset(blow_known, 0, z_info->mon_blows_max * sizeof(bool));
 	memset(lore, 0, sizeof(*lore));
+	lore->blows = blows;
+	lore->blow_known = blow_known;
 }
 
 /**

--- a/src/mon-lore.c
+++ b/src/mon-lore.c
@@ -374,13 +374,14 @@ void wipe_monster_lore(const struct monster_race *race, struct monster_lore *lor
 {
 	struct monster_blow *blows;
 	bool *blow_known;
+	struct monster_drop *d;
+	struct monster_friends *f;
+	struct monster_friends_base *fb;
+	struct monster_mimic *mk;
+
 	assert(race);
 	assert(lore);
 
-	mem_free(lore->drops);
-	mem_free(lore->friends);
-	mem_free(lore->friends_base);
-	mem_free(lore->mimic_kinds);
 	/*
 	 * Keep the blows and blown_known pointers - other code assumes they
 	 * are not NULL.  Wipe the pointed to memory.
@@ -389,6 +390,30 @@ void wipe_monster_lore(const struct monster_race *race, struct monster_lore *lor
 	memset(blows, 0, z_info->mon_blows_max * sizeof(struct monster_blow));
 	blow_known = lore->blow_known;
 	memset(blow_known, 0, z_info->mon_blows_max * sizeof(bool));
+	d = lore->drops;
+	while (d) {
+		struct monster_drop *dn = d->next;
+		mem_free(d);
+		d = dn;
+	}
+	f = lore->friends;
+	while (f) {
+		struct monster_friends *fn = f->next;
+		mem_free(f);
+		f = fn;
+	}
+	fb = lore->friends_base;
+	while (fb) {
+		struct monster_friends_base *fbn = fb->next;
+		mem_free(fb);
+		fb = fbn;
+	}
+	mk = lore->mimic_kinds;
+	while (mk) {
+		struct monster_mimic *mkn = mk->next;
+		mem_free(mk);
+		mk = mkn;
+	}
 	memset(lore, 0, sizeof(*lore));
 	lore->blows = blows;
 	lore->blow_known = blow_known;


### PR DESCRIPTION
…code assumes those are not NULL.  The previous behavior would cause a crash if the monster lore subwindow was updated after using the debug command to wipe all monster lore.