### PR TITLE
OS X: fix updateGlyphInfo() regression in 4.2.1

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -2198,7 +2198,8 @@ static int compare_advances(const void *ap, const void *bp)
     for (i=0; i < GLYPH_COUNT; i++) latinString[i] = (unsigned char)i;
 
     /* Turn that into unichar. Angband uses ISO Latin 1. */
-    NSString *allCharsString = [[NSString alloc] initWithBytes:latinString length:sizeof latinString encoding:NSISOLatin1StringEncoding];
+    NSString *allCharsString = [[NSString alloc] initWithBytes:latinString
+        length:GLYPH_COUNT encoding:NSISOLatin1StringEncoding];
     unichar *unicharString = malloc(GLYPH_COUNT * sizeof(unichar));
     if (unicharString == 0) {
 	free(latinString);


### PR DESCRIPTION
Wasn't considering the full GLYPH_COUNT glyphs:  introduced with the change to dynamically allocate working space.  With the default font, fixing the regression doesn't affect the display.  I didn't identify if there's one of the standard Mac fonts where it does make a difference.