### PR TITLE
Add space after question mark in two prompts for get_check() …

### DIFF
--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -112,7 +112,7 @@ void do_cmd_go_down(struct command *cmd)
 	if (OPT(player, birth_force_descend)) {
 		descend_to = dungeon_get_next_level(player->max_depth, 1);
 		if (is_quest(descend_to) &&
-			!get_check("Are you sure you want to descend?"))
+			!get_check("Are you sure you want to descend? "))
 			return;
 	}
 

--- a/src/game-input.c
+++ b/src/game-input.c
@@ -218,7 +218,7 @@ bool confirm_debug(void)
 	event_signal(EVENT_MESSAGE_FLUSH);
 
 	/* Then verify. */
-	return get_check("Are you sure you want to use the debug commands?");
+	return get_check("Are you sure you want to use the debug commands? ");
 }
 
 /**


### PR DESCRIPTION
… that did not already have it.  The one in game-input.c is a post-4.2.2 regression from changing the way the debugging commands are dispatched.