### PR TITLE
Additional logic for thrown items in quiver

### DIFF
--- a/lib/gamedata/constants.txt
+++ b/lib/gamedata/constants.txt
@@ -137,6 +137,9 @@ carry-cap:quiver-size:10
 # Max number of missiles per quiver slot
 carry-cap:quiver-slot-size:40
 
+# For computing quiver capacity, is the multiplier for non-ammo thrown items
+carry-cap:thrown-quiver-mult:5
+
 # Maximum number of objects allowed in a single dungeon grid.
 #
 # The main screen originally had a minimum size of 24 rows, so it could always

--- a/src/cmd-pickup.c
+++ b/src/cmd-pickup.c
@@ -167,7 +167,7 @@ static int auto_pickup_okay(const struct object *obj)
 	 * inscriptions.  The player option to pickup if in the inventory
 	 * honors those inscriptions.
 	 */
-	int num = inven_carry_num(obj, false);
+	int num = inven_carry_num(obj);
 	unsigned obj_has_auto, obj_has_maxauto;
 	int obj_maxauto;
 
@@ -236,7 +236,7 @@ static int auto_pickup_okay(const struct object *obj)
 static void player_pickup_aux(struct player *p, struct object *obj,
 							  int auto_max, bool domsg)
 {
-	int max = inven_carry_num(obj, false);
+	int max = inven_carry_num(obj);
 
 	/* Confirm at least some of the object can be picked up */
 	if (max == 0)

--- a/src/init.c
+++ b/src/init.c
@@ -601,6 +601,8 @@ static enum parser_error parse_constants_carry_cap(struct parser *p) {
 		z->quiver_size = value;
 	else if (streq(label, "quiver-slot-size"))
 		z->quiver_slot_size = value;
+	else if (streq(label, "thrown-quiver-mult"))
+		z->thrown_quiver_mult = value;
 	else if (streq(label, "floor-size"))
 		z->floor_size = value;
 	else

--- a/src/init.h
+++ b/src/init.h
@@ -99,6 +99,7 @@ struct angband_constants
 	u16b pack_size;		/**< Maximum number of pack slots */
 	u16b quiver_size;	/**< Maximum number of quiver slots */
 	u16b quiver_slot_size;	/**< Maximum number of missiles per quiver slot */
+	u16b thrown_quiver_mult;/**< Size multiplier for non-ammo in quiver */
 	u16b floor_size;	/**< Maximum number of items per floor grid */
 
 	/* Store parameters, read from constants.txt */

--- a/src/obj-gear.c
+++ b/src/obj-gear.c
@@ -544,28 +544,9 @@ static int quiver_absorb_num(const struct object *obj)
 
 /**
  * Calculate how much of an item is can be carried in the inventory or quiver.
- *
- * Optionally only return a positive value if there is already a similar object.
  */
-int inven_carry_num(const struct object *obj, bool stack)
+int inven_carry_num(const struct object *obj)
 {
-	/* Check for similarity */
-	if (stack) {
-		struct object *gear_obj;
-
-		for (gear_obj = player->gear; gear_obj; gear_obj = gear_obj->next) {
-			if (!object_is_equipped(player->body, gear_obj) &&
-					object_stackable(gear_obj, obj, OSTACK_PACK)) {
-				break;
-			}
-		}
-
-		/* No similar object, so no stacking */
-		if (!gear_obj) {
-			return 0;
-		}
-	}
-
 	/* Free inventory slots, so there is definitely room */
 	if (pack_slots_used(player) < z_info->pack_size) {
 		return obj->number;
@@ -589,12 +570,11 @@ int inven_carry_num(const struct object *obj, bool stack)
 }
 
 /**
- * Check if we have space for some of an item in the pack, optionally requiring
- * stacking
+ * Check if we have space for some of an item in the pack.
  */
 bool inven_carry_okay(const struct object *obj)
 {
-	return inven_carry_num(obj, false) > 0;
+	return inven_carry_num(obj) > 0;
 }
 
 /**

--- a/src/obj-gear.c
+++ b/src/obj-gear.c
@@ -662,8 +662,12 @@ void inven_carry(struct player *p, struct object *obj, bool absorb,
 
 		struct object *gear_obj = p->gear;
 		while ((combine_item == NULL) && (gear_obj != NULL)) {
+			object_stack_t stack_mode =
+				object_is_in_quiver(p, gear_obj) ?
+				OSTACK_QUIVER : OSTACK_PACK;
+
 			if (!object_is_equipped(p->body, gear_obj) &&
-					object_similar(gear_obj, obj, OSTACK_PACK)) {
+					object_similar(gear_obj, obj, stack_mode)) {
 				combine_item = gear_obj;
 			}
 

--- a/src/obj-gear.c
+++ b/src/obj-gear.c
@@ -531,6 +531,8 @@ static void quiver_absorb_num(const struct object *obj, int *n_add_pack,
 					 * available.
 					 */
 					displaces = true;
+					assert(quiver_obj->number * mult <=
+						z_info->quiver_slot_size);
 					space_free += z_info->quiver_slot_size -
 						quiver_obj->number * mult;
 				}

--- a/src/obj-gear.c
+++ b/src/obj-gear.c
@@ -176,7 +176,8 @@ int pack_slots_used(struct player *p)
 				for (i = 0; i < z_info->quiver_size; i++) {
 					if (p->upkeep->quiver[i] == obj) {
 						quiver_ammo += obj->number *
-							(tval_is_ammo(obj) ? 1 : 5);
+							(tval_is_ammo(obj) ?
+							1 : z_info->thrown_quiver_mult);
 						found = true;
 						break;
 					}
@@ -503,7 +504,8 @@ static int quiver_absorb_num(const struct object *obj)
 		for (i = 0; i < z_info->quiver_size; i++) {
 			struct object *quiver_obj = player->upkeep->quiver[i];
 			if (quiver_obj) {
-				int mult = tval_is_ammo(quiver_obj) ? 1 : 5;
+				int mult = tval_is_ammo(quiver_obj) ?
+					 1 : z_info->thrown_quiver_mult;
 
 				quiver_count += quiver_obj->number * mult;
 				if (object_stackable(quiver_obj, obj, OSTACK_PACK))
@@ -531,8 +533,8 @@ static int quiver_absorb_num(const struct object *obj)
 
 			/* Return the number, or the number that will fit */
 			space_free = MIN(space_free, z_info->quiver_slot_size - quiver_count);
-			return MIN(obj->number,
-				space_free / (tval_is_ammo(obj) ? 1 : 5));
+			return MIN(obj->number, space_free /
+				(tval_is_ammo(obj) ? 1 : z_info->thrown_quiver_mult));
 		}
 	}
 

--- a/src/obj-gear.h
+++ b/src/obj-gear.h
@@ -60,6 +60,7 @@ void combine_pack(void);
 bool pack_is_full(void);
 bool pack_is_overfull(void);
 void pack_overflow(struct object *obj);
+int preferred_quiver_slot(const struct object *obj);
 
 
 #endif /* OBJECT_GEAR_H */

--- a/src/obj-gear.h
+++ b/src/obj-gear.h
@@ -48,7 +48,7 @@ char gear_to_label(struct object *obj);
 struct object *gear_last_item(void);
 struct object *gear_object_for_use(struct object *obj, int num, bool message,
 								   bool *none_left);
-int inven_carry_num(const struct object *obj, bool stack);
+int inven_carry_num(const struct object *obj);
 bool inven_carry_okay(const struct object *obj);
 void inven_item_charges(struct object *obj);
 void inven_carry(struct player *p, struct object *obj, bool absorb,

--- a/src/obj-gear.h
+++ b/src/obj-gear.h
@@ -40,12 +40,14 @@ struct object *equipped_item_by_slot_name(struct player *p, const char *name);
 int object_slot(struct player_body body, const struct object *obj);
 bool object_is_equipped(struct player_body body, const struct object *obj);
 bool object_is_carried(struct player *p, const struct object *obj);
+int pack_slots_used(struct player *p);
 const char *equip_mention(struct player *p, int slot);
 const char *equip_describe(struct player *p, int slot);
 int wield_slot(const struct object *obj);
 bool minus_ac(struct player *p);
 char gear_to_label(struct object *obj);
 struct object *gear_last_item(void);
+void gear_insert_end(struct object *obj);
 struct object *gear_object_for_use(struct object *obj, int num, bool message,
 								   bool *none_left);
 int inven_carry_num(const struct object *obj);

--- a/src/obj-pile.c
+++ b/src/obj-pile.c
@@ -491,8 +491,24 @@ bool object_similar(const struct object *obj1, const struct object *obj2,
 	int total = obj1->number + obj2->number;
 
 	/* Check against stacking limit - except in stores which absorb anyway */
-	if (!(mode & OSTACK_STORE) && (total > obj1->kind->base->max_stack))
-		return false;
+	if (!(mode & OSTACK_STORE)) {
+		if (total > obj1->kind->base->max_stack) {
+			return false;
+		}
+		/* The quiver can impose stricter limits. */
+		if (mode & OSTACK_QUIVER) {
+			if (tval_is_ammo(obj1)) {
+				if (total > z_info->quiver_slot_size) {
+					return false;
+				}
+			} else {
+				if (total > z_info->quiver_slot_size /
+						z_info->thrown_quiver_mult) {
+					return false;
+				}
+			}
+		}
+	}
 
 	return object_stackable(obj1, obj2, mode);
 }
@@ -582,14 +598,61 @@ static void object_absorb_merge(struct object *obj1, const struct object *obj2)
 
 /**
  * Merge a smaller stack into a larger stack, leaving two uneven stacks.
+ * \param obj1 Is the first of the stacks to combine.  When the stacking
+ * limits (from mode1 and mode2) are the same, this stack will be larger
+ * when the function returns.
+ * \param obj2 Is the second of the stacks to combine.
+ * \param mode1 Describes the behavior, most notably the upper limit on size,
+ * for the first stack. Can not include OSTACK_STORE, which typically has no
+ * limit on the stack size.
+ * \param mode2 Describes the behavior, most notable the upper limit on size,
+ * for the second stack.  Can not include OSTACK_STORE, which typically has
+ * no limit on the stack size.
  */
-void object_absorb_partial(struct object *obj1, struct object *obj2)
+void object_absorb_partial(struct object *obj1, struct object *obj2,
+	object_stack_t mode1, object_stack_t mode2)
 {
 	int smallest = MIN(obj1->number, obj2->number);
 	int largest = MAX(obj1->number, obj2->number);
-	int difference = obj1->kind->base->max_stack - largest;
-	obj1->number = largest + difference;
-	obj2->number = smallest - difference;
+	int newsz1, newsz2;
+
+	assert(!(mode1 & OSTACK_STORE) && !(mode2 & OSTACK_STORE));
+
+	/* The quiver can have stricter limits. */
+	if (mode1 & OSTACK_QUIVER) {
+		int limit = z_info->quiver_slot_size /
+			(tval_is_ammo(obj1) ?
+			1 : z_info->thrown_quiver_mult);
+
+		if (mode2 & OSTACK_QUIVER) {
+			int difference = limit - largest;
+
+			newsz1 = largest + difference;
+			newsz2 = smallest - difference;
+		} else {
+			/* Handle the possibly different limits. */
+			newsz1 = limit;
+			newsz2 = (largest + smallest) - limit;
+			assert(newsz2 < obj1->kind->base->max_stack);
+		}
+	} else if (mode2 & OSTACK_QUIVER) {
+		/* Handle the possibly different limits. */
+		int limit = z_info->quiver_slot_size /
+			(tval_is_ammo(obj2) ?
+			1 : z_info->thrown_quiver_mult);
+
+		newsz1 = (largest + smallest) - limit;
+		newsz2 = limit;
+		assert(newsz1 < obj1->kind->base->max_stack);
+	} else {
+		int difference = obj1->kind->base->max_stack - largest;
+
+		newsz1 = largest + difference;
+		newsz2 = smallest - difference;
+	}
+
+	obj1->number = newsz1;
+	obj2->number = newsz2;
 
 	object_absorb_merge(obj1, obj2);
 }

--- a/src/obj-pile.h
+++ b/src/obj-pile.h
@@ -64,7 +64,8 @@ bool object_stackable(const struct object *obj1, const struct object *obj2,
 bool object_similar(const struct object *obj1, const struct object *obj2,
 					object_stack_t mode);
 void object_origin_combine(struct object *obj1, const struct object *obj2);
-void object_absorb_partial(struct object *obj1, struct object *obj2);
+void object_absorb_partial(struct object *obj1, struct object *obj2,
+	object_stack_t mode1, object_stack_t mode2);
 void object_absorb(struct object *obj1, struct object *obj2);
 void object_wipe(struct object *obj);
 void object_copy(struct object *obj1, const struct object *obj2);

--- a/src/player-calcs.c
+++ b/src/player-calcs.c
@@ -1048,30 +1048,17 @@ void calc_inventory(struct player_upkeep *upkeep, struct object *gear,
 
 		/* Find the first quiver object with the correct label */
 		for (current = gear; current; current = current->next) {
-			bool throwing = of_has(current->flags, OF_THROWING);
-
-			/* Only allow ammo and throwing weapons */
-			if (!(tval_is_ammo(current) || throwing)) continue;
-
 			/* Allocate inscribed objects if it's the right slot */
-			if (current->note) {
-				const char *s = strchr(quark_str(current->note), '@');
-				if (s && (s[1] == 'f' || s[1] == 'v')) {
-					int choice = s[2] - '0';
+			if (preferred_quiver_slot(current) == i) {
+				int mult = tval_is_ammo(current) ? 1 : 5;
+				upkeep->quiver[i] = current;
+				upkeep->quiver_cnt += current->number * mult;
 
-					/* Correct slot, fill it straight away */
-					if (choice == i) {
-						int mult = tval_is_ammo(current) ? 1 : 5;
-						upkeep->quiver[i] = current;
-						upkeep->quiver_cnt += current->number * mult;
+				/* In the quiver counts as worn */
+				object_learn_on_wield(player, current);
 
-						/* In the quiver counts as worn */
-						object_learn_on_wield(player, current);
-
-						/* Done with this slot */
-						break;
-					}
-				}
+				/* Done with this slot */
+				break;
 			}
 		}
 	}

--- a/src/player-calcs.c
+++ b/src/player-calcs.c
@@ -1072,9 +1072,22 @@ void calc_inventory(struct player_upkeep *upkeep, struct object *gear,
 					assert(nsplit < current->number);
 					if (nsplit > 0 && n_stack_split <=
 							n_pack_remaining) {
-						to_quiver = object_split(
-							current, nsplit);
-						gear_insert_end(to_quiver);
+						/*
+						 * Split off the portion that
+						 * go to the pack.  Since the
+						 * stack in the quiver is
+						 * earlier in the gear list
+						 * it will prefer to remain
+						 * in the quiver in future
+						 * calls to calc_inventory()
+						 * and will be the preferential
+						 * destination for merges in
+						 * combine_pack().
+						 */
+						to_quiver = current;
+						gear_insert_end(object_split(
+							current, current->number
+							- nsplit));
 						++n_stack_split;
 					} else {
 						to_quiver = NULL;
@@ -1131,9 +1144,13 @@ void calc_inventory(struct player_upkeep *upkeep, struct object *gear,
 			to_quiver = first;
 		} else if (z_info->quiver_slot_size > 0 &&
 				n_stack_split <= n_pack_remaining) {
-			to_quiver = object_split(first,
-				z_info->quiver_slot_size);
-			gear_insert_end(to_quiver);
+			/*
+			 * As above, split off the portion that goes to the
+			 * pack.
+			 */
+			to_quiver = first;
+			gear_insert_end(object_split(first,
+				first->number - z_info->quiver_slot_size));
 			++n_stack_split;
 		} else {
 			to_quiver = NULL;

--- a/src/player-calcs.c
+++ b/src/player-calcs.c
@@ -1050,7 +1050,8 @@ void calc_inventory(struct player_upkeep *upkeep, struct object *gear,
 		for (current = gear; current; current = current->next) {
 			/* Allocate inscribed objects if it's the right slot */
 			if (preferred_quiver_slot(current) == i) {
-				int mult = tval_is_ammo(current) ? 1 : 5;
+				int mult = tval_is_ammo(current) ?
+					 1 : z_info->thrown_quiver_mult;
 				upkeep->quiver[i] = current;
 				upkeep->quiver_cnt += current->number * mult;
 

--- a/src/store.c
+++ b/src/store.c
@@ -1652,7 +1652,7 @@ void do_cmd_buy(struct command *cmd)
 	object_copy_amt(bought, obj, amt);
 
 	/* Ensure we have room */
-	if (bought->number > inven_carry_num(bought, false)) {
+	if (bought->number > inven_carry_num(bought)) {
 		msg("You cannot carry that many items.");
 		object_delete(&bought);
 		return;
@@ -1779,7 +1779,7 @@ void do_cmd_retrieve(struct command *cmd)
 	object_copy_amt(picked_item, obj, amt);
 
 	/* Ensure we have room */
-	if (picked_item->number > inven_carry_num(picked_item, false)) {
+	if (picked_item->number > inven_carry_num(picked_item)) {
 		msg("You cannot carry that many items.");
 		object_delete(&picked_item);
 		return;

--- a/src/tests/player/calc-inventory.c
+++ b/src/tests/player/calc-inventory.c
@@ -228,6 +228,40 @@ static bool verify_quiver(struct player *p, const struct out_slot_desc *slots) {
 	return true;
 }
 
+/*
+ * Verify that another call to calc_inventory() with the gear unchanged gives
+ * the same result.
+ */
+static bool verify_stability(struct player *p) {
+	struct object **old_pack =
+		mem_alloc(z_info->pack_size * sizeof(*old_pack));
+	struct object **old_quiver =
+		mem_alloc(z_info->quiver_size * sizeof(old_quiver));
+	bool result = true;
+	int i;
+
+	for (i = 0; i < z_info->pack_size; ++i) {
+		old_pack[i] = p->upkeep->inven[i];
+	}
+	for (i = 0; i < z_info->quiver_size; ++i) {
+		old_quiver[i] = p->upkeep->quiver[i];
+	}
+	calc_inventory(p->upkeep, p->gear, p->body);
+	for (i = 0; i < z_info->pack_size; ++i) {
+		if (old_pack[i] != p->upkeep->inven[i]) {
+			result = false;
+		}
+	}
+	for (i = 0; i < z_info->quiver_size; ++i) {
+		if (old_quiver[i] != p->upkeep->quiver[i]) {
+			result = false;
+		}
+	}
+	mem_free(old_quiver);
+	mem_free(old_pack);
+	return true;
+}
+
 static int test_calc_inventory_empty(void *state) {
 	struct out_slot_desc empty = { -1, -1, -1 };
 
@@ -235,6 +269,7 @@ static int test_calc_inventory_empty(void *state) {
 	calc_inventory(player->upkeep, player->gear, player->body);
 	require(verify_pack(player, &empty, 0));
 	require(verify_quiver(player, &empty));
+	require(verify_stability(player));
 	ok;
 }
 
@@ -257,6 +292,7 @@ static int test_calc_inventory_only_equipped(void *state) {
 	calc_inventory(player->upkeep, player->gear, player->body);
 	require(verify_pack(player, only_equipped_case.pack_out, 0));
 	require(verify_quiver(player, only_equipped_case.quiv_out));
+	require(verify_stability(player));
 	ok;
 }
 
@@ -300,6 +336,7 @@ static int test_calc_inventory_only_pack(void *state) {
 	calc_inventory(player->upkeep, player->gear, player->body);
 	require(verify_pack(player, only_pack_case.pack_out, 0));
 	require(verify_quiver(player, only_pack_case.quiv_out));
+	require(verify_stability(player));
 	ok;
 }
 
@@ -351,6 +388,7 @@ static int test_calc_inventory_only_quiver(void *state) {
 		(quiver_size + z_info->quiver_slot_size - 1) /
 		z_info->quiver_slot_size));
 	require(verify_quiver(player, only_quiver_case.quiv_out));
+	require(verify_stability(player));
 	ok;
 }
 
@@ -435,6 +473,7 @@ static int test_calc_inventory_equipped_pack_quiver(void *state) {
 		(quiver_size + z_info->quiver_slot_size - 1) /
 		z_info->quiver_slot_size));
 	require(verify_quiver(player, this_test_case.quiv_out));
+	require(verify_stability(player));
 	ok;
 }
 
@@ -497,6 +536,7 @@ static int test_calc_inventory_oversubscribed_quiver(void *state) {
 		(quiver_size + z_info->quiver_slot_size - 1) /
 		z_info->quiver_slot_size));
 	require(verify_quiver(player, this_test_case.quiv_out));
+	require(verify_stability(player));
 	ok;
 }
 
@@ -561,6 +601,7 @@ static int test_calc_inventory_oversubscribed_quiver_slot(void *state) {
 		(quiver_size + z_info->quiver_slot_size - 1) /
 		z_info->quiver_slot_size));
 	require(verify_quiver(player, this_test_case.quiv_out));
+	require(verify_stability(player));
 	ok;
 }
 
@@ -588,6 +629,7 @@ static test_calc_inventory_quiver_split_pile(void *state) {
 	calc_inventory(player->upkeep, player->gear, player->body);
 	require(verify_pack(player, this_test_case.pack_out, 1));
 	require(verify_quiver(player, this_test_case.quiv_out));
+	require(verify_stability(player));
 	ok;
 }
 

--- a/src/tests/player/calc-inventory.c
+++ b/src/tests/player/calc-inventory.c
@@ -1,0 +1,605 @@
+/* player/calc-inventory.c */
+/* Exercise calc_inventory(). */
+
+#include "unit-test.h"
+#include "test-utils.h"
+#include "cave.h"
+#include "cmd-core.h"
+#include "game-world.h"
+#include "init.h"
+#include "obj-gear.h"
+#include "obj-knowledge.h"
+#include "obj-make.h"
+#include "obj-pile.h"
+#include "obj-properties.h"
+#include "obj-tval.h"
+#include "obj-util.h"
+#include "player-calcs.h"
+#include "z-quark.h"
+
+/*
+ * This is the maximum number of things (one of which will be a sentinel
+ * element) to put in the gear for a test.
+ */
+#define TEST_SLOT_COUNT (40)
+
+struct in_slot_desc { int tval, sval, num; bool known; bool equipped; };
+struct out_slot_desc { int tval, sval, num; };
+struct simple_test_case {
+	struct in_slot_desc gear_in[TEST_SLOT_COUNT];
+	struct out_slot_desc pack_out[TEST_SLOT_COUNT];
+	struct out_slot_desc quiv_out[TEST_SLOT_COUNT];
+};
+
+int setup_tests(void **state) {
+	set_file_paths();
+	init_angband();
+
+	/* Set up the player. */
+	cmdq_push(CMD_BIRTH_INIT);
+	cmdq_push(CMD_BIRTH_RESET);
+	cmdq_push(CMD_CHOOSE_RACE);
+	cmd_set_arg_choice(cmdq_peek(), "choice", 0);
+	/* Use a mage so magic books are browseable. */
+	cmdq_push(CMD_CHOOSE_CLASS);
+	cmd_set_arg_choice(cmdq_peek(), "choice", 1);
+	cmdq_push(CMD_ROLL_STATS);
+	cmdq_push(CMD_NAME_CHOICE);
+	cmd_set_arg_string(cmdq_peek(), "name", "Tester");
+	cmdq_push(CMD_ACCEPT_CHARACTER);
+	cmdq_execute(CTX_BIRTH);
+	prepare_next_level(&cave, player);
+	on_new_level();
+
+	return 0;
+}
+
+int teardown_tests(void *state) {
+	cleanup_angband();
+
+	return 0;
+}
+
+/* Forget all known flavors. */
+static void forget_flavors(void) {
+	int i;
+
+	for (i = 1; i < z_info->k_max; ++i) {
+		struct object_kind *kind = &k_info[i];
+
+		kind->aware = false;
+	}
+}
+
+/* Remove all of the gear. */
+static bool flush_gear(void) {
+	struct object *curr = player->gear;
+
+	while (curr != NULL) {
+		struct object *next = curr->next;
+		bool none_left = false;
+
+		if (object_is_equipped(player->body, curr)) {
+			inven_takeoff(curr);
+		}
+		curr = gear_object_for_use(curr, curr->number, false,
+			&none_left);
+		if (curr->known) {
+			object_free(curr->known);
+		}
+		object_free(curr);
+		curr = next;
+		if (!none_left) {
+			return false;
+		}
+	}
+	return true;
+}
+
+/* Fill the gear with specified, simple, items. */
+static bool populate_gear(const struct in_slot_desc *slots) {
+	while (slots->tval > 0) {
+		struct object_kind *kind =
+			lookup_kind(slots->tval, slots->sval);
+		struct object *obj;
+
+		if (!kind) {
+			return false;
+		}
+		obj = object_new();
+		object_prep(obj, kind, 0, RANDOMISE);
+		obj->number = slots->num;
+		obj->known = object_new();
+		object_set_base_known(obj);
+		object_touch(player, obj);
+		if (slots->known && ! object_flavor_is_aware(obj)) {
+			object_learn_on_use(player, obj);
+		}
+		gear_insert_end(obj);
+		if (!object_is_carried(player, obj)) {
+			return false;
+		}
+		if (slots->equipped) {
+			inven_wield(obj, wield_slot(obj));
+			if (!object_is_equipped(player->body, obj)) {
+				return false;
+			}
+		}
+
+		++slots;
+	}
+
+	return true;
+}
+
+/* Verify that the pack matches a given layout. */
+static bool verify_pack(struct player *p, const struct out_slot_desc *slots,
+		int slots_for_quiver) {
+	int curr_slot = 0;
+	int n_slots_used;
+
+	if (!p->upkeep || !p->upkeep->inven) {
+		return false;
+	}
+	n_slots_used = pack_slots_used(p);
+	while (slots->tval > 0) {
+		struct object_kind *kind =
+			lookup_kind(slots->tval, slots->sval);
+
+		if (curr_slot >= n_slots_used) {
+			return false;
+		}
+		if (!p->upkeep->inven[curr_slot]) {
+			return false;
+		}
+		if (p->upkeep->inven[curr_slot]->kind != kind) {
+			return false;
+		}
+		if (p->upkeep->inven[curr_slot]->number != slots->num) {
+			return false;
+		}
+		if (!object_is_carried(p, p->upkeep->inven[curr_slot])) {
+			return false;
+		}
+		if (object_is_equipped(p->body, p->upkeep->inven[curr_slot])) {
+			return false;
+		}
+		++curr_slot;
+		++slots;
+	}
+	if (curr_slot + slots_for_quiver != n_slots_used) {
+		return false;
+	}
+	return true;
+}
+
+/* Verify that the quiver matches a given layout. */
+static bool verify_quiver(struct player *p, const struct out_slot_desc *slots) {
+	int curr_slot = 0;
+	int total = 0;
+
+	if (!p->upkeep || !p->upkeep->quiver) {
+		return false;
+	}
+	while (slots->tval >= 0) {
+		if (slots->tval == 0) {
+			if (p->upkeep->quiver[curr_slot]) {
+				return false;
+			}
+		} else {
+			struct object_kind *kind =
+				lookup_kind(slots->tval, slots->sval);
+			if (curr_slot >= z_info->quiver_size) {
+				return false;
+			}
+			if (!p->upkeep->quiver[curr_slot]) {
+				return false;
+			}
+			if (p->upkeep->quiver[curr_slot]->kind != kind) {
+				return false;
+			}
+			if (p->upkeep->quiver[curr_slot]->number !=
+					slots->num) {
+				return false;
+			}
+			if (!object_is_carried(p,
+					p->upkeep->quiver[curr_slot])) {
+				return false;
+			}
+			if (object_is_equipped(p->body,
+					p->upkeep->quiver[curr_slot])) {
+				return false;
+			}
+			total += slots->num *
+				(tval_is_ammo(p->upkeep->quiver[curr_slot]) ?
+				1 : z_info->thrown_quiver_mult);
+		}
+		++curr_slot;
+		++slots;
+	}
+	for (; curr_slot < z_info->quiver_size; ++curr_slot) {
+		if (p->upkeep->quiver[curr_slot]) {
+			return false;
+		}
+	}
+	if (total != p->upkeep->quiver_cnt) {
+		return false;
+	}
+	return true;
+}
+
+static int test_calc_inventory_empty(void *state) {
+	struct out_slot_desc empty = { -1, -1, -1 };
+
+	require(flush_gear());
+	calc_inventory(player->upkeep, player->gear, player->body);
+	require(verify_pack(player, &empty, 0));
+	require(verify_quiver(player, &empty));
+	ok;
+}
+
+static int test_calc_inventory_only_equipped(void *state) {
+	struct simple_test_case only_equipped_case = {
+		{
+			{ TV_SWORD, 1, 1, true, true },
+			{ TV_BOW, 2, 1, true, true },
+			{ TV_SHIELD, 1, 1, true, true },
+			{ TV_CLOAK, 1, 1, true, true },
+			{ TV_SOFT_ARMOR, 2, 1, true, true },
+			{ -1, -1, -1, false, false, }
+		},
+		{ { -1, -1, -1 }, },
+		{ { -1, -1, -1 }, }
+	};
+
+	require(flush_gear());
+	require(populate_gear(only_equipped_case.gear_in));
+	calc_inventory(player->upkeep, player->gear, player->body);
+	require(verify_pack(player, only_equipped_case.pack_out, 0));
+	require(verify_quiver(player, only_equipped_case.quiv_out));
+	ok;
+}
+
+static int test_calc_inventory_only_pack(void *state) {
+	struct simple_test_case only_pack_case = {
+		{
+			{ TV_SCROLL, 5, 3, true, false },
+			{ TV_WAND, 3, 1, true, false },
+			{ TV_FOOD, 2, 4, true, false },
+			{ TV_ROD, 2, 2, true, false },
+			{ TV_POTION, 4, 5, true, false },
+			{ TV_MAGIC_BOOK, 1, 1, true, false },
+			{ TV_LIGHT, 1, 6, true, false },
+			{ TV_DIGGING, 1, 1, true, false },
+			{ TV_FLASK, 1, 1, true, false },
+			{ TV_STAFF, 3, 1, true, false },
+			{ -1, -1, -1, false, false }
+		},
+		/*
+		 * Usable book is first; then appear in order of decreasing
+		 * tval.
+		 */
+		{
+			{ TV_MAGIC_BOOK, 1, 1 },
+			{ TV_FOOD, 2, 4 },
+			{ TV_FLASK, 1, 1 },
+			{ TV_POTION, 4, 5 },
+			{ TV_SCROLL, 5, 3 },
+			{ TV_ROD, 2, 2 },
+			{ TV_WAND, 3, 1 },
+			{ TV_STAFF, 3, 1 },
+			{ TV_LIGHT, 1, 6 },
+			{ TV_DIGGING, 1, 1 },
+			{ -1, -1, -1 }
+		},
+		{ { -1, -1, -1 } }
+	};
+
+	require(flush_gear());
+	require(populate_gear(only_pack_case.gear_in));
+	calc_inventory(player->upkeep, player->gear, player->body);
+	require(verify_pack(player, only_pack_case.pack_out, 0));
+	require(verify_quiver(player, only_pack_case.quiv_out));
+	ok;
+}
+
+static int test_calc_inventory_only_quiver(void *state) {
+	struct simple_test_case only_quiver_case = {
+		{
+			{ TV_BOLT, 1, 20, true, false },
+			/* spear */
+			{ TV_POLEARM, 1, 1, true, false },
+			{ TV_SHOT, 1, 27, true, false },
+			{ TV_ARROW, 1, 15, true, false },
+		},
+		{ { -1, -1, -1 } },
+		/*
+		 * There's no launcher equipped, so the ammunition will be
+		 * ordered by decreasing tval.
+		 */
+		{
+			{ TV_BOLT, 1, 20 },
+			{ TV_POLEARM, 1, 1 },
+			{ TV_ARROW, 1, 15 },
+			{ TV_SHOT, 1, 27 },
+			{ -1, -1, -1 }
+		}
+	};
+	struct object *obj;
+	int quiver_size;
+
+	require(flush_gear());
+	require(populate_gear(only_quiver_case.gear_in));
+	/*
+	 * Inscribe the spear so it goes to the quiver.  Also, compute how
+	 * much space the quiver will take.
+	 */
+	obj = player->gear;
+	quiver_size = 0;
+	while (obj) {
+		if (obj->tval == TV_POLEARM) {
+			require(of_has(obj->flags, OF_THROWING));
+			obj->note = quark_add("@v1");
+			quiver_size += z_info->thrown_quiver_mult * obj->number;
+		} else {
+			quiver_size += obj->number;
+		}
+		obj = obj->next;
+	}
+	calc_inventory(player->upkeep, player->gear, player->body);
+	require(verify_pack(player, only_quiver_case.pack_out,
+		(quiver_size + z_info->quiver_slot_size - 1) /
+		z_info->quiver_slot_size));
+	require(verify_quiver(player, only_quiver_case.quiv_out));
+	ok;
+}
+
+static int test_calc_inventory_equipped_pack_quiver(void *state) {
+	struct simple_test_case this_test_case = {
+		{
+			{ TV_BOLT, 1, 10, true, false },
+			{ TV_SCROLL, 3, 4, true, false },
+			{ TV_SOFT_ARMOR, 2, 1, false, true },
+			/* dagger */
+			{ TV_SWORD, 1, 1, false, false },
+			{ TV_POTION, 2, 3, false, false },
+			{ TV_ARROW, 2, 7, true, false },
+			{ TV_SHOT, 1, 13, true, false },
+			{ TV_ARROW, 1, 15, true, false },
+			{ TV_NATURE_BOOK, 1, 1, false, false },
+			{ TV_SCROLL, 1, 3, false, false },
+			{ TV_POTION, 3, 1, true, false },
+			{ TV_PRAYER_BOOK, 1, 1, false, false },
+			{ TV_BOLT, 2, 5, true, false },
+			{ TV_SHOT, 2, 3, true, false },
+			{ TV_MAGIC_BOOK, 1, 1, false, false },
+			/* sling */
+			{ TV_BOW, 1, 1, false, true },
+			{ TV_POTION, 5, 2, true, false },
+		},
+		{
+			{ TV_MAGIC_BOOK, 1, 1 },
+			{ TV_NATURE_BOOK, 1, 1 },
+			{ TV_PRAYER_BOOK, 1, 1 },
+			{ TV_POTION, 3, 1 },
+			{ TV_POTION, 5, 2 },
+			{ TV_POTION, 2, 3 },
+			{ TV_SCROLL, 3, 4 },
+			{ TV_SCROLL, 1, 3 },
+			{ -1, -1, -1 }
+		},
+		/*
+		 * A sling is equipped, so the shots should appear before the
+		 * other ammunition. The rest appear in order of decreasing
+		 * tval.
+		 */
+		{
+			{ TV_SHOT, 1, 13 },
+			{ TV_SHOT, 2, 3 },
+			{ TV_SWORD, 1, 1 },
+			{ TV_BOLT, 1, 10 },
+			{ TV_BOLT, 2, 5 },
+			{ TV_ARROW, 1, 15 },
+			{ TV_ARROW, 2, 7 },
+			{ -1, -1, -1 }
+		}
+	};
+	struct object *obj;
+	int quiver_size;
+
+	/*
+	 * Forget all flavors so the order of the known/unknown flavors set
+	 * locally won't depend on previously run tests.
+	 */
+	forget_flavors();
+	require(flush_gear());
+	require(populate_gear(this_test_case.gear_in));
+	/*
+	 * Inscribe the spear so it goes to the quiver.  Also, compute how
+	 * much space the quiver will take.
+	 */
+	obj = player->gear;
+	quiver_size = 0;
+	while (obj) {
+		if (obj->tval == TV_SWORD) {
+			require(of_has(obj->flags, OF_THROWING));
+			obj->note = quark_add("@v2");
+			quiver_size += z_info->thrown_quiver_mult * obj->number;
+		} else if (tval_is_ammo(obj)) {
+			quiver_size += obj->number;
+		}
+		obj = obj->next;
+	}
+	calc_inventory(player->upkeep, player->gear, player->body);
+	require(verify_pack(player, this_test_case.pack_out,
+		(quiver_size + z_info->quiver_slot_size - 1) /
+		z_info->quiver_slot_size));
+	require(verify_quiver(player, this_test_case.quiv_out));
+	ok;
+}
+
+static int test_calc_inventory_oversubscribed_quiver(void *state) {
+	struct simple_test_case this_test_case = {
+		{
+			{ TV_SHOT, 2, 40, true, false },
+			{ TV_ARROW, 1, 40, true, false },
+			{ TV_BOLT, 1, 40, true, false },
+			{ TV_ARROW, 1, 40, true, false },
+			{ TV_SHOT, 2, 40, true, false },
+			{ TV_ARROW, 2, 10, true, false },
+			/* short bow */
+			{ TV_BOW, 2, 1, true, true },
+			{ TV_BOLT, 3, 7, true, false },
+			{ TV_ARROW, 3, 15, true, false },
+			{ TV_BOLT, 1, 40, true, false },
+			{ TV_SHOT, 1, 25, true, false },
+			{ TV_BOLT, 2, 12, true, false },
+			{ TV_SHOT, 3, 17, true, false },
+			{ -1, -1, -1 }
+		},
+		{
+			{ TV_SHOT, 2, 40 },
+			{ TV_SHOT, 3, 17 },
+			{ -1, -1, -1 }
+		},
+		{
+			{ TV_ARROW, 1, 40 },
+			{ TV_ARROW, 1, 40 },
+			{ TV_ARROW, 2, 10 },
+			{ TV_ARROW, 3, 15 },
+			{ TV_BOLT, 1, 40 },
+			{ TV_BOLT, 1, 40 },
+			{ TV_BOLT, 2, 12 },
+			{ TV_BOLT, 3, 7 },
+			{ TV_SHOT, 1, 25 },
+			{ TV_SHOT, 2, 40 },
+			{ -1, -1, -1 }
+		}
+	};
+	struct object *obj;
+	int quiver_size;
+
+	require(flush_gear());
+	require(populate_gear(this_test_case.gear_in));
+	/* Compute how much space the quiver will take. */
+	obj = player->gear;
+	quiver_size = 0;
+	while (obj) {
+		if (tval_is_ammo(obj)) {
+			quiver_size += obj->number;
+		}
+		obj = obj->next;
+	}
+	/* Adjust for the ones that will end up in the pack. */
+	quiver_size -= 57;
+	calc_inventory(player->upkeep, player->gear, player->body);
+	require(verify_pack(player, this_test_case.pack_out,
+		(quiver_size + z_info->quiver_slot_size - 1) /
+		z_info->quiver_slot_size));
+	require(verify_quiver(player, this_test_case.quiv_out));
+	ok;
+}
+
+static int test_calc_inventory_oversubscribed_quiver_slot(void *state) {
+	struct simple_test_case this_test_case = {
+		{
+			{ TV_BOLT, 1, 10, true, false },
+			/* dagger */
+			{ TV_SWORD, 1, 1, true, false },
+			{ TV_ARROW, 2, 7, true, false },
+			{ TV_SHOT, 1, 13, true, false },
+			/* spear */
+			{ TV_POLEARM, 1, 1, true, false },
+			{ TV_ARROW, 1, 15, true, false },
+			{ TV_BOLT, 2, 5, true, false },
+			{ TV_SHOT, 2, 3, true, false },
+		},
+		{
+			{ TV_SWORD, 1, 1 },
+			{ -1, -1, -1 }
+		},
+		{
+			{ TV_BOLT, 1, 10 },
+			{ TV_ARROW, 2, 7 },
+			{ TV_POLEARM, 1, 1 },
+			{ TV_BOLT, 2, 5 },
+			{ TV_ARROW, 1, 15 },
+			{ TV_SHOT, 1, 13 },
+			{ TV_SHOT, 2, 3 },
+			{ -1, -1, -1 },
+		}
+	};
+	struct object *obj;
+	int i, quiver_size;
+
+	require(flush_gear());
+	require(populate_gear(this_test_case.gear_in));
+	/*
+	 * Inscribe everything going to the quiver with more than one targeting
+	 * each slot.  Also, compute the total size for the things in the
+	 * quiver;
+	 */
+	obj = player->gear;
+	i = 0;
+	quiver_size = 0;
+	while (obj) {
+		if (tval_is_ammo(obj)) {
+			obj->note = quark_add(format("@f%d", i / 2));
+			quiver_size += obj->number;
+		} else {
+			obj->note = quark_add(format("@v%d", i / 2));
+			if (i % 2 == 0) {
+				quiver_size += z_info->thrown_quiver_mult *
+					obj->number;
+			}
+		}
+		++i;
+		obj = obj->next;
+	}
+	calc_inventory(player->upkeep, player->gear, player->body);
+	require(verify_pack(player, this_test_case.pack_out,
+		(quiver_size + z_info->quiver_slot_size - 1) /
+		z_info->quiver_slot_size));
+	require(verify_quiver(player, this_test_case.quiv_out));
+	ok;
+}
+
+static test_calc_inventory_quiver_split_pile(void *state) {
+	struct simple_test_case this_test_case = {
+		{
+			{ TV_FLASK, 1, 10 },
+			{ -1, -1, -1 }
+		},
+		{
+			{ TV_FLASK, 1, 2 },
+			{ -1, -1, -1 }
+		},
+		{
+			{ 0, 0, 0 },
+			{ TV_FLASK, 1, 8 },
+			{ -1, -1, -1 }
+		}
+	};
+
+	require(flush_gear());
+	require(populate_gear(this_test_case.gear_in));
+	/* Inscribe the flasks so they want to go to the quiver. */
+	player->gear->note = quark_add("@v1");
+	calc_inventory(player->upkeep, player->gear, player->body);
+	require(verify_pack(player, this_test_case.pack_out, 1));
+	require(verify_quiver(player, this_test_case.quiv_out));
+	ok;
+}
+
+const char *suite_name = "player/calc-inventory";
+struct test tests[] = {
+	{ "calc_inventory empty", test_calc_inventory_empty },
+	{ "calc_inventory only equipped", test_calc_inventory_only_equipped },
+	{ "calc_inventory only pack", test_calc_inventory_only_pack },
+	{ "calc_inventory only quiver", test_calc_inventory_only_quiver },
+	{ "calc_inventory equipped/pack/quiver", test_calc_inventory_equipped_pack_quiver },
+	{ "calc_inventory oversubscribed quiver", test_calc_inventory_oversubscribed_quiver },
+	{ "calc_inventory oversubscribed quiver slot", test_calc_inventory_oversubscribed_quiver_slot },
+	{ "calc_inventory split pile for quiver", test_calc_inventory_quiver_split_pile },
+	{ NULL, NULL }
+};

--- a/src/tests/player/inven-carry-num.c
+++ b/src/tests/player/inven-carry-num.c
@@ -1,0 +1,701 @@
+/* player/inven-carry-num.c */
+/* Exercise inven_carry_num() and inven_carry_okay(). */
+
+#include "test-utils.h"
+#include "unit-test.h"
+#include "cmd-core.h"
+#include "init.h"
+#include "obj-gear.h"
+#include "obj-knowledge.h"
+#include "obj-make.h"
+#include "obj-pile.h"
+#include "obj-util.h"
+#include "player-calcs.h"
+
+struct carry_num_state {
+	struct player *p;
+	/*
+	 * Want something that is neither ammunition nor good for throwing
+	 * (torch), ammunition but not good for throwing (arrow), ammunition
+	 * and good for throwing (shot), and good for throwing but not
+	 * ammunition (flask of oil) when testing how the quiver fills.
+	 */
+	struct object *torch;
+	struct object *arrow;
+	struct object *shot;
+	struct object *flask;
+	struct object *inscribed_flask;
+};
+
+int setup_tests(void **state) {
+	struct carry_num_state *cns;
+	int i;
+
+	set_file_paths();
+	init_angband();
+
+	/*
+	 * Use a smaller than normal pack and quiver so it is less tedious to
+	 * fill them up.  The tests are structured to assume that pack_size is
+	 * at least two larger than the quiver size.  Use a quiver size of
+	 * three so it is possible to fill it up with one stack of arrows, one
+	 * stack of shots, and one stack of flasks.
+	 */
+	z_info->pack_size = 5;
+	z_info->quiver_size = 3;
+
+	/* Set up the player. */
+	cmdq_push(CMD_BIRTH_INIT);
+	cmdq_push(CMD_BIRTH_RESET);
+	cmdq_push(CMD_CHOOSE_RACE);
+	cmd_set_arg_choice(cmdq_peek(), "choice", 0);
+	cmdq_push(CMD_CHOOSE_CLASS);
+	cmd_set_arg_choice(cmdq_peek(), "choice", 0);
+	cmdq_push(CMD_ROLL_STATS);
+	cmdq_push(CMD_NAME_CHOICE);
+	cmd_set_arg_string(cmdq_peek(), "name", "Tester");
+	cmdq_push(CMD_ACCEPT_CHARACTER);
+	cmdq_execute(CTX_BIRTH);
+
+	cns = mem_zalloc(sizeof *cns);
+	cns->p = player;
+	cns->torch = object_new();
+	object_prep(cns->torch, lookup_kind(TV_LIGHT, 1), 0, RANDOMISE);
+	cns->torch->known = object_new();
+	object_set_base_known(cns->torch);
+	object_touch(cns->p, cns->torch);
+	cns->arrow = object_new();
+	object_prep(cns->arrow, lookup_kind(TV_ARROW, 1), 0, RANDOMISE);
+	cns->arrow->known = object_new();
+	object_set_base_known(cns->arrow);
+	object_touch(cns->p, cns->arrow);
+	cns->shot = object_new();
+	object_prep(cns->shot, lookup_kind(TV_SHOT, 1), 0, RANDOMISE);
+	cns->shot->known = object_new();
+	object_set_base_known(cns->shot);
+	object_touch(cns->p, cns->shot);
+	cns->flask = object_new();
+	object_prep(cns->flask, lookup_kind(TV_FLASK, 1), 0, RANDOMISE);
+	cns->flask->known = object_new();
+	object_set_base_known(cns->flask);
+	object_touch(cns->p, cns->flask);
+	/* Make a version that is inscribed so it will go into the quiver. */
+	cns->inscribed_flask = object_new();
+	object_prep(cns->inscribed_flask, cns->flask->kind, 0, RANDOMISE);
+	cns->inscribed_flask->note =
+		quark_add(format("@v%d", z_info->quiver_size - 1));
+	cns->inscribed_flask->known = object_new();
+	object_set_base_known(cns->inscribed_flask);
+	object_touch(cns->p, cns->inscribed_flask);
+	*state = cns;
+
+	return 0;
+}
+
+int teardown_tests(void *state) {
+	struct carry_num_state *cns = state;
+	int i;
+
+	if (cns->torch->known) {
+		object_free(cns->torch->known);
+	}
+	object_free(cns->torch);
+	if (cns->arrow->known) {
+		object_free(cns->arrow->known);
+	}
+	object_free(cns->arrow);
+	if (cns->shot->known) {
+		object_free(cns->shot->known);
+	}
+	object_free(cns->shot);
+	if (cns->flask->known) {
+		object_free(cns->flask->known);
+	}
+	object_free(cns->flask);
+	if (cns->inscribed_flask->known) {
+		object_free(cns->inscribed_flask->known);
+	}
+	object_free(cns->inscribed_flask);
+	mem_free(state);
+
+	cleanup_angband();
+
+	return 0;
+}
+
+static bool fill_pack_quiver(struct carry_num_state *cns, int n_pack,
+		int n_arrow, int n_shot, int n_flask) {
+	struct object *curr = cns->p->gear;
+	int qslot = 0;
+	int i;
+
+	/* Empty out the pack and quiver. */
+	while (curr != NULL) {
+		if (! object_is_equipped(cns->p->body, curr)) {
+			struct object *next = curr->next;
+			bool none_left = false;
+
+			curr = gear_object_for_use(curr, curr->number, false,
+				&none_left);
+			if (curr->known) {
+				object_free(curr->known);
+			}
+			object_free(curr);
+			curr = next;
+			if (!none_left) {
+				return false;
+			}
+		} else {
+			curr = curr->next;
+		}
+	}
+
+	/* Add to pack. */
+	for (i = 0; i < n_pack; ++i) {
+		if (pack_is_full()) {
+			return false;
+		}
+		curr = object_new();
+		object_copy(curr, cns->torch);
+		/* Vary inscriptions so they won't stack. */
+		curr->note = quark_add(format("dummy%d", i));
+		if (cns->torch->known) {
+			curr->known = object_new();
+			object_copy(curr->known, cns->torch->known);
+		}
+		inven_carry(cns->p, curr, false, false);
+		calc_inventory(cns->p->upkeep, cns->p->gear, cns->p->body);
+		if (! object_is_carried(cns->p, curr) ||
+				object_is_equipped(cns->p->body, curr)) {
+			return false;
+		}
+	}
+
+	/* Add arrows. */
+	i = 0;
+	while (i < n_arrow) {
+		int n = n_arrow - i;
+
+		if (n > z_info->quiver_slot_size) {
+			n = z_info->quiver_slot_size;
+		}
+		if (pack_is_full()) {
+			return false;
+		}
+		curr = object_new();
+		object_copy(curr, cns->arrow);
+		curr->number = n;
+		if (cns->arrow->known) {
+			curr->known = object_new();
+			object_copy(curr->known, cns->arrow->known);
+			curr->known->number = n;
+		}
+		inven_carry(cns->p, curr, false, false);
+		calc_inventory(cns->p->upkeep, cns->p->gear, cns->p->body);
+		if (! object_is_carried(cns->p, curr) ||
+				object_is_equipped(cns->p->body, curr)) {
+			return false;
+		}
+		i += n;
+		++qslot;
+	}
+
+	/* Add shots. */
+	i = 0;
+	while (i < n_shot) {
+		int n = n_shot - i;
+
+		if (n > z_info->quiver_slot_size) {
+			n = z_info->quiver_slot_size;
+		}
+		if (pack_is_full()) {
+			return false;
+		}
+		curr = object_new();
+		object_copy(curr, cns->shot);
+		curr->number = n;
+		if (cns->shot->known) {
+			curr->known = object_new();
+			object_copy(curr->known, cns->shot->known);
+			curr->known->number = n;
+		}
+		inven_carry(cns->p, curr, false, false);
+		calc_inventory(cns->p->upkeep, cns->p->gear, cns->p->body);
+		if (! object_is_carried(cns->p, curr) ||
+				object_is_equipped(cns->p->body, curr)) {
+			return false;
+		}
+		i += n;
+		++qslot;
+	}
+
+	/* Add flasks. */
+	i = 0;
+	while (i < n_flask) {
+		int n = n_flask - i;
+
+		if (n * z_info->thrown_quiver_mult > z_info->quiver_slot_size) {
+			n = z_info->quiver_slot_size /
+				z_info->thrown_quiver_mult;
+		}
+		if (pack_is_full()) {
+			return false;
+		}
+		curr = object_new();
+		object_copy(curr, cns->flask);
+		curr->number = n;
+		/* Inscribe so it goes into the quiver. */
+		if (qslot >= 0 && qslot < z_info->quiver_size) {
+			curr->note = quark_add(format("@v%d", qslot));
+		} else {
+			if (curr->known) {
+				object_free(curr->known);
+			}
+			object_free(curr);
+			return false;
+		}
+		if (cns->flask->known) {
+			curr->known = object_new();
+			object_copy(curr->known, cns->flask->known);
+			curr->known->number = n;
+			curr->known->note = curr->note;
+		}
+		inven_carry(cns->p, curr, false, false);
+		calc_inventory(cns->p->upkeep, cns->p->gear, cns->p->body);
+		if (! object_is_carried(cns->p, curr) ||
+				object_is_equipped(cns->p->body, curr)) {
+			return false;
+		}
+		i += n;
+		++qslot;
+	}
+
+	return true;
+}
+
+/* Try inven_carry() and inven_carry_okay() for one specific object. */
+static bool perform_one_test(struct carry_num_state *cns, struct object *obj,
+		int n_try, int n_expected) {
+	int n_old = obj->number;
+	bool success = true;
+
+	obj->number = n_try;
+	if (inven_carry_num(obj) != n_expected) {
+		success = false;
+	}
+	if (inven_carry_okay(obj)) {
+		if (n_expected == 0) {
+			success = false;
+		}
+	} else {
+		if (n_expected > 0) {
+			success = false;
+		}
+	}
+	obj->number = n_old;
+	return success;
+}
+
+static int test_carry_num_empty_pack_empty_quiver(void *state) {
+	struct carry_num_state *cns = state;
+	require(fill_pack_quiver(cns, 0, 0, 0, 0));
+	require(perform_one_test(cns, cns->torch, 3, 3));
+	require(perform_one_test(cns, cns->arrow, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	require(perform_one_test(cns, cns->shot, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	require(perform_one_test(cns, cns->flask, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	require(perform_one_test(cns, cns->inscribed_flask,
+		z_info->quiver_slot_size, z_info->quiver_slot_size));
+	ok;
+}
+
+static int test_carry_num_partial_pack_empty_quiver(void *state) {
+	struct carry_num_state *cns = state;
+	require(fill_pack_quiver(cns, z_info->pack_size - 1, 0, 0, 0));
+	require(perform_one_test(cns, cns->torch, 3, 3));
+	require(perform_one_test(cns, cns->arrow, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	require(perform_one_test(cns, cns->shot, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	/* Since it is not inscribed, it goes into the remaining pack slot. */
+	require(perform_one_test(cns, cns->flask, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	/*
+	 * Since it is inscribed, it should go into the quiver, taking up one
+	 * slot and expanding the quiver to take the remaining pack slot.
+	 */
+	require(perform_one_test(cns, cns->inscribed_flask,
+		z_info->quiver_slot_size,
+		z_info->quiver_slot_size / z_info->thrown_quiver_mult));
+	ok;
+}
+
+static int test_carry_num_full_pack_empty_quiver(void *state) {
+	struct carry_num_state *cns = state;
+	require(fill_pack_quiver(cns, z_info->pack_size, 0, 0, 0));
+	/* Will fit because it will stack with torches already there. */
+	require(perform_one_test(cns, cns->torch, 3, 3));
+	/*
+	 * No pack slots are available so the quiver can not expand and
+	 * nothing can be added to it.
+	 */
+	require(perform_one_test(cns, cns->arrow, z_info->quiver_slot_size, 0));
+	require(perform_one_test(cns, cns->shot, z_info->quiver_slot_size, 0));
+	require(perform_one_test(cns, cns->flask, z_info->quiver_slot_size, 0));
+	require(perform_one_test(cns, cns->inscribed_flask,
+		z_info->quiver_slot_size, 0));
+	ok;
+}
+
+static int test_carry_num_empty_pack_partial_quiver(void *state) {
+	const int n_arrow_miss = 8;
+	const int n_shot_miss = 9;
+	const int n_flask_miss = 2;
+	struct carry_num_state *cns = state;
+	/* First do tests with one quiver slot empty. */
+	require(fill_pack_quiver(cns, 0,
+		z_info->quiver_slot_size - n_arrow_miss,
+		z_info->quiver_slot_size - n_shot_miss, 0));
+	require(perform_one_test(cns, cns->torch, 3, 3));
+	require(perform_one_test(cns, cns->arrow, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	require(perform_one_test(cns, cns->shot, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	/* It is not inscribed, so it should go into the pack. */
+	require(perform_one_test(cns, cns->flask,
+		z_info->quiver_slot_size, z_info->quiver_slot_size));
+	/*
+         * It is inscribed and should go into the one quiver slot with the
+	 * remainder going to the other available pack slot.
+	 */
+	require(perform_one_test(cns, cns->inscribed_flask,
+		z_info->quiver_slot_size, z_info->quiver_slot_size));
+
+	require(fill_pack_quiver(cns, 0,
+		z_info->quiver_slot_size - n_arrow_miss, 0,
+		(z_info->quiver_slot_size - z_info->thrown_quiver_mult *
+		n_flask_miss) / z_info->thrown_quiver_mult));
+	require(perform_one_test(cns, cns->torch, 3, 3));
+	require(perform_one_test(cns, cns->arrow, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	require(perform_one_test(cns, cns->shot, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	/*
+	 * It is not inscribed; some can combine with what's in the quiver; the
+	 * rest should go to the pack.
+	 */
+	require(perform_one_test(cns, cns->flask,
+		z_info->quiver_slot_size, z_info->quiver_slot_size));
+	/*
+	 * It is inscribed (but at a different pack slot than what's there) so
+	 * some will go into the remaining quiver slot and the rest will go
+	 * to the pack.
+	 */
+	require(perform_one_test(cns, cns->inscribed_flask,
+		z_info->quiver_slot_size, z_info->quiver_slot_size));
+
+	require(fill_pack_quiver(cns, 0, 0,
+		z_info->quiver_slot_size - n_shot_miss,
+		(z_info->quiver_slot_size - z_info->thrown_quiver_mult *
+		n_flask_miss) / z_info->thrown_quiver_mult));
+	require(perform_one_test(cns, cns->torch, 3, 3));
+	require(perform_one_test(cns, cns->arrow, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	require(perform_one_test(cns, cns->shot, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	/*
+	 * It is not inscribed; some can combine with what's in the quiver; the
+	 * rest should go to the pack.
+	 */
+	require(perform_one_test(cns, cns->flask,
+		z_info->quiver_slot_size, z_info->quiver_slot_size));
+	/*
+	 * It is inscribed (but at a different pack slot than what's there) so
+	 * some will go into the remaining quiver slot and the rest will go to
+	 * the pack.
+	 */
+	require(perform_one_test(cns, cns->inscribed_flask,
+		z_info->quiver_slot_size, z_info->quiver_slot_size));
+
+	/* Then do tests with all slots filled but with room in each stack. */
+	require(fill_pack_quiver(cns, 0,
+		z_info->quiver_slot_size - n_arrow_miss,
+		z_info->quiver_slot_size - n_shot_miss,
+		(z_info->quiver_slot_size - z_info->thrown_quiver_mult *
+		n_flask_miss) / z_info->thrown_quiver_mult));
+	require(perform_one_test(cns, cns->torch, 3, 3));
+	/*
+	 * n_arrow_miss should go to the quiver; the remainder should go to
+	 * the pack.
+	 */
+	require(perform_one_test(cns, cns->arrow, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	/*
+	 * n_shot_miss should go to the quiver; the remainder should go to
+	 * the pack.
+	 */
+	require(perform_one_test(cns, cns->shot, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	/*
+	 * It is not inscribed; some can combine with what's in the quiver; the
+	 * rest should go to the pack.
+	 */
+	require(perform_one_test(cns, cns->flask,
+		z_info->quiver_slot_size, z_info->quiver_slot_size));
+	/*
+	 * It is inscribed for the same slot as what's there.  Some will go
+	 * to the quiver.  The rest will go to the pack.
+	 */
+	require(perform_one_test(cns, cns->inscribed_flask,
+		z_info->quiver_slot_size, z_info->quiver_slot_size));
+
+	ok;
+}
+
+static int test_carry_num_partial_pack_partial_quiver(void *state) {
+	const int n_arrow_miss = 9;
+	const int n_shot_miss = 8;
+	const int n_flask_miss = 1;
+	struct carry_num_state *cns = state;
+	/*
+	 * First do tests with one quiver slot empty.  Always leave one pack
+	 * slot available.
+	 */
+	require(fill_pack_quiver(cns, z_info->pack_size - 3,
+		z_info->quiver_slot_size - n_arrow_miss,
+		z_info->quiver_slot_size - n_shot_miss, 0));
+	require(perform_one_test(cns, cns->torch, 3, 3));
+	require(perform_one_test(cns, cns->arrow, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	require(perform_one_test(cns, cns->shot, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	/* Not inscribed, so it goes into the remaining pack slot. */
+	require(perform_one_test(cns, cns->flask, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	/*
+	 * Goes into the remaining quiver slot, but that leaves no pack slots
+	 * for the remainder.
+	 */
+	require(perform_one_test(cns, cns->inscribed_flask,
+		z_info->quiver_slot_size,
+		z_info->quiver_slot_size / z_info->thrown_quiver_mult));
+
+	require(fill_pack_quiver(cns, z_info->pack_size - 3,
+		z_info->quiver_slot_size - n_arrow_miss, 0,
+		(z_info->quiver_slot_size - z_info->thrown_quiver_mult *
+		n_flask_miss) / z_info->thrown_quiver_mult));
+	require(perform_one_test(cns, cns->torch, 3, 3));
+	require(perform_one_test(cns, cns->arrow, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	require(perform_one_test(cns, cns->shot, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	/*
+	 * Combines with those in the quiver; remainder goes to empty pack slot.
+	 */
+	require(perform_one_test(cns, cns->flask, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	/*
+	 * Goes into the remaining quiver slot, but that leaves no pack slots
+	 * for the remainder.
+	 */
+	require(perform_one_test(cns, cns->inscribed_flask,
+		z_info->quiver_slot_size,
+		z_info->quiver_slot_size / z_info->thrown_quiver_mult));
+
+	require(fill_pack_quiver(cns, z_info->pack_size - 3, 0,
+		z_info->quiver_slot_size - n_shot_miss,
+		(z_info->quiver_slot_size - z_info->thrown_quiver_mult *
+		n_flask_miss) / z_info->thrown_quiver_mult));
+	require(perform_one_test(cns, cns->torch, 3, 3));
+	require(perform_one_test(cns, cns->arrow, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	require(perform_one_test(cns, cns->shot, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	/*
+	 * Combines with those in the quiver; remainder goes to empty pack slot.
+	 */
+	require(perform_one_test(cns, cns->flask, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	/*
+	 * Goes into the remaining quiver slot, but that leaves no pack slots
+	 * for the remainder.
+	 */
+	require(perform_one_test(cns, cns->inscribed_flask,
+		z_info->quiver_slot_size,
+		z_info->quiver_slot_size / z_info->thrown_quiver_mult));
+
+	/* Then do tests with all slots filled but with room in each stack. */
+	require(fill_pack_quiver(cns, z_info->pack_size - 4,
+		z_info->quiver_slot_size - n_arrow_miss,
+		z_info->quiver_slot_size - n_shot_miss,
+		(z_info->quiver_slot_size - z_info->thrown_quiver_mult *
+		n_flask_miss) / z_info->thrown_quiver_mult));
+	require(perform_one_test(cns, cns->torch, 3, 3));
+	require(perform_one_test(cns, cns->arrow, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	require(perform_one_test(cns, cns->shot, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	/*
+	 * Combines with those in the quiver; remainder goes to empty pack slot.
+	 */
+	require(perform_one_test(cns, cns->flask, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	/*
+	 * Inscription now matches what's in the quiver so it can combine.
+	 * Remainder go to the empty pack slot.
+	 */
+	require(perform_one_test(cns, cns->inscribed_flask,
+		z_info->quiver_slot_size, z_info->quiver_slot_size));
+
+	ok;
+}
+
+static int test_carry_num_full_pack_partial_quiver(void *state) {
+	const int n_arrow_miss = 5;
+	const int n_shot_miss = 4;
+	const int n_flask_miss = 3;
+	struct carry_num_state *cns = state;
+	/* First do tests with one quiver slot empty. */
+	require(fill_pack_quiver(cns, z_info->pack_size - 2,
+		z_info->quiver_slot_size - n_arrow_miss,
+		z_info->quiver_slot_size - n_shot_miss, 0));
+	require(perform_one_test(cns, cns->torch, 3, 3));
+	require(perform_one_test(cns, cns->arrow, z_info->quiver_slot_size,
+		n_arrow_miss + n_shot_miss));
+	require(perform_one_test(cns, cns->shot, z_info->quiver_slot_size,
+		n_arrow_miss + n_shot_miss));
+	/*
+	 * It's not inscribed so it only goes to the quiver if it stacks with
+	 * something already there.
+	 */
+	require(perform_one_test(cns, cns->flask, z_info->quiver_slot_size, 0));
+	/*
+	 * Goes to the empty slot in the quiver, only add enough so that the
+	 * quiver does not need more pack slots.
+	 */
+	require(perform_one_test(cns, cns->inscribed_flask,
+		z_info->quiver_slot_size,
+		(n_arrow_miss + n_shot_miss) / z_info->thrown_quiver_mult));
+
+	require(fill_pack_quiver(cns, z_info->pack_size - 2,
+		z_info->quiver_slot_size - n_arrow_miss, 0,
+		(z_info->quiver_slot_size - z_info->thrown_quiver_mult *
+		n_flask_miss) / z_info->thrown_quiver_mult));
+	require(perform_one_test(cns, cns->torch, 3, 3));
+	require(perform_one_test(cns, cns->arrow, z_info->quiver_slot_size,
+		n_arrow_miss + z_info->thrown_quiver_mult * n_flask_miss));
+	/* Goes to the empty quiver slot. */
+	require(perform_one_test(cns, cns->shot, z_info->quiver_slot_size,
+		n_arrow_miss + z_info->thrown_quiver_mult * n_flask_miss));
+	/* Only stacks with what's there and won't go to the empty slot. */
+	require(perform_one_test(cns, cns->flask, z_info->quiver_slot_size,
+		n_flask_miss));
+	/*
+	 * Inscribed differently than what's in the quiver, so it can't stack.
+	 * Some go into the empty slot targeted by the inscription.
+	 */
+	require(perform_one_test(cns, cns->inscribed_flask,
+		z_info->quiver_slot_size,
+		n_arrow_miss / z_info->thrown_quiver_mult + n_flask_miss));
+
+	require(fill_pack_quiver(cns, z_info->pack_size - 2, 0,
+		z_info->quiver_slot_size - n_shot_miss,
+		(z_info->quiver_slot_size - z_info->thrown_quiver_mult *
+		n_flask_miss) / z_info->thrown_quiver_mult));
+	require(perform_one_test(cns, cns->torch, 3, 3));
+	/* Goes to the empty quiver slot. */
+	require(perform_one_test(cns, cns->arrow, z_info->quiver_slot_size,
+		n_shot_miss + n_flask_miss * z_info->thrown_quiver_mult));
+	require(perform_one_test(cns, cns->shot, z_info->quiver_slot_size,
+		n_shot_miss + n_flask_miss * z_info->thrown_quiver_mult));
+	require(perform_one_test(cns, cns->flask, z_info->quiver_slot_size,
+		n_flask_miss));
+	require(perform_one_test(cns, cns->inscribed_flask,
+		z_info->quiver_slot_size,
+		n_shot_miss / z_info->thrown_quiver_mult + n_flask_miss));
+
+	/* Then do tests with all slots filled but with room in each stack. */
+	require(fill_pack_quiver(cns, z_info->pack_size - 3,
+		z_info->quiver_slot_size - n_arrow_miss,
+		z_info->quiver_slot_size - n_shot_miss,
+		(z_info->quiver_slot_size - z_info->thrown_quiver_mult *
+		n_flask_miss) / z_info->thrown_quiver_mult));
+	require(perform_one_test(cns, cns->torch, 3, 3));
+	require(perform_one_test(cns, cns->arrow, z_info->quiver_slot_size,
+		n_arrow_miss));
+	require(perform_one_test(cns, cns->shot, z_info->quiver_slot_size,
+		n_shot_miss));
+	require(perform_one_test(cns, cns->flask, z_info->quiver_slot_size,
+		n_flask_miss));
+	require(perform_one_test(cns, cns->inscribed_flask,
+		z_info->quiver_slot_size, n_flask_miss));
+
+	ok;
+}
+
+static int test_carry_num_empty_pack_full_quiver(void *state) {
+	struct carry_num_state *cns = state;
+	require(fill_pack_quiver(cns, 0, z_info->quiver_slot_size,
+		z_info->quiver_slot_size,
+		z_info->quiver_slot_size / z_info->thrown_quiver_mult));
+	require(perform_one_test(cns, cns->torch, 3, 3));
+	require(perform_one_test(cns, cns->arrow, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	require(perform_one_test(cns, cns->shot, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	require(perform_one_test(cns, cns->flask, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	require(perform_one_test(cns, cns->inscribed_flask,
+		z_info->quiver_slot_size, z_info->quiver_slot_size));
+	ok;
+}
+
+static int test_carry_num_partial_pack_full_quiver(void *state) {
+	struct carry_num_state *cns = state;
+	require(fill_pack_quiver(cns, z_info->pack_size - 4,
+		z_info->quiver_slot_size,
+		z_info->quiver_slot_size,
+		z_info->quiver_slot_size / z_info->thrown_quiver_mult));
+	require(perform_one_test(cns, cns->torch, 3, 3));
+	require(perform_one_test(cns, cns->arrow, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	require(perform_one_test(cns, cns->shot, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	require(perform_one_test(cns, cns->flask, z_info->quiver_slot_size,
+		z_info->quiver_slot_size));
+	require(perform_one_test(cns, cns->inscribed_flask,
+		z_info->quiver_slot_size, z_info->quiver_slot_size));
+	ok;
+}
+
+static int test_carry_num_full_pack_full_quiver(void *state) {
+	struct carry_num_state *cns = state;
+	require(fill_pack_quiver(cns, z_info->pack_size - 3,
+		z_info->quiver_slot_size,
+		z_info->quiver_slot_size,
+		z_info->quiver_slot_size / z_info->thrown_quiver_mult));
+	require(perform_one_test(cns, cns->torch, 3, 3));
+	require(perform_one_test(cns, cns->arrow, z_info->quiver_slot_size, 0));
+	require(perform_one_test(cns, cns->shot, z_info->quiver_slot_size, 0));
+	require(perform_one_test(cns, cns->flask, z_info->quiver_slot_size, 0));
+	require(perform_one_test(cns, cns->inscribed_flask,
+		z_info->quiver_slot_size, 0));
+	ok;
+}
+
+const char *suite_name = "player/inven-carry-num";
+struct test tests[] = {
+	{ "carry num empty/empty", test_carry_num_empty_pack_empty_quiver },
+	{ "carry num partial/empty", test_carry_num_partial_pack_empty_quiver },
+	{ "carry num full/empty", test_carry_num_full_pack_empty_quiver },
+	{ "carry num empty/partial", test_carry_num_empty_pack_partial_quiver },
+	{ "carry num partial/partial", test_carry_num_partial_pack_partial_quiver },
+	{ "carry num full/partial", test_carry_num_full_pack_partial_quiver },
+	{ "carry num empty/full", test_carry_num_empty_pack_full_quiver },
+	{ "carry num partial/full", test_carry_num_partial_pack_full_quiver },
+	{ "carry num full/full", test_carry_num_full_pack_full_quiver },
+	{ NULL, NULL }
+};
+

--- a/src/tests/player/suite.mk
+++ b/src/tests/player/suite.mk
@@ -1,4 +1,5 @@
 TESTPROGS += player/birth \
+             player/calc-inventory \
              player/inven-carry-num \
              player/history \
              player/pathfind \

--- a/src/tests/player/suite.mk
+++ b/src/tests/player/suite.mk
@@ -1,4 +1,5 @@
 TESTPROGS += player/birth \
+             player/inven-carry-num \
              player/history \
              player/pathfind \
              player/playerstat

--- a/src/ui-store.c
+++ b/src/ui-store.c
@@ -639,7 +639,7 @@ static bool store_purchase(struct store_context *ctx, int item, bool single)
 		}
 
 		/* Limit to the number that can be carried */
-		amt = MIN(amt, inven_carry_num(obj, false));
+		amt = MIN(amt, inven_carry_num(obj));
 
 		/* Fail if there is no room */
 		if ((amt <= 0) || (!object_flavor_is_aware(obj) && pack_is_full())) {


### PR DESCRIPTION
- Add a utility function to test if the inscription on an item would put it in the quiver.
- Put the multiplier for non-ammo thrown items in constants.txt.
- Rewrite the logic in quiver_absorb_num() so it can consider expanding the number of slots used by the quiver or displacing an item in the quiver to another empty slot in the quiver.  Change calc_inventory() so it honors the limit imposed by quiver_slot_size when placing stacks in the quiver.  Allow it to consider splitting a stack in some circumstances to that part can go to the quiver.
- Modify combine_pack() so it honors the limit imposed by quiver_slot_size when trying to add to a stack in the quiver.

Along with those changes, simplify inven_carry_num() to drop the second argument since all current code calls it with the second argument set to false.  That change and those in the third item should resolve the cases mentioned in https://github.com/angband/angband/issues/4655 .

Add test cases for inven_carry_num(), inven_carry_okay(), and calc_inventory() to exercise most of these changes and the logic for filling up the quiver slots.  Tests for combine_pack(), however, have not been implemented.