### PR TITLE
Allow customization of the defaults for the birth options

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -18,6 +18,7 @@
 #include "angband.h"
 #include "init.h"
 #include "option.h"
+#include "z-util.h"
 
 /**
  * Option screen interface
@@ -115,11 +116,155 @@ void options_init_defaults(struct player_options *opts)
 	for (opt = 0; opt < OPT_MAX; opt++)
 		(*opts).opt[opt] = options[opt].normal;
 
+	/* Override with customized birth options. */
+	options_restore_custom_birth(opts);
+
 	/* 40ms for the delay factor */
 	(*opts).delay_factor = 40;
 
 	/* 30% of HP */
 	(*opts).hitpoint_warn = 3;
+}
+
+/**
+ * Record the birth options for later recall.
+ *
+ * Return true if successful.  Return false if the operation failed.
+ */
+bool options_save_custom_birth(struct player_options *opts)
+{
+	bool success = true;
+	char path[1024];
+	ang_file *f;
+
+	path_build(path, sizeof(path), ANGBAND_DIR_USER,
+		"customized_birth_options.txt");
+	f = file_open(path, MODE_WRITE, FTYPE_TEXT);
+	if (f) {
+		int opt;
+
+		if (!file_put(f, "# These are customized defaults for the birth options.\n")) {
+			success = false;
+		}
+		if (!file_put(f, "# All lines begin with \"option:\" followed by the internal option name.\n")) {
+			success = false;
+		}
+		if (!file_put(f, "# After the name is a colon followed by yes or no for the option's state.\n")) {
+			success = false;
+		}
+		for (opt = 0; opt < OPT_MAX; opt++) {
+			if (options[opt].type == OP_BIRTH) {
+				if (!file_putf(f, "# %s\n",
+						 options[opt].description)) {
+					success = false;
+				}
+				if (!file_putf(f, "option:%s:%s\n",
+						options[opt].name,
+						((*opts).opt[opt]) ? "yes" : "no")) {
+					success = false;
+				}
+			}
+		}
+
+		if (!file_close(f)) {
+			success = false;
+		}
+	} else {
+		success = false;
+	}
+	return success;
+}
+
+/**
+ * Reset the birth options to the customized defaults.
+ *
+ * Return true if successful.  That includes the case where no customized
+ * defaults are available.  When that happens, the birth options are reset
+ * to the maintainer's defaults.  Return false if the customized defaults
+ * are present but unreadable.
+ */
+bool options_restore_custom_birth(struct player_options *opts)
+{
+	bool success = true;
+	char path[1024];
+
+	path_build(path, sizeof(path), ANGBAND_DIR_USER,
+		"customized_birth_options.txt");
+	if (file_exists(path)) {
+		/*
+		 * Could use run_parser(), but that exits the application if
+		 * there are syntax errors.  Therefore, use our own parsing.
+		 */
+		ang_file *f = file_open(path, MODE_READ, FTYPE_TEXT);
+
+		if (f) {
+			int linenum = 1;
+			char buf[1024];
+
+			while (file_getl(f, buf, sizeof(buf))) {
+				int offset = 0;
+
+				if (sscanf(buf, "option:%n%*s", &offset) == 0 &&
+						offset > 0) {
+					int opt = 0;
+
+					while (1) {
+						size_t lname;
+
+						if (opt >= OPT_MAX) {
+							msg("Unrecognized birth option at line %d of the customized birth options.", linenum);
+							break;
+						}
+						if (!options[opt].name) {
+							++opt;
+							continue;
+						}
+						lname = strlen(
+							options[opt].name);
+						if (strncmp(options[opt].name,
+							buf + offset, lname) == 0 &&
+							buf[offset + lname] == ':') {
+							if (strncmp("yes", buf + offset + lname + 1, 3) == 0 && contains_only_spaces(buf + offset + lname + 4)) {
+								(*opts).opt[opt] = true;
+							} else if (strncmp("no", buf + offset + lname + 1, 2) == 0 && contains_only_spaces(buf + offset + lname + 3)) {
+								(*opts).opt[opt] = false;
+							} else {
+								msg("Value at line %d of the customized birth options is not yes or no.", linenum);
+							}
+							break;
+						}
+						++opt;
+					}
+				} else {
+					offset = 0;
+					if (sscanf(buf, "#%n*s", &offset) == 0 && offset == 0 && ! contains_only_spaces(buf)) {
+						msg("Line %d of the customized birth options is not parseable.", linenum);
+					}
+				}
+				++linenum;
+			}
+			if (!file_close(f)) {
+				success = false;
+			}
+		} else {
+			success = false;
+		}
+	} else {
+		options_reset_birth(opts);
+	}
+	return success;
+}
+
+/**
+ * Reset the birth options to the maintainer's defaults.
+ */
+void options_reset_birth(struct player_options *opts)
+{
+	int opt;
+	for (opt = 0; opt < OPT_MAX; opt++)
+		if (options[opt].type == OP_BIRTH) {
+			(*opts).opt[opt] = options[opt].normal;
+		}
 }
 
 /**

--- a/src/option.h
+++ b/src/option.h
@@ -81,5 +81,8 @@ bool option_set(const char *opt, int val);
 void options_init_cheat(void);
 void options_init_defaults(struct player_options *opts);
 void init_options(void);
+bool options_save_custom_birth(struct player_options *opts);
+bool options_restore_custom_birth(struct player_options *opts);
+void options_reset_birth(struct player_options *opts);
 
 #endif /* !INCLUDED_OPTIONS_H */

--- a/src/ui-options.c
+++ b/src/ui-options.c
@@ -143,6 +143,34 @@ static bool option_toggle_handle(struct menu *m, const ui_event *event,
 			next = true;
 		} else if (event->key.code == 't' || event->key.code == 'T') {
 			option_set(option_name(oid), !player->opts.opt[oid]);
+		} else if (event->key.code == 's' || event->key.code == 'S') {
+			char dummy;
+
+			screen_save();
+			if (options_save_custom_birth(&player->opts)) {
+				get_com("Successfully saved.  Press any key to continue.", &dummy);
+			} else {
+				get_com("Save failed.  Press any key to continue.", &dummy);
+			}
+			screen_load();
+		/* Only allow restore from custom defaults at birth. */
+		} else if ((event->key.code == 'r' || event->key.code == 'R') &&
+				m->flags == MN_DBL_TAP) {
+			screen_save();
+			if (options_restore_custom_birth(&player->opts)) {
+				screen_load();
+				menu_refresh(m, false);
+			} else {
+				char dummy;
+
+				get_com("Restore failed.  Press any key to continue.", &dummy);
+				screen_load();
+			}
+		/* Only allow reset to maintainer's defaults at birth. */
+		} else if ((event->key.code == 'm' || event->key.code == 'M') &&
+				m->flags == MN_DBL_TAP) {
+			options_reset_birth(&player->opts);
+			menu_refresh(m, false);
 		} else if (event->key.code == '?') {
 			screen_save();
 			show_file(format("option.txt#%s", option_name(oid)), NULL, 0, 0);
@@ -195,6 +223,8 @@ static void option_toggle_menu(const char *name, int page)
 		m->cmd_keys = "?";
 		m->flags = MN_NO_TAGS;
 	} else if (page == OPT_PAGE_BIRTH + 10) {
+		m->prompt = "Set option (y/n/t), 's' to save, 'r' to restore, 'm' to reset, '?' for help";
+		m->cmd_keys = "?YyNnTtSsRrMm";
 		page -= 10;
 	}
 


### PR DESCRIPTION
Did that by adding three commands to the screen displaying the birth options at character generation.  They are:  's' to save the current settings for use as the defaults for future characters, 'r' to restore the current settings to what's in the saved defaults, and 'm' to restore the current settings to the maintainer's defaults.  The saved defaults appear as the file, customized_birth_options.txt, in the ANGBAND_DIR_USER directory.