### PR TITLE
For SDL2, turn on the send keypad modifier option by default

### DIFF
--- a/src/main-sdl2.c
+++ b/src/main-sdl2.c
@@ -564,7 +564,7 @@ static SDL_Color g_colors[MAX_COLORS];
 static struct font_info g_font_info[MAX_FONTS];
 /* True if KC_MOD_KEYPAD will be sent for numeric keypad keys at the expense
  * of not handling some keyboard layouts properly. */
-static int g_kp_as_mod = 0;
+static int g_kp_as_mod = 1;
 
 /* Forward declarations */
 


### PR DESCRIPTION
Resolves https://github.com/NickMcConnell/FirstAgeAngband/issues/153 and a similar problem in Angband post-4.2.1 (though, to see the effect, someone with settings from after the change that introduced that setting will either need to manually change the setting or clear the store SDL2 settings).  Means that the player will have to turn off that setting for better handling of some keyboard layouts (see https://github.com/angband/angband/issues/4522 ).