### PR TITLE
In the compiling documentation, briefly mention result and how to run for some common cases

### DIFF
--- a/docs/hacking/compiling.rst
+++ b/docs/hacking/compiling.rst
@@ -17,6 +17,10 @@ To build the new Cocoa front-end::
     cd src
     make -f Makefile.osx
 
+That'll create a self-contained Mac application, Angband.app, in the directory
+above src.  You may use that application where it is or move it to wherever
+is convenient for you.
+
 Debug build
 ~~~~~~~~~~~
 
@@ -64,6 +68,15 @@ To build Angband to be run in-place, then run this::
 
     ./configure --with-no-install [other options as needed]
     make
+
+That'll create an executable in the src directory.  You can run it from the
+same directory where you ran make with
+
+    src/angband
+
+To see what command line options are accepted, use
+
+    src/angband -?
 
 To build Angband to be installed in some other location, run this::
 
@@ -122,6 +135,16 @@ Then configure the cross-comilation and perform the compilation itself::
 
 	./configure --enable-win --disable-curses --build=i686-pc-linux-gnu --host=i586-mingw32msvc
 	make
+
+One way to run the generated executable, src/angband.exe, with wine is to first
+set up symbolic links to the executable and DLLs it uses
+
+        ln -s src/angband.exe .
+        ln -s src/win/dll/*.dll .
+
+Then use wine:
+
+        wine angband.exe
 
 Mingw installs commands like 'i586-mingw32msvc-gcc'. The value of --host
 should be that same command with the '-gcc' removed. Instead of i586 you may


### PR DESCRIPTION
Do that since there was some confusion in https://github.com/angband/angband/issues/4745 about what to do after compiling on Linux.