### PR TITLE
Two adjustments for zip file produced by release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,7 +95,7 @@ jobs:
           echo "::set-output name=upload_url::$upload_url"
 
       - name: Install Build Dependencies
-        run: sudo apt-get install gcc-mingw-w64 automake autoconf make zip
+        run: sudo apt-get install gcc-mingw-w64 automake autoconf git make zip
 
       # Need commit history and tags for scripts/version.sh to work as expected
       # so use 0 for fetch-depth.

--- a/scripts/pkg_win
+++ b/scripts/pkg_win
@@ -92,7 +92,7 @@ for f in `find ../lib/customize -name '*.prf' -print` ; do
 	cp_unix2dos "$f" `echo "$f" | sed -E -e 's%^\.\./%%'`
 done
 
-cp ../lib/fonts/*.fon lib/fonts
+cp ../lib/fonts/*.fon ../lib/fonts/*.woff lib/fonts
 
 for f in `find ../lib/icons \( -name '*.desktop' -o -name '*.svg' \) \
 		-print` ; do


### PR DESCRIPTION
- Ensure git is installed (likely a no-op since the Ubuntu runner has it already installed) so scripts/version.sh will work as expected.  If not present, would affect what angband.exe displays for the version number.
- Change pkg_win to include the *.woff fonts in the zip file: Angband 4.2.1's zip includes lib/fonts/16x16xw.woff.