### PR TITLE
Apply a (mostly-)random symmetry transformation when inserting vaults or room templates

### DIFF
--- a/src/gen-chunk.c
+++ b/src/gen-chunk.c
@@ -190,6 +190,137 @@ void symmetry_transform(struct loc *grid, int y0, int x0, int height, int width,
 }
 
 /**
+ * Select a random symmetry transformation subject to certain constraints.
+ * \param height Is the height of the piece to transform.
+ * \param width Is the height of the piece to transform.
+ * \param flags Is a bitwise-or of one or more of SYMTR_FLAG_NONE,
+ * SYMTR_FLAG_NO_ROT (disallow 90 and 270 degree rotation and 180 degree
+ * rotation if not accompanied by a horizontal reflection - equivalent to a
+ * vertical reflection), SYMTR_FLAG_NO_REF (forbid horizontal reflection), and
+ * SYMTR_FLAG_FORCE_REF (force horizontal reflection).  If flags
+ * includes both SYMTR_FLAG_NO_REF and SYMTR_FLAG_FORCE_REF, the former takes
+ * precedence.
+ * \param transpose_weight Is the probability weight to use for transformations
+ * that include a tranposition (90 degree rotation, 270 degree rotation,
+ * 90 degree rotation + horizontal reflection, 270 degree rotation + horizontal
+ * reflection).  Coerced to be in the range of [0, SYMTR_MAX_WEIGHT] where 0
+ * means forbidding such transformations.
+ * \param rotate *rotate is set to the number of 90 degree clockwise rotations
+ * to perform for the random transform.
+ * \param reflect *reflect is set to whether the random transform includes a
+ * horizontal reflection.
+ * \param theight If theight is not NULL, *theight is set to the height of the
+ * piece after applying the transform.
+ * \param twidth If twidth is not NULL, *twidth is set to the width of the
+ * piece after applying the transform.
+ */
+void get_random_symmetry_transform(int height, int width, int flags,
+	int transpose_weight, int *rotate, bool *reflect,
+	int *theight, int *twidth)
+{
+	/*
+	 * Without any constraints there are 8 possibilities (4 rotations times
+	 * 2 options for whether or not there is a horizontal reflection).
+	 * Use an array of 9 elements (extra element for a leading zero) to
+	 * store the cumulative probability weights.  The first four are for
+	 * rotations without reflection.  The remainder are for the rotations
+	 * with reflection.
+	 */
+	int weights[9], draw, ilow, ihigh;
+
+	transpose_weight = MIN(SYMTR_MAX_WEIGHT, MAX(0, transpose_weight));
+	weights[0] = 0;
+	if ((flags & SYMTR_FLAG_NO_REF) || !(flags & SYMTR_FLAG_FORCE_REF)) {
+		weights[1] = weights[0] + SYMTR_MAX_WEIGHT;
+	} else {
+		weights[1] = weights[0];
+	}
+	if (flags & SYMTR_FLAG_NO_ROT) {
+		weights[2] = weights[1];
+		weights[3] = weights[2];
+		weights[4] = weights[3];
+	} else if ((flags & SYMTR_FLAG_NO_REF) ||
+			!(flags & SYMTR_FLAG_FORCE_REF)) {
+		weights[2] = weights[1] + transpose_weight;
+		weights[3] = weights[2] + SYMTR_MAX_WEIGHT;
+		weights[4] = weights[3] + transpose_weight;
+	} else {
+		/* Reflection is forced so these all have zero weight. */
+		weights[2] = weights[1];
+		weights[3] = weights[2];
+		weights[4] = weights[3];
+	}
+	if (flags & SYMTR_FLAG_NO_REF) {
+		/* Reflection is forbidden so these all have zero weight. */
+		weights[5] = weights[4];
+		weights[6] = weights[5];
+		weights[7] = weights[6];
+		weights[8] = weights[7];
+	} else {
+		weights[5] = weights[4] + SYMTR_MAX_WEIGHT;
+		if (flags & SYMTR_FLAG_NO_ROT) {
+			weights[6] = weights[5];
+			/*
+			 * 180 degree rotation with a horizontal reflection is
+			 * equivalent to a vertical reflection so don't exclude
+			 * in when forbidding rotations.
+			 */
+			weights[7] = weights[6] + SYMTR_MAX_WEIGHT;
+			weights[8] = weights[7];
+		} else {
+			weights[6] = weights[5] + transpose_weight;
+			weights[7] = weights[6] + SYMTR_MAX_WEIGHT;
+			weights[8] = weights[7] + transpose_weight;
+		}
+	}
+	assert(weights[8] > 0);
+
+	draw = randint0(weights[8]);
+
+	/* Find by a binary search. */
+	ilow = 0;
+	ihigh = 8;
+	while (1) {
+		int imid;
+
+		if (ilow == ihigh - 1) {
+			break;
+		}
+		imid = (ilow + ihigh) / 2;
+		if (weights[imid] <= draw) {
+			ilow = imid;
+		} else {
+			ihigh = imid;
+		}
+	}
+
+	*rotate = ilow % 4;
+	*reflect = (ilow >= 4);
+	if (theight) {
+		*theight = (*rotate == 0 || *rotate == 2) ?  height : width;
+	}
+	if (twidth) {
+		*twidth = (*rotate == 0 || *rotate == 2) ?  width : height;
+	}
+}
+
+/**
+ * Select a weight for transforms that involve transpositions so that
+ * such transforms are forbidden if width >= 2 * height and the probability of
+ * such a transform increases as height / width up to a maximum of
+ * SYMTR_MAX_WEIGHT when the height is greater than or equal to the width.
+ * That's so transformed pieces will usually fit well into the aspect ratio
+ * of generated levels.
+ * \param height Is the height of the piece being transformed.
+ * \param width Is the width of the piece being transformed.
+ */
+int calc_default_transpose_weight(int height, int width)
+{
+	return (SYMTR_MAX_WEIGHT / 64) *
+		MAX(0, MIN(64, (128 * height) / width - 64));
+}
+
+/**
  * Write a chunk, transformed, to a given offset in another chunk.
  *
  * This function assumes that it is being called at level generation, when

--- a/src/gen-chunk.c
+++ b/src/gen-chunk.c
@@ -166,18 +166,23 @@ struct chunk *chunk_find_adjacent(struct player *p, bool above)
 void symmetry_transform(struct loc *grid, int y0, int x0, int height, int width,
 						int rotate, bool reflect)
 {
+	/* Track what the dimensions are after rotations. */
+	int rheight = height, rwidth = width;
 	int i;
 
 	/* Rotate (in multiples of 90 degrees clockwise) */
-    for (i = 0; i < rotate % 4; i++) {
-        int temp = grid->x;
-        grid->x = height - 1 - (grid->y);
-        grid->y = temp;
-    }
+	for (i = 0; i < rotate % 4; i++) {
+		int temp = grid->x;
+		grid->x = rheight - 1 - (grid->y);
+		grid->y = temp;
+		temp = rwidth;
+		rwidth = rheight;
+		rheight = temp;
+	}
 
-	/* Reflect (horizontally) */
+	/* Reflect (horizontally in the rotated system) */
 	if (reflect)
-		grid->x = width - 1 - grid->x;
+		grid->x = rwidth - 1 - grid->x;
 
 	/* Translate */
 	grid->y += y0;

--- a/src/gen-room.c
+++ b/src/gen-room.c
@@ -1064,7 +1064,8 @@ static bool build_room_template(struct chunk *c, struct loc centre, int ymax,
 	int dx, dy, rnddoors, doorpos;
 	const char *t;
 	bool rndwalls, light;
-	
+	int rotate, txmax, tymax;
+	bool reflect;
 
 	assert(c);
 
@@ -1080,16 +1081,30 @@ static bool build_room_template(struct chunk *c, struct loc centre, int ymax,
 
 	/* Find and reserve some space in the dungeon.  Get center of room. */
 	if ((centre.y >= c->height) || (centre.x >= c->width)) {
-		if (!find_space(&centre, ymax + 2, xmax + 2))
+		get_random_symmetry_transform(ymax, xmax, SYMTR_FLAG_NONE,
+			calc_default_transpose_weight(ymax, xmax),
+			&rotate, &reflect, &tymax, &txmax);
+		if (!find_space(&centre, tymax + 2, txmax + 2))
 			return (false);
+	} else {
+		/* Given the preset centre, don't allow transposition. */
+		get_random_symmetry_transform(ymax, xmax, SYMTR_FLAG_NONE, 0,
+			&rotate, &reflect, &tymax, &txmax);
+		assert(tymax == ymax && txmax == xmax);
 	}
+
+	/* Convert centre to translation for the symmetry transformation. */
+	centre.x -= txmax / 2;
+	centre.y -= tymax / 2;
 
 	/* Place dungeon features, objects, and monsters for specific grids. */
 	for (t = data, dy = 0; dy < ymax && *t; dy++) {
 		for (dx = 0; dx < xmax && *t; dx++, t++) {
 			/* Extract the location */
-			struct loc grid = loc(centre.x - (xmax / 2) + dx,
-								  centre.y - (ymax / 2) + dy);
+			struct loc grid = loc(dx, dy);
+
+			symmetry_transform(&grid, centre.y, centre.x,
+				ymax, xmax, rotate, reflect);
 
 			/* Skip non-grids */
 			if (*t == ' ') continue;
@@ -1183,8 +1198,10 @@ static bool build_room_template(struct chunk *c, struct loc centre, int ymax,
 	for (t = data, dy = 0; dy < ymax && *t; dy++) {
 		for (dx = 0; dx < xmax && *t; dx++, t++) {
 			/* Extract the location */
-			struct loc grid = loc(centre.x - (xmax / 2) + dx,
-				centre.y - (ymax / 2) + dy);
+			struct loc grid = loc(dx, dy);
+
+			symmetry_transform(&grid, centre.y, centre.x,
+				ymax, xmax, rotate, reflect);
 
 			/* Analyze the grid. */
 			switch (*t) {
@@ -1277,28 +1294,48 @@ bool build_vault(struct chunk *c, struct loc centre, struct vault *v)
 	const char *t;
 	char racial_symbol[30] = "";
 	bool icky;
+	int rotate, thgt, twid;
+	bool reflect;
 
 	assert(c);
 
 	/* Find and reserve some space in the dungeon.  Get center of room. */
 	if ((centre.y >= c->height) || (centre.x >= c->width)) {
-		if (!find_space(&centre, v->hgt + 2, v->wid + 2))
+		get_random_symmetry_transform(v->hgt, v->wid, SYMTR_FLAG_NONE,
+			calc_default_transpose_weight(v->hgt, v->wid),
+			&rotate, &reflect, &thgt, &twid);
+		if (!find_space(&centre, thgt + 2, twid + 2))
 			return (false);
+	} else {
+		/* Given the preset centre, don't allow transposition. */
+		get_random_symmetry_transform(v->hgt, v->wid, SYMTR_FLAG_NONE,
+			0, &rotate, &reflect, &thgt, &twid);
+		assert(v->hgt == thgt && v->wid == twid);
 	}
 
+	/* Convert centre to translation for the symmetry transformation. */
+	centre.x -= twid / 2;
+	centre.y -= thgt / 2;
+
 	/* Get the room corners */
-	y1 = centre.y - (v->hgt / 2);
-	x1 = centre.x - (v->wid / 2);
-	y2 = y1 + v->hgt - 1;
-	x2 = x1 + v->wid - 1;
+	y1 = centre.y;
+	x1 = centre.x;
+	y2 = y1 + thgt - 1;
+	x2 = x1 + twid - 1;
 
 	/* No random monsters in vaults. */
 	generate_mark(c, y1, x1, y2, x2, SQUARE_MON_RESTRICT);
 
 	/* Place dungeon features and objects */
-	for (t = data, y = y1; y <= y2 && *t; y++) {
-		for (x = x1; x <= x2 && *t; x++, t++) {
+	for (t = data, y = 0; y < v->hgt && *t; y++) {
+		for (x = 0; x < v->wid && *t; x++, t++) {
 			struct loc grid = loc(x, y);
+
+			symmetry_transform(&grid, centre.y, centre.x, v->hgt,
+				v->wid, rotate, reflect);
+			assert(grid.x >= x1 && grid.x <= x2 &&
+				grid.y >= y1 && grid.y <= y2);
+
 			/* Skip non-grids */
 			if (*t == ' ') continue;
 
@@ -1381,9 +1418,15 @@ bool build_vault(struct chunk *c, struct loc centre, struct vault *v)
 
 
 	/* Place regular dungeon monsters and objects */
-	for (t = data, y = y1; y <= y2 && *t; y++) {
-		for (x = x1; x <= x2 && *t; x++, t++) {
+	for (t = data, y = 0; y < v->hgt && *t; y++) {
+		for (x = 0; x < v->wid && *t; x++, t++) {
 			struct loc grid = loc(x, y);
+
+			symmetry_transform(&grid, centre.y, centre.x, v->hgt,
+				v->wid, rotate, reflect);
+			assert(grid.x >= x1 && grid.x <= x2 &&
+				grid.y >= y1 && grid.y <= y2);
+
 			/* Hack -- skip "non-grids" */
 			if (*t == ' ') continue;
 

--- a/src/generate.h
+++ b/src/generate.h
@@ -243,6 +243,15 @@ struct room_template {
     byte tval;			/*!< tval for objects in this room */
 };
 
+/**
+ * Constants for working with random symmetry transforms
+ */
+#define SYMTR_FLAG_NONE (0)
+#define SYMTR_FLAG_NO_ROT (1)
+#define SYMTR_FLAG_NO_REF (2)
+#define SYMTR_FLAG_FORCE_REF (4)
+#define SYMTR_MAX_WEIGHT (32768)
+
 extern struct dun_data *dun;
 extern struct vault *vaults;
 extern struct room_template *room_templates;
@@ -267,6 +276,12 @@ bool chunk_list_remove(char *name);
 struct chunk *chunk_find_name(char *name);
 bool chunk_find(struct chunk *c);
 struct chunk *chunk_find_adjacent(struct player *p, bool above);
+void symmetry_transform(struct loc *grid, int y0, int x0, int height, int width,
+	int rotate, bool reflect);
+void get_random_symmetry_transform(int height, int width, int flags,
+	int transpose_weight, int *rotate, bool *reflect,
+	int *theight, int *twidth);
+int calc_default_transpose_weight(int height, int width);
 bool chunk_copy(struct chunk *dest, struct chunk *source, int y0, int x0,
 				int rotate, bool reflect);
 


### PR DESCRIPTION
That's to add a little more variety in level generation.  I didn't edit room_template.txt to take out the ones that are now redundant with the internally applied transformations.

Transformations that would transpose the dimensions (90 or 270 degree rotations for instance) are disallowed if the centre is fixed rather than being dynamically chosen in the room builder.  When the center is not fixed, transformations that transpose the dimensions will be down weighted if the resulting room would be taller than it is wide.