### PR TITLE
For pillared rooms, cut off the corners when not adjacent to a floor

### DIFF
--- a/src/gen-room.c
+++ b/src/gen-room.c
@@ -1794,7 +1794,31 @@ bool build_simple(struct chunk *c, struct loc centre, int rating)
 		for (y = y1; y <= y2; y += 2)
 			for (x = x1; x <= x2; x += 2)
 				set_marked_granite(c, loc(x, y), SQUARE_WALL_INNER);
-
+		/*
+		 * Drop room/outer wall flags on corners if not adjacent to a
+		 * floor.  Lets tunnels enter those grids.
+		 */
+		sqinfo_off(square(c, loc(x1 - 1, y1 - 1))->info, SQUARE_ROOM);
+		sqinfo_off(square(c, loc(x1 - 1, y1 - 1))->info,
+			SQUARE_WALL_OUTER);
+		if ((x2 - x1) % 2 == 0) {
+			sqinfo_off(square(c, loc(x2 + 1, y1 - 1))->info,
+				SQUARE_ROOM);
+			sqinfo_off(square(c, loc(x1 + 1, y1 - 1))->info,
+				SQUARE_WALL_OUTER);
+		}
+		if ((y2 - y1) % 2 == 0) {
+			sqinfo_off(square(c, loc(x1 - 1, y2 + 1))->info,
+				SQUARE_ROOM);
+			sqinfo_off(square(c, loc(x1 - 1, y2 + 1))->info,
+				SQUARE_WALL_OUTER);
+			if ((x2 - x1) % 2 == 0) {
+				sqinfo_off(square(c, loc(x2 + 1, y2 + 1))->info,
+					SQUARE_ROOM);
+				sqinfo_off(square(c, loc(x2 + 1, y2 + 1))->info,
+					SQUARE_WALL_OUTER);
+			}
+		}
 	} else if (one_in_(50)) {
 		/* Sometimes make a ragged-edge room */
 		for (y = y1 + 2; y <= y2 - 2; y += 2) {


### PR DESCRIPTION
It may not be worth the extra code but does allow tunnels to access those grids.  Would need a change to the tunneling code to have a tunnel coming through where the corner was to enter the room without bending away from the room and then bending back (i.e. tunnel goes through corner, considers going horizontally or vertically to a grid in the room's outer wall, and then, with a change to the tunneling code, is allowed to make the diagonal step to the room's interior).