### PR TITLE
OS X:  don't bother to call Term_activate() from drawRect()

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -3287,7 +3287,6 @@ static int compare_nsrect_yorigin_greater(const void *ap, const void *bp)
     NSGraphicsContext *nsctx = nil;
     CGContextRef ctx = 0;
     NSFont* screenFont = nil;
-    term *old = 0;
     int graf_width = 0, graf_height = 0;
     int overdraw_row = 0, overdraw_max = 0;
     wchar_t blank = 0;
@@ -3295,8 +3294,6 @@ static int compare_nsrect_yorigin_greater(const void *ap, const void *bp)
 	rect.origin.x + rect.size.width > self.borderSize.width &&
 	rect.origin.y < bottomY &&
 	rect.origin.y + rect.size.height > self.borderSize.height) {
-	old = Term;
-	Term_activate(self->terminal);
 	nsctx = [NSGraphicsContext currentContext];
 	ctx = [nsctx graphicsPort];
 	screenFont = [self.angbandViewFont screenFont];
@@ -3322,9 +3319,6 @@ static int compare_nsrect_yorigin_greater(const void *ap, const void *bp)
     if (overdraw_row && invalidCount > 1) {
 	sortedRects = malloc(invalidCount * sizeof(NSRect));
 	if (sortedRects == 0) {
-	    if (old != 0) {
-		Term_activate(old);
-	    }
 	    NSException *exc = [NSException exceptionWithName:@"OutOfMemory"
 					    reason:@"sorted rects in drawRect"
 					    userInfo:nil];
@@ -3698,9 +3692,6 @@ static int compare_nsrect_yorigin_greater(const void *ap, const void *bp)
     }
 
     free(sortedRects);
-    if (old != 0) {
-	Term_activate(old);
-    }
 }
 
 - (BOOL)isOrderedIn


### PR DESCRIPTION
Since the contents of Term aren't used, it isn't necessary.  Removing the call appears to resolve #4554 , a segmentation fault at startup on OS X 10.12.6 due to recursion (Term_init_cocoa() causes drawRect() to be called, which calls Term_activate(), which, in turn, ends up calling Term_init_cocoa()).