### PR TITLE
Adjust some logic for hard centre levels

### DIFF
--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -2404,13 +2404,13 @@ struct chunk *vault_chunk(struct player *p)
 void connect_caverns(struct chunk *c, struct loc floor[])
 {
 	int i;
-    int size = c->height * c->width;
-    int *colors = mem_zalloc(size * sizeof(int));
-    int *counts = mem_zalloc(size * sizeof(int));
+	int size = c->height * c->width;
+	int *colors = mem_zalloc(size * sizeof(int));
+	int *counts = mem_zalloc(size * sizeof(int));
 	int color_of_floor[4];
 
 	/* Color the regions, find which cavern is which color */
-    build_colors(c, colors, counts, true);
+	build_colors(c, colors, counts, true);
 	for (i = 0; i < 4; i++) {
 		int spot = grid_to_i(floor[i], c->width);
 		color_of_floor[i] = colors[spot];
@@ -2420,16 +2420,15 @@ void connect_caverns(struct chunk *c, struct loc floor[])
 	join_region(c, colors, counts, color_of_floor[0], color_of_floor[1]);
 	join_region(c, colors, counts, color_of_floor[2], color_of_floor[3]);
 
-	/* Redo the colors, join the two big caverns */
-    build_colors(c, colors, counts, true);
+	/* Join the two big caverns */
 	for (i = 1; i < 3; i++) {
 		int spot = grid_to_i(floor[i], c->width);
 		color_of_floor[i] = colors[spot];
 	}
 	join_region(c, colors, counts, color_of_floor[1], color_of_floor[2]);
 
-    mem_free(colors);
-    mem_free(counts);
+	mem_free(colors);
+	mem_free(counts);
 }
 /**
  * Generate a hard centre level - a greater vault surrounded by caverns

--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -2538,9 +2538,6 @@ struct chunk *hard_centre_gen(struct player *p, int min_height, int min_width)
 	/* Connect up all the caverns */
 	connect_caverns(c, floor);
 
-	/* Connect to the centre */
-	ensure_connectedness(c);
-
 	/* Temporary until connecting to vault entrances works better */
 	for (y = 0; y < centre_cavern_hgt; y++) {
 		square_set_feat(c, loc(left_cavern_wid, y + centre_cavern_ypos),
@@ -2555,6 +2552,9 @@ struct chunk *hard_centre_gen(struct player *p, int min_height, int min_width)
 							   centre_cavern_ypos + centre_cavern_hgt - 1),
 						FEAT_FLOOR);
 	}
+
+	/* Connect to the centre */
+	ensure_connectedness(c);
 
 	/* Free all the chunks */
 	cave_free(left_cavern);


### PR DESCRIPTION
- Skip the recoloring when connecting the cavern since the current version of join_region() maintains a consistent set of colors.  Also, the recoloring that was done was missing the step to reset the colors array to zero.
- Call ensure_connectedness() after drawing the landing area about the vault.  That way, the landing area will always be connected to the caverns.  For 5000 simulations with the disconnect stats debugging command at level 60 where only hard centre levels could be generated, without that change there were 93 levels with disconnected non-vault areas and 171 levels where the player was disconnected from the down stairs.  After the change, there were 0 levels with disconnected non-vault areas and 137 levels where the player was disconnected from the stairs (apparently all the down stairs in those cases were placed in the vault).