### PR TITLE
Put -DHAVE_CONFIG_H in CPPFLAGS so it affects generated dependencies as well

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -94,7 +94,7 @@ AC_TYPE_SIGNAL
 AC_CHECK_FUNCS([mkdir setresgid setegid stat])
 
 dnl needed because h-basic.h checks for this define for autoconf support.
-CFLAGS="$CFLAGS -DHAVE_CONFIG_H"
+CPPFLAGS="$CPPFLAGS -DHAVE_CONFIG_H"
 CPPFLAGS="$CPPFLAGS -I." 
 
 if test "$GCC" = "yes"; then

--- a/src/Makefile
+++ b/src/Makefile
@@ -25,7 +25,7 @@ GCOVS = $(OBJECTS:.o=.c.gcov)
 CLEAN = angband.o $(OBJECTS) win/angband.res
 DISTCLEAN = autoconf.h
 
-export CFLAGS LDFLAGS LIBS
+export CFLAGS CPPFLAGS LDFLAGS LIBS
 
 $(PROG): $(PROGNAME).o $(MAINFILES)
 	$(CC) -o $@ $(PROGNAME).o $(MAINFILES) $(LDFLAGS) $(LDADD) $(LIBS)

--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -21,11 +21,11 @@ run : build
 	@./run-tests
 
 %.o : %.c
-	@$(CC) $(CFLAGS) -c -o $@ $^
+	@$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $^
 
 bin/% : %.o ../angband.o test-utils.o unit-test.o
 	@mkdir -p $(shell echo "$$(dirname $@)")
-	@$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) $(LDADD) $(LIBS)
+	@$(CC) $(CFLAGS) $(CPPFLAGS) -o $@ $^ $(LDFLAGS) $(LDADD) $(LIBS)
 	@echo "  CC $@"
 
 clean :


### PR DESCRIPTION
Resolves a problem that came up in https://github.com/angband/angband/issues/4745 : rerunning configure with different flags for the front ends and then running make did not rebuild main.o.