### PR TITLE
log_obj():  output string as is (no % formatting)

### DIFF
--- a/src/obj-power.c
+++ b/src/obj-power.c
@@ -140,7 +140,7 @@ static ang_file *object_log;
  */
 void log_obj(char *message)
 {
-	file_putf(object_log, message);
+	file_putf(object_log, "%s", message);
 }
 
 /**


### PR DESCRIPTION
Fixes garbling of "Adding ... for extra shots ..." in randart.log.