### PR TITLE
Reinitialize sound if restarting after death without exiting

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -5746,6 +5746,16 @@ static bool cocoa_get_file(const char *suggested_name, char *path, size_t len)
 }
 
 /**
+ * Perform (as ui-game.c's reinit_hook) platform-specific actions necessary
+ * when restarting without exiting.  Also called directly at startup.
+ */
+static void cocoa_reinit(void)
+{
+    /* Register the sound hook */
+    event_add_handler(EVENT_SOUND, play_sound, NULL);
+}
+
+/**
  * ------------------------------------------------------------------------
  * Main program
  * ------------------------------------------------------------------------ */
@@ -5983,8 +5993,12 @@ static bool cocoa_get_file(const char *suggested_name, char *path, size_t len)
 	init_angband();
 	textui_init();
 
-	/* Register the sound hook */
-	event_add_handler(EVENT_SOUND, play_sound, (__bridge void*) self);
+	/*
+	 * Set action that needs to be done if restarting without exiting.
+	 * Also need to do it now.
+	 */
+	reinit_hook = cocoa_reinit;
+	cocoa_reinit();
 
 	/* Initialize some save file stuff */
 	player_egid = getegid();

--- a/src/main-win.c
+++ b/src/main-win.c
@@ -5000,6 +5000,17 @@ static void init_stuff(void)
 }
 
 
+/**
+ * Perform (as ui-game.c's reinit_hook) platform-specific actions necessary
+ * when restarting without exiting.  Also called directly at startup.
+ */
+static void win_reinit(void)
+{
+	/* Initialise sound. */
+	init_sound("win", 0, NULL);
+}
+
+
 int FAR PASCAL WinMain(HINSTANCE hInst, HINSTANCE hPrevInst,
                        LPSTR lpCmdLine, int nCmdShow)
 {
@@ -5152,8 +5163,12 @@ int FAR PASCAL WinMain(HINSTANCE hInst, HINSTANCE hPrevInst,
 	/* Set command hook */
 	cmd_get_hook = textui_get_cmd;
 
-	/* Initialise sound */
-	init_sound("win", 0, NULL);
+	/*
+	 * Set action that needs to be done if restarting without exiting.
+	 * Also need to do it now.
+	 */
+	reinit_hook = win_reinit;
+	win_reinit();
 
 	/* Set up the display handlers and things. */
 	init_display();

--- a/src/main.c
+++ b/src/main.c
@@ -149,6 +149,27 @@ static void init_stuff(void)
 }
 
 
+#ifdef SOUND
+/* State shared by generic_reinit() and main(). */
+static const char *soundstr = NULL;
+static int saved_argc = 0;
+static char **saved_argv = NULL;
+#endif
+
+
+/**
+ * Perform (as ui-game.c's reinit_hook) platform-specific actions necessary
+ * when restarting without exiting.  Also called directly at startup.
+ */
+static void generic_reinit(void)
+{
+#ifdef SOUND
+	/* Initialise sound */
+	init_sound(soundstr, saved_argc, saved_argv);
+#endif
+}
+
+
 static const struct {
 	const char *name;
 	char **path;
@@ -313,9 +334,6 @@ int main(int argc, char *argv[])
 	bool done = false;
 
 	const char *mstr = NULL;
-#ifdef SOUND
-	const char *soundstr = NULL;
-#endif
 	bool args = true;
 
 	/* Save the "program name" XXX XXX XXX */
@@ -517,10 +535,16 @@ int main(int argc, char *argv[])
 	/* Set up the command hook */
 	cmd_get_hook = textui_get_cmd;
 
+	/*
+	 * Set action that needs to be done if restarting without exiting.
+	 * Also need to do it now.
+	 */
 #ifdef SOUND
-	/* Initialise sound */
-	init_sound(soundstr, argc, argv);
+	saved_argc = argc;
+	saved_argv = argv;
 #endif
+	reinit_hook = generic_reinit;
+	generic_reinit();
 
 	/* Set up the display handlers and things. */
 	init_display();

--- a/src/sound-core.c
+++ b/src/sound-core.c
@@ -347,6 +347,7 @@ static void close_audio(void)
  */
 errr init_sound(const char *soundstr, int argc, char **argv)
 {
+	static bool firstcall = true;
 	int i = 0;
 	bool done = false;
 
@@ -371,7 +372,10 @@ errr init_sound(const char *soundstr, int argc, char **argv)
 
 	/* Enable sound */
 	event_add_handler(EVENT_SOUND, play_sound, NULL);
-	atexit(close_audio);
+	if (firstcall) {
+		atexit(close_audio);
+		firstcall = false;
+	}
 
 	/* Success */
 	return (0);

--- a/src/ui-game.c
+++ b/src/ui-game.c
@@ -64,6 +64,12 @@ bool arg_wizard;			/* Command arg -- Request wizard mode */
  */
 char savefile[1024];
 
+/**
+ * Set by the front end to perform necessary actions when restarting after death
+ * without exiting.  May be NULL.
+ */
+void (*reinit_hook)(void) = NULL;
+
 
 /**
  * Here are lists of commands, stored in this format so that they can be
@@ -456,6 +462,9 @@ void play_game(bool new_game)
 		init_display();
 		init_angband();
 		textui_init();
+		if (reinit_hook != NULL) {
+			(*reinit_hook)();
+		}
 		play_game(true);
 	}
 }

--- a/src/ui-game.h
+++ b/src/ui-game.h
@@ -25,6 +25,7 @@
 
 extern bool arg_wizard;
 extern char savefile[1024];
+extern void (*reinit_hook)(void);
 
 void cmd_init(void);
 unsigned char cmd_lookup_key(cmd_code lookup_cmd, int mode);


### PR DESCRIPTION
Resolves https://github.com/angband/angband/issues/4687 . The Mac, curses, X11, SDL, and SDL2 front ends have had some testing with this change.  The Windows front end was compiled (with a MinGW cross-compiler on Linux), but hasn't been tested.