### PR TITLE
Require at least two rooms in moria_chunk().  …

### DIFF
--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -2174,8 +2174,10 @@ struct chunk *moria_chunk(int depth, int height, int width)
     dun->pit_num = 0;
     dun->cent_n = 0;
 
-    /* Build rooms until we have enough floor grids */
-    while (c->feat_count[FEAT_FLOOR] < num_floors) {
+    /* Build rooms until we have enough floor grids and at least two rooms
+     * (the latter is to make it easier to satisfy the constraints for player
+     * placement) */
+    while (c->feat_count[FEAT_FLOOR] < num_floors || dun->cent_n < 2) {
 
 		/* Roll for random key (to be compared against a profile's cutoff) */
 		key = randint0(100);


### PR DESCRIPTION
That's to mitigate failures to place the player on levels with a single large vault as the only room (part of https://github.com/angband/angband/issues/4549 ; had repeated failures, with different seeds, when generating disconnection statistics for 50000 levels at level 25 so the probability of such levels is likely greater than 1/50000 at level 25).