### PR TITLE
Slightly tighten shape change logic.  Do not allow a shape changed …

### DIFF
--- a/src/mon-move.c
+++ b/src/mon-move.c
@@ -149,7 +149,11 @@ static bool monster_can_kill(struct chunk *c, struct monster *mon,
 	if (!mon1) return true;
 
 	/* No trampling uniques */
-	if (rf_has(mon1->race->flags, RF_UNIQUE)) return false;
+	if (rf_has(mon1->race->flags, RF_UNIQUE) ||
+			(mon1->original_race &&
+			rf_has(mon1->original_race->flags, RF_UNIQUE))) {
+		return false;
+	}
 
 	if (rf_has(mon->race->flags, RF_KILL_BODY) &&
 		compare_monsters(mon, mon1) > 0) {

--- a/src/mon-util.c
+++ b/src/mon-util.c
@@ -1650,7 +1650,7 @@ bool monster_change_shape(struct monster *mon)
 
 	/* Set the race */
 	if (race) {
-		mon->original_race = mon->race;
+		if (!mon->original_race) mon->original_race = mon->race;
 		mon->race = race;
 		mon->mspeed += mon->race->speed - mon->original_race->speed;
 	}


### PR DESCRIPTION
…unique to be trampled if in a non-unique shape.  Do not overwrite the original race if something changes shape while already in an alternate shape.

With the current monster list, neither of those changes should have an impact.  All current unique shape changers change into shapes that are also flagged as unique.  All current shape changers change into things that do not also have the shape change ability.