### PR TITLE
Override iswprint with new hooks on Mac and Windows

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -5015,6 +5015,18 @@ static int Term_wctomb_cocoa(char *s, wchar_t wchar)
 }
 
 /**
+ * Return whether a UTF-32 value is printable.
+ *
+ * This is a necessary counterpart to Term_mbcs_cocoa() so that screening
+ * of wide characters in the core's text_out_to_screen() is consistent with
+ * what Term_mbcs_cocoa() does.
+ */
+static int Term_iswprint_cocoa(wint_t wc)
+{
+	return utf32_isprint((u32b) wc);
+}
+
+/**
  * Return the maximum number of bytes needed for a multibyte encoding of a
  * wchar.
  */
@@ -5979,6 +5991,7 @@ static bool cocoa_get_file(const char *suggested_name, char *path, size_t len)
 	text_mbcs_hook = Term_mbcs_cocoa;
 	text_wctomb_hook = Term_wctomb_cocoa;
 	text_wcsz_hook = Term_wcsz_cocoa;
+	text_iswprint_hook = Term_iswprint_cocoa;
 
 	/* Set up game event handlers */
 	init_display();

--- a/src/main-win.c
+++ b/src/main-win.c
@@ -2312,6 +2312,25 @@ int Term_wctomb_win(char *s, wchar_t wchar)
 }
 
 
+/**
+ * Return whether a wide character is printable.
+ *
+ * This is a necessary counterpart to Term_mbstowcs_win() so that screening
+ * of wide characters in the core's text_out_to_screen() is consistent with what
+ * Term_mbstowcs_win() does.
+ */
+int Term_iswprint_win(wint_t wc)
+{
+	/*
+	 * It's a UTF-16 value, but can cast and test as UTF-32 (if it's the
+	 * leading part of a surrogate pair it'll be treated as unprintable
+	 * which is desirable:  on Windows, ui-term as it is can't handle
+	 * characters that have to be encoded as surrogate pairs in UTF-16).
+	 */
+	return utf32_isprint((u32b) wc);
+}
+
+
 #ifndef AC_SRC_ALPHA
 #define AC_SRC_ALPHA     0x01
 #endif
@@ -2720,6 +2739,7 @@ static void init_windows(void)
 	text_mbcs_hook = Term_mbstowcs_win;
 	text_wctomb_hook = Term_wctomb_win;
 	text_wcsz_hook = Term_wcsz_win;
+	text_iswprint_hook = Term_iswprint_win;
 
 	/* Activate the main window */
 	SetActiveWindow(td->w);

--- a/src/z-util.c
+++ b/src/z-util.c
@@ -709,7 +709,7 @@ int text_wcsz(void)
  */
 int text_iswprint(wint_t wc)
 {
-	return (text_iswprint_hook) ? (*text_iswprint)(wc) : iswprint(wc);
+	return (text_iswprint_hook) ? (*text_iswprint_hook)(wc) : iswprint(wc);
 }
 
 /**


### PR DESCRIPTION
Helps more on the Mac - perhaps because the custom fonts on Windows are missing glyphs for the multibyte characters I was using, ¢ and €, in my tests.

Also fixes a bug in the implementation of the iswprint hook in z-util.c.

Potential outstanding issues with multibyte characters:

-  choice of font with coverage for the characters of interest (the custom fonts on Windows and the old X11 font used by default with X11 may be the most problematic)
- for player input of multibyte characters, the interaction between the platform's input mechanism for those characters and Angband's event handling (definitely a problem with the Mac front end and entry of accented characters)
- whether the screening of the characters in player_safe_name() is still appropriate
- handling of character dumps on the ladder (I tried one with multibyte characters in the character name, and it was rejected with an error similar to those people recently got after pav's update; don't know if the initial player history may also be trouble)
- whether there's any issues with Angband.live, especially for player names with multibyte characters