### PR TITLE
In lair_gen(), remove correction to the player's position after chunk_copy()

### DIFF
--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -2687,9 +2687,6 @@ struct chunk *lair_gen(struct player *p, int min_height, int min_width) {
 	if (one_in_(2)) {
 		chunk_copy(c, lair, 0, 0, 0, false);
 		chunk_copy(c, normal, 0, x_size / 2, 0, false);
-
-		/* The player needs to move */
-		p->grid.x += x_size / 2;
 	} else {
 		chunk_copy(c, normal, 0, 0, 0, false);
 		chunk_copy(c, lair, 0, x_size / 2, 0, false);


### PR DESCRIPTION
When copying the normal half to the right side,  chunk_copy() already adjusts that position.  This may resolve Sphara's bug report, http://angband.oook.cz/forum/showpost.php?p=149394&postcount=138 , but I haven't seen the savefile to know.