### PR TITLE
Switch runner for Mac CI environment

### DIFF
--- a/.github/workflows/mac.yaml
+++ b/.github/workflows/mac.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Cocoa
-    runs-on: macos-11.0
+    runs-on: macos-latest
     steps:
       - name: Clone Project
         uses: actions/checkout@v2

--- a/.github/workflows/mac.yaml
+++ b/.github/workflows/mac.yaml
@@ -16,4 +16,4 @@ jobs:
       - name: Build
         run: |
           cd src
-          make -f Makefile.osx
+          env SDKROOT=macosx11.1 make -f Makefile.osx


### PR DESCRIPTION
- The macos11.0 runner is, for now only private preview (see https://github.com/actions/virtual-environments/issues/2486 ), so use macos-latest.
- Override the default SDK in the macos-latest runner so building a universal binary with the arm64 architecture works.