### PR TITLE
Improve quiver inscriptions

### DIFF
--- a/src/obj-gear.c
+++ b/src/obj-gear.c
@@ -1164,8 +1164,13 @@ int preferred_quiver_slot(const struct object *obj)
 			of_has(obj->flags, OF_THROWING))) {
 		const char *s = strchr(quark_str(obj->note), '@');
 
-		if (s && (s[1] == 'f' || s[1] == 'v')) {
-			desired_slot = s[2] - '0';
+		while (1) {
+			if (!s) break;
+			if (s[1] == 'f' || s[1] == 'v') {
+				desired_slot = s[2] - '0';
+				break;
+			}
+			s = strchr(s + 1, '@');
 		}
 	}
 

--- a/src/obj-gear.c
+++ b/src/obj-gear.c
@@ -1163,10 +1163,22 @@ int preferred_quiver_slot(const struct object *obj)
 	if (obj->note && (tval_is_ammo(obj) ||
 			of_has(obj->flags, OF_THROWING))) {
 		const char *s = strchr(quark_str(obj->note), '@');
+		char fire_key, throw_key;
 
+		/*
+		 * Would be nice to use cmd_lookup_key() for this, but that is
+		 * part of the ui layer (declared in ui-game.h).  Instead,
+		 * hardwire the keys for the fire and throw commands.
+		 */
+		if (OPT(player, rogue_like_commands)) {
+			fire_key = 't';
+		} else {
+			fire_key = 'f';
+		}
+		throw_key = 'v';
 		while (1) {
 			if (!s) break;
-			if (s[1] == 'f' || s[1] == 'v') {
+			if (s[1] == fire_key || s[1] == throw_key) {
 				desired_slot = s[2] - '0';
 				break;
 			}


### PR DESCRIPTION
- Don't require the inscription targeting the quiver to be the first inscription with '@'.  Allows a dagger inscribed with '@w0@v9' to appear in quiver slot 9.  As before, when choosing the preferred slot, only the first inscription targeting the quiver is consulted.
- Account for whether the original or Rogue-like keys are used when testing for an inscription to fire.  That resolves part of https://github.com/angband/angband/issues/4724 :  "@t1" as the inscription when using the Rogue-like keys did not place the object in quiver slot 1.