### PR TITLE
Fix reference to non-existent variable in file_exists() for Windows

### DIFF
--- a/src/z-file.c
+++ b/src/z-file.c
@@ -325,7 +325,7 @@ bool file_exists(const char *fname)
 	DWORD attrib;
 
 	/* API says we mustn't pass anything larger than MAX_PATH */
-	my_strcpy(path, s, sizeof(path));
+	my_strcpy(path, fname, sizeof(path));
 
 	attrib = GetFileAttributes(path);
 	if (attrib == INVALID_FILE_NAME) return false;


### PR DESCRIPTION
Reported by PowerWyrm here, http://angband.oook.cz/forum/showpost.php?p=151925&postcount=83 .  At least for Mingw cross-compiler builds on Linux, doesn't matter since autoconf.h sets HAVE_STAT for that environment.  With no autoconf.h, h-basic.h currently always sets HAVE_STAT so the defect would be hidden in that case as well.