### PR TITLE
OS X:  in the default preferences, use the keys, FontName-0 and FontS…

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -5634,8 +5634,8 @@ static void load_prefs(void)
     }
 
     NSDictionary *defaults = [[NSDictionary alloc] initWithObjectsAndKeys:
-                              @"Menlo", @"FontName",
-                              [NSNumber numberWithFloat:13.f], @"FontSize",
+                              @"Menlo", @"FontName-0",
+                              [NSNumber numberWithFloat:13.f], @"FontSize-0",
                               [NSNumber numberWithInt:60], AngbandFrameRateDefaultsKey,
                               [NSNumber numberWithBool:YES], AngbandSoundDefaultsKey,
                               [NSNumber numberWithInt:GRAPHICS_NONE], AngbandGraphicsDefaultsKey,


### PR DESCRIPTION
…ize-0, since those, rather than FontName and FontSize, are what are examined to get the name and size of the font for the main window.