### PR TITLE
Plug memory leak from early return in design_artifact()

### DIFF
--- a/src/obj-randart.c
+++ b/src/obj-randart.c
@@ -2589,6 +2589,8 @@ static void design_artifact(struct artifact_set_data *data, int tv, int *aidx)
 		kf_has(kind->kind_flags, KF_QUEST_ART)) {
 		(*aidx)++;
 		if ((*aidx) >= z_info->a_max) {
+			string_free(new_name);
+			mem_free(a_old);
 			return;
 		}
 		art = &a_info[*aidx];


### PR DESCRIPTION
With the current set of standard artifacts, the leak is triggered once for each full set of artifacts generated.