### PR TITLE
Allow selection of store's contents by number in the knowledge menu

### DIFF
--- a/src/ui-knowledge.c
+++ b/src/ui-knowledge.c
@@ -3195,6 +3195,26 @@ static void do_cmd_knowledge_equip_cmp(const char* name, int row)
 	equip_cmp_display();
 }
 
+static bool handle_store_shortcuts(struct menu *m, const ui_event *ev, int oid)
+{
+	int i = 0;
+
+	assert(ev->type == EVT_KBRD);
+	while (1) {
+		if (! m->cmd_keys[i]) {
+			return false;
+		}
+		if (ev->key.code == (unsigned) m->cmd_keys[i]) {
+			menu_action *acts = menu_priv(m);
+
+			do_cmd_knowledge_store(
+				acts[i + STORE_KNOWLEDGE_ROW].name,
+				i + STORE_KNOWLEDGE_ROW);
+			return true;
+		}
+		++i;
+	}
+}
 
 /**
  * Definition of the "player knowledge" menu.
@@ -3209,21 +3229,20 @@ static menu_action knowledge_actions[] =
 { 0, 0, "Display feature knowledge",  	   do_cmd_knowledge_features  },
 { 0, 0, "Display trap knowledge",          do_cmd_knowledge_traps  },
 { 0, 0, "Display shapechange effects",     do_cmd_knowledge_shapechange },
-{ 0, 0, "Display contents of general store", do_cmd_knowledge_store     },
-{ 0, 0, "Display contents of armourer",      do_cmd_knowledge_store     },
-{ 0, 0, "Display contents of weaponsmith",   do_cmd_knowledge_store     },
-{ 0, 0, "Display contents of bookseller",    do_cmd_knowledge_store     },
-{ 0, 0, "Display contents of alchemist",     do_cmd_knowledge_store     },
-{ 0, 0, "Display contents of magic shop",    do_cmd_knowledge_store     },
-{ 0, 0, "Display contents of black market",  do_cmd_knowledge_store     },
-{ 0, 0, "Display contents of home",   	   do_cmd_knowledge_store     },
+{ 0, 0, "Display contents of general store (1)", do_cmd_knowledge_store },
+{ 0, 0, "Display contents of armourer (2)",      do_cmd_knowledge_store },
+{ 0, 0, "Display contents of weaponsmith (3)",   do_cmd_knowledge_store },
+{ 0, 0, "Display contents of bookseller (4)",    do_cmd_knowledge_store },
+{ 0, 0, "Display contents of alchemist (5)",     do_cmd_knowledge_store },
+{ 0, 0, "Display contents of magic shop (6)",    do_cmd_knowledge_store },
+{ 0, 0, "Display contents of black market (7)",  do_cmd_knowledge_store },
+{ 0, 0, "Display contents of home (8)",          do_cmd_knowledge_store },
 { 0, 0, "Display hall of fame",       	   do_cmd_knowledge_scores    },
 { 0, 0, "Display character history",  	   do_cmd_knowledge_history   },
 { 0, 0, "Display equipable comparison",    do_cmd_knowledge_equip_cmp },
 };
 
 static struct menu knowledge_menu;
-
 
 /**
  * Keep macro counts happy.
@@ -3241,6 +3260,10 @@ void textui_knowledge_init(void)
 
 	menu->title = "Display current knowledge";
 	menu->selections = lower_case;
+	/* Shortcuts to get the contents of the stores by number; does prevent
+	 * the normal use of 4 and 6 to go to the previous or next menu */
+	menu->cmd_keys = "12345678";
+	menu->keys_hook = handle_store_shortcuts;
 
 	/* initialize other static variables */
 	if (!obj_group_order) {

--- a/src/ui-menu.c
+++ b/src/ui-menu.c
@@ -102,6 +102,8 @@ static bool menu_action_handle(struct menu *m, const ui_event *event, int oid)
 			acts[oid].action(acts[oid].name, m->cursor);
 			return true;
 		}
+	} else if (m->keys_hook && event->type == EVT_KBRD) {
+		return m->keys_hook(m, event, oid);
 	}
 
 	return false;
@@ -125,7 +127,8 @@ static const menu_iter menu_iter_actions =
  * MN_STRINGS HELPER FUNCTIONS
  *
  * MN_STRINGS is the type of menu iterator that displays a simple list of 
- * strings - no action is associated, as selection will just return the index.
+ * strings - an action is associated, but only for cmd_keys and switch_keys
+ * handling via keys_hook as selection will just return the index.
  * ------------------------------------------------------------------------ */
 static void display_string(struct menu *m, int oid, bool cursor,
 		int row, int col, int width)
@@ -135,13 +138,21 @@ static void display_string(struct menu *m, int oid, bool cursor,
 	Term_putstr(col, row, width, color, items[oid]);
 }
 
+static bool handle_string(struct menu *m, const ui_event *event, int oid)
+{
+	if (m->keys_hook && event->type == EVT_KBRD) {
+		return m->keys_hook(m, event, oid);
+	}
+	return false;
+}
+
 /* Virtual function table for displaying arrays of strings */
 static const menu_iter menu_iter_strings =
 { 
 	NULL,              /* get_tag() */
 	NULL,              /* valid_row() */
 	display_string,    /* display_row() */
-	NULL, 	           /* row_handler() */
+	handle_string, 	   /* row_handler() */
 	NULL
 };
 

--- a/src/ui-menu.h
+++ b/src/ui-menu.h
@@ -226,6 +226,13 @@ struct menu
   	/* auxiliary browser help function */
 	void (*browse_hook)(int oid, void *db, const region *loc);
 
+	/* This is an auxiliary function to allow predefined skins to handle
+	 * events for cmd_keys or switch_keys within menu_select() rather than
+	 * have menu_select()'s caller handle them.  If used, the function
+	 * should return true if the event, ev, was handled or false if it was
+	 * not. oid is the index of the cursor position in the list. */
+	bool (*keys_hook)(struct menu *m, const ui_event *ev, int oid);
+
 	/* Flags specifying the behavior of this menu (from struct menu_flags) */
 	int flags;
 


### PR DESCRIPTION
Resolves https://github.com/angband/angband/issues/4519 .  Could be partially done without the extension to ui-menu.c in the first commit (by setting cmd_keys and handling those keys after menu_select() returns), but then 4 and 6 are caught in the menu handling so alternate keys for the bookseller and magic shop would be needed.