### PR TITLE
Windows and release workflows: skip Arch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,8 +74,6 @@ jobs:
     needs: setup
     name: Windows
     runs-on: ubuntu-latest
-    container:
-      image: archlinux
     steps:
       - name: Download Artifact with Configuration Information
         uses: actions/download-artifact@v2
@@ -97,7 +95,7 @@ jobs:
           echo "::set-output name=upload_url::$upload_url"
 
       - name: Install Build Dependencies
-        run: pacman -Sy mingw-w64-gcc automake autoconf make zip --noconfirm
+        run: sudo apt-get install gcc-mingw-w64 automake autoconf make zip
 
       # Need commit history and tags for scripts/version.sh to work as expected
       # so use 0 for fetch-depth.

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -9,11 +9,9 @@ jobs:
   build:
     name: Stock 
     runs-on: ubuntu-latest
-    container:
-      image: archlinux
     steps:
       - name: Install Build Dependencies
-        run: pacman -Sy mingw-w64-gcc automake autoconf make --noconfirm
+        run: sudo apt-get install gcc-mingw-w64 automake autoconf make
 
       - name: Clone Project
         uses: actions/checkout@v2


### PR DESCRIPTION
Since the Windows workflow has also broken, this changes the both it and the release workflow to run directly on Ubuntu.