### PR TITLE
Add new wide character hooks

### DIFF
--- a/src/main-win.c
+++ b/src/main-win.c
@@ -2281,6 +2281,37 @@ size_t Term_mbstowcs_win(wchar_t *dest, const char *src, int n)
 }
 
 
+int Term_wcsz_win(void)
+{
+	/*
+	 * Any Unicode code point is representable by at most 4 bytes in UTF-8.
+	 */
+	return 4;
+}
+
+
+/**
+ * Convert back to UTF-8 from a wide character.
+ *
+ * This is a necessary counterpart to Term_mbstowcs_win():  since the forward
+ * conversion from UTF-8 to wide characters was overridden, need to override
+ * the reverse conversion so that file output from screen captures and text
+ * blocks properly translates any multibyte characters.
+ */
+int Term_wctomb_win(char *s, wchar_t wchar)
+{
+	/*
+	 * If only want compatibility with Vista and later, could use
+	 * WC_ERR_INVALID_CHARS rather than zero for the second argument;
+	 * that would give an error if converting something not representable
+	 * in UTF-8.
+	 */
+	int n = WideCharToMultiByte(CP_UTF8, 0, &wchar, 1, s, Term_wcsz_win(),
+		NULL, NULL);
+	return (n > 0) ? n : -1;
+}
+
+
 #ifndef AC_SRC_ALPHA
 #define AC_SRC_ALPHA     0x01
 #endif
@@ -2687,6 +2718,8 @@ static void init_windows(void)
 	term_data_link(td);
 	term_screen = &td->t;
 	text_mbcs_hook = Term_mbstowcs_win;
+	text_wctomb_hook = Term_wctomb_win;
+	text_wcsz_hook = Term_wcsz_win;
 
 	/* Activate the main window */
 	SetActiveWindow(td->w);

--- a/src/mon-lore.c
+++ b/src/mon-lore.c
@@ -926,20 +926,12 @@ void lore_append_kills(textblock *tb, const struct monster_race *race,
  *
  * \param tb is the textblock we are adding to.
  * \param race is the monster race we are describing.
- * \param append_utf8 indicates if we should append the flavor text as UTF-8
- *        (which is preferred for spoiler files).
  */
-void lore_append_flavor(textblock *tb, const struct monster_race *race,
-						bool append_utf8)
+void lore_append_flavor(textblock *tb, const struct monster_race *race)
 {
 	assert(tb && race);
 
-	if (append_utf8)
-		textblock_append_utf8(tb, race->text);
-	else
-		textblock_append(tb, "%s", race->text);
-
-	textblock_append(tb, "\n");
+	textblock_append(tb, "%s\n", race->text);
 }
 
 /**

--- a/src/mon-lore.h
+++ b/src/mon-lore.h
@@ -76,8 +76,7 @@ void get_attack_colors(int *melee_colors);
 void lore_append_kills(textblock *tb, const struct monster_race *race,
 					   const struct monster_lore *lore,
 					   const bitflag known_flags[RF_SIZE]);
-void lore_append_flavor(textblock *tb, const struct monster_race *race,
-						bool append_utf8);
+void lore_append_flavor(textblock *tb, const struct monster_race *race);
 void lore_append_movement(textblock *tb, const struct monster_race *race,
 						  const struct monster_lore *lore,
 						  bitflag known_flags[RF_SIZE]);

--- a/src/ui-command.c
+++ b/src/ui-command.c
@@ -272,7 +272,7 @@ void textui_quit(void)
  * Screenshot loading/saving code
  * ------------------------------------------------------------------------ */
 
-static void write_html_escape_char(ang_file *fp, wchar_t c)
+static void write_html_escape_char(ang_file *fp, char *mbbuf, wchar_t c)
 {
 	switch (c)
 	{
@@ -287,14 +287,15 @@ static void write_html_escape_char(ang_file *fp, wchar_t c)
 			break;
 		default:
 		{
-			char *mbseq = (char*) mem_alloc(sizeof(char)*(MB_CUR_MAX+1));
-			byte len;
-			len = wctomb(mbseq, c);
-			if (len > MB_CUR_MAX) 
-				len = MB_CUR_MAX;
-			mbseq[len] = '\0';
-			file_putf(fp, "%s", mbseq);
-			mem_free(mbseq);
+			int nc = text_wctomb(mbbuf, c);
+
+			if (nc > 0) {
+				mbbuf[nc] = 0;
+			} else {
+				mbbuf[0] = ' ';
+				mbbuf[1] = 0;
+			}
+			file_putf(fp, "%s", mbbuf);
 			break;
 		}
 	}
@@ -346,12 +347,15 @@ void html_screenshot(const char *path, int mode)
 					: "[/COLOR][COLOR=\"#%02X%02X%02X\"]";
 	const char *close_color_fmt = mode ==  0 ? "</font>" : "[/COLOR]";
 
+	char *mbbuf;
 	ang_file *fp;
 
+	mbbuf = mem_alloc(text_wcsz() + 1);
 	fp = file_open(path, MODE_WRITE, FTYPE_TEXT);
 
 	/* Oops */
 	if (!fp) {
+		mem_free(mbbuf);
 		plog_fmt("Cannot write the '%s' file!", path);
 		return;
 	}
@@ -424,11 +428,17 @@ void html_screenshot(const char *path, int mode)
 			}
 
 			/* Write the character and escape special HTML characters */
-			if (mode == 0) write_html_escape_char(fp, c);
+			if (mode == 0) write_html_escape_char(fp, mbbuf, c);
 			else {
-				char mbseq[MB_LEN_MAX+1] = {0};
-				wctomb(mbseq, c);
-				file_putf(fp, "%s", mbseq);
+				int nc = text_wctomb(mbbuf, c);
+
+				if (nc > 0) {
+					mbbuf[nc] = 0;
+				} else {
+					mbbuf[0] = ' ';
+					mbbuf[1] = 0;
+				}
+				file_putf(fp, "%s", mbbuf);
 			}
 		}
 
@@ -449,6 +459,8 @@ void html_screenshot(const char *path, int mode)
 
 	/* Close it */
 	file_close(fp);
+
+	mem_free(mbbuf);
 }
 
 

--- a/src/ui-entry-renderers.c
+++ b/src/ui-entry-renderers.c
@@ -381,14 +381,32 @@ char *ui_entry_renderer_get_label_colors(int ind)
 /*
  * If ind is valid, returns a dynamically allocated string with the current
  * setting for the palette of symbols.  That string should be released
- * with string_free().  Otherwise, returns NULL.
+ * with mem_free().  Otherwise, returns NULL.
  */
 char *ui_entry_renderer_get_symbols(int ind)
 {
+	char *result, *p;
+	int isym;
+
 	if (ind < 1 || ind > renderer_count) {
 		return NULL;
 	}
-	return string_make(format("%ls", renderers[ind - 1].symbols));
+
+	result = mem_alloc(renderers[ind - 1].nsym * text_wcsz() + 1);
+	p = result;
+	for (isym = 0; isym < renderers[ind - 1].nsym; ++isym) {
+		int n = text_wctomb(p, renderers[ind - 1].symbols[isym]);
+
+		if (n > 0) {
+			p += n;
+		} else {
+			*p++ = ' ';
+		}
+	}
+	/* Terminate the string. */
+	*p = 0;
+
+	return result;
 }
 
 

--- a/src/ui-equip-cmp.c
+++ b/src/ui-equip-cmp.c
@@ -1189,7 +1189,7 @@ static void append_to_file(ang_file *fff)
 		s_for_file->maxpage : s_for_file->nfilt;
 
 	Term_get_size(&wid, &hgt);
-	buf = mem_alloc(5 * wid);
+	buf = mem_alloc(text_wcsz() * wid + 1);
 
 	(void) display_page(s_for_file, player, false);
 
@@ -1198,13 +1198,18 @@ static void append_to_file(ang_file *fff)
 		y < s_for_file->irow_combined_equip + 1 + s_for_file->npage;
 		++y) {
 		char *p = buf;
-		int x, a;
+		int x, a, n;
 		wchar_t c;
 
 		/* Dump a row. */
 		for (x = 0; x < wid; ++x) {
 			(void) Term_what(x, y, &a, &c);
-			p += wctomb(p, c);
+			n = text_wctomb(p, c);
+			if (n > 0) {
+				p += n;
+			} else {
+				*p++ = ' ';
+			}
 		}
 		/* Back up over spaces */
 		while ((p > buf) && (p[-1] == ' ')) {
@@ -1246,13 +1251,18 @@ static void append_to_file(ang_file *fff)
 			y < s_for_file->irow_combined_equip + 1 +
 			s_for_file->npage; ++y) {
 			char *p = buf;
-			int x, a;
+			int x, a, n;
 			wchar_t c;
 
 			/* Dump a row. */
 			for (x = 0; x < wid; ++x) {
 				(void) Term_what(x, y, &a, &c);
-				p += wctomb(p, c);
+				n = text_wctomb(p, c);
+				if (n > 0) {
+					p += n;
+				} else {
+					*p++ = ' ';
+				}
 			}
 			/* Back up over spaces */
 			while ((p > buf) && (p[-1] == ' ')) {

--- a/src/ui-mon-lore.c
+++ b/src/ui-mon-lore.c
@@ -116,10 +116,7 @@ void lore_description(textblock *tb, const struct monster_race *race,
 	if (!spoilers)
 		lore_append_kills(tb, race, lore, known_flags);
 
-	/* If we are generating spoilers, we want to output as UTF-8. As of 3.5,
-	 * the values in race->name and race->text remain unconverted from the
-	 * UTF-8 edit files. */
-	lore_append_flavor(tb, race, spoilers);
+	lore_append_flavor(tb, race);
 
 	/* Describe the monster type, speed, life, and armor */
 	lore_append_movement(tb, race, lore, known_flags);

--- a/src/ui-output.c
+++ b/src/ui-output.c
@@ -293,7 +293,7 @@ void text_out_to_screen(byte a, const char *str)
 		}
 
 		/* Clean up the char */
-		ch = (iswprint(*s) ? *s : L' ');
+		ch = (text_iswprint(*s) ? *s : L' ');
 
 		/* Wrap words as needed */
 		if ((x >= wrap - 1) && (ch != L' ')) {

--- a/src/ui-player.c
+++ b/src/ui-player.c
@@ -922,8 +922,14 @@ void write_character_dump(ang_file *fff)
 										   z_info->store_inven_max);
 	char o_name[80];
 
-	char buf[1024];
-	char *p;
+	int n;
+	char *buf, *p;
+
+	n = 80;
+	if (n < 2 * cached_config->res_cols + 1) {
+		n = 2 * cached_config->res_cols + 1;
+	}
+	buf = mem_alloc(text_wcsz() * n + 1);
 
 	/* Begin dump */
 	file_putf(fff, "  [%s Character Dump]\n\n", buildid);
@@ -940,7 +946,12 @@ void write_character_dump(ang_file *fff)
 			(void)(Term_what(x, y, &a, &c));
 
 			/* Dump it */
-			p += wctomb(p, c);
+			n = text_wctomb(p, c);
+			if (n > 0) {
+				p += n;
+			} else {
+				*p++ = ' ';
+			}
 		}
 
 		/* Back up over spaces */
@@ -973,7 +984,12 @@ void write_character_dump(ang_file *fff)
 			(void)(Term_what(x, y, &a, &c));
 
 			/* Dump it */
-			p += wctomb(p, c);
+			n = text_wctomb(p, c);
+			if (n > 0) {
+				p += n;
+			} else {
+				*p++ = ' ';
+			}
 		}
 
 		/* Back up over spaces */
@@ -1006,7 +1022,12 @@ void write_character_dump(ang_file *fff)
 			(void)(Term_what(x + 2 * cached_config->res_cols + 2, y, &a, &c));
 
 			/* Dump it */
-			p += wctomb(p, c);
+			n = text_wctomb(p, c);
+			if (n > 0) {
+				p += n;
+			} else {
+				*p++ = ' ';
+			}
 		}
 
 		/* Back up over spaces */
@@ -1124,6 +1145,7 @@ void write_character_dump(ang_file *fff)
 	}
 
 	mem_free(home_list);
+	mem_free(buf);
 }
 
 /**

--- a/src/ui-prefs.c
+++ b/src/ui-prefs.c
@@ -337,7 +337,7 @@ void dump_ui_entry_renderers(ang_file *fff)
 		file_putf(fff, "entry-renderer:%s:%s:%s:%s\n",
 			ui_entry_renderer_get_name(i), colors, labcolors,
 			symbols);
-		string_free(symbols);
+		mem_free(symbols);
 		string_free(labcolors);
 		string_free(colors);
 	}

--- a/src/wiz-spoil.c
+++ b/src/wiz-spoil.c
@@ -673,7 +673,7 @@ static void spoil_mon_info(const char *fname)
 
 		/* As of 3.5, race->name and race->text are stored as UTF-8 strings;
 		 * there is no conversion from the source edit files. */
-		textblock_append_utf8(tb, race->name);
+		textblock_append(tb, "%s", race->name);
 		textblock_append(tb, "  (");	/* ---)--- */
 		textblock_append(tb, "%s", attr_to_text(race->d_attr));
 		textblock_append(tb, " '%c')\n", race->d_char);

--- a/src/z-textblock.c
+++ b/src/z-textblock.c
@@ -134,35 +134,6 @@ void textblock_append_pict(textblock *tb, byte attr, int c)
 }
 
 /**
- * Append a UTF-8 string to the textblock.
- *
- * This is needed in order for proper file writing. Normally, textblocks convert
- * to the system's encoding when a string is appended. However, there are still
- * some strings in the game that are imported from external files as UTF-8.
- * Instead of requiring each port to provide another converter back to UTF-8,
- * we'll just use the original strings as is.
- *
- * \param tb is the textblock we are appending to.
- * \param utf8_string is the C string that is encoded as UTF-8.
- */
-void textblock_append_utf8(textblock *tb, const char *utf8_string)
-{
-	size_t i;
-	size_t new_length = strlen(utf8_string);
-
-	textblock_resize_if_needed(tb, new_length);
-
-	/* Append each UTF-8 char one at a time, so we don't trigger any
-	 * conversions (which would require multiple bytes). */
-	for (i = 0; i < new_length; i++) {
-		tb->text[tb->strlen + i] = (wchar_t)utf8_string[i];
-	}
-
-	memset(tb->attrs + tb->strlen, COLOUR_WHITE, new_length);
-	tb->strlen += new_length;
-}
-
-/**
  * Append one textblock to another.
  *
  * \param tb is the textblock we are appending to.
@@ -341,23 +312,35 @@ void textblock_to_file(textblock *tb, ang_file *f, int indent, int wrap_at)
 	size_t *line_starts = NULL;
 	size_t *line_lengths = NULL;
 
-	size_t n_lines, i;
+	size_t n_lines, i, j;
+	char *mbbuf;
 
 	int width = wrap_at - indent;
 	assert(width > 0);
 
 	n_lines = textblock_calculate_lines(tb, &line_starts, &line_lengths, width);
+	mbbuf = mem_alloc(text_wcsz() + 1);
 
 	for (i = 0; i < n_lines; i++) {
-		/* For some reason, the %*c part of the format string was still
-		 * indenting, even when indent was zero */
-		if (indent == 0)
-			file_putf(f, "%.*ls\n", line_lengths[i], tb->text + line_starts[i]);
-		else
-			file_putf(f, "%*c%.*ls\n", indent, ' ', line_lengths[i],
-					  tb->text + line_starts[i]);
+		if (indent > 0) {
+			file_putf(f, "%*c", indent, ' ');
+		}
+		for (j = 0; j < line_lengths[i]; ++j) {
+			int nc = text_wctomb(mbbuf,
+				tb->text[line_starts[i] + j]);
+
+			if (nc > 0) {
+				mbbuf[nc] = 0;
+			} else {
+				mbbuf[0] = ' ';
+				mbbuf[1] = 0;
+			}
+			file_putf(f, "%s", mbbuf);
+		}
+		file_putf(f, "\n");
 	}
 
+	mem_free(mbbuf);
 	mem_free(line_starts);
 	mem_free(line_lengths);
 }

--- a/src/z-textblock.h
+++ b/src/z-textblock.h
@@ -32,7 +32,6 @@ void textblock_free(textblock *tb);
 void textblock_append(textblock *tb, const char *fmt, ...);
 void textblock_append_c(textblock *tb, byte attr, const char *fmt, ...);
 void textblock_append_pict(textblock *tb, byte attr, int c);
-void textblock_append_utf8(textblock *tb, const char *utf8_string);
 void textblock_append_textblock(textblock *tb, const textblock *tba);
 
 const wchar_t *textblock_text(textblock *tb);

--- a/src/z-util.h
+++ b/src/z-util.h
@@ -38,6 +38,9 @@ extern char *argv0;
  * Aux functions
  */
 extern size_t (*text_mbcs_hook)(wchar_t *dest, const char *src, int n);
+extern int (*text_wctomb_hook)(char *s, wchar_t wchar);
+extern int (*text_wcsz_hook)(void);
+extern int (*text_iswprint_hook)(wint_t wc);
 extern void (*plog_aux)(const char *);
 extern void (*quit_aux)(const char *);
 
@@ -168,6 +171,21 @@ bool is_a_vowel(int ch);
  * Allow override of the multi-byte to wide char conversion
  */
 size_t text_mbstowcs(wchar_t *dest, const char *src, int n);
+
+/**
+ * Convert a wide character to multibyte representation.
+ */
+int text_wctomb(char *s, wchar_t wchar);
+
+/**
+ * Get the maximum size to store a wide character converted to multibyte.
+ */
+int text_wcsz(void);
+
+/**
+ * Return whether the given wide character is printable.
+ */
+int text_iswprint(wint_t wc);
 
 /**
  * Print an error message


### PR DESCRIPTION
This is a resubmit of #4599 that will cleanly apply to the current master branch.

Those allow a front-end to override calls by the core to wctomb() or iswprint() so that a front-end that supplies a text_mbcs_hook can select behavior for reverse conversion and testing for printable characters that is compatible with what it does in text_mbcs_hook.

Replaced the current calls to wctomb() and iswprint() in the core with calls to functions that allow the platform-specific override.

In two places (textblock_to_file() and ui_entry_renderer_get_symbols()) where the core converted wide characters back to characters with simple casts, now use the replacement function for wctomb() to do the conversion. Removed the textblock_append_utf8() function since the back conversion in textblock_to_file() handles what it was meant to do: allow proper handling for multibyte characters when the textblock will only be dumped to a file.

Modify the Mac and Windows front end to supply a hook for the wctomb() replacement. The change for Windows could use more testing: I only exercised it by compiling with mingw on Linux and running the result under Wine.