### PR TITLE
Add a facility to dump the level as HTML in gen-util.c

### DIFF
--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -1935,6 +1935,8 @@ struct chunk *modified_chunk(int depth, int height, int width)
 		while (join) {
 			if (!room_build(c, dun->join->grid.y, dun->join->grid.x, profile,
 							true)) {
+				dump_level_simple(NULL, "Modified Generation:"
+					"  Failed to Build Staircase Room", c);
 				quit("Failed to place stairs");
 			}
 			join = join->next;

--- a/src/gen-util.c
+++ b/src/gen-util.c
@@ -884,28 +884,28 @@ void dump_level_body(ang_file *fo, const char *title, struct chunk *c,
 			const char *s = "#";
 
 			if (square_in_bounds_fully(c, grid)) {
-				if (square_isplayer(cave, grid)) {
+				if (square_isplayer(c, grid)) {
 					s = "@";
 				} else if (square_isoccupied(c, grid)) {
 					s = (dist == NULL || dist[y][x] >= 0) ?
 						"M" : "*";
-				} else if (square_isdoor(cave, grid)) {
+				} else if (square_isdoor(c, grid)) {
 					s = (dist == NULL || dist[y][x] >= 0) ?
 						"+" : "*";
-				} else if (square_isrubble(cave, grid)) {
+				} else if (square_isrubble(c, grid)) {
 					s = (dist == NULL || dist[y][x] >= 0) ?
 						":" : "*";
-				} else if (square_isdownstairs(cave, grid)) {
+				} else if (square_isdownstairs(c, grid)) {
 					s = (dist == NULL || dist[y][x] >= 0) ?
 						"&gt;" : "*";
-				} else if (square_isupstairs(cave, grid)) {
+				} else if (square_isupstairs(c, grid)) {
 					s = (dist == NULL || dist[y][x] >= 0) ?
 						"&lt;" : "*";
-				} else if (square_istrap(cave, grid) ||
-					square_isplayertrap(cave, grid)) {
+				} else if (square_istrap(c, grid) ||
+					square_isplayertrap(c, grid)) {
 					s = (dist == NULL || dist[y][x] >= 0) ?
 						"^" : "*";
-				} else if (square_iswebbed(cave, grid)) {
+				} else if (square_iswebbed(c, grid)) {
 					s = (dist == NULL || dist[y][x] >= 0) ?
 						"w" : "*";
 				} else if (square_object(c, grid)) {
@@ -916,7 +916,7 @@ void dump_level_body(ang_file *fo, const char *title, struct chunk *c,
 						square_isno_stairs(c, grid))) {
 					s = (dist == NULL || dist[y][x] >= 0) ?
 						" " : "*";
-				} else if (square_ispassable(cave, grid)) {
+				} else if (square_ispassable(c, grid)) {
 					s = (dist == NULL || dist[y][x] >= 0) ?
 						"." : "*";
 				}

--- a/src/gen-util.c
+++ b/src/gen-util.c
@@ -778,7 +778,7 @@ void dump_level_simple(const char *basefilename, const char *title,
  * least c->width elements.  For a location (x,y) in the level, if dist[y][x]
  * is negative, the contents will be rendered differently.
  *
- * The current output format is HTML since a typical brower will happily
+ * The current output format is HTML since a typical browser will happily
  * display the content in a scrollable area without wrapping lines.  This
  * function is a convenience to replace a set of calls to dump_level_header(),
  * dump_level_body(), and dump_level_footer().

--- a/src/gen-util.c
+++ b/src/gen-util.c
@@ -738,3 +738,170 @@ void vault_monsters(struct chunk *c, struct loc grid, int depth, int num)
 }
 
 
+/**
+ * Dump the given level to a file for post-mortem analysis.
+ * \param fo Is the file handle to use.  Must be capable of sequential writes
+ * in text format.  The level is dumped starting at the current offset in the
+ * file.
+ * \param title Is the title to use for the contents.
+ * \param c Is the chunk to dump.
+ * \param dist If not NULL, must act like a two dimensional C array with the
+ * first dimension being at least c->height elements and the second being at
+ * least c->width elements.  For a location (x,y) in the level, if dist[y][x]
+ * is negative, the contents will be rendered differently.
+ *
+ * The current output format is HTML since a typical brower will happily
+ * display the content in a scrollable area without wrapping lines.  This
+ * function is a convenience to replace a set of calls to dump_level_header(),
+ * dump_level_body(), and dump_level_footer().
+ */
+void dump_level(ang_file *fo, const char *title, struct chunk *c, int **dist)
+{
+	dump_level_header(fo, title);
+	dump_level_body(fo, title, c, dist);
+	dump_level_footer(fo);
+}
+
+
+/**
+ * Helper function to write a string while escaping any special characters.
+ * \param fo Is the file handle to use.
+ * \param s Is the string to write.
+ */
+static void dump_level_escaped_string(ang_file *fo, const char *s)
+{
+	while (*s) {
+		switch (*s) {
+		case '&':
+			file_put(fo, "&amp;");
+			break;
+
+		case '<':
+			file_put(fo, "&lt;");
+			break;
+
+		case '>':
+			file_put(fo, "&gt;");
+			break;
+
+		case '\"':
+			file_put(fo, "&quot;");
+			break;
+
+		default:
+			file_putf(fo, "%c", *s);
+			break;
+		}
+		++s;
+	}
+}
+
+
+/**
+ * Write the introductory material for the dump of one or move levels.
+ * \param fo Is the file handle to use.  Must be capable of sequential writes
+ * in text format.  Writes start at the current offset in the file.
+ * \param title Is the title to use for the contents of the file.
+ *
+ * The current format uses HTML.  This should be called once per dump (or
+ * take other measures to overwrite a previous call).
+ */
+void dump_level_header(ang_file *fo, const char *title)
+{
+	file_put(fo,
+		"<!DOCTYPE html>\n"
+		"<html lang=\"en\" xml:lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+		"  <head>\n"
+		"    <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">\n"
+		"    <title>");
+	dump_level_escaped_string(fo, title);
+	file_put(fo, "</title>\n  </head>\n  <body>\n");
+}
+
+
+/**
+ * Dump the given level to a file.
+ * \param fo Is the file handle to use.  Must be capable of sequential writes
+ * in text format.  The level is dumped starting at the current offset in the
+ * file.
+ * \param title Is the title to use for the level.
+ * \param c Is the chunk to dump.
+ * \param dist If not NULL, must act like a two dimensional C array with the
+ * first dimension being at least c->height elements and the second being at
+ * least c->width elements.  For a location (x,y) in the level, if dist[y][x]
+ * is negative, the contents will be rendered differently.
+ *
+ * The current output format is HTML.  You can dump more than one level to
+ * the same file by calling dump_level_header() once for the file, followed
+ * by calling dump_level_body() for each level of interest, then calling
+ * dump_level_footer() once to finish things off before you close the file
+ * with file_close().
+ */
+void dump_level_body(ang_file *fo, const char *title, struct chunk *c,
+	int **dist)
+{
+	int y;
+
+	file_put(fo, "    <p>");
+	dump_level_escaped_string(fo, title);
+	if (dist != NULL) {
+		file_put(fo, "\n    <p>A location where the distance array was negative is marked with *.");
+	}
+	file_put(fo, "\n    <pre>\n");
+	for (y = 0; y < c->height; ++y) {
+		int x;
+
+		for (x = 0; x < c->width; ++x) {
+			struct loc grid = loc(x, y);
+			const char *s = "#";
+
+			if (square_in_bounds_fully(c, grid)) {
+				if (square_isplayer(cave, grid)) {
+					s = "@";
+				} else if (square_isoccupied(c, grid)) {
+					s = (dist == NULL || dist[y][x] >= 0) ?
+						"M" : "*";
+				} else if (square_isdoor(cave, grid)) {
+					s = (dist == NULL || dist[y][x] >= 0) ?
+						"+" : "*";
+				} else if (square_isrubble(cave, grid)) {
+					s = (dist == NULL || dist[y][x] >= 0) ?
+						":" : "*";
+				} else if (square_isdownstairs(cave, grid)) {
+					s = (dist == NULL || dist[y][x] >= 0) ?
+						"&gt;" : "*";
+				} else if (square_isupstairs(cave, grid)) {
+					s = (dist == NULL || dist[y][x] >= 0) ?
+						"&lt;" : "*";
+				} else if (square_istrap(cave, grid) ||
+					square_isplayertrap(cave, grid)) {
+					s = (dist == NULL || dist[y][x] >= 0) ?
+						"^" : "*";
+				} else if (square_iswebbed(cave, grid)) {
+					s = (dist == NULL || dist[y][x] >= 0) ?
+						"w" : "*";
+				} else if (square_object(c, grid)) {
+					s = (dist == NULL || dist[y][x] >= 0) ?
+						"$" : "*";
+				} else if (square_ispassable(cave, grid)) {
+					s = (dist == NULL || dist[y][x] >= 0) ?
+						" " : "*";
+				}
+			}
+			file_put(fo, s);
+		}
+		file_put(fo, "\n");
+	}
+	file_put(fo, "    </pre>\n");
+}
+
+
+/**
+ * Write the concluding material for the dump of one or more levels.
+ * \param fo Is the file handle to use.  Must be capable of sequential writes
+ * in text format.  Writes start at the current offset in the file.
+ */
+void dump_level_footer(ang_file *fo)
+{
+	file_put(fo, "  </body>\n</html>\n");
+}

--- a/src/gen-util.c
+++ b/src/gen-util.c
@@ -911,9 +911,14 @@ void dump_level_body(ang_file *fo, const char *title, struct chunk *c,
 				} else if (square_object(c, grid)) {
 					s = (dist == NULL || dist[y][x] >= 0) ?
 						"$" : "*";
-				} else if (square_ispassable(cave, grid)) {
+				} else if (square_isempty(c, grid) &&
+						(square_isvault(c, grid) ||
+						square_isno_stairs(c, grid))) {
 					s = (dist == NULL || dist[y][x] >= 0) ?
 						" " : "*";
+				} else if (square_ispassable(cave, grid)) {
+					s = (dist == NULL || dist[y][x] >= 0) ?
+						"." : "*";
 				}
 			}
 			file_put(fo, s);

--- a/src/gen-util.c
+++ b/src/gen-util.c
@@ -348,6 +348,7 @@ void new_player_spot(struct chunk *c, struct player *p)
 		square_isstairs(c, p->grid)) {
 		grid = p->grid;
 	} else if (!find_start(c, &grid)) {
+		dump_level_simple(NULL, "Player Placement Failure", c);
 		quit("Failed to place player!");
 	}
 
@@ -735,6 +736,33 @@ void vault_monsters(struct chunk *c, struct loc grid, int depth, int num)
 			break;
 		}
     }
+}
+
+
+/**
+ * Dump the given level for post-mortem analysis; handle all I/O.
+ * \param basefilename Is the base name (no directory or extension) for the
+ * file to use.  If NULL, "dumpedlevel" will be used.
+ * \param title Is the label to use within the file.  If NULL, "Dumped Level"
+ * will be used.
+ * \param c Is the chunk to dump.
+ */
+void dump_level_simple(const char *basefilename, const char *title,
+	struct chunk *c)
+{
+	char path[1024];
+	ang_file *fo;
+
+	path_build(path, sizeof(path), ANGBAND_DIR_USER, (basefilename) ?
+		format("%s.html", basefilename) : "dumpedlevel.html");
+	fo = file_open(path, MODE_WRITE, FTYPE_TEXT);
+	if (fo) {
+		dump_level(fo, (title) ? title : "Dumped Level", c, NULL);
+		if (file_close(fo)) {
+			msg(format("Level dumped to %s.html",
+				(basefilename) ? basefilename : "dumpedlevel"));
+		}
+	}
 }
 
 

--- a/src/generate.h
+++ b/src/generate.h
@@ -337,6 +337,11 @@ void vault_traps(struct chunk *c, struct loc grid, int yd, int xd, int num);
 void vault_monsters(struct chunk *c, struct loc grid, int depth, int num);
 void alloc_objects(struct chunk *c, int set, int typ, int num, int depth, byte origin);
 bool alloc_object(struct chunk *c, int set, int typ, int depth, byte origin);
+void dump_level(ang_file *fo, const char *title, struct chunk *c, int **dist);
+void dump_level_header(ang_file *fo, const char *title);
+void dump_level_body(ang_file *fo, const char *title, struct chunk *c,
+	int **dist);
+void dump_level_footer(ang_file *fo);
 
 /* gen-monster.c */
 bool mon_restrict(const char *monster_type, int depth, bool unique_ok);

--- a/src/generate.h
+++ b/src/generate.h
@@ -337,6 +337,8 @@ void vault_traps(struct chunk *c, struct loc grid, int yd, int xd, int num);
 void vault_monsters(struct chunk *c, struct loc grid, int depth, int num);
 void alloc_objects(struct chunk *c, int set, int typ, int num, int depth, byte origin);
 bool alloc_object(struct chunk *c, int set, int typ, int depth, byte origin);
+void dump_level_simple(const char *basefilename, const char *title,
+	struct chunk *c);
 void dump_level(ang_file *fo, const char *title, struct chunk *c, int **dist);
 void dump_level_header(ang_file *fo, const char *title);
 void dump_level_body(ang_file *fo, const char *title, struct chunk *c,

--- a/src/wiz-stats.c
+++ b/src/wiz-stats.c
@@ -2007,8 +2007,6 @@ void disconnect_stats(void)
 			if (stop_for_dis) i = tries;
 		}
 
-		msg("Iteration: %d",i); 
-
 		/* Free arrays */
 		for (y = 0; y < cave->height; y++)
 			mem_free(cave_dist[y]);


### PR DESCRIPTION
Use it in a couple of places in the generation code when it bails on a failure.  Also use it in the implementation of the disconnection statistics to see the levels that are disconnected.  In the disconnection statistics, add an option to break out on the first level that is disconnected and remove the per-simulation message so a large number of simulations is less painful.