### PR TITLE
Make a pointer to struct player an argument to object_flag_is_known()…

### DIFF
--- a/src/obj-knowledge.c
+++ b/src/obj-knowledge.c
@@ -758,18 +758,20 @@ bool object_fully_known(const struct object *obj)
 
 
 /**
- * Checks whether the player knows whether an object has a given flag
+ * Checks whether a player knows whether an object has a given flag
  *
+ * \param p is the player
  * \param obj is the object
  * \param flag is the flag
  */
-bool object_flag_is_known(const struct object *obj, int flag)
+bool object_flag_is_known(const struct player *p, const struct object *obj,
+	int flag)
 {
 	/* Object fully known means OK */
 	if (object_fully_known(obj)) return true;
 
 	/* Player knows the flag means OK */
-	if (of_has(player->obj_k->flags, flag)) return true;
+	if (of_has(p->obj_k->flags, flag)) return true;
 
 	/* Object has had a chance to display the flag means OK */
 	if (of_has(obj->known->flags, flag)) return true;
@@ -778,12 +780,14 @@ bool object_flag_is_known(const struct object *obj, int flag)
 }
 
 /**
- * Checks whether the player knows the given element properties of an object
+ * Checks whether a player knows the given element properties of an object
  *
+ * \param p is the player
  * \param obj is the object
  * \param element is the element
  */
-bool object_element_is_known(const struct object *obj, int element)
+bool object_element_is_known(const struct player *p, const struct object *obj,
+	int element)
 {
 	if (element < 0 || element >= ELEM_MAX) return false;
 
@@ -791,7 +795,7 @@ bool object_element_is_known(const struct object *obj, int element)
 	if (object_fully_known(obj)) return true;
 
 	/* Player knows the element means OK */
-	if (player->obj_k->el_info[element].res_level) return true;
+	if (p->obj_k->el_info[element].res_level) return true;
 
 	/* Object has been exposed to the element means OK */
 	if (obj->known->el_info[element].res_level) return true;

--- a/src/obj-knowledge.h
+++ b/src/obj-knowledge.h
@@ -65,8 +65,10 @@ bool object_has_standard_to_h(const struct object *obj);
 bool object_has_rune(const struct object *obj, int rune_no);
 bool object_runes_known(const struct object *obj);
 bool object_fully_known(const struct object *obj);
-bool object_flag_is_known(const struct object *obj, int flag);
-bool object_element_is_known(const struct object *obj, int element);
+bool object_flag_is_known(const struct player *p, const struct object *obj,
+	int flag);
+bool object_element_is_known(const struct player *p, const struct object *obj,
+	int element);
 
 void object_set_base_known(struct object *obj);
 void object_sense(struct player *p, struct object *obj);

--- a/src/store.c
+++ b/src/store.c
@@ -562,7 +562,7 @@ static bool store_will_buy(struct store *store, const struct object *obj)
 
 		/* OK if the object is known to have the flag */
 		if (of_has(obj->flags, buy->flag) &&
-			object_flag_is_known(obj, buy->flag))
+			object_flag_is_known(player, obj, buy->flag))
 			return true;
 	}
 

--- a/src/ui-entry.c
+++ b/src/ui-entry.c
@@ -633,7 +633,7 @@ void compute_ui_entry_values_for_object(const struct ui_entry *entry,
 				break;
 
 			case OBJ_PROPERTY_FLAG:
-				if (object_flag_is_known(obj, ind)) {
+				if (object_flag_is_known(p, obj, ind)) {
 					int v = of_has(cache2->f, ind) ? 1 : 0;
 					int a = 0;
 
@@ -659,7 +659,7 @@ void compute_ui_entry_values_for_object(const struct ui_entry *entry,
 				break;
 
 			case OBJ_PROPERTY_IGNORE:
-				if (object_element_is_known(obj, ind)) {
+				if (object_element_is_known(p, obj, ind)) {
 					int v = (obj->el_info[ind].flags &
 						EL_INFO_IGNORE) ? 1 : 0;
 					int a = 0;
@@ -688,7 +688,7 @@ void compute_ui_entry_values_for_object(const struct ui_entry *entry,
 			case OBJ_PROPERTY_RESIST:
 			case OBJ_PROPERTY_VULN:
 			case OBJ_PROPERTY_IMM:
-				if (object_element_is_known(obj, ind)) {
+				if (object_element_is_known(p, obj, ind)) {
 					int v = obj->el_info[ind].res_level;
 					int a = 0;
 


### PR DESCRIPTION
… and object_element_is_known() rather than implicitly using the player global.  That's for consistency with compute_ui_entry_values_for_object() which has a pointer to struct player argument and is one of the two callers for those functions (the other is in store.c).

The remaining uses of the global player in obj-knowledge.c are in object_set_base_known() and object_flavor_aware().  At least within obj-knowledge.c, both are called from functions that have a struct player pointer argument.  Could make the struct player pointer an argument for them, but it would be more disruptive since they're used in more places.