### PR TITLE
Fix crash on selection from empty list in textui_get_item()

### DIFF
--- a/src/ui-object.c
+++ b/src/ui-object.c
@@ -932,7 +932,7 @@ bool get_item_action(struct menu *menu, const ui_event *event, int oid)
 	int mode = OPT(player, rogue_like_commands) ? KEYMAP_MODE_ROGUE : KEYMAP_MODE_ORIG;
 
 	if (event->type == EVT_SELECT) {
-		if (get_item_allow(choice[oid].object, cmd_lookup_key(item_cmd, mode),
+		if (choice[oid].object && get_item_allow(choice[oid].object, cmd_lookup_key(item_cmd, mode),
 						   item_cmd, is_harmless))
 			selection = choice[oid].object;
 	}


### PR DESCRIPTION
The empty lists (i.e. quiver with nothing in it or equipment list with nothing equipped) are possible when allow_all is set in textui_get_item().  Pressing enter when displaying one causes a crash in get_item_allow().  This change avoids the crash and resolves https://github.com/angband/angband/issues/4691 .

An alternative would be to change the menu display in textui_get_item() so, even in the situations which currently set allow_all to true, the empty lists can't be displayed.