### PR TITLE
Initial attempt to generate releases from a GitHub workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,188 @@
+name: create-github-release
+
+on:
+  push:
+    branches: [ master ]
+
+env:
+    # Used as the name when uploading or downloading the artifact for passing
+    # configuration data from the Setup job to those dependent on it.
+    CONFIG_ARTIFACT: release-config
+    # Used as the path for the file with the configuration data passed from
+    # the Setup job to those dependent on it.
+    CONFIG_ARTIFACT_PATH: release-config.txt
+
+jobs:
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+    steps:
+      # Need commit history and tags for scripts/version.sh to work as expected
+      # so use 0 for fetch-depth.
+      - name: Clone Project
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Extract Names from Makefile
+        id: get_names
+        run: |
+          name=`sed -E -n -e 's/^[[:blank:]]*NAME[[:blank:]]+=[[:blank:]]+//p' src/Makefile.src || tr ' #' '\t\t' | tail -1 | cut -f 1`
+          echo "::set-output name=name::$name"
+          progname=`sed -E -n -e 's/^[[:blank:]]*PROGNAME[[:blank:]]+=[[:blank:]]+//p' src/Makefile.src || tr ' #' '\t\t' | tail -1 | cut -f 1`
+          echo "::set-output name=progname::$progname"
+
+      - name: Set Release Version
+        id: get_release_vars
+        run: |
+          version=`scripts/version.sh`
+          echo "::set-output name=version::$version"
+          prerelease=`echo $version | awk '/^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$/ { print "false" ; exit 0 } ; { print "true"; exit 0 } ;'`
+          echo "::set-output name=prerelease::$prerelease"
+
+      # Largely cribbed from the example in README.md at
+      # https://github.com/actions/upload-release-asset .
+      - name: Create Bare Release
+        id: create_bare_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Token provided by Actions
+        with:
+          tag_name: ${{ steps.get_release_vars.outputs.version }}
+          release_name: Release ${{ steps.get_release_vars.outputs.version }}
+          commitish: ${{ github.sha }}
+          prerelease: ${{ steps.get_release_vars.outputs.prerelease }}
+
+      # The quoting here may be too simple-minded:  what if there are single
+      # quotes in the steps.*.outputs.* stuff.
+      - name: Create Artifact with Configuration Details
+        run: |
+          echo name= '${{ steps.get_names.outputs.name }}' > $CONFIG_ARTIFACT_PATH
+          echo progname= '${{ steps.get_names.outputs.progname }}' >> $CONFIG_ARTIFACT_PATH
+          echo version= '${{ steps.get_release_vars.outputs.version }}' >> $CONFIG_ARTIFACT_PATH
+          echo prerelease= '${{ steps.get_release_vars.outputs.prerelease }}' >> $CONFIG_ARTIFACT_PATH
+          echo upload_url= '${{ steps.create_bare_release.outputs.upload_url }}' >> $CONFIG_ARTIFACT_PATH
+
+      - name: Upload Artifact for Use by Dependent Steps
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.CONFIG_ARTIFACT }}
+          path: ${{ env.CONFIG_ARTIFACT_PATH }}
+          retention-days: 1
+
+  windows:
+    needs: setup
+    name: Windows
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux
+    steps:
+      - name: Download Artifact with Configuration Information
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ env.CONFIG_ARTIFACT }}
+
+      - name: Extract Configuration Information and Store in Step Outputs
+        id: store_config
+        run: |
+          name=`sed -E -n -e 's/name= //p' $CONFIG_ARTIFACT_PATH`
+          echo "::set-output name=name::$name"
+          progname=`sed -E -n -e 's/progname= //p' $CONFIG_ARTIFACT_PATH`
+          echo "::set-output name=progname::$progname"
+          version=`sed -E -n -e 's/version= //p' $CONFIG_ARTIFACT_PATH`
+          echo "::set-output name=version::$version"
+          prerelease=`sed -E -n -e 's/prerelease= //p' $CONFIG_ARTIFACT_PATH`
+          echo "::set-output name=prerelease::$prerelease"
+          upload_url=`sed -E -n -e 's/upload_url= //p' $CONFIG_ARTIFACT_PATH`
+          echo "::set-output name=upload_url::$upload_url"
+
+      - name: Install Build Dependencies
+        run: pacman -Sy mingw-w64-gcc automake autoconf make zip --noconfirm
+
+      # Need commit history and tags for scripts/version.sh to work as expected
+      # so use 0 for fetch-depth.
+      - name: Clone Project
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Create Windows Archive
+        id: create_windows_archive
+        run: |
+          ./autogen.sh
+          ./configure --enable-win --disable-curses --build=i686-pc-linux-gnu --host=i686-w64-mingw32
+          make
+          cp src/${{ steps.store_config.outputs.progname }}.exe src/win/dll/libpng12.dll src/win/dll/zlib1.dll .
+          archive_prefix=${{ steps.store_config.outputs.name }}-${{ steps.store_config.outputs.version }}
+          echo "::set-output name=archive_file::${archive_prefix}-win.zip"
+          echo "::set-output name=archive_content_type::application/zip"
+          scripts/pkg_win $archive_prefix ${archive_prefix}-win.zip
+
+      # Largely cribbed from the example in README.md at
+      # https://github.com/actions/upload-release-asset .
+      - name: Upload Windows Archive
+        id: upload_windows_archive
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.store_config.outputs.upload_url }}
+          asset_path: ./${{ steps.create_windows_archive.outputs.archive_file }}
+          asset_name: ${{ steps.create_windows_archive.outputs.archive_file }}
+          asset_content_type: ${{ steps.create_windows_archive.outputs.archive_content_type }}
+
+  mac:
+    needs: setup
+    name: Mac
+    runs-on: macos-latest
+    steps:
+      - name: Download Artifact with Configuration Information
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ env.CONFIG_ARTIFACT }}
+
+      - name: Extract Configuration Information and Store in Step Outputs
+        id: store_config
+        run: |
+          name=`sed -E -n -e 's/name= //p' $CONFIG_ARTIFACT_PATH`
+          echo "::set-output name=name::$name"
+          progname=`sed -E -n -e 's/progname= //p' $CONFIG_ARTIFACT_PATH`
+          echo "::set-output name=progname::$progname"
+          version=`sed -E -n -e 's/version= //p' $CONFIG_ARTIFACT_PATH`
+          echo "::set-output name=version::$version"
+          prerelease=`sed -E -n -e 's/prerelease= //p' $CONFIG_ARTIFACT_PATH`
+          echo "::set-output name=prerelease::$prerelease"
+          upload_url=`sed -E -n -e 's/upload_url= //p' $CONFIG_ARTIFACT_PATH`
+          echo "::set-output name=upload_url::$upload_url"
+
+      # Need commit history and tags for scripts/version.sh to work as expected
+      # so use 0 for fetch-depth.
+      - name: Clone Project
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      # Currently, macos-latest defaults to using the 10.15 SDK which does not
+      # support creating arm64 objects.  Override the default using SDKROOT # set to an SDK that can generate both x86_64 and arm64 objects.
+      - name: Create Mac Archive
+        id: create_mac_archive
+        run: |
+          cd src
+          env SDKROOT=macosx11.1 make -f Makefile.osx dist
+          archive_prefix=${{ steps.store_config.outputs.name }}-${{ steps.store_config.outputs.version }}-osx
+          echo "::set-output name=archive_file::${archive_prefix}.dmg"
+          echo "::set-output name=archive_content_type::application/octet-stream"
+
+      # Largely cribbed from the example in README.md at
+      # https://github.com/actions/upload-release-asset .
+      - name: Upload Mac Archive
+        id: upload_mac_archive
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.store_config.outputs.upload_url }}
+          asset_path: ./${{ steps.create_mac_archive.outputs.archive_file }}
+          asset_name: ${{ steps.create_mac_archive.outputs.archive_file }}
+          asset_content_type: ${{ steps.create_mac_archive.outputs.archive_content_type }}
+

--- a/scripts/pkg_win
+++ b/scripts/pkg_win
@@ -64,6 +64,8 @@ cp ../*.dll .
 
 # Copy the readmes and suchlike, converting to DOS line endings on the way
 
+cp_unix2dos ../changes.txt changes.txt
+
 # Assumes that all those files in docs have names that don't contain spaces
 # or other characters that the shell uses as field separators.
 for f in `find ../docs \( -name '*.rst' -o -name '*.sty' -o -name '*.svg' \

--- a/scripts/pkg_win
+++ b/scripts/pkg_win
@@ -33,6 +33,9 @@ mkdir -p $DIR
 cd $DIR
 
 mkdir docs
+mkdir docs/_static
+mkdir docs/_templates
+mkdir docs/hacking
 mkdir lib
 mkdir lib/gamedata
 mkdir lib/customize
@@ -60,7 +63,15 @@ cp ../*.exe .
 cp ../*.dll .
 
 # Copy the readmes and suchlike, converting to DOS line endings on the way
-cp_unix2dos ../docs/*.rst docs/
+
+# Assumes that all those files in docs have names that don't contain spaces
+# or other characters that the shell uses as field separators.
+for f in `find ../docs \( -name '*.rst' -o -name '*.sty' -o -name '*.svg' \
+		-o -name '*.css' -o -name '*.html' -o -name '*.txt' \
+		-o -name 'Makefile*' -o -name 'make.bat' -o -name '*.py' \) \
+		-print` ; do
+	cp_unix2dos "$f" `echo "$f" | sed -E -e 's%^\.\./%%'`
+done
 
 cp ../lib/readme.txt lib/
 

--- a/scripts/pkg_win
+++ b/scripts/pkg_win
@@ -92,6 +92,12 @@ done
 
 cp ../lib/fonts/*.fon lib/fonts
 
+for f in `find ../lib/icons \( -name '*.desktop' -o -name '*.svg' \) \
+		-print` ; do
+	cp_unix2dos "$f" `echo "$f" | sed -E -e 's%^\.\./%%'`
+done
+cp ../lib/icons/*.png lib/icons
+
 for f in `find ../lib/tiles \( -name '*.txt' -o -name '*.prf' \) -print` ; do
 	cp_unix2dos "$f" `echo "$f" | sed -E -e 's%^\.\./%%'`
 done

--- a/scripts/pkg_win
+++ b/scripts/pkg_win
@@ -73,29 +73,41 @@ for f in `find ../docs \( -name '*.rst' -o -name '*.sty' -o -name '*.svg' \
 	cp_unix2dos "$f" `echo "$f" | sed -E -e 's%^\.\./%%'`
 done
 
-cp ../lib/readme.txt lib/
+cp_unix2dos ../lib/readme.txt lib/readme.txt
 
-cp ../lib/gamedata/*.txt lib/gamedata
-cp ../lib/screens/*.txt lib/screens
+# Ditto the comment above for the way find is used here.
+for f in `find ../lib/gamedata -name '*.txt' -print` ; do
+	cp_unix2dos "$f" `echo "$f" | sed -E -e 's%^\.\./%%'`
+done
+for f in `find ../lib/screens -name '*.txt' -print` ; do
+	cp_unix2dos "$f" `echo "$f" | sed -E -e 's%^\.\./%%'`
+done
+for f in `find ../lib/help -name '*.txt' -print` ; do
+	cp_unix2dos "$f" `echo "$f" | sed -E -e 's%^\.\./%%'`
+done
 
-cp ../lib/help/*.txt lib/help
-
-cp ../lib/customize/*.prf lib/customize
+for f in `find ../lib/customize -name '*.prf' -print` ; do
+	cp_unix2dos "$f" `echo "$f" | sed -E -e 's%^\.\./%%'`
+done
 
 cp ../lib/fonts/*.fon lib/fonts
 
-cp ../lib/tiles/*.txt lib/tiles
-cp ../lib/tiles/adam-bolt/* lib/tiles/adam-bolt
-cp ../lib/tiles/gervais/* lib/tiles/gervais
-cp ../lib/tiles/nomad/* lib/tiles/nomad
-cp ../lib/tiles/old/* lib/tiles/old
-cp ../lib/tiles/shockbolt/* lib/tiles/shockbolt
-rm lib/tiles/*/Makefile
+for f in `find ../lib/tiles \( -name '*.txt' -o -name '*.prf' \) -print` ; do
+	cp_unix2dos "$f" `echo "$f" | sed -E -e 's%^\.\./%%'`
+done
+cp ../lib/tiles/adam-bolt/*.png lib/tiles/adam-bolt
+cp ../lib/tiles/gervais/*.png lib/tiles/gervais
+cp ../lib/tiles/nomad/*.png lib/tiles/nomad
+cp ../lib/tiles/old/*.png lib/tiles/old
+cp ../lib/tiles/shockbolt/*.png lib/tiles/shockbolt
 
-cp ../lib/sounds/sound.cfg lib/sounds
+cp_unix2dos ../lib/sounds/sound.cfg lib/sounds/sound.cfg
 cp ../lib/sounds/*.mp3 lib/sounds
 
-cp ../lib/user/info/*.txt lib/user/info
+for f in `find ../lib/user/info \( -name '*.txt' -o -name '*.hlp' \) \
+		-print` ; do
+	cp_unix2dos "$f" `echo "$f" | sed -E -e 's%^\.\./%%'`
+done
 
 cd ..
 zip -9 -r $OUT $DIR


### PR DESCRIPTION
Intends to meet the goals stated by Nick here, https://github.com/angband/angband/pull/4615#issuecomment-750850535 .

Uses scripts/pkg-win to generate the zip file for Windows.  Made some modifications to that so the result is closer to what's in the 4.2.1 zip file.

A sample release generated by workflow can be seen here https://github.com/backwardsEric/angband/releases/tag/4.2.0-565-g62dd324d .

Outstanding issues:
- Given the current state of the repository, the workflow gets the wrong version (4.2.0 rather than 4.2.1) for the release.  My best lead on why that happens is that the workflow uses git fetch with the --prune option when cloning the repository.  Running that command locally gives messages like "error: * Ignoring funny ref 'refs/remotes/origin//4.2-release' locally".  The resulting cloned repository is missing the 4.2.1 tag so scripts/version.sh (based on what git describe produces) gets a version string beginning with 4.2.0.
- The Windows zip file generated has not been tested other than to check that key files are there.  Some more iteration on scripts/pkg_win may also be necessary to get it to match what was done for past releases.
- Nothing has been done to populate the GitHub "release" with something like brief release notes (platform requirements and save file compatibility) or change logs.
- Per Nick's goal, the workflow will run on every push to master.  The documentation, https://docs.github.com/en/rest/reference/repos#create-a-release , mentions abuse rate limits which may limit how often that can be done.
- There's repetition of the logic from the mac.yaml and windows.yaml for the build steps.  Perhaps writing separate custom GitHub "actions" which do a build and have optional input to say that an archive should be generated and attached to an existing GitHub "release" would be a way to avoid the repetition.
- The workflow has some logic that's getting the equivalents of NAME, PROGNAME, VERSION, and the resulting archive names in the makefiles.  If the makefiles had some auxiliary targets (write-name, for instance that would write the contents of NAME to a file, say name.out, in the top-level directory), then the workflow could use those and reduce the chance of inconsistencies between the workflow and what the makefiles do.
