### PR TITLE
macOS: round median advance to nearest to be more compact in some instances

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -2315,10 +2315,15 @@ static int compare_advances(const void *ap, const void *bp)
     }
 
     /*
-     * Record the tile size.  Round both values up to have tile boundaries
-     * match pixel boundaries.
+     * Record the tile size.  Round the values (height rounded up; width to
+     * nearest unless that would be zero) to have tile boundaries match pixel
+     * boundaries.
      */
-    self->_tileSize.width = ceil(medianAdvance);
+    if (medianAdvance < 1.0) {
+	self->_tileSize.width = 1.0;
+    } else {
+	self->_tileSize.width = floor(medianAdvance + 0.5);
+    }
     self->_tileSize.height = ceil(self.fontAscender - self.fontDescender);
 
     /*


### PR DESCRIPTION
That addresses part of Bogatyr's report, http://angband.oook.cz/forum/showpost.php?p=151593&postcount=10 , since the default font for the subwindows is Menlo 10 which has a median advance of 6.0205.  For the default font in the main window, Menlo 13, the change doesn't affect the width used since the median advance is 7.8267.  It doesn't address the other part of Bogatyr's report, that the response to width changes in the macOS front end in 4.2.1 and 4.2.2 isn't correct.  I haven't seen behavior seems wrong to me in that respect.