### PR TITLE
Change sound-core.c to allow Windows builds without SOUND set

### DIFF
--- a/src/sound-core.c
+++ b/src/sound-core.c
@@ -24,7 +24,7 @@
 #include "snd-sdl.h"
 #endif
 
-#if (!defined(WIN32_CONSOLE_MODE) && defined(WINDOWS) && !defined(USE_SDL) && !defined(USE_SDL2))
+#if (!defined(WIN32_CONSOLE_MODE) && defined(WINDOWS) && defined(SOUND) && !defined(USE_SDL) && !defined(USE_SDL2))
 #include "snd-win.h"
 #endif
 
@@ -58,7 +58,7 @@ static const struct sound_module sound_modules[] =
 #if defined(SOUND_SDL) || defined(SOUND_SDL2)
 	{ "sdl", "SDL_mixer sound module", init_sound_sdl },
 #endif /* SOUND_SDL */
-#if (!defined(WIN32_CONSOLE_MODE) && defined(WINDOWS) && !defined(USE_SDL) && !defined(USE_SDL2)) 
+#if (!defined(WIN32_CONSOLE_MODE) && defined(WINDOWS) && defined(SOUND) && !defined(USE_SDL) && !defined(USE_SDL2))
 	{ "win", "Windows sound module", init_sound_win },
 #endif
 


### PR DESCRIPTION
From http://angband.oook.cz/forum/showthread.php?t=8779 , that helps resolve a problem people had when following the instructions for compiling with Visual Studio.