### PR TITLE
Make a first attempt at compiling a Windows version in the CI …

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,0 +1,26 @@
+name: Windows
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  build:
+    name: Stock 
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux
+    steps:
+      - name: Install Build Dependencies
+        run: pacman -Sy mingw-w64-gcc automake autoconf make --noconfirm
+
+      - name: Clone Project
+        uses: actions/checkout@v2
+
+      - name: Build
+        run: |
+          ./autogen.sh
+          ./configure --enable-win --disable-curses --build=i686-pc-linux-gnu --host=i686-w64-mingw32
+          make
+


### PR DESCRIPTION
…environment using the mingw cross-compiler.

Potential issues:

- I didn't try to extract the generated executable and see if it was usable on a Windows system.
- During make's dependency generation step, png.h could not be found for win/readpng.c and win/scrnshot.c.  However, both were compiled and make ran to completion without signaling an error.