### PR TITLE
Recalculate player equipment bonuses after digging.

### DIFF
--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -540,6 +540,7 @@ static bool do_cmd_tunnel_aux(struct loc grid)
 			best_digger->number = oldn;
 		}
 		player->body.slots[weapon_slot].obj = current_weapon;
+		calc_bonuses(player, &local_state, false, true);
 	}
 
 	/* Success */


### PR DESCRIPTION
When digging, the game switches you automatically to your best digger and recalculates your equipment bonuses.  After digging is complete it switches your weapon back, but doesn't recalculate equipment bonuses, so stat boosts from your weapon will not be applied until the next event that triggers a recalculation (such as equiping or taking off a piece of equipment).

This commit adds a recalculation after reequiping so that @s abilities will be accurate immediately.