### PR TITLE
Build in handling of double-height tiles into ui-term.c's change tracking

### DIFF
--- a/src/grafmode.c
+++ b/src/grafmode.c
@@ -227,3 +227,29 @@ graphics_mode *get_graphics_mode(byte id) {
 	}
 	return NULL;
 }
+
+/**
+ * Test for whether an attribute/character pair corresponds to a double-height
+ * tile.
+ * \param a Is the attribute.
+ * \param c Is the character.
+ * Intended for use as struct term's dblh_hook field.
+ */
+int is_dh_tile(int a, wchar_t c)
+{
+	int tileset_row;
+
+	/*
+	 * If it's not a tile (assumes tiles have high-bit set on the
+	 * attribute), graphics aren't enabled, or the graphics mode doesn't
+	 * use double-height tiles, it can't be double-height.
+	 */
+	if (!(a & 0x80) || !current_graphics_mode ||
+			!current_graphics_mode->overdrawRow) {
+		return 0;
+	}
+	/* Test the row for the tile. */
+	tileset_row = a & 0x7f;
+	return tileset_row >= current_graphics_mode->overdrawRow &&
+		tileset_row <= current_graphics_mode->overdrawMax;
+}

--- a/src/grafmode.h
+++ b/src/grafmode.h
@@ -63,4 +63,6 @@ bool init_graphics_modes();
 void close_graphics_modes(void);
 graphics_mode* get_graphics_mode(byte id);
 
+int is_dh_tile(int a, wchar_t c);
+
 #endif /* INCLUDED_GRAFMODE_H */

--- a/src/main-win.c
+++ b/src/main-win.c
@@ -1656,6 +1656,7 @@ static errr Term_xtra_win_react(void)
 				td->t.pict_hook = Term_pict_win;
 			}
 		}
+		td->t.dblh_hook = (overdraw) ? is_dh_tile : NULL;
 
 		/* make sure the current graphics mode is set */
 		current_graphics_mode = get_graphics_mode(arg_graphics);
@@ -2415,9 +2416,6 @@ static errr Term_pict_win_alpha(int x, int y, int n,
 			(trow <= overdrawmax)) {
 			AlphaBlend(hdc, x2, y2-th2, tw2, th2, hdcSrc, x3, y3-h1, w1, h1,
 					   blendfn);
-			/* Tell the core that the top tile is not what it thinks */
-			Term_mark(x, y-tile_height);
-			Term_mark(x, y); /* This tile is drawn every frame */
 		}
 
 		/* Only draw if terrain and overlay are different */
@@ -2428,12 +2426,6 @@ static errr Term_pict_win_alpha(int x, int y, int n,
 				(row <= overdrawmax)) {
 				AlphaBlend(hdc, x2, y2-th2, tw2, th2*2, hdcSrc, x1, y1-h1, w1,
 						   h1*2, blendfn);
-				/* Tell the core that the top tile is not what it thinks */
-				Term_mark(x, y-tile_height);
-				/* This tile is drawn every frame but it is needed, otherwise
-				 * the top does not get drawn again when the user of this tile
-				 * does not move, but something else does */
-				Term_mark(x, y); 
 			} else {
 				AlphaBlend(hdc, x2, y2, tw2, th2, hdcSrc, x1, y1, w1, h1,
 						   blendfn);
@@ -2571,6 +2563,7 @@ static void term_data_link(term_data *td)
 	t->wipe_hook = Term_wipe_win;
 	t->text_hook = Term_text_win;
 	t->pict_hook = Term_pict_win;
+	t->dblh_hook = NULL;
 
 	/* Remember where we came from */
 	t->data = td;

--- a/src/ui-term.h
+++ b/src/ui-term.h
@@ -155,6 +155,8 @@ struct term_win
  *	- Hook for drawing a string of chars using an attr
  *
  *	- Hook for drawing a sequence of special attr/char pairs
+ *
+ *      - Hook to test if an attr/char pair is a double-height tile
  */
 
 typedef struct term term;
@@ -233,6 +235,8 @@ struct term
 	errr (*pict_hook)(int x, int y, int n, const int *ap, const wchar_t *cp, const int *tap, const wchar_t *tcp);
 
 	void (*view_map_hook)(term *t);
+
+        int (*dblh_hook)(int a, wchar_t c);
 
 };
 


### PR DESCRIPTION
A front end will have to set the dblh_hook on the terminal to enable it and, to avoid unnecessary overhead, may want to set dblh_hook to NULL when using a tile set without double-height tiles.  As a convenience, provide a function, is_dh_tile(), in grafmode.h/grafmode.c that can be used for dblh_hook.  Modify the front ends that currently support double-height tiles (main-cocoa.m, main-sdl.c, main-sdl2.c, and main-win.c) to use this and not use the old method of calling Term_mark().  Tries to address performance issues when using the Shockbolt tiles.  See this thread, http://angband.oook.cz/forum/showthread.php?t=10720 , for a discussion.