### PR TITLE
Minor optimization for obj_kind_can_browse()

### DIFF
--- a/src/obj-util.c
+++ b/src/obj-util.c
@@ -655,7 +655,7 @@ bool obj_kind_can_browse(const struct object_kind *kind)
 
 	for (i = 0; i < player->class->magic.num_books; i++) {
 		struct class_book book = player->class->magic.books[i];
-		if (kind == lookup_kind(book.tval, book.sval))
+		if (kind->tval == book.tval && kind->sval == book.sval)
 			return true;
 	}
 


### PR DESCRIPTION
Elide the call to lookup_kind() and compare the tval and sval values directly since profiling while playing a mage indicated that obj_kind_can_browse() was a significant contributor to the computation time for update_statusline() and earlier_object() (the latter is used in calc_inventory()).
