### PR TITLE
Avoid simple rooms overwriting the permanent rock border

### DIFF
--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -529,7 +529,7 @@ struct chunk *classic_gen(struct player *p, int min_height, int min_width) {
 
     /* Generate permanent walls around the edge of the generated area */
     draw_rectangle(c, 0, 0, c->height - 1, c->width - 1, 
-				   FEAT_PERM, SQUARE_NONE);
+				   FEAT_PERM, SQUARE_NONE, true);
 
     /* Hack -- Scramble the room order */
     for (i = 0; i < dun->cent_n; i++) {
@@ -703,7 +703,7 @@ struct chunk *labyrinth_chunk(int depth, int h, int w, bool lit, bool soft)
     walls = mem_zalloc(n * sizeof(int));
 
     /* Bound with perma-rock */
-    draw_rectangle(c, 0, 0, h + 1, w + 1, FEAT_PERM, SQUARE_NONE);
+    draw_rectangle(c, 0, 0, h + 1, w + 1, FEAT_PERM, SQUARE_NONE, true);
 
     /* Fill the labyrinth area with rock */
 	if (soft)
@@ -1370,7 +1370,7 @@ struct chunk *cavern_gen(struct player *p, int min_height, int min_width) {
 	c->depth = p->depth;
 
 	/* Surround the level with perma-rock */
-    draw_rectangle(c, 0, 0, h - 1, w - 1, FEAT_PERM, SQUARE_NONE);
+	draw_rectangle(c, 0, 0, h - 1, w - 1, FEAT_PERM, SQUARE_NONE, true);
 
 	/* Place 2-3 down stairs near some walls */
 	alloc_stairs(c, FEAT_MORE, rand_range(1, 3));
@@ -1712,7 +1712,7 @@ static void town_gen_layout(struct chunk *c, struct player *p)
 
 	/* Create walls */
 	draw_rectangle(c, 0, 0, c->height - 1, c->width - 1, FEAT_PERM,
-				   SQUARE_NONE);
+				   SQUARE_NONE, true);
 
 	while (!success) {
 		/* Initialize to ROCK for build_streamer precondition */
@@ -1923,7 +1923,7 @@ struct chunk *modified_chunk(int depth, int height, int width)
 
     /* Generate permanent walls around the generated area (temporarily!) */
     draw_rectangle(c, 0, 0, c->height - 1, c->width - 1, 
-				   FEAT_PERM, SQUARE_NONE);
+				   FEAT_PERM, SQUARE_NONE, true);
 
     /* Actual maximum number of blocks on this level */
     dun->row_blocks = c->height / dun->block_hgt;
@@ -2028,7 +2028,7 @@ struct chunk *modified_chunk(int depth, int height, int width)
 
     /* Turn the outer permanent walls back to granite  */
     draw_rectangle(c, 0, 0, c->height - 1, c->width - 1, 
-				   FEAT_GRANITE, SQUARE_NONE);
+				   FEAT_GRANITE, SQUARE_NONE, true);
 
 	return c;
 }
@@ -2087,7 +2087,7 @@ struct chunk *modified_gen(struct player *p, int min_height, int min_width) {
 
     /* Generate permanent walls around the edge of the generated area */
     draw_rectangle(c, 0, 0, c->height - 1, c->width - 1,
-				   FEAT_PERM, SQUARE_NONE);
+				   FEAT_PERM, SQUARE_NONE, true);
 
     /* Add some magma streamers */
     for (i = 0; i < dun->profile->str.mag; i++)
@@ -2174,7 +2174,7 @@ struct chunk *moria_chunk(int depth, int height, int width)
 
     /* Generate permanent walls around the generated area (temporarily!) */
     draw_rectangle(c, 0, 0, c->height - 1, c->width - 1, 
-				   FEAT_PERM, SQUARE_NONE);
+				   FEAT_PERM, SQUARE_NONE, true);
 
     /* Actual maximum number of blocks on this level */
     dun->row_blocks = c->height / dun->block_hgt;
@@ -2261,9 +2261,9 @@ struct chunk *moria_chunk(int depth, int height, int width)
 
     /* Turn the outer permanent walls back to granite  */
     draw_rectangle(c, 0, 0, c->height - 1, c->width - 1, 
-				   FEAT_GRANITE, SQUARE_NONE);
+				   FEAT_GRANITE, SQUARE_NONE, true);
 
-	return c;
+    return c;
 }
 
 /**
@@ -2313,7 +2313,7 @@ struct chunk *moria_gen(struct player *p, int min_height, int min_width) {
 
     /* Generate permanent walls around the edge of the generated area */
     draw_rectangle(c, 0, 0, c->height - 1, c->width - 1,
-				   FEAT_PERM, SQUARE_NONE);
+				   FEAT_PERM, SQUARE_NONE, true);
 
     /* Add some magma streamers */
     for (i = 0; i < dun->profile->str.mag; i++)
@@ -2533,8 +2533,8 @@ struct chunk *hard_centre_gen(struct player *p, int min_height, int min_width)
 	floor[2] = grid;
 
 	/* Encase in perma-rock */
-    draw_rectangle(c, 0, 0, c->height - 1, c->width - 1,
-				   FEAT_PERM, SQUARE_NONE);
+	draw_rectangle(c, 0, 0, c->height - 1, c->width - 1,
+				   FEAT_PERM, SQUARE_NONE, true);
 
 	/* Connect up all the caverns */
 	connect_caverns(c, floor);
@@ -2712,9 +2712,9 @@ struct chunk *lair_gen(struct player *p, int min_height, int min_width) {
 	cave_free(normal);
 	cave_free(lair);
 
-    /* Generate permanent walls around the edge of the generated area */
-    draw_rectangle(c, 0, 0, c->height - 1, c->width - 1, 
-				   FEAT_PERM, SQUARE_NONE);
+	/* Generate permanent walls around the edge of the generated area */
+	draw_rectangle(c, 0, 0, c->height - 1, c->width - 1,
+				   FEAT_PERM, SQUARE_NONE, true);
 
 	/* Connect */
 	ensure_connectedness(c);
@@ -2916,7 +2916,7 @@ struct chunk *gauntlet_gen(struct player *p, int min_height, int min_width) {
 
 	/* Generate permanent walls around the edge of the generated area */
 	draw_rectangle(c, 0, 0, c->height - 1, c->width - 1, 
-				   FEAT_PERM, SQUARE_NONE);
+				   FEAT_PERM, SQUARE_NONE, true);
 
 	/* Connect */
 	ensure_connectedness(c);
@@ -2960,9 +2960,9 @@ struct chunk *arena_gen(struct player *p, int min_height, int min_width) {
     fill_rectangle(c, 0, 0, c->height - 1, c->width - 1, FEAT_FLOOR,
 				   SQUARE_NONE);
 
-    /* Bound with perma-rock */
-    draw_rectangle(c, 0, 0, c->height - 1, c->width - 1, FEAT_PERM,
-				   SQUARE_NONE);
+	/* Bound with perma-rock */
+	draw_rectangle(c, 0, 0, c->height - 1, c->width - 1, FEAT_PERM,
+				   SQUARE_NONE, true);
 
 	/* Place the player */
 	player_place(c, p, loc(1, c->height - 2));

--- a/src/gen-room.c
+++ b/src/gen-room.c
@@ -165,23 +165,33 @@ void fill_rectangle(struct chunk *c, int y1, int x1, int y2, int x2, int feat,
  * \param x2 inclusive room boundaries
  * \param feat the terrain feature
  * \param flag the SQUARE_* flag we are marking with
+ * \param overwrite_perm whether to overwrite features already marked as
+ * permanent
  */
 void draw_rectangle(struct chunk *c, int y1, int x1, int y2, int x2, int feat,
-					int flag)
+					int flag, bool overwrite_perm)
 {
 	int y, x;
 
 	for (y = y1; y <= y2; y++) {
-		square_set_feat(c, loc(x1, y), feat);
-		square_set_feat(c, loc(x2, y), feat);
+		if (overwrite_perm || !square_isperm(c, loc(x1, y))) {
+			square_set_feat(c, loc(x1, y), feat);
+		}
+		if (overwrite_perm || !square_isperm(c, loc(x2, y))) {
+			square_set_feat(c, loc(x2, y), feat);
+		}
 	}
 	if (flag) {
 		generate_mark(c, y1, x1, y2, x1, flag);
 		generate_mark(c, y1, x2, y2, x2, flag);
 	}
 	for (x = x1; x <= x2; x++) {
-		square_set_feat(c, loc(x, y1), feat);
-		square_set_feat(c, loc(x, y2), feat);
+		if (overwrite_perm || !square_isperm(c, loc(x, y1))) {
+			square_set_feat(c, loc(x, y1), feat);
+		}
+		if (overwrite_perm || !square_isperm(c, loc(x, y2))) {
+			square_set_feat(c, loc(x, y2), feat);
+		}
 	}
 	if (flag) {
 		generate_mark(c, y1, x1, y1, x2, flag);
@@ -1763,7 +1773,7 @@ bool build_staircase(struct chunk *c, struct loc centre, int rating)
 	generate_room(c, centre.y - 1, centre.x - 1, centre.y + 1, centre.x + 1,
 				  false);
 	draw_rectangle(c, centre.y - 1, centre.x - 1, centre.y + 1, centre.x + 1,
-				   FEAT_GRANITE, SQUARE_WALL_OUTER);
+		FEAT_GRANITE, SQUARE_WALL_OUTER, false);
 
 	/* Place the correct stair */
 	while (join) {
@@ -1817,7 +1827,7 @@ bool build_circular(struct chunk *c, struct loc centre, int rating)
 
 		/* draw a room with a closed door on a random side */
 		draw_rectangle(c, centre.y - 2, centre.x - 2, centre.y + 2,
-					   centre.x + 2, FEAT_GRANITE, SQUARE_WALL_INNER);
+			centre.x + 2, FEAT_GRANITE, SQUARE_WALL_INNER, false);
 		place_closed_door(c, loc(centre.x + offset.x * 2,
 								 centre.y + offset.y * 2));
 
@@ -1866,7 +1876,8 @@ bool build_simple(struct chunk *c, struct loc centre, int rating)
 	generate_room(c, y1-1, x1-1, y2+1, x2+1, light);
 
 	/* Generate outer walls and inner floors */
-	draw_rectangle(c, y1-1, x1-1, y2+1, x2+1, FEAT_GRANITE, SQUARE_WALL_OUTER);
+	draw_rectangle(c, y1-1, x1-1, y2+1, x2+1, FEAT_GRANITE,
+		SQUARE_WALL_OUTER, false);
 	fill_rectangle(c, y1, x1, y2, x2, FEAT_FLOOR, SQUARE_NONE);
 
 	if (one_in_(20)) {
@@ -1995,11 +2006,11 @@ bool build_overlap(struct chunk *c, struct loc centre, int rating)
 
 	/* Generate outer walls (a) */
 	draw_rectangle(c, y1a-1, x1a-1, y2a+1, x2a+1, 
-				   FEAT_GRANITE, SQUARE_WALL_OUTER);
+		FEAT_GRANITE, SQUARE_WALL_OUTER, false);
 
 	/* Generate outer walls (b) */
 	draw_rectangle(c, y1b-1, x1b-1, y2b+1, x2b+1, 
-				   FEAT_GRANITE, SQUARE_WALL_OUTER);
+		FEAT_GRANITE, SQUARE_WALL_OUTER, false);
 
 	/* Generate inner floors (a) */
 	fill_rectangle(c, y1a, x1a, y2a, x2a, FEAT_FLOOR, SQUARE_NONE);
@@ -2089,11 +2100,11 @@ bool build_crossed(struct chunk *c, struct loc centre, int rating)
 
 	/* Generate outer walls (a) */
 	draw_rectangle(c, y1a - 1, x1a - 1, y2a + 1, x2a + 1, 
-				   FEAT_GRANITE, SQUARE_WALL_OUTER);
+		FEAT_GRANITE, SQUARE_WALL_OUTER, false);
 
 	/* Generate outer walls (b) */
 	draw_rectangle(c, y1b - 1, x1b - 1, y2b + 1, x2b + 1, 
-				   FEAT_GRANITE, SQUARE_WALL_OUTER);
+		FEAT_GRANITE, SQUARE_WALL_OUTER, false);
 
 	/* Generate inner floors (a) */
 	fill_rectangle(c, y1a, x1a, y2a, x2a, FEAT_FLOOR, SQUARE_NONE);
@@ -2115,7 +2126,8 @@ bool build_crossed(struct chunk *c, struct loc centre, int rating)
 		/* Inner treasure vault */
 	case 3: {
 		/* Generate a small inner vault */
-		draw_rectangle(c, y1b, x1a, y2b, x2a, FEAT_GRANITE, SQUARE_WALL_INNER);
+		draw_rectangle(c, y1b, x1a, y2b, x2a, FEAT_GRANITE,
+			SQUARE_WALL_INNER, false);
 
 		/* Open the inner vault with a secret door */
 		generate_hole(c, y1b, x1a, y2b, x2a, FEAT_SECRET);
@@ -2215,7 +2227,7 @@ bool build_large(struct chunk *c, struct loc centre, int rating)
 
 	/* Generate outer walls */
 	draw_rectangle(c, y1 - 1, x1 - 1, y2 + 1, x2 + 1, FEAT_GRANITE,
-				   SQUARE_WALL_OUTER);
+		SQUARE_WALL_OUTER, false);
 
 	/* Generate inner floors */
 	fill_rectangle(c, y1, x1, y2, x2, FEAT_FLOOR, SQUARE_NONE);
@@ -2228,7 +2240,7 @@ bool build_large(struct chunk *c, struct loc centre, int rating)
 
 	/* Generate inner walls */
 	draw_rectangle(c, y1 - 1, x1 - 1, y2 + 1, x2 + 1, FEAT_GRANITE,
-				   SQUARE_WALL_INNER);
+		SQUARE_WALL_INNER, false);
 
 	/* Inner room variations */
 	switch (randint1(5)) {
@@ -2248,7 +2260,7 @@ bool build_large(struct chunk *c, struct loc centre, int rating)
 
 		/* Place another inner room */
 		draw_rectangle(c, centre.y - 1, centre.x - 1, centre.y + 1,
-					   centre.x + 1, FEAT_GRANITE, SQUARE_WALL_INNER);
+			centre.x + 1, FEAT_GRANITE, SQUARE_WALL_INNER, false);
 
 		/* Open the inner room with a locked door */
 		generate_hole(c, centre.y - 1, centre.x - 1, centre.y + 1, centre.x + 1,
@@ -2306,7 +2318,8 @@ bool build_large(struct chunk *c, struct loc centre, int rating)
 		if (one_in_(3)) {
 			/* Inner rectangle */
 			draw_rectangle(c, centre.y - 1, centre.x - 5, centre.y + 1,
-						   centre.x + 5, FEAT_GRANITE, SQUARE_WALL_INNER);
+				centre.x + 5, FEAT_GRANITE,
+				SQUARE_WALL_INNER, false);
 
 			/* Secret doors (random top/bottom) */
 			place_secret_door(c, loc(centre.x - 3,
@@ -2456,7 +2469,7 @@ bool build_nest(struct chunk *c, struct loc centre, int rating)
 
 	/* Generate outer walls */
 	draw_rectangle(c, y1 - 1, x1 - 1, y2 + 1, x2 + 1, FEAT_GRANITE,
-				   SQUARE_WALL_OUTER);
+		SQUARE_WALL_OUTER, false);
 
 	/* Generate inner floors */
 	fill_rectangle(c, y1, x1, y2, x2, FEAT_FLOOR, SQUARE_NONE);
@@ -2469,7 +2482,7 @@ bool build_nest(struct chunk *c, struct loc centre, int rating)
 
 	/* Generate inner walls */
 	draw_rectangle(c, y1 - 1, x1 - 1, y2 + 1, x2 + 1, FEAT_GRANITE,
-				   SQUARE_WALL_INNER);
+		SQUARE_WALL_INNER, false);
 
 	/* Open the inner room with a secret door */
 	generate_hole(c, y1 - 1, x1 - 1, y2 + 1, x2 + 1, FEAT_CLOSED);
@@ -2584,7 +2597,7 @@ bool build_pit(struct chunk *c, struct loc centre, int rating)
 	/* Generate new room, outer walls and inner floor */
 	generate_room(c, y1 - 1, x1 - 1, y2 + 1, x2 + 1, light);
 	draw_rectangle(c, y1 - 1, x1 - 1, y2 + 1, x2 + 1, FEAT_GRANITE,
-				   SQUARE_WALL_OUTER);
+		SQUARE_WALL_OUTER, false);
 	fill_rectangle(c, y1, x1, y2, x2, FEAT_FLOOR, SQUARE_NONE);
 
 	/* Advance to the center room */
@@ -2595,7 +2608,7 @@ bool build_pit(struct chunk *c, struct loc centre, int rating)
 
 	/* Generate inner walls, and open with a secret door */
 	draw_rectangle(c, y1 - 1, x1 - 1, y2 + 1, x2 + 1, FEAT_GRANITE,
-				   SQUARE_WALL_INNER);
+		SQUARE_WALL_INNER, false);
 	generate_hole(c, y1 - 1, x1 - 1, y2 + 1, x2 + 1, FEAT_CLOSED);
 
 	/* Decide on the pit type */

--- a/src/generate.h
+++ b/src/generate.h
@@ -293,7 +293,7 @@ void fill_rectangle(struct chunk *c, int y1, int x1, int y2, int x2, int feat,
 					int flag);
 void generate_mark(struct chunk *c, int y1, int x1, int y2, int x2, int flag);
 void draw_rectangle(struct chunk *c, int y1, int x1, int y2, int x2, int feat, 
-					int flag);
+					int flag, bool overwrite_perm);
 void set_marked_granite(struct chunk *c, struct loc grid, int flag);
 extern bool generate_starburst_room(struct chunk *c, int y1, int x1, int y2, 
 									int x2, bool light, int feat, 


### PR DESCRIPTION
Use a rather brutish approach to do that:

1. Add an argument to draw_rectangle() for whether it should overwrite something marked as permanent.
2. All calls to draw_rectangle() from gen-room.c don't allow the overwrite.
3. The calls to draw_rectangle() from gen-cave.c usually do allow overwrite as they set up or erase the borders.
