### PR TITLE
Release script: generate source archive with "make dist"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -123,6 +123,65 @@ jobs:
           path: ${{ env.DOC_ARTIFACT_PATH }}
           retention-days: 1
 
+  source:
+    needs: setup
+    name: Source Archive
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Artifact with Configuration Information
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ env.CONFIG_ARTIFACT }}
+
+      - name: Extract Configuration Information and Store in Step Outputs
+        id: store_config
+        run: |
+          name=`sed -E -n -e 's/name= //p' $CONFIG_ARTIFACT_PATH`
+          echo "::set-output name=name::$name"
+          progname=`sed -E -n -e 's/progname= //p' $CONFIG_ARTIFACT_PATH`
+          echo "::set-output name=progname::$progname"
+          version=`sed -E -n -e 's/version= //p' $CONFIG_ARTIFACT_PATH`
+          echo "::set-output name=version::$version"
+          prerelease=`sed -E -n -e 's/prerelease= //p' $CONFIG_ARTIFACT_PATH`
+          echo "::set-output name=prerelease::$prerelease"
+          draft=`sed -E -n -e 's/draft= //p' $CONFIG_ARTIFACT_PATH`
+          echo "::set-output name=draft::$draft"
+          upload_url=`sed -E -n -e 's/upload_url= //p' $CONFIG_ARTIFACT_PATH`
+          echo "::set-output name=upload_url::$upload_url"
+
+      - name: Install Build Dependencies
+        run: sudo apt-get install automake autoconf git make
+
+      # Need commit history and tags for scripts/version.sh to work as expected
+      # so use 0 for fetch-depth.
+      - name: Clone Project
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Create Source Archive
+        id: create_source_archive
+        run: |
+          ./autogen.sh
+          ./configure
+          archive_prefix=${{ steps.store_config.outputs.name }}-${{ steps.store_config.outputs.version }}
+          echo "::set-output name=archive_file::${archive_prefix}.tar.gz"
+          echo "::set-output name=archive_content_type::application/gzip"
+          make TAG="$archive_prefix" OUT="$archive_prefix".tar.gz dist
+
+      # Largely cribbed from the example in README.md at
+      # https://github.com/actions/upload-release-asset .
+      - name: Upload Source Archive
+        id: upload_source_archive
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.store_config.outputs.upload_url }}
+          asset_path: ./${{ steps.create_source_archive.outputs.archive_file }}
+          asset_name: ${{ steps.create_source_archive.outputs.archive_file }}
+          asset_content_type: ${{ steps.create_source_archive.outputs.archive_content_type }}
+
   windows:
     needs: [setup, docconvert]
     name: Windows

--- a/Makefile
+++ b/Makefile
@@ -19,5 +19,6 @@ dist:
 	scripts/version.sh > $(TAG)/version
 	$(TAG)/autogen.sh
 	rm -rf $(TAG)/autogen.sh $(TAG)/autom4te.cache
-	tar --exclude .gitignore --exclude *.dll -czvf $(OUT) $(TAG)
+	tar --exclude .gitignore --exclude *.dll --exclude .github \
+		--exclude .travis.yml -czvf $(OUT) $(TAG)
 	rm -rf $(TAG)

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CLEAN = config.status config.log *.dll *.exe
 tests:
 	$(MAKE) -C src tests
 
-TAG = angband-`git describe`
+TAG = angband-`scripts/version.sh`
 OUT = $(TAG).tar.gz
 
 manual:
@@ -16,7 +16,7 @@ manual:
 
 dist:
 	git checkout-index --prefix=$(TAG)/ -a
-	git describe > $(TAG)/version
+	scripts/version.sh > $(TAG)/version
 	$(TAG)/autogen.sh
 	rm -rf $(TAG)/autogen.sh $(TAG)/autom4te.cache
 	tar --exclude .gitignore --exclude *.dll -czvf $(OUT) $(TAG)


### PR DESCRIPTION
Also some slight tweaks to how "make dist" works:

1. Exclude the continuous integration scripts (.travis.yml and contents of .github) from the result.
2. For the default TAG and version file, use the result of scripts/version.sh rather than call "git describe" directly.

This tries to address the second part of https://github.com/angband/angband/issues/4658 .