### PR TITLE
Learn all curse effects when an object is bought or sold

### DIFF
--- a/src/obj-knowledge.h
+++ b/src/obj-knowledge.h
@@ -95,6 +95,7 @@ void object_learn_on_use(struct player *p, struct object *obj);
 void object_learn_brand(struct player *p, struct object *obj, int index);
 void object_learn_slay(struct player *p, struct object *obj, int index);
 void missile_learn_on_ranged_attack(struct player *p, struct object *obj);
+void object_learn_on_trade(struct player *p, struct object *obj);
 
 bool easy_know(const struct object *obj);
 bool object_flavor_is_aware(const struct object *obj);

--- a/src/store.c
+++ b/src/store.c
@@ -1703,12 +1703,7 @@ void do_cmd_buy(struct command *cmd)
 	bought->known = known_obj;
 
 	/* Learn flavor, any effect and all the runes */
-	object_flavor_aware(bought);
-	bought->known->effect = bought->effect;
-	while (!object_fully_known(bought)) {
-		object_learn_unknown_rune(player, bought);
-		player_know_object(player, bought);
-	}
+	object_learn_on_trade(player, bought);
 
 	/* Give it to the player */
 	inven_carry(player, bought, true, true);
@@ -1900,13 +1895,8 @@ void do_cmd_sell(struct command *cmd)
 	 */
 	object_wipe(&dummy_item);
 
-	/* Know flavor of consumables */
-	object_flavor_aware(obj);
-	obj->known->effect = obj->effect;
-	while (!object_fully_known(obj)) {
-		object_learn_unknown_rune(player, obj);
-		player_know_object(player, obj);
-	}
+	/* Learn flavor, any effect and all the runes */
+	object_learn_on_trade(player, obj);
 
 	/* Take a proper copy of the now known-about object. */
 	sold_item = gear_object_for_use(obj, amt, false, &none_left);


### PR DESCRIPTION
If there's a change of mind about how to handle Ingwe Ingweron's report of selling a helm with the impair mana recovery curse, http://angband.oook.cz/forum/showpost.php?p=151262&postcount=225 , this pull request implements learning all the runes affected by a curse when a cursed object is bought or sold.
