### PR TITLE
Allow callers to set clipping for bottom of padding in Term_big_queue_char()

### DIFF
--- a/src/ui-display.c
+++ b/src/ui-display.c
@@ -1325,6 +1325,7 @@ static void update_maps(game_event_type type, game_event_data *data, void *user)
 
 		int ky, kx;
 		int vy, vx;
+		int clipy;
 
 		/* Location relative to panel */
 		ky = data->point.y - t->offset_y;
@@ -1338,6 +1339,9 @@ static void update_maps(game_event_type type, game_event_data *data, void *user)
 			/* Location in window */
 			vy = tile_height * ky + ROW_MAP;
 			vx = tile_width * kx + COL_MAP;
+
+			/* Protect the status line against modification. */
+			clipy = ROW_MAP + SCREEN_ROWS;
 		} else {
 			/* Verify location */
 			if ((ky < 0) || (ky >= t->hgt / tile_height)) return;
@@ -1346,6 +1350,9 @@ static void update_maps(game_event_type type, game_event_data *data, void *user)
 			/* Location in window */
 			vy = tile_height * ky;
 			vx = tile_width * kx;
+
+			/* All the rows may be used for the map. */
+			clipy = t->hgt;
 		}
 
 
@@ -1359,7 +1366,7 @@ static void update_maps(game_event_type type, game_event_data *data, void *user)
 #endif
 
 		if ((tile_width > 1) || (tile_height > 1))
-			Term_big_queue_char(t, vx, vy, a, c, COLOUR_WHITE, L' ');
+			Term_big_queue_char(t, vx, vy, clipy, a, c, COLOUR_WHITE, L' ');
 	}
 
 	/* Refresh the main screen unless the map needs to center */

--- a/src/ui-map.c
+++ b/src/ui-map.c
@@ -475,7 +475,13 @@ static void print_rel_map(wchar_t c, byte a, int y, int x)
 		Term_queue_char(t, kx, ky, a, c, 0, 0);
 
 		if ((tile_width > 1) || (tile_height > 1))
-			Term_big_queue_char(t, kx, ky, a, c, 0, 0);
+			/*
+			 * The overhead view can make use of the last row in
+			 * the terminal.  Others leave it be.
+			 */
+			Term_big_queue_char(t, kx, ky, t->hgt -
+				((window_flag[j] & PW_OVERHEAD) ? 0 : 1),
+				a, c, 0, 0);
 	}
 }
 
@@ -518,7 +524,8 @@ void print_rel(wchar_t c, byte a, int y, int x)
 	Term_queue_char(Term, vx, vy, a, c, 0, 0);
 
 	if ((tile_width > 1) || (tile_height > 1))
-		Term_big_queue_char(Term, vx, vy, a, c, 0, 0);
+		Term_big_queue_char(Term, vx, vy, ROW_MAP + SCREEN_ROWS,
+			a, c, 0, 0);
   
 }
 
@@ -538,6 +545,7 @@ static void prt_map_aux(void)
 	/* Scan windows */
 	for (j = 0; j < ANGBAND_TERM_MAX; j++) {
 		term *t = angband_term[j];
+		int clipy;
 
 		/* No window */
 		if (!t) continue;
@@ -549,6 +557,12 @@ static void prt_map_aux(void)
 		ty = t->offset_y + (t->hgt / tile_height);
 		tx = t->offset_x + (t->wid / tile_width);
 
+		/*
+		 * The overhead view can use the last row of the terminal.
+		 * Others can not.
+		 */
+		clipy = t->hgt - ((window_flag[j] & PW_OVERHEAD) ? 0 : 1);
+
 		/* Dump the map */
 		for (y = t->offset_y, vy = 0; y < ty; vy += tile_height, y++) {
 			for (x = t->offset_x, vx = 0; x < tx; vx += tile_width, x++) {
@@ -559,7 +573,7 @@ static void prt_map_aux(void)
 						0, 0);
 					if (tile_width > 1 || tile_height > 1) {
 						Term_big_queue_char(t, vx, vy,
-							t->attr_blank,
+							clipy, t->attr_blank,
 							t->char_blank, 0, 0);
 					}
 					continue;
@@ -571,7 +585,8 @@ static void prt_map_aux(void)
 				Term_queue_char(t, vx, vy, a, c, ta, tc);
 
 				if ((tile_width > 1) || (tile_height > 1))
-					Term_big_queue_char(t, vx, vy, 255, -1, 0, 0);
+					Term_big_queue_char(t, vx, vy, clipy,
+						255, -1, 0, 0);
 			}
 			/* Clear partial tile at the end of each line. */
 			for (; vx < t->wid; ++vx) {
@@ -607,6 +622,7 @@ void prt_map(void)
 	int y, x;
 	int vy, vx;
 	int ty, tx;
+	int clipy;
 
 	/* Redraw map sub-windows */
 	prt_map_aux();
@@ -614,6 +630,9 @@ void prt_map(void)
 	/* Assume screen */
 	ty = Term->offset_y + SCREEN_HGT;
 	tx = Term->offset_x + SCREEN_WID;
+
+	/* Avoid overwriting the last row with padding for big tiles. */
+	clipy = ROW_MAP + SCREEN_ROWS;
 
 	/* Dump the map */
 	for (y = Term->offset_y, vy = ROW_MAP; y < ty; vy += tile_height, y++)
@@ -629,7 +648,8 @@ void prt_map(void)
 			Term_queue_char(Term, vx, vy, a, c, ta, tc);
 
 			if ((tile_width > 1) || (tile_height > 1))
-				Term_big_queue_char(Term, vx, vy, a, c, COLOUR_WHITE, L' ');
+				Term_big_queue_char(Term, vx, vy, clipy, a, c,
+					COLOUR_WHITE, L' ');
 		}
 }
 
@@ -723,7 +743,9 @@ void display_map(int *cy, int *cx)
 				Term_queue_char(Term, col + 1, row + 1, a, c, ta, tc);
 
 				if ((tile_width > 1) || (tile_height > 1))
-					Term_big_queue_char(Term, col + 1, row + 1, 255, -1, 0, 0);
+					Term_big_queue_char(Term, col + 1,
+						row + 1, Term->hgt - 1,
+						255, -1, 0, 0);
 
 				/* Save priority */
 				mp[row][col] = tp;

--- a/src/ui-term.c
+++ b/src/ui-term.c
@@ -590,7 +590,13 @@ void Term_queue_char(term *t, int x, int y, int a, wchar_t c, int ta,
 }
 
 /**
- * Queue a large-sized tile
+ * Queue a large-sized tile.
+ * \param x Is the column for the upper left corner of the tile.
+ * \param y Is the row for the upper left corner of the tile.
+ * \param a Is the foreground attribute.
+ * \param c Is the foreground character.
+ * \param a1 Is the background attribute.
+ * \param c1 Is the background character.
  */
 void Term_big_queue_char(term *t, int x, int y, int a, wchar_t c, int a1,
 						 wchar_t c1)

--- a/src/ui-term.c
+++ b/src/ui-term.c
@@ -593,21 +593,24 @@ void Term_queue_char(term *t, int x, int y, int a, wchar_t c, int ta,
  * Queue a large-sized tile.
  * \param x Is the column for the upper left corner of the tile.
  * \param y Is the row for the upper left corner of the tile.
+ * \param clipy Is the lower bound for rows that should not be modified when
+ * writing the large-sized tile.
  * \param a Is the foreground attribute.
  * \param c Is the foreground character.
  * \param a1 Is the background attribute.
  * \param c1 Is the background character.
  */
-void Term_big_queue_char(term *t, int x, int y, int a, wchar_t c, int a1,
-						 wchar_t c1)
+void Term_big_queue_char(term *t, int x, int y, int clipy,
+	int a, wchar_t c, int a1, wchar_t c1)
 {
-	/* Leave space on bottom for status */
-	int vmax = (y + tile_height < t->hgt - 1) ?
-	    tile_height : t->hgt - 1 - y;
+	int vmax;
 	int hor, vert;
 
 	/* Avoid warning */
 	(void)c;
+
+	/* Leave space on bottom if requested */
+	vmax = (y + tile_height <= clipy) ? tile_height : clipy - y;
 
 	/* No tall skinny tiles */
 	if (tile_width > 1) {

--- a/src/ui-term.h
+++ b/src/ui-term.h
@@ -370,7 +370,8 @@ extern u32b window_flag[ANGBAND_TERM_MAX];
 extern errr Term_xtra(int n, int v);
 
 extern void Term_queue_char(term *t, int x, int y, int a, wchar_t c, int ta, wchar_t tc);
-extern void Term_big_queue_char(term *t, int x, int y, int a, wchar_t c, int a1, wchar_t c1);
+extern void Term_big_queue_char(term *t, int x, int y, int clipy,
+	int a, wchar_t c, int a1, wchar_t c1);
 extern void Term_queue_chars(int x, int y, int n, int a, const wchar_t *s);
 
 extern errr Term_fresh(void);


### PR DESCRIPTION
Do that since the callers better know the purpose of the window than Term_big_queue_char() does (would have to look up the current terminal in angband_term and then get the flags from window_flag).  Resolves the last problem from https://github.com/angband/angband/issues/4717 : with big tiles there were clearing artifacts in the last row of the overhead view using the Mac front end.