### PR TITLE
Fix hard centre level generation for PowerWyrm's reports …

### DIFF
--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -2532,7 +2532,7 @@ struct chunk *hard_centre_gen(struct player *p, int min_height, int min_width)
 		square_set_feat(c, loc(x + left_cavern_wid, centre_cavern_ypos),
 						FEAT_FLOOR);
 		square_set_feat(c, loc(x + left_cavern_wid,
-							   centre_cavern_ypos + centre->height - 1),
+							   centre_cavern_ypos + centre_cavern_hgt - 1),
 						FEAT_FLOOR);
 	}
 

--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -2359,7 +2359,6 @@ struct chunk *vault_chunk(struct player *p)
 {
 	struct vault *v;
 	struct chunk *c;
-	int y;
 
 	if (one_in_(2)) v = random_vault(p->depth, "Greater vault (new)");
 	else v = random_vault(p->depth, "Greater vault");
@@ -2369,13 +2368,8 @@ struct chunk *vault_chunk(struct player *p)
 	c->depth = p->depth;
 
 	/* Fill with granite; the vault will override for the grids it sets. */
-	for (y = 0; y < v->hgt; ++y) {
-		int x;
-
-		for (x = 0; x < v->wid; ++x) {
-			square_set_feat(c, loc(x, y), FEAT_GRANITE);
-		}
-	}
+	fill_rectangle(c, 0, 0, v->hgt - 1, v->wid - 1, FEAT_GRANITE,
+		SQUARE_NONE);
 
 	/* Build the vault in it */
 	build_vault(c, loc(v->wid / 2, v->hgt / 2), v);


### PR DESCRIPTION
…at http://angband.oook.cz/forum/showpost.php?p=148614&postcount=86 and http://angband.oook.cz/forum/showpost.php?p=148616&postcount=87 :

1) The search range for the connecting point in the upper part accounts for the left offset as suggested by PowerWyrm.
2) Set the bounds on the parts to fill the space when the dungeon dimension minus the vault dimension is not even.
3) Account for rotation of the vault when marking its boundary as floors.
4) Initialize the grids in the centre portion to granite in case the vault does not specify the contents of all grids.