### PR TITLE
Fix handling of necromancer's command spell

### DIFF
--- a/src/cmd-core.c
+++ b/src/cmd-core.c
@@ -252,12 +252,9 @@ errr cmdq_push_copy(struct command *cmd)
 void process_command(cmd_context ctx, struct command *cmd)
 {
 	int oldrepeats = cmd->nrepeats;
-	int idx = cmd_idx(cmd->code);
-
 	/* Hack - command a monster */
-	if (player->timed[TMD_COMMAND]) {
-		idx = (int) N_ELEMENTS(game_cmds) - 1;
-	}
+	int idx = cmd_idx(player->timed[TMD_COMMAND] ?
+		CMD_COMMAND_MONSTER : cmd->code);
 
 	/* Reset so that when selecting items, we look in the default location */
 	player->upkeep->command_wrk = 0;


### PR DESCRIPTION
The changes to put the debugging commands in the Angband 4 command system broke it.  Cuboideb's bug report is here, http://angband.oook.cz/forum/showpost.php?p=152457&postcount=8 .