### PR TITLE
macOS: tweak the default window layout

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -4301,13 +4301,6 @@ static void Term_init_cocoa(term *t)
 
 	    if( termIdx == 0 )
 	    {
-		/*
-		 * The height and width adjustments were determined
-		 * experimentally, so that the rest of the windows line up
-		 * nicely without overlapping.
-		 */
-		windowFrame.size.width += 7.0;
-		windowFrame.size.height += 9.0;
 		windowFrame.origin.x = NSMinX( overallBoundingRect );
 		windowFrame.origin.y =
 		    NSMaxY( overallBoundingRect ) - NSHeight( windowFrame );
@@ -5601,28 +5594,28 @@ static void load_prefs(void)
 
 	switch (i) {
 	case 0:
-	    columns = 129;
-	    rows = 32;
+	    columns = 100;
+	    rows = 30;
 	    break;
 	case 1:
-	    columns = 84;
-	    rows = 20;
+	    columns = 66;
+	    rows = 10;
 	    break;
 	case 2:
-	    columns = 42;
+	    columns = 38;
 	    rows = 24;
 	    break;
 	case 3:
-	    columns = 42;
-	    rows = 20;
+	    columns = 38;
+	    rows = 10;
 	    break;
 	case 4:
-	    columns = 42;
-	    rows = 16;
+	    columns = 38;
+	    rows = 15;
 	    break;
 	case 5:
-	    columns = 84;
-	    rows = 20;
+	    columns = 66;
+	    rows = 10;
 	    break;
 	default:
 	    columns = 80;


### PR DESCRIPTION
Rendering changes and constraining the window sizes to be a multiple of the tile size caused overlaps (at least on an early 2015 13" MacBook Pro; native resolution is 2560 x 1600) with the old defaults.  Set the sizes so they should work without overlap using the default fonts (Menlo 13 pt for the main window; Menlo 10 pt for the rest) on the smallest native resolution for currently supported Retina Macs (MacBook; 2304 x 1440).