### PR TITLE
For Shockbolt Dark, don't use the General Store, Armoury and Weapon Smiths …

### DIFF
--- a/lib/tiles/shockbolt/graf-shb-dark.prf
+++ b/lib/tiles/shockbolt/graf-shb-dark.prf
@@ -47,13 +47,13 @@ feat:down staircase:lit:0x9A:0xF2
 feat:down staircase:dark:0x9A:0xF3
 
 # General Store
-feat:General Store:*:0x9B:0xF1
+feat:General Store:*:0x99:0x83
 
 # Armoury
-feat:Armoury:*:0x9B:0xF2
+feat:Armoury:*:0x99:0x84
 
 # Weapon Smiths
-feat:Weapon Smiths:*:0x9B:0xF3
+feat:Weapon Smiths:*:0x99:0x85
 
 # Bookseller
 feat:Bookseller:*:0x9B:0xF4


### PR DESCRIPTION
… tiles from the double-height row.  Fixes part of https://github.com/angband/angband/issues/4717 .  Should also resolve this report for FAangband, http://angband.oook.cz/forum/showpost.php?p=152881&postcount=293 .

The other store tiles in that row currently have transparent upper halves so they are okay to use for now.