### PR TITLE
Correct two logic errors in build_tunnel()

### DIFF
--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -250,7 +250,8 @@ static void build_tunnel(struct chunk *c, struct loc grid1, struct loc grid2)
 			/* Forbid re-entry near this piercing */
 			for (grid.y = grid1.y - 1; grid.y <= grid1.y + 1; grid.y++) {
 				for (grid.x = grid1.x - 1; grid.x <= grid1.x + 1; grid.x++) {
-					if (square_is_granite_with_flag(c, grid, SQUARE_WALL_OUTER))
+					if (square_in_bounds(c, grid) &&
+							square_is_granite_with_flag(c, grid, SQUARE_WALL_OUTER))
 						set_marked_granite(c, grid, SQUARE_WALL_SOLID);
 				}
 			}

--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -296,10 +296,10 @@ static void build_tunnel(struct chunk *c, struct loc grid1, struct loc grid2)
 			/* Hack -- allow pre-emptive tunnel termination */
 			if (randint0(100) >= dun->profile->tun.con) {
 				/* Offset between grid1 and start */
-				offset = loc_diff(grid1, start);
+				tmp_grid = loc_diff(grid1, start);
 
 				/* Terminate the tunnel if too far vertically or horizontally */
-				if ((ABS(offset.x) > 10) || (ABS(offset.y) > 10)) break;
+				if ((ABS(tmp_grid.x) > 10) || (ABS(tmp_grid.y) > 10)) break;
 			}
 		}
     }


### PR DESCRIPTION
- When testing for preemptive tunnel termination, don't overwrite the current state for the tunnel direction.
- Check for in bounds before attempting to suppress wall piercing at a grid.  Saw some out of bounds assertions without that change when running with modified dungeon profiles (only simple rooms for the modified and classic profiles; with the current state of find_space(), those could give an occasional room with a wall on the edge of the chunk).