### PR TITLE
Have compare_items() return zero when both items are unknown

### DIFF
--- a/src/obj-util.c
+++ b/src/obj-util.c
@@ -554,9 +554,10 @@ static int compare_types(const struct object *o1, const struct object *o2)
 int compare_items(const struct object *o1, const struct object *o2)
 {
 	/* unknown objects go at the end, order doesn't matter */
-	if (is_unknown(o1) || is_unknown(o2)) {
-		if (!is_unknown(o1)) return -1;
-		return 1;
+	if (is_unknown(o1)) {
+		return (is_unknown(o2)) ? 0 : 1;
+	} else if (is_unknown(o2)) {
+		return -1;
 	}
 
 	/* known artifacts will sort first */


### PR DESCRIPTION
That's to satisfy qsort()'s typical requirement that the comparison function represent a total ordering: previously, compare_items(o1, o2) and compare_items(o2, o1) with both items unknown would return 1.

That might (though it seems unlikely) have an effect on #4664 .  That report was from a Windows system.  Running with or without this change on a Mac seemed to have no effect:  unknown items always ended up at the end of the object list.