### PR TITLE
Use $(PROGNAME).res as the name of the windows resource file…

### DIFF
--- a/src/Makefile.src
+++ b/src/Makefile.src
@@ -71,7 +71,7 @@ SNDSDLFILES = snd-sdl.o
 TESTMAINFILES = main-test.o
 
 WINMAINFILES = \
-        win/angband.res \
+        win/$(PROGNAME).res \
         main-win.o \
         win/readdib.o \
         win/readpng.o \


### PR DESCRIPTION
…to be consistent with Makefile.  Has no affect on angband ($(PROGNAME).res evaluates to angband.res) but could impact variants.  This is a backport of a change from FAangband.