### PR TITLE
Replace instances of textblock_append*(tb, not_local_string_constant)…

### DIFF
--- a/lib/gamedata/activation.txt
+++ b/lib/gamedata/activation.txt
@@ -107,7 +107,7 @@ effect:CURE:POISONED
 effect:CURE:STUN
 effect:CURE:AMNESIA
 effect:CURE:CONFUSED
-desc:heals 35%% of max HP (minimum 300HP), cut damage, and cures stunning, poisoning, blindness, and confusion
+desc:heals 35% of max HP (minimum 300HP), cut damage, and cures stunning, poisoning, blindness, and confusion
 
 name:CURE_FULL2
 aim:0

--- a/src/mon-lore.c
+++ b/src/mon-lore.c
@@ -627,7 +627,7 @@ void lore_adjective_speed(textblock *tb, const struct monster_race *race)
 	if (race->speed == 110)
 		textblock_append(tb, "at ");
 
-	textblock_append_c(tb, COLOUR_GREEN, lore_describe_speed(race->speed));
+	textblock_append_c(tb, COLOUR_GREEN, "%s", lore_describe_speed(race->speed));
 }
 
 /**
@@ -648,7 +648,7 @@ void lore_multiplier_speed(textblock *tb, const struct monster_race *race)
 	byte attr = COLOUR_ORANGE;
 
 	strnfmt(buf, sizeof(buf), "%d.%dx", int_mul, dec_mul);
-	textblock_append_c(tb, COLOUR_L_BLUE, buf);
+	textblock_append_c(tb, COLOUR_L_BLUE, "%s", buf);
 
 	textblock_append(tb, " normal speed, which is ");
 	multiplier = 100 * extract_energy[race->speed]
@@ -671,7 +671,7 @@ void lore_multiplier_speed(textblock *tb, const struct monster_race *race)
 	if (player->state.speed == race->speed) {
 		textblock_append(tb, "the same as you");
 	} else {
-		textblock_append_c(tb, attr, buf);
+		textblock_append_c(tb, attr, "%s", buf);
 		textblock_append(tb, " your speed");
 	}
 }
@@ -770,7 +770,7 @@ static void lore_append_clause(textblock *tb, bitflag *f, byte attr,
 
 	if (count) {
 		int flag;
-		textblock_append(tb, start);
+		textblock_append(tb, "%s", start);
 		for (flag = rf_next(f, FLAG_START); flag; flag = rf_next(f, flag + 1)) {
 			/* First entry starts immediately */
 			if (flag != rf_next(f, FLAG_START)) {
@@ -780,13 +780,13 @@ static void lore_append_clause(textblock *tb, bitflag *f, byte attr,
 				/* Last entry */
 				if (rf_next(f, flag + 1) == FLAG_END) {
 					textblock_append(tb, " ");
-					textblock_append(tb, conjunction);
+					textblock_append(tb, "%s", conjunction);
 				}
 				textblock_append(tb, " ");
 			}
-			textblock_append_c(tb, attr, describe_race_flag(flag));
+			textblock_append_c(tb, attr, "%s", describe_race_flag(flag));
 		}
-		textblock_append(tb, end);
+		textblock_append(tb, "%s", end);
 	}
 }
 
@@ -826,17 +826,17 @@ static void lore_append_spell_clause(textblock *tb, bitflag *f, bool know_hp,
 				/* Last entry */
 				if (rsf_next(f, spell + 1) == FLAG_END) {
 					textblock_append(tb, " ");
-					textblock_append(tb, conjunction);
+					textblock_append(tb, "%s", conjunction);
 				}
 				textblock_append(tb, " ");
 			}
-			textblock_append_c(tb, color,
+			textblock_append_c(tb, color, "%s",
 							   mon_spell_lore_description(spell, race));
 			if (damage > 0) {
 				textblock_append_c(tb, color, " (%d)", damage);
 			}
 		}
-		textblock_append(tb, end);
+		textblock_append(tb, "%s", end);
 	}
 }
 
@@ -937,7 +937,7 @@ void lore_append_flavor(textblock *tb, const struct monster_race *race,
 	if (append_utf8)
 		textblock_append_utf8(tb, race->text);
 	else
-		textblock_append(tb, race->text);
+		textblock_append(tb, "%s", race->text);
 
 	textblock_append(tb, "\n");
 }
@@ -1647,14 +1647,14 @@ void lore_append_attack(textblock *tb, const struct monster_race *race,
 			textblock_append(tb, ", and ");
 
 		/* Describe the method */
-		textblock_append(tb, race->blow[i].method->desc);
+		textblock_append(tb, "%s", race->blow[i].method->desc);
 
 		/* Describe the effect (if any) */
 		if (effect_str && strlen(effect_str) > 0) {
 			int index = blow_index(race->blow[i].effect->name);
 			/* Describe the attack type */
 			textblock_append(tb, " to ");
-			textblock_append_c(tb, blow_color(player, index), effect_str);
+			textblock_append_c(tb, blow_color(player, index), "%s", effect_str);
 
 			textblock_append(tb, " (");
 			/* Describe damage (if known) */

--- a/src/obj-info.c
+++ b/src/obj-info.c
@@ -1699,7 +1699,7 @@ static bool describe_effect(textblock *tb, const struct object *obj,
 	/* Activations get a special message */
 	if (obj->activation && obj->activation->desc) {
 		textblock_append(tb, "When activated, it ");
-		textblock_append(tb, obj->activation->desc);
+		textblock_append(tb, "%s", obj->activation->desc);
 	} else {
 		int level = obj->artifact ?
 			obj->artifact->level : obj->kind->level;

--- a/src/obj-info.c
+++ b/src/obj-info.c
@@ -80,7 +80,7 @@ static void info_out_list(textblock *tb, const char *list[], size_t count)
 	size_t i;
 
 	for (i = 0; i < count; i++) {
-		textblock_append(tb, list[i]);
+		textblock_append(tb, "%s", list[i]);
 		if (i != (count - 1)) textblock_append(tb, ", ");
 	}
 
@@ -124,7 +124,7 @@ static bool describe_curses(textblock *tb, const struct object *obj,
 	for (i = 1; i < z_info->curse_max; i++) {
 		if (c[i].power) {
 			textblock_append(tb, "It ");
-			textblock_append_c(tb, COLOUR_L_RED, curses[i].desc);
+			textblock_append_c(tb, COLOUR_L_RED, "%s", curses[i].desc);
 			if (c[i].power == 100) {
 				textblock_append(tb, "; this curse cannot be removed");
 			}
@@ -381,7 +381,7 @@ static bool describe_slays(textblock *tb, const struct object *obj)
 	for (i = 1; i < z_info->slay_max; i++) {
 		if (!s[i]) continue;
 
-		textblock_append(tb, slays[i].name);
+		textblock_append(tb, "%s", slays[i].name);
 		if (slays[i].multiplier > 3)
 			textblock_append(tb, " (powerfully)");
 		if (count > 1)
@@ -421,7 +421,7 @@ static bool describe_brands(textblock *tb, const struct object *obj)
 
 		if (brands[i].multiplier < 3)
 			textblock_append(tb, "weak ");
-		textblock_append(tb, brands[i].name);
+		textblock_append(tb, "%s", brands[i].name);
 		if (count > 1)
 			textblock_append(tb, ", ");
 		else

--- a/src/ui-birth.c
+++ b/src/ui-birth.c
@@ -881,7 +881,7 @@ int edit_text(char *buffer, int buflen) {
 
 		/* Display on screen */
 		clear_from(HIST_INSTRUCT_ROW);
-		textblock_append(tb, buffer);
+		textblock_append(tb, "%s", buffer);
 		textui_textblock_place(tb, area, NULL);
 
 		n_lines = textblock_calculate_lines(tb,

--- a/src/ui-command.c
+++ b/src/ui-command.c
@@ -163,7 +163,7 @@ void do_cmd_version(void)
 			  format("You are playing %s.  Type '?' for more info.", buildver),
 			  sizeof(header_buf));
 	textblock_append(tb, "\n");
-	textblock_append(tb, copyright);
+	textblock_append(tb, "%s", copyright);
 	textui_textblock_show(tb, local_area, header_buf);
 	textblock_free(tb);
 }

--- a/src/ui-knowledge.c
+++ b/src/ui-knowledge.c
@@ -2113,9 +2113,9 @@ static void rune_lore(int oid)
 	char *title = string_make(rune_name(oid));
 
 	my_strcap(title);
-	textblock_append_c(tb, COLOUR_L_BLUE, title);
+	textblock_append_c(tb, COLOUR_L_BLUE, "%s", title);
 	textblock_append(tb, "\n");
-	textblock_append(tb, rune_desc(oid));
+	textblock_append(tb, "%s", rune_desc(oid));
 	textblock_append(tb, "\n");
 	textui_textblock_show(tb, SCREEN_REGION, NULL);
 	textblock_free(tb);
@@ -2302,9 +2302,9 @@ static void feat_lore(int oid)
 
 	if (feat->desc) {
 		my_strcap(title);
-		textblock_append_c(tb, COLOUR_L_BLUE, title);
+		textblock_append_c(tb, COLOUR_L_BLUE, "%s", title);
 		textblock_append(tb, "\n");
-		textblock_append(tb, feat->desc);
+		textblock_append(tb, "%s", feat->desc);
 		textblock_append(tb, "\n");
 		textui_textblock_show(tb, SCREEN_REGION, NULL);
 		textblock_free(tb);
@@ -2487,9 +2487,9 @@ static void trap_lore(int oid)
 
 	if (trap->text) {
 		my_strcap(title);
-		textblock_append_c(tb, COLOUR_L_BLUE, title);
+		textblock_append_c(tb, COLOUR_L_BLUE, "%s", title);
 		textblock_append(tb, "\n");
-		textblock_append(tb, trap->text);
+		textblock_append(tb, "%s", trap->text);
 		textblock_append(tb, "\n");
 		textui_textblock_show(tb, SCREEN_REGION, NULL);
 		textblock_free(tb);

--- a/src/ui-mon-lore.c
+++ b/src/ui-mon-lore.c
@@ -60,7 +60,7 @@ void lore_title(textblock *tb, const struct monster_race *race)
 	}
 
 	/* Dump the name and then append standard attr/char info */
-	textblock_append(tb, race->name);
+	textblock_append(tb, "%s", race->name);
 
 	textblock_append(tb, " ('");
 	textblock_append_pict(tb, standard_attr, standard_char);

--- a/src/wiz-spoil.c
+++ b/src/wiz-spoil.c
@@ -637,7 +637,7 @@ static void spoil_mon_info(const char *fname)
 		 * there is no conversion from the source edit files. */
 		textblock_append_utf8(tb, race->name);
 		textblock_append(tb, "  (");	/* ---)--- */
-		textblock_append(tb, attr_to_text(race->d_attr));
+		textblock_append(tb, "%s", attr_to_text(race->d_attr));
 		textblock_append(tb, " '%c')\n", race->d_char);
 
 		/* Line 2: number, level, rarity, speed, HP, AC, exp */


### PR DESCRIPTION
… with textblock_append*(tb, "%s", not_local_string_constant) to prevent unexpected behavior if an unescaped "%" should happen to be in the string.
