### PR TITLE
OS X: Build Mach-O universal binary

### DIFF
--- a/.github/workflows/mac.yaml
+++ b/.github/workflows/mac.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Cocoa
-    runs-on: macos-latest
+    runs-on: macos-11.0
     steps:
       - name: Clone Project
         uses: actions/checkout@v2

--- a/src/Makefile.osx
+++ b/src/Makefile.osx
@@ -13,7 +13,7 @@ OPT ?= -O2
 # for consistency with older versions, use a lower case bundle ID
 BUNDLE_IDENTIFIER = org.rephial.angband
 
-ARCHS = x86_64
+ARCHS = x86_64 arm64
 ARCHFLAGS = $(addprefix -arch ,$(ARCHS))
 OSXVERSFLAGS = -mmacosx-version-min=10.9
 WARNINGS = -W -Wall -Wno-unused-parameter -Wno-missing-field-initializers \


### PR DESCRIPTION
Build universal binary targeting both x86_64 and arm64 architectures.

The game compiles on my computer (macOS 11.1, Xcode 12.3, ARM64) and yields a universal binary:
```
[brett] ~/git/angband [universal] ?? % file src/angband
src/angband: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64]
src/angband (for architecture x86_64):	Mach-O 64-bit executable x86_64
src/angband (for architecture arm64):	Mach-O 64-bit executable arm64
```
<del>But I don't have a macOS 10.x machine and don't know if this will work on macOS 10.x.</del> CI check result turns out to be, no. 😢 