### PR TITLE
Treat '#' similarly for vaults and room templates

### DIFF
--- a/src/cave.c
+++ b/src/cave.c
@@ -632,6 +632,44 @@ int count_feats(struct loc *grid,
 	return count;
 }
 
+/**
+ * Return the number of matching grids around a location.
+ * \param match If not NULL, *match is set to the location of the last match.
+ * \param c Is the chunk to use.
+ * \param grid Is the location whose neighbors will be tested.
+ * \param test Is the predicate to use when testing for a match.
+ * \param under If true, grid is tested as well.
+ */
+int count_neighbors(struct loc *match, struct chunk *c, struct loc grid,
+	bool (*test)(struct chunk *c, struct loc grid), bool under)
+{
+	int dlim = (under) ? 9 : 8;
+	int count = 0; /* Count how many matches */
+	int d;
+	struct loc grid1;
+
+	/* Check the grid's neighbors and, if under is true, grid */
+	for (d = 0; d < dlim; d++) {
+		/* Extract adjacent (legal) location */
+		grid1 = loc_sum(grid, ddgrid_ddd[d]);
+		if (!square_in_bounds(c, grid1)) continue;
+
+		/* Reject those that don't match */
+		if (!((*test)(c, grid1))) continue;
+
+		/* Count it */
+		++count;
+
+		/* Remember the location of the last match */
+		if (match) {
+			*match = grid1;
+		}
+	}
+
+	/* All done */
+	return count;
+}
+
 struct loc cave_find_decoy(struct chunk *c)
 {
 	return c->decoy;

--- a/src/cave.h
+++ b/src/cave.h
@@ -460,6 +460,8 @@ int cave_monster_count(struct chunk *c);
 
 int count_feats(struct loc *grid,
 				bool (*test)(struct chunk *c, struct loc grid), bool under);
+int count_neighbors(struct loc *match, struct chunk *c, struct loc grid,
+	bool (*test)(struct chunk *c, struct loc grid), bool under);
 struct loc cave_find_decoy(struct chunk *c);
 void prepare_next_level(struct chunk **c, struct player *p);
 bool is_quest(int level);


### PR DESCRIPTION
In initial pass add '#' as granite with the SQUARE_WALL_SOLID flag.  In the second pass through the room, convert the ones in the interior to SQUARE_WALL_INNER.  Simplifies compatibility with the tunneling code's procedure for passing through rooms.
