### PR TITLE
Implement PowerWyrm's fix for inven_wield() changing the total weight…

### DIFF
--- a/src/obj-gear.c
+++ b/src/obj-gear.c
@@ -733,6 +733,10 @@ void inven_wield(struct object *obj, int slot)
 		if (obj->number > 1) {
 			wielded = gear_object_for_use(obj, 1, false, &dummy);
 
+			/* It's still carried; keep it's weight in the total. */
+			assert(wielded->number == 1);
+			player->upkeep->total_weight += wielded->weight;
+
 			/* The new item needs new gear and known gear entries */
 			wielded->next = obj->next;
 			obj->next = wielded;


### PR DESCRIPTION
… carried when the wielded item is split from a stack.  See [this post ](http://angband.oook.cz/forum/showpost.php?p=151764&postcount=60)