### PR TITLE
In release workflow, copy converted docs to zip and dmg files

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,11 @@ env:
     # Used as the path for the file with the configuration data passed from
     # the Setup job to those dependent on it.
     CONFIG_ARTIFACT_PATH: release-config.txt
+    # Used as the name when uploading or downloading the artifact with the
+    # converted document files.
+    DOC_ARTIFACT: release-docs
+    # Used as the path for the file with the converted document files.
+    DOC_ARTIFACT_PATH: release-docs.tar
 
 jobs:
   setup:
@@ -70,8 +75,50 @@ jobs:
           path: ${{ env.CONFIG_ARTIFACT_PATH }}
           retention-days: 1
 
+  docconvert:
+    name: Document Conversion
+    runs-on: ubuntu-latest
+    steps:
+      # Need both Sphinx (Python documentation tool) and a 3rd party theme.
+      # Also install pip (to get theme), make (for make html), and git (so
+      # scripts/version.sh works).
+      - name: Install Build Dependencies
+        id: build_dep
+        run: |
+          sudo apt-get install make python-pip sphinx-common git
+          # On Debian and Arch, could just use sphinx-build since they put it
+          # in /usr/bin.  Ubuntu, however, does it differently.  This will
+          # need to changed if the default python switches to python 3.
+          sphinxpath=/usr/share/sphinx/scripts/python2/sphinx-build
+          echo "::set-output name=sphinxpath::$sphinxpath"
+          "$sphinxpath" --version
+          pip install sphinx-better-theme
+
+      # Need commit history and tags for scripts/version.sh to work as expected
+      # so use 0 for fetch-depth.
+      - name: Clone Project
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Convert
+        run: |
+          cd docs
+          make SPHINXBUILD=${{ steps.build_dep.outputs.sphinxpath }} html
+
+      - name: Archive
+        run: |
+          tar -cf ${{ env.DOC_ARTIFACT_PATH }} docs/_build/html
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.DOC_ARTIFACT }}
+          path: ${{ env.DOC_ARTIFACT_PATH }}
+          retention-days: 1
+
   windows:
-    needs: setup
+    needs: [setup, docconvert]
     name: Windows
     runs-on: ubuntu-latest
     steps:
@@ -104,6 +151,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Download Artifact with Converted Documents
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ env.DOC_ARTIFACT }}
+
+      - name: Extract Converted Documents
+        run: |
+          tar -xf ${{ env.DOC_ARTIFACT_PATH }}
+
       - name: Create Windows Archive
         id: create_windows_archive
         run: |
@@ -130,7 +186,7 @@ jobs:
           asset_content_type: ${{ steps.create_windows_archive.outputs.archive_content_type }}
 
   mac:
-    needs: setup
+    needs: [setup, docconvert]
     name: Mac
     runs-on: macos-latest
     steps:
@@ -159,6 +215,15 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - name: Download Artifact with Converted Documents
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ env.DOC_ARTIFACT }}
+
+      - name: Extract Converted Documents
+        run: |
+          tar -xf ${{ env.DOC_ARTIFACT_PATH }}
 
       # Currently, macos-latest defaults to using the 10.15 SDK which does not
       # support creating arm64 objects.  Override the default using SDKROOT # set to an SDK that can generate both x86_64 and arm64 objects.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,10 @@ release = version
 
 # -- General configuration ---------------------------------------------------
 
+# 2.0 changed the default value to 'index'.  Set this manually for backwards
+# compatibility with previous versions.
+master_doc = 'index'
+
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,12 +22,12 @@ copyright = "2019, Angband developers past and present"
 author = "Angband developers past and present"
 
 # The full version, including alpha/beta/rc tags
-import re
-
-version_regex = r"AC_INIT\([a-zA-Z]+, (.+),"
-parsed_lines = [re.findall(version_regex, line) for line in open("../configure.ac")]
-versions = [line[0] for line in parsed_lines if len(line) != 0]
-release = versions[0]
+import subprocess
+# Python 3.5 introduces subprocess.run(); use check_output() instead in case
+# the system's Python is older than that.
+version = subprocess.check_output(['../scripts/version.sh'],
+        universal_newlines=True)
+release = version
 
 # -- General configuration ---------------------------------------------------
 

--- a/scripts/pkg_win
+++ b/scripts/pkg_win
@@ -33,8 +33,9 @@ mkdir -p $DIR
 cd $DIR
 
 mkdir docs
+mkdir docs/_sources
+mkdir docs/_sources/hacking
 mkdir docs/_static
-mkdir docs/_templates
 mkdir docs/hacking
 mkdir lib
 mkdir lib/gamedata
@@ -66,13 +67,20 @@ cp ../*.dll .
 
 cp_unix2dos ../changes.txt changes.txt
 
-# Assumes that all those files in docs have names that don't contain spaces
-# or other characters that the shell uses as field separators.
-for f in `find ../docs \( -name '*.rst' -o -name '*.sty' -o -name '*.svg' \
-		-o -name '*.css' -o -name '*.html' -o -name '*.txt' \
-		-o -name 'Makefile*' -o -name 'make.bat' -o -name '*.py' \) \
-		-print` ; do
-	cp_unix2dos "$f" `echo "$f" | sed -E -e 's%^\.\./%%'`
+# Assumes that all the converted files in docs have names that don't contain
+# spaces or other characters that the shell uses as field separators.
+# First copy the ones that will benefit from newline conversion; then
+# do the rest.
+for f in `find ../docs/_build/html \( -name '*.css' -o -name '*.html' \
+		-o -name '*.js' -o -name '*.svg' -o -name '*.txt' \) \
+		\! -type d -print` ; do
+	cp_unix2dos "$f" \
+		`echo "$f" | sed -E -e 's%^\.\./docs/_build/html%docs%'`
+done
+for f in `find ../docs/_build/html \! -name '*.css' \! -name '*.html' \
+		\! -name '*.js' \! -name '*.svg' \! -name '*.txt' \
+		\! -type d -print` ; do
+	cp "$f" `echo "$f" | sed -E -e 's%^\.\./docs/_build/html%docs%'`
 done
 
 cp_unix2dos ../lib/readme.txt lib/readme.txt

--- a/src/Makefile.osx
+++ b/src/Makefile.osx
@@ -200,7 +200,7 @@ PACKAGE_NAME = $(NAME)-$(VERSION)
 dist: install
 	@rm -rf disttemp*
 	mkdir -p disttemp/Docs
-	cp -r ../docs/* disttemp/Docs
+	(cd ../docs/_build/html && tar -cf - .) | (cd disttemp/Docs && tar -xf -)
 	cp -R -p "$(APPBNDL)" disttemp
 	SetFile -a B disttemp/$(APPNAME)
 


### PR DESCRIPTION
Should resolve https://github.com/angband/angband/issues/4630 : the zip and dmg files will get a set of HTML files that look like those on https://angband.readthedocs.io/en/latest/ .