### PR TITLE
Build Windows release on Ubuntu 18

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,6 +93,7 @@ jobs:
       - name: Install Build Dependencies
         id: build_dep
         run: |
+          sudo apt-get update
           sudo apt-get install make sphinx-common git
           use_python3=`python --version 2>&1 | awk "/^Python 3\\./ { print \"YES\" ; exit 0 ; } ; { print \"NO\" ; exit 0; }"`
           # On Debian and Arch, could just use sphinx-build since they put it
@@ -158,7 +159,9 @@ jobs:
           echo "::set-output name=upload_url::$upload_url"
 
       - name: Install Build Dependencies
-        run: sudo apt-get install automake autoconf git make
+        run: |
+          sudo apt-get update
+          sudo apt-get install automake autoconf git make
 
       # Need commit history and tags for scripts/version.sh to work as expected
       # so use 0 for fetch-depth.
@@ -217,7 +220,9 @@ jobs:
           echo "::set-output name=upload_url::$upload_url"
 
       - name: Install Build Dependencies
-        run: sudo apt-get install gcc-mingw-w64 automake autoconf git make zip
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc-mingw-w64 automake autoconf git make zip
 
       # Need commit history and tags for scripts/version.sh to work as expected
       # so use 0 for fetch-depth.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -193,7 +193,7 @@ jobs:
   windows:
     needs: [setup, docconvert]
     name: Windows
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Download Artifact with Configuration Information
         uses: actions/download-artifact@v2


### PR DESCRIPTION
Do that since there's some evidence, though not conclusive, that the builds on Ubuntu 20 aren't compatible with Windows 8.1:  see the posts starting with http://angband.oook.cz/forum/showpost.php?p=151841&postcount=253 .

Also run apt-get update before apt-get install for extra resilience against out-of-date package lists.