### PR TITLE
Require at least two rooms in moria_chunk()

### DIFF
--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -2174,8 +2174,10 @@ struct chunk *moria_chunk(int depth, int height, int width)
     dun->pit_num = 0;
     dun->cent_n = 0;
 
-    /* Build rooms until we have enough floor grids */
-    while (c->feat_count[FEAT_FLOOR] < num_floors) {
+    /* Build rooms until we have enough floor grids and at least two rooms
+     * (the latter is to make it easier to satisfy the constraints for player
+     * placement) */
+    while (c->feat_count[FEAT_FLOOR] < num_floors && dun->cent_n < 2) {
 
 		/* Roll for random key (to be compared against a profile's cutoff) */
 		key = randint0(100);


### PR DESCRIPTION
That's to mitigate instances where the player could not be placed because the level had one large vault as the only room (part of https://github.com/angband/angband/issues/4549 ).  At level 25 had several consecutive failures from different starting seeds trying to collect disconnection statistics for 50000 levels so the probability of such a level is likely to be more than 1/50000 at level 25.