### PR TITLE
Improve the alignment of the columns in the brief monster spoilers …

### DIFF
--- a/src/wiz-spoil.c
+++ b/src/wiz-spoil.c
@@ -257,13 +257,34 @@ static void spoil_obj_desc(const char *fname)
 			for (s = 0; s < n; s++) {
 				int e;
 				s32b v;
+				size_t u8len;
 
 				/* Describe the kind */
 				kind_info(buf, sizeof(buf), dam, sizeof(dam), wgt, sizeof(wgt),
 						  &e, &v, who[s]);
 
 				/* Dump it */
-				file_putf(fh, "  %-51s%7s%6s%4d%9ld\n", buf, dam, wgt, e,
+				/*
+				 * Per C99, width specifications to %s measure
+				 * bytes.  To align the columns if the
+				 * description has characters that take
+				 * multiple bytes, handle the first column
+				 * separately.  If the description has
+				 * decomposed characters (ones where multiple
+				 * Unicode code points combine to form one
+				 * printed character), the following columns
+				 * will still be out of alignment, but they'll
+				 * be closer to aligned than what the standard
+				 * library functions would do.
+				 */
+				u8len = utf8_strlen(buf);
+				if (u8len < 51) {
+					file_putf(fh, "  %s%*s", buf,
+						(int) (51 - u8len), " ");
+				} else {
+					file_putf(fh, "  %s", buf);
+				}
+				file_putf(fh, "%7s%6s%4d%9ld\n", dam, wgt, e,
 						  (long)(v));
 			}
 
@@ -513,6 +534,7 @@ static void spoil_mon_desc(const char *fname)
 	for (i = 0; i < n; i++) {
 		struct monster_race *race = &r_info[who[i]];
 		const char *name = race->name;
+		size_t u8len;
 
 		/* Get the "name" */
 		if (rf_has(race->flags, RF_QUESTOR))
@@ -547,9 +569,22 @@ static void spoil_mon_desc(const char *fname)
 		strnfmt(exp, sizeof(exp), "%s '%c'", attr_to_text(race->d_attr),
 				race->d_char);
 
-		/* Dump the info */
-		file_putf(fh, "%-40.40s%4s%4s%6s%8s%4s  %11.11s\n",
-		        nam, lev, rar, spd, hp, ac, exp);
+		/*
+		 * Dump the info.  The rationale for handling the first column
+		 * separately is the same as in spoil_obj_desc():  better
+		 * alignment if there are multibyte characters in the name.
+		 */
+		u8len = utf8_strlen(nam);
+		if (u8len < 40) {
+			file_putf(fh, "%s%*s", nam, (int) (40 - u8len), " ");
+		} else {
+			if (u8len > 40) {
+				utf8_clipto(nam, 40);
+			}
+			file_putf(fh, "%s", nam);
+		}
+		file_putf(fh, "%4s%4s%6s%8s%4s  %11.11s\n",
+		        lev, rar, spd, hp, ac, exp);
 	}
 
 	/* End it */


### PR DESCRIPTION
…when the names include multibyte characters.  Also, add similar logic to the handling of the object spoilers (with the current object names, there are no multibyte characters so that has no effect on the output).