### PR TITLE
Work around an archlinux container problem in the workflows

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -12,8 +12,11 @@ jobs:
     container:
       image: archlinux
     steps:
+      # Force a system update (u added to -Sy) because had problems with the
+      # clone step failing because the system libc lacked a symbol needed by
+      # docker.
       - name: Install Build Dependencies
-        run: pacman -Sy gcc automake autoconf make libx11 --noconfirm
+        run: pacman -Syu gcc automake autoconf make libx11 --noconfirm
 
       - name: Clone Project
         uses: actions/checkout@v2
@@ -32,8 +35,9 @@ jobs:
     container:
       image: archlinux
     steps:
+      # See above comment for why a system update is forced.
       - name: Install Build Dependencies
-        run: pacman -Sy gcc make cmake libx11 --noconfirm
+        run: pacman -Syu gcc make cmake libx11 --noconfirm
 
       - name: Clone Project
         uses: actions/checkout@v2
@@ -51,8 +55,9 @@ jobs:
     container:
       image: archlinux
     steps:
+      # See above comment for why a system update is forced.
       - name: Install Build Dependencies
-        run: pacman -Sy gcc make cmake ncurses --noconfirm
+        run: pacman -Syu gcc make cmake ncurses --noconfirm
 
       - name: Clone Project
         uses: actions/checkout@v2
@@ -70,8 +75,9 @@ jobs:
     container:
       image: archlinux
     steps:
+      # See above comment for why a system update is forced.
       - name: Install Build Dependencies
-        run: pacman -Sy gcc make cmake sdl_image sdl_ttf --noconfirm
+        run: pacman -Syu gcc make cmake sdl_image sdl_ttf --noconfirm
 
       - name: Clone Project
         uses: actions/checkout@v2


### PR DESCRIPTION
Force a system update when downloading the build dependencies to resolve the problems seen with recent runs (after 2020/2/4) using the archlinux container: docker would exit in the clone repository step with the message "/usr/lib/libc.so.6: version `GLIBC_2.33' not found (required by /usr/lib/libstdc++.so.6)".

At least on my fork, that lets everything but Linux/Tests run to completion successfully.  With Linux/Tests, autoconf thinks the shell is broken.  I haven't worked out a solution to that.