### PR TITLE
Fix crash in compute_ui_entry_values_for_player() with ranger character

### DIFF
--- a/src/ui-entry.c
+++ b/src/ui-entry.c
@@ -831,7 +831,7 @@ void compute_ui_entry_values_for_player(const struct ui_entry *entry,
 				case PF_FAST_SHOT:
 					launcher = equipped_item_by_slot_name(
 						p, "shooting");
-					if (kf_has(launcher->kind->kind_flags,
+					if (launcher && kf_has(launcher->kind->kind_flags,
 						KF_SHOOTS_ARROWS)) {
 						v = p->lev / 3;
 						a = 0;


### PR DESCRIPTION
launcher will be null when a ranger character opens the resistances
window without a ranged weapon equipped, which causes a crash.