### PR TITLE
Clear customized activation message for random artifacts

### DIFF
--- a/src/obj-randart.c
+++ b/src/obj-randart.c
@@ -1394,6 +1394,8 @@ void artifact_prep(struct artifact *art, const struct object_kind *kind,
 	art->brands = NULL;
 	copy_brands(&art->brands, kind->brands);
 	art->activation = NULL;
+	string_free(art->alt_msg);
+	art->alt_msg = NULL;
 	for (i = 0; i < OBJ_MOD_MAX; i++) {
 		art->modifiers[i] = randcalc(kind->modifiers[i], 0, MINIMISE);
 	}


### PR DESCRIPTION
Prevents the random artifact from inheriting it from the base standard artifact (previously would inherit it if there wasn't a rollback during the design process).  Prevents a memory leak on the first rollback in the design process when the base artifact has a customized activation message.