### PR TITLE
Accommodate multibyte characters in user text input

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -5144,10 +5144,26 @@ static BOOL send_event(NSEvent *event)
                 case NSBreakFunctionKey: ch = KC_BREAK; break;
                     
                 default:
-                    if (c <= 0x7F)
+                    if (c <= 0x7F) {
                         ch = (char)c;
-                    else
+                    } else if (c > 0x9f) {
+                        /*
+                         * It's beyond the range of the C1 control
+                         * characters.  Pass it on.
+                         */
+                        if (CFStringIsSurrogateHighCharacter(c)) {
+                            ch = CFStringGetLongCharacterForSurrogatePair(c,
+                                [[event characters] characterAtIndex:1]);
+                        } else {
+                            ch = c;
+                        }
+                    } else {
+                        /*
+                         * Exclude the control characters not caught by the
+                         * special cases.
+                         */
                         ch = '\0';
+                    }
                     break;
             }
             

--- a/src/tests/z-util/util.c
+++ b/src/tests/z-util/util.c
@@ -41,8 +41,185 @@ int test_alloc(void *state) {
 	ok;
 }
 
+int test_utf8_fskip(void *state) {
+	/*
+	 * dollar sign (U+0024; 1 byte as UTF-8), cent sign (U+00A2; 2 bytes
+	 * as UTF-8)), euro sign (U+20AC; 3 bytes as UTF-8), gothic letter
+	 * hwair (U+10348; 4 bytes as UTF-8), and Shavian letter hung
+	 * (U+10459; 4 bytes as UTF-8).
+	 */
+	char buffer[] = "$¢€𐍈𐑙";
+	int offsets[] = { 0, 1, 3, 6, 10, 14 };
+
+	require(utf8_fskip(buffer, 1, NULL) == buffer + offsets[1]);
+	require(utf8_fskip(buffer, 3, NULL) == buffer + offsets[3]);
+	/* Check case when advancing lands at terminating null. */
+	require(utf8_fskip(buffer, 5, NULL) == buffer + offsets[5]);
+	/* Check case where advancing would go past terminating null. */
+	require(utf8_fskip(buffer, 6, NULL) == NULL);
+	/*
+	 * Advancing zero should do nothing if already at the start of
+	 * a character.
+	 */
+	require(utf8_fskip(buffer + offsets[3], 0, NULL) ==
+		buffer + offsets[3]);
+	/*
+	 * Advancing zero should go to the next character if in the middle
+	 * of a character.
+	 */
+	require(utf8_fskip(buffer + offsets[3] + 1, 0, NULL) ==
+		buffer + offsets[4]);
+	/*
+	 * Check cases where limit is imposed on advance:  limit has no
+	 * effect, advance ends on the limit, and advance tries to go
+	 * past limit.
+	 */
+	require(utf8_fskip(buffer, 1, buffer + offsets[3]) ==
+		buffer + offsets[1]);
+	require(utf8_fskip(buffer, 3, buffer + offsets[3]) ==
+		buffer + offsets[3]);
+	require(utf8_fskip(buffer, 4, buffer + offsets[3]) == NULL);
+
+	ok;
+}
+
+int test_utf8_rskip(void *state) {
+	/*
+	 * dollar sign (U+0024; 1 byte as UTF-8), cent sign (U+00A2; 2 bytes
+	 * as UTF-8)), euro sign (U+20AC; 3 bytes as UTF-8), gothic letter
+	 * hwair (U+10348; 4 bytes as UTF-8), and Shavian letter hung
+	 * (U+10459; 4 bytes as UTF-8).
+	 */
+	char buffer[] = "$¢€𐍈𐑙";
+	int offsets[] = { 0, 1, 3, 6, 10, 14 };
+
+	require(utf8_rskip(buffer + offsets[4], 1, buffer) ==
+		buffer + offsets[3]);
+	require(utf8_rskip(buffer + offsets[4], 3, buffer) ==
+		buffer + offsets[1]);
+	/* Check case where backtracking ends at the limit. */
+	require(utf8_rskip(buffer + offsets[4], 4, buffer) == buffer);
+	/* Check case where backtracking would go past the limit. */
+	require(utf8_rskip(buffer + offsets[4], 5, buffer) == NULL);
+	/*
+	 * Backtracking zero should do nothing if already at the start of
+	 * a character.
+	 */
+	require(utf8_rskip(buffer + offsets[4], 0, buffer) ==
+		buffer + offsets[4]);
+	/*
+	 * Backtracking zero should get to the start of the character if
+	 * in the middle of that character.
+	 */
+	require(utf8_rskip(buffer + offsets[4] + 2, 0, buffer) ==
+		buffer + offsets[4]);
+
+	ok;
+}
+
+int test_utf32_to_utf8(void *state) {
+	/*
+	 * dollar sign (U+0024; 1 byte as UTF-8), cent sign (U+00A2; 2 bytes
+	 * as UTF-8)), euro sign (U+20AC; 3 bytes as UTF-8), gothic letter
+	 * hwair (U+10348; 4 bytes as UTF-8), and Shavian letter hung
+	 * (U+10459; 4 bytes as UTF-8).
+	 */
+	char expected[] = "$¢€𐍈𐑙";
+	u32b in[] = { 0x0024, 0x00a2, 0x20ac, 0x10348, 0x10459 };
+	u32b bad_in[5];
+	char out[32];
+	size_t n_in = sizeof(in) / sizeof(in[0]);
+	size_t n_out = sizeof(out) / sizeof(out[0]);
+	size_t n_written, n_cnvt;
+
+	(void) memset(out, 'a', n_out);
+	n_cnvt = 99;
+	n_written = utf32_to_utf8(out, n_out, in, n_in, &n_cnvt);
+	require(n_written == strlen(expected) && out[n_written] == 0 &&
+		strcmp(out, expected) == 0 && n_cnvt == n_in);
+	if (n_written < n_out - 1) {
+		require(out[n_written + 1] == 'a');
+	}
+
+	/* Check handling when the number of conversions isn't requested. */
+	(void) memset(out, 'a', n_out);
+	n_cnvt = 99;
+	n_written = utf32_to_utf8(out, n_out, in, n_in, NULL);
+	require(n_written == strlen(expected) && out[n_written] == 0 &&
+		strcmp(out, expected) == 0);
+	if (n_written < n_out - 1) {
+		require(out[n_written + 1] == 'a');
+	}
+
+	/* Check that output limit prevents overflow. */
+	(void) memset(out, 'a', n_out);
+	n_cnvt = 99;
+	n_written = utf32_to_utf8(out, 4, in, n_in, &n_cnvt);
+	require(n_written == 3 && out[3] == 0 &&
+		expected[0] == out[0] && expected[1] == out[1] &&
+		expected[2] == out[2] && out[4] == 'a' && n_cnvt == 2);
+
+	/*
+	 * Check degenerate cases where the output buffer has zero or one
+	 * bytes.
+	 */
+	(void) memset(out, 'a', n_out);
+	n_cnvt = 99;
+	n_written = utf32_to_utf8(out, 1, in, n_in, &n_cnvt);
+	require(n_written == 0 && out[0] == 0 && out[1] == 'a' && n_cnvt == 0);
+	(void) memset(out, 'a', n_out);
+	n_cnvt = 99;
+	n_written = utf32_to_utf8(out, 0, in, n_in, &n_cnvt);
+	require(n_written == 0 && n_cnvt == 0 && out[0] == 'a');
+
+	/* Check handling of invalid code points. */
+	bad_in[0] = 0xd800;
+	(void) memset(out, 'a', n_out);
+	n_cnvt = 99;
+	n_written = utf32_to_utf8(out, n_out, bad_in, 1, &n_cnvt);
+	require(n_written == 0 && out[0] == 0 && out[1] == 'a' && n_cnvt == 0);
+
+	bad_in[0] = 0xda12;
+	(void) memset(out, 'a', n_out);
+	n_cnvt = 99;
+	n_written = utf32_to_utf8(out, n_out, bad_in, 1, &n_cnvt);
+	require(n_written == 0 && out[0] == 0 && out[1] == 'a' && n_cnvt == 0);
+
+	bad_in[0] = 0xdfff;
+	(void) memset(out, 'a', n_out);
+	n_cnvt = 99;
+	n_written = utf32_to_utf8(out, n_out, bad_in, 1, &n_cnvt);
+	require(n_written == 0 && out[0] == 0 && out[1] == 'a' && n_cnvt == 0);
+
+	bad_in[0] = 0x110000;
+	(void) memset(out, 'a', n_out);
+	n_cnvt = 99;
+	n_written = utf32_to_utf8(out, n_out, bad_in, 1, &n_cnvt);
+	require(n_written == 0 && out[0] == 0 && out[1] == 'a' && n_cnvt == 0);
+
+	/*
+	 * This is a combined test for the case or prematurely terminated input
+	 * and of code points just before or after the invalid ones.
+	 */
+	bad_in[0] = 0xd799;
+	bad_in[1] = 0xe000;
+	bad_in[2] = 0x10ffff;
+	bad_in[3] = 0;
+	bad_in[4] = in[0];
+	(void) memset(out, 'a', n_out);
+	n_cnvt = 99;
+	n_written = utf32_to_utf8(out, n_out, bad_in, 5, &n_cnvt);
+	require(n_written == 10 && out[10] == 0 && out[11] == 'a' &&
+		n_cnvt == 3);
+
+	ok;
+}
+
 const char *suite_name = "z-util/util";
 struct test tests[] = {
 	{ "utf8_clipto", test_alloc },
+	{ "utf8_fskip", test_utf8_fskip },
+	{ "utf8_rskip", test_utf8_rskip },
+	{ "utf32_to_utf8", test_utf32_to_utf8 },
 	{ NULL, NULL }
 };

--- a/src/ui-birth.c
+++ b/src/ui-birth.c
@@ -878,6 +878,13 @@ int edit_text(char *buffer, int buflen) {
 
 		size_t *line_starts = NULL, *line_lengths = NULL;
 		size_t n_lines;
+		/*
+		 * This is the total number of UTF-8 characters; can be less
+		 * less than len, the number of 8-bit units in the buffer,
+		 * if a single character is encoded with more than one 8-bit
+		 * unit.
+		 */
+		int ulen;
 
 		/* Display on screen */
 		clear_from(HIST_INSTRUCT_ROW);
@@ -886,6 +893,8 @@ int edit_text(char *buffer, int buflen) {
 
 		n_lines = textblock_calculate_lines(tb,
 				&line_starts, &line_lengths, area.width);
+		ulen = (n_lines > 0) ? line_starts[n_lines - 1] +
+			line_lengths[n_lines - 1]: 0;
 
 		/* Set cursor to current editing position */
 		get_screen_loc(cursor, &x, &y, n_lines, line_starts, line_lengths);
@@ -905,12 +914,12 @@ int edit_text(char *buffer, int buflen) {
 				break;
 
 			case ARROW_RIGHT:
-				if (cursor < len) cursor++;
+				if (cursor < ulen) cursor++;
 				break;
 
 			case ARROW_DOWN: {
 				int add = line_lengths[y] + 1;
-				if (cursor + add < len) cursor += add;
+				if (cursor + add < ulen) cursor += add;
 				break;
 			}
 
@@ -922,7 +931,7 @@ int edit_text(char *buffer, int buflen) {
 				break;
 
 			case KC_END:
-				cursor = MAX(0, len);
+				cursor = MAX(0, ulen);
 				break;
 
 			case KC_HOME:
@@ -931,21 +940,38 @@ int edit_text(char *buffer, int buflen) {
 
 			case KC_BACKSPACE:
 			case KC_DELETE: {
+				char *ocurs, *oshift;
+
 				/* Refuse to backspace into oblivion */
 				if ((ke.code == KC_BACKSPACE && cursor == 0) ||
-						(ke.code == KC_DELETE && cursor >= len))
+						(ke.code == KC_DELETE && cursor >= ulen))
 					break;
 
-				/* Move the string from k to nul along to the left by 1 */
-				if (ke.code == KC_BACKSPACE)
-					memmove(&buffer[cursor - 1], &buffer[cursor], len - cursor);
-				else
-					memmove(&buffer[cursor], &buffer[cursor + 1], len - cursor - 1);
-
-				/* Decrement */
-				if (ke.code == KC_BACKSPACE)
-					cursor--;
-				len--;
+				/*
+				 * Move the string from k to nul along to the
+				 * left by 1.  First, have to get offset
+				 * corresponding to the cursor position.
+				 */
+				ocurs = utf8_fskip(buffer, cursor, NULL);
+				assert(ocurs);
+				if (ke.code == KC_BACKSPACE) {
+					/* Get offset of the previous character. */
+					oshift = utf8_rskip(ocurs, 1, buffer);
+					assert(oshift);
+					memmove(oshift, ocurs,
+						len - (ocurs - buffer));
+					/* Decrement */
+					--cursor;
+					len -= ocurs - oshift;
+				} else {
+					/* Get offset of the next character. */
+					oshift = utf8_fskip(ocurs, 1, NULL);
+					assert(oshift);
+					memmove(ocurs, oshift,
+						len - (oshift - buffer));
+					/* Decrement. */
+					len -= oshift - ocurs;
+				}
 
 				/* Terminate */
 				buffer[len] = '\0';
@@ -954,27 +980,43 @@ int edit_text(char *buffer, int buflen) {
 			}
 			
 			default: {
-				bool atnull = (buffer[cursor] == 0);
+				bool atnull = (cursor == ulen);
+				char encoded[5];
+				int n_enc;
+				char *ocurs;
 
-				if (!isprint(ke.code))
+				if (!keycode_isprint(ke.code))
 					break;
 
-				if (atnull) {
-					/* Make sure we have enough room for a new character */
-					if ((cursor + 1) >= buflen) break;
-					if ((len + 1) >= buflen) break;
-				} else {
-					/* Make sure we have enough room to add a new character */
-					if ((cursor + 1) >= buflen) break;
-					if ((len + 1) >= buflen) break;
+				n_enc = utf32_to_utf8(encoded,
+					N_ELEMENTS(encoded), &ke.code, 1, NULL);
 
-					/* Move the rest of the buffer along to make room */
-					memmove(&buffer[cursor + 1], &buffer[cursor], len - cursor);
+				/*
+				 * Make sure we have something to add and have
+				 * enough space.
+				 */
+				if (n_enc == 0 || n_enc + len >= buflen) {
+					break;
 				}
 
-				/* Insert the character */
-				buffer[cursor++] = (char)ke.code;
-				len++;
+				/* Insert the encoded character. */
+				if (atnull) {
+					ocurs = buffer + len;
+				} else {
+					ocurs = utf8_fskip(buffer, cursor, NULL);
+					assert(ocurs);
+					/*
+					 * Move the rest of the buffer along
+					 * to make room.
+					 */
+					memmove(ocurs + n_enc, ocurs,
+						len - (ocurs - buffer));
+				}
+				memcpy(ocurs, encoded, n_enc);
+
+				/* Update cursor position and length. */
+				++cursor;
+				len += n_enc;
 
 				/* Terminate */
 				buffer[len] = '\0';

--- a/src/ui-event.c
+++ b/src/ui-event.c
@@ -90,6 +90,19 @@ const char *keycode_find_desc(keycode_t kc)
 
 
 /**
+ * Given a keycode, return whether it corresponds to a printable character.
+ */
+bool keycode_isprint(keycode_t kc)
+{
+	/*
+	 * Exclude ESCAPE (not part of the Unicode standard).  Otherwise,
+	 * treat the keycode as a Unicode code point.
+	 */
+	return kc != ESCAPE && utf32_isprint(kc);
+}
+
+
+/**
  * Convert a hexidecimal-digit into a decimal
  */
 static int dehex(char c)

--- a/src/ui-event.h
+++ b/src/ui-event.h
@@ -213,6 +213,11 @@ keycode_t keycode_find_code(const char *str, size_t len);
 const char *keycode_find_desc(keycode_t kc);
 
 /**
+ * Given a keycode, return whether it corresponds to a printable character.
+ */
+bool keycode_isprint(keycode_t kc);
+
+/**
  * Convert a string of keypresses into their textual representation
  */
 void keypress_to_text(char *buf, size_t len, const struct keypress *src,

--- a/src/z-util.h
+++ b/src/z-util.h
@@ -71,6 +71,28 @@ size_t utf8_strlen(char *s);
 void utf8_clipto(char *s, size_t n);
 
 /**
+ * Advance a pointer to a UTF-8 buffer by a given number of Unicode code points.
+ */
+char *utf8_fskip(char *s, size_t n, char *lim);
+
+/**
+ * Decrement a pointer to a UTF-8 buffer by a given number of Unicode code
+ * points.
+ */
+char *utf8_rskip(char *s, size_t n, char *lim);
+
+/**
+ * Convert a sequence of UTF-32 values, in the native byte order, to UTF-8.
+ */
+size_t utf32_to_utf8(char *out, size_t n_out, const u32b *in, size_t n_in,
+	size_t *pn_cnvt);
+
+/**
+ * Return whether a given UTF-32 value corresponds to a printable character.
+ */
+bool utf32_isprint(u32b v);
+
+/**
  * Case insensitive comparison between two strings
  */
 extern int my_stricmp(const char *s1, const char *s2);


### PR DESCRIPTION
The first two commits may be enough so [the change to remove the accents in FirstAgeAngband's history.txt](https://github.com/NickMcConnell/FirstAgeAngband/commit/8eb8c34bdbd8d627dc06fae214dd50696cbfd8c5#diff-bc2f48e9f8cac33b054e51af3816dfcbb73bae4c73634dfef18629694818eef7l) can be reverted, if the crashes that were seen were when someone tried to revise the history during birth.

There's some rough edges with this, especially with the Mac front-end:

- On all platforms, if a multibyte character is added to the character's name, player_safe_name() may be unduly restrictive in restricting the multibyte characters from filenames.
- The event handling by the Mac front-end bypasses the typical mechanisms for entering accented characters on a Mac so many of the multibyte characters that someone might want for a name or character history can't be readily typed in.  Copy/pasting text from another source, as a workaround for not being able to directly key it in, also doesn't currently work.  Likely want to keep the event handling as it is in most cases, but use an alternate mechanism with askfor_aux_keypress() or the history editing from the birth screen.
- Likely because the Mac front end provides a custom text_mbcs_hook, the screening of characters with iswprint() in text_out_to_screen() replaced multibyte characters that would have displayed okay with spaces.  Probably for a similar reason, the conversion from a wchar_t back to UTF-8 did not recover the original UTF-8 for multibyte characters when processing the captured character screens to generate a character dump.
- I wasn't savvy enough with Linux to work out how to enter accented characters with the X11 front-end so I don't know if there may be issues there.
- I haven't tested this at all on Windows.  Since that front-end also provides a custom text_mbcs_hook, it may have some of the same problems that the Mac front end does if multibyte characters are included in the character sheet.