### PR TITLE
From update_bonuses(), flag inventory display for update …

### DIFF
--- a/src/player-calcs.c
+++ b/src/player-calcs.c
@@ -2310,6 +2310,11 @@ static void update_bonuses(struct player *p)
 		p->upkeep->update |= (PU_UPDATE_VIEW | PU_MONSTERS);
 	}
 
+	/* Notice changes to the weight limit. */
+	if (weight_limit(&p->state) != weight_limit(&state)) {
+		p->upkeep->redraw |= (PR_INVEN);
+	}
+
 	/* Hack -- handle partial mode */
 	if (!p->upkeep->only_partial) {
 		/* Take note when "heavy bow" changes */


### PR DESCRIPTION
… if the weight limit has changed.  Do so since the subwindow version of the inventory display includes how far the character is from being overburdened.  Resolves https://github.com/angband/angband/issues/4677 .