### PR TITLE
configure.ac:  adjust CPPFLAGS for more --enable options

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -289,7 +289,9 @@ if test "$enable_sdl2" = "yes"; then
 
 		if test "$with_sdl2" = "yes"; then
 			AC_DEFINE(USE_SDL2, 1, [Define to 1 if using the SDL2 interface and SDL2 is found.])
-			CFLAGS="${CFLAGS} ${SDL2_CFLAGS}"
+			SDL2_CFLAGS=`sdl2-config --cflags`
+			CPPFLAGS="${CPPFLAGS} ${SDL2_CFLAGS}"
+			SDL2_LIBS=`sdl2-config --libs`
 			LIBS="${LIBS} ${SDL2_LIBS} -lSDL2_image -lSDL2_ttf"
 			MAINFILES="${MAINFILES} \$(SDL2MAINFILES)"
 			enable_sdl=no
@@ -309,7 +311,9 @@ else
 
 			if test "$with_sdl" = "yes"; then
 			   		AC_DEFINE(USE_SDL, 1, [Define to 1 if using the SDL interface and SDL is found.])
-					CFLAGS="${CFLAGS} ${SDL_CFLAGS}"
+					SDL_CFLAGS=`sdl-config --cflags`
+					CPPFLAGS="${CPPFLAGS} ${SDL_CFLAGS}"
+					SDL_LIBS=`sdl-config --libs`
 					LIBS="${LIBS} ${SDL_LIBS} -lSDL_image -lSDL_ttf"
 					MAINFILES="${MAINFILES} \$(SDLMAINFILES)"
 		    fi
@@ -343,7 +347,7 @@ if test "$enable_sdl2_mixer" = "yes"; then
 			LIBS="${LIBS} -lSDL2_mixer"
 		else
 			SDL2_CFLAGS=`sdl2-config --cflags`
-			CFLAGS="${CFLAGS} ${SDL2_CFLAGS}"
+			CPPFLAGS="${CPPFLAGS} ${SDL2_CFLAGS}"
 			SDL2_LIBS=`sdl2-config --libs`
 			LIBS="${LIBS} ${SDL2_LIBS} -lSDL2_mixer"
 		fi
@@ -362,7 +366,7 @@ if test "$enable_sdl_mixer" = "yes"; then
 			LIBS="${LIBS} -lSDL_mixer"
 		else
 			SDL_CFLAGS=`sdl-config --cflags`
-			CFLAGS="${CFLAGS} ${SDL_CFLAGS}"
+			CPPFLAGS="${CPPFLAGS} ${SDL_CFLAGS}"
 			SDL_LIBS=`sdl-config --libs`
 			LIBS="${LIBS} ${SDL_LIBS} -lSDL_mixer"
 		fi

--- a/configure.ac
+++ b/configure.ac
@@ -321,7 +321,8 @@ dnl Windows checking
 if test "$enable_win" = "yes"; then
 	AC_DEFINE(USE_WIN, 1, [Define to 1 if using the Windows interface.])
 	AC_DEFINE(SOUND, 1, [Define to 1 if including sound support.])
-	CFLAGS="${CFLAGS} -DWINDOWS -static -Iwin/include"
+	CPPFLAGS="${CPPFLAGS} -DWINDOWS -Iwin/include"
+	CFLAGS="${CFLAGS} -static"
 	LDFLAGS="${LDFLAGS} -Lwin/lib"
 	LIBS="${LIBS} -mwindows -lwinmm -lzlib -llibpng -lmsimg32"
 dnl Note complete replacement of all main files


### PR DESCRIPTION
That's to avoid error messages during the dependency generation step which do not halt compilation (despite "fatal" in the message).  For --enable-sdl and --enable-sdl2, the error messages appeared after the recent change to put "-DHAVE_CONFIG_H" in CPPFLAGS.  For --enable-win, the error message was appearing before that change (see any of the old workflow results for Windows builds for messages about not finding png.h).