### PR TITLE
Tweak equipable comparison

### DIFF
--- a/src/ui-equip-cmp.c
+++ b/src/ui-equip-cmp.c
@@ -446,7 +446,7 @@ static int handle_key_equip_cmp_general(struct keypress ch, int istate,
 	static const char *trans_msg_onlystore =
 		"Only showing goods from stores; press c to change";
 	static const char *trans_msg_withstore =
-		"Showing possesions and goods from stores; press c to change";
+		"Showing possessions and goods from stores; press c to change";
 	static const char *trans_msg_carried =
 		"Only showing carried items; press c to change";
 	static const char *trans_msg_save_ok = "Successfully saved to file";

--- a/src/ui-equip-cmp.c
+++ b/src/ui-equip-cmp.c
@@ -386,7 +386,7 @@ static void display_equip_cmp_help(void)
 	++irow;
 	prt("q           quick filter     !           use opposite quick", irow, 0);
 	++irow;
-	prt("c           cycle inclusion of stores' goods", irow, 0);
+	prt("c           cycle through sources of items", irow, 0);
 	++irow;
 	prt("r           reverse", irow, 0);
 	++irow;


### PR DESCRIPTION
- Fix typo in displayed message (cosmetic problem present since 4.2.1).
- Like the resistance panel in the character sheet, alternate shading of columns so they're easier to track down the display.   Alternate the shading of the column labels as well to to hint that they should be parsed vertically rather than horizontally.  Both are responses to the suggestions here, http://angband.oook.cz/forum/showpost.php?p=150429&postcount=21 , and here, http://angband.oook.cz/forum/showpost.php?p=150844&postcount=8 .  The color choices for the labels are not currently configurable like the other colors used for the character sheet's resistance panel.
- Add an additional stage to the 'c' command so that only equipped items or items in the pack are shown.  That's a response to this suggestion, http://angband.oook.cz/forum/showpost.php?p=150411&postcount=19 .