### PR TITLE
Fix issues with statistics option in the object play debugging command

### DIFF
--- a/src/wiz-debug.c
+++ b/src/wiz-debug.c
@@ -1163,6 +1163,9 @@ static void wiz_statistics(struct object *obj, int level)
 			/* Allow multiple artifacts, because breaking the game is OK here */
 			if (obj->artifact) obj->artifact->created = false;
 
+			/* Check for failures to generate an object */
+			if (!test_obj) continue;
+
 			/* Test for the same tval and sval. */
 			if ((obj->tval) != (test_obj->tval)) continue;
 			if ((obj->sval) != (test_obj->sval)) continue;

--- a/src/wiz-debug.c
+++ b/src/wiz-debug.c
@@ -1167,8 +1167,11 @@ static void wiz_statistics(struct object *obj, int level)
 			if (!test_obj) continue;
 
 			/* Test for the same tval and sval. */
-			if ((obj->tval) != (test_obj->tval)) continue;
-			if ((obj->sval) != (test_obj->sval)) continue;
+			if (obj->tval != test_obj->tval ||
+					obj->sval != test_obj->sval) {
+				object_delete(&test_obj);
+				continue;
+			}
 
 			/* Check modifiers */
 			ismatch = true;

--- a/src/wiz-debug.c
+++ b/src/wiz-debug.c
@@ -1140,14 +1140,14 @@ static void wiz_statistics(struct object *obj, int level)
 		for (i = 0; i <= TEST_ROLL; i++) {
 			/* Output every few rolls */
 			if ((i < 100) || (i % 100 == 0)) {
-				struct keypress kp;
+				ui_event e;
 
 				/* Do not wait */
 				inkey_scan = SCAN_INSTANT;
 
 				/* Allow interupt */
-				kp = inkey();
-				if (kp.type != EVT_NONE) {
+				e = inkey_ex();
+				if (e.type != EVT_NONE) {
 					event_signal(EVENT_INPUT_FLUSH);
 					break;
 				}


### PR DESCRIPTION
- Was waiting for a keystroke which then interrupted the calculation before it started.
- Since make_object() can return NULL, there were crashes.
- Leaked the objects which were not matched to the original object's tval and sval.