### PR TITLE
OS X:  in Term_pict_cocoa(), step through the passed in arrays in ...

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -4789,11 +4789,15 @@ static errr Term_pict_cocoa(int x, int y, int n, const int *ap,
     }
 
     for (int i = x; i < x + n * tile_width; i += tile_width) {
-	int a = *ap++;
-	wchar_t c = *cp++;
-        int ta = *tap++;
-	wchar_t tc = *tcp++;
+	int a = *ap;
+	wchar_t c = *cp;
+	int ta = *tap;
+	char tc = *tcp;
 
+	ap += tile_width;
+	cp += tile_width;
+	tap += tile_width;
+	tcp += tile_width;
 	if (use_graphics && (a & 0x80) && (c & 0x80)) {
 	    char fgdRow = ((byte)a & 0x7F) % pict_rows;
 	    char fgdCol = ((byte)c & 0x7F) % pict_cols;


### PR DESCRIPTION
…increments of the tile width scaling.  Does not matter in the current configuration, with always_pict off, but would matter if always_pict was on or if the core terminal code was modified to pass more than one tile at a time when higher_pict is on.