### PR TITLE
Allow CMD_WIELD to select from the quiver

### DIFF
--- a/src/cmd-obj.c
+++ b/src/cmd-obj.c
@@ -276,7 +276,7 @@ void do_cmd_wield(struct command *cmd)
 			/* Prompt */ "Wear or wield which item?",
 			/* Error  */ "You have nothing to wear or wield.",
 			/* Filter */ obj_can_wear,
-			/* Choice */ USE_INVEN | USE_FLOOR) != CMD_OK)
+			/* Choice */ USE_INVEN | USE_FLOOR | USE_QUIVER) != CMD_OK)
 		return;
 
 	/* Get the slot the object wants to go in, and the item currently there */


### PR DESCRIPTION
Since a wieldable thrown item can be placed in the quiver, that allows wielding the item without first dropping it or removing the inscription that places it in the quiver.