### PR TITLE
ui-term.c:  check for changes in padded areas of big tiles and trigger redraw of tile if found

### DIFF
--- a/src/ui-output.c
+++ b/src/ui-output.c
@@ -437,10 +437,6 @@ void screen_load(void)
 	event_signal(EVENT_MESSAGE_FLUSH);
 	Term_load();
 	screen_save_depth--;
-
-	/* Redraw big graphics */
-	if (screen_save_depth == 0 && (tile_width > 1 || tile_height > 1))
-		Term_redraw();
 }
 
 bool textui_map_is_visible(void)


### PR DESCRIPTION
Take advantage of that to remove the forced clear in screen_load() when big tiles are used.  Relates to Cuboideb's post, http://angband.oook.cz/forum/showpost.php?p=152990&postcount=35 .