### PR TITLE
Explicitly mark single character constants passed to Term_addch()/…

### DIFF
--- a/src/ui-context.c
+++ b/src/ui-context.c
@@ -1125,14 +1125,14 @@ static void cmd_sub_entry(struct menu *menu, int oid, bool cursor, int row,
 	Term_putstr(col, row, -1, attr, commands[oid].desc);
 
 	/* Include keypress */
-	Term_addch(attr, ' ');
-	Term_addch(attr, '(');
+	Term_addch(attr, L' ');
+	Term_addch(attr, L'(');
 
 	/* Get readable version */
 	keypress_to_readable(buf, sizeof buf, kp);
 	Term_addstr(-1, attr, buf);
 
-	Term_addch(attr, ')');
+	Term_addch(attr, L')');
 }
 
 /**

--- a/src/ui-display.c
+++ b/src/ui-display.c
@@ -287,7 +287,7 @@ static void prt_equippy(int row, int col)
 			c = object_char(obj);
 			a = object_attr(obj);
 		} else {
-			c = ' ';
+			c = L' ';
 			a = COLOUR_WHITE;
 		}
 
@@ -1359,7 +1359,7 @@ static void update_maps(game_event_type type, game_event_data *data, void *user)
 #endif
 
 		if ((tile_width > 1) || (tile_height > 1))
-			Term_big_queue_char(t, vx, vy, a, c, COLOUR_WHITE, ' ');
+			Term_big_queue_char(t, vx, vy, a, c, COLOUR_WHITE, L' ');
 	}
 
 	/* Refresh the main screen unless the map needs to center */

--- a/src/ui-equip-cmp.c
+++ b/src/ui-equip-cmp.c
@@ -2386,7 +2386,7 @@ static int display_page(struct equipable_summary *s, const struct player *p,
 	rdetails.vertical_label = true;
 	rdetails.alternate_color_first = false;
 	rdetails.show_combined = false;
-	Term_putch(s->icol_name - 4, rdetails.value_position.y, color, '@');
+	Term_putch(s->icol_name - 4, rdetails.value_position.y, color, L'@');
 	for (i = 0; i < (int)N_ELEMENTS(s->propcats); ++i) {
 		int j;
 

--- a/src/ui-knowledge.c
+++ b/src/ui-knowledge.c
@@ -861,10 +861,10 @@ static void display_knowledge(const char *title, int *obj_list, int o_count,
 
 			/* Print dividers: horizontal and vertical */
 			for (i = 0; i < 79; i++)
-				Term_putch(i, 5, COLOUR_WHITE, '=');
+				Term_putch(i, 5, COLOUR_WHITE, L'=');
 
 			for (i = 0; i < browser_rows; i++)
-				Term_putch(g_name_len + 1, 6 + i, COLOUR_WHITE, '|');
+				Term_putch(g_name_len + 1, 6 + i, COLOUR_WHITE, L'|');
 
 
 			/* Reset redraw flag */
@@ -3100,7 +3100,7 @@ static void do_cmd_knowledge_shapechange(const char *name, int row)
 			prt("Knowledge - shapes", 2, 0);
 			prt("Name", 4, 0);
 			for (i = 0; i < MIN(80, wnew); i++) {
-				Term_putch(i, 5, COLOUR_WHITE, '=');
+				Term_putch(i, 5, COLOUR_WHITE, L'=');
 			}
 			prt("<dir>, 'r' to recall, ESC", h - 2, 0);
 			redraw = false;

--- a/src/ui-options.c
+++ b/src/ui-options.c
@@ -316,7 +316,7 @@ static void do_cmd_options_win(const char *name, int row)
 
 			/* Display the windows */
 			for (j = 0; j < ANGBAND_TERM_MAX; j++) {
-				char c = '.';
+				wchar_t c = L'.';
 
 				a = COLOUR_WHITE;
 
@@ -324,7 +324,7 @@ static void do_cmd_options_win(const char *name, int row)
 				if ((i == y) && (j == x)) a = COLOUR_L_BLUE;
 
 				/* Active flag */
-				if (new_flags[j] & (1L << i)) c = 'X';
+				if (new_flags[j] & (1L << i)) c = L'X';
 
 				/* Flag value */
 				Term_putch(35 + j * 5, i + 5, a, c);

--- a/src/ui-output.c
+++ b/src/ui-output.c
@@ -468,19 +468,19 @@ void window_make(int origin_x, int origin_y, int end_x, int end_y)
 
 	region_erase(&to_clear);
 
-	Term_putch(origin_x, origin_y, COLOUR_WHITE, '+');
-	Term_putch(end_x, origin_y, COLOUR_WHITE, '+');
-	Term_putch(origin_x, end_y, COLOUR_WHITE, '+');
-	Term_putch(end_x, end_y, COLOUR_WHITE, '+');
+	Term_putch(origin_x, origin_y, COLOUR_WHITE, L'+');
+	Term_putch(end_x, origin_y, COLOUR_WHITE, L'+');
+	Term_putch(origin_x, end_y, COLOUR_WHITE, L'+');
+	Term_putch(end_x, end_y, COLOUR_WHITE, L'+');
 
 	for (n = 1; n < (end_x - origin_x); n++) {
-		Term_putch(origin_x + n, origin_y, COLOUR_WHITE, '-');
-		Term_putch(origin_x + n, end_y, COLOUR_WHITE, '-');
+		Term_putch(origin_x + n, origin_y, COLOUR_WHITE, L'-');
+		Term_putch(origin_x + n, end_y, COLOUR_WHITE, L'-');
 	}
 
 	for (n = 1; n < (end_y - origin_y); n++) {
-		Term_putch(origin_x, origin_y + n, COLOUR_WHITE, '|');
-		Term_putch(end_x, origin_y + n, COLOUR_WHITE, '|');
+		Term_putch(origin_x, origin_y + n, COLOUR_WHITE, L'|');
+		Term_putch(end_x, origin_y + n, COLOUR_WHITE, L'|');
 	}
 }
 

--- a/src/ui-term.c
+++ b/src/ui-term.c
@@ -562,7 +562,7 @@ void Term_big_queue_char(term *t, int x, int y, int a, wchar_t c, int a1,
 			if (a & 0x80)
 				Term_queue_char(t, x + hor, y, 255, -1, 0, 0);
 			else
-				Term_queue_char(t, x + hor, y, COLOUR_WHITE, ' ', a1, c1);
+				Term_queue_char(t, x + hor, y, COLOUR_WHITE, L' ', a1, c1);
 		}
 
 		/* Now vertical */
@@ -572,7 +572,7 @@ void Term_big_queue_char(term *t, int x, int y, int a, wchar_t c, int a1,
 				if (a & 0x80)
 					Term_queue_char(t, x + hor, y + vert, 255, -1, 0, 0);
 				else
-					Term_queue_char(t, x + hor, y + vert, COLOUR_WHITE, ' ', a1, c1);
+					Term_queue_char(t, x + hor, y + vert, COLOUR_WHITE, L' ', a1, c1);
 			}
 		}
 	} else {
@@ -582,7 +582,7 @@ void Term_big_queue_char(term *t, int x, int y, int a, wchar_t c, int a1,
 			if (a & 0x80)
 				Term_queue_char(t, x, y + vert, 255, -1, 0, 0);
 			else
-				Term_queue_char(t, x, y + vert, COLOUR_WHITE, ' ', a1, c1);
+				Term_queue_char(t, x, y + vert, COLOUR_WHITE, L' ', a1, c1);
 		}
 	}
 }
@@ -1549,7 +1549,7 @@ void Term_big_putch(int x, int y, int a, wchar_t c)
 				if (a & 0x80)
 					Term_putch(x + hor, y, 255, -1);
 				else
-					Term_putch(x + hor, y, COLOUR_WHITE, ' ');
+					Term_putch(x + hor, y, COLOUR_WHITE, L' ');
 			}
 
 			/* Now vertical */
@@ -1558,7 +1558,7 @@ void Term_big_putch(int x, int y, int a, wchar_t c)
 				if (a & 0x80)
 					Term_putch(x + hor, y + vert, 255, -1);
 				else
-					Term_putch(x + hor, y + vert, COLOUR_WHITE, ' ');
+					Term_putch(x + hor, y + vert, COLOUR_WHITE, L' ');
 			}
 		}
 	} else {
@@ -1568,7 +1568,7 @@ void Term_big_putch(int x, int y, int a, wchar_t c)
 			if (a & 0x80)
 				Term_putch(x, y + vert, 255, -1);
 			else
-				Term_putch(x, y + vert, COLOUR_WHITE, ' ');
+				Term_putch(x, y + vert, COLOUR_WHITE, L' ');
 		}
 	}
 }

--- a/src/wiz-debug.c
+++ b/src/wiz-debug.c
@@ -213,7 +213,7 @@ static void do_cmd_wiz_hack_nick(void)
  * Output part of a bitflag set in binary format.
  */
 static void prt_binary(const bitflag *flags, int offset, int row, int col,
-					   char ch, int num)
+					   wchar_t ch, int num)
 {
 	int flag;
 
@@ -222,7 +222,7 @@ static void prt_binary(const bitflag *flags, int offset, int row, int col,
 		if (of_has(flags, flag))
 			Term_putch(col++, row, COLOUR_BLUE, ch);
 		else
-			Term_putch(col++, row, COLOUR_WHITE, '-');
+			Term_putch(col++, row, COLOUR_WHITE, L'-');
 }
 
 /**
@@ -476,9 +476,9 @@ static void wiz_display_item(const struct object *obj, bool all)
 	prt("siwdcelotdfrei  plommfegrccc....", 19, j);
 	prt("tnieoannuiaesnfhcefhsrlgxuuu....", 20, j);
 	prt("rtsxnrdfnglgpvaltsuppderprrr....", 21, j);
-	prt_binary(f, 0, 22, j, '*', 28);
+	prt_binary(f, 0, 22, j, L'*', 28);
 	if (obj->known) {
-		prt_binary(obj->known->flags, 0, 23, j, '+', 28);
+		prt_binary(obj->known->flags, 0, 23, j, L'+', 28);
 	}
 }
 


### PR DESCRIPTION
…Term_putch()/Term_queue_char() as wide character constants in the cases where they weren't already marked as such.
