### PR TITLE
Correct loop logic in Term_big_putch():  affect only tile_width x …

### DIFF
--- a/src/ui-term.c
+++ b/src/ui-term.c
@@ -2130,7 +2130,7 @@ void Term_big_putch(int x, int y, int a, wchar_t c)
 	/* No tall skinny tiles */
 	if (tile_width > 1) {
 		/* Horizontal first */
-		for (hor = 0; hor <= tile_width; hor++) {
+		for (hor = 0; hor < tile_width; hor++) {
 			/* Queue dummy character */
 			if (hor != 0) {
 				if (a & 0x80)
@@ -2140,7 +2140,7 @@ void Term_big_putch(int x, int y, int a, wchar_t c)
 			}
 
 			/* Now vertical */
-			for (vert = 1; vert <= tile_height; vert++) {
+			for (vert = 1; vert < tile_height; vert++) {
 				/* Queue dummy character */
 				if (a & 0x80)
 					Term_putch(x + hor, y + vert, 255, -1);
@@ -2150,7 +2150,7 @@ void Term_big_putch(int x, int y, int a, wchar_t c)
 		}
 	} else {
 		/* Only vertical */
-		for (vert = 1; vert <= tile_height; vert++) {
+		for (vert = 1; vert < tile_height; vert++) {
 			/* Queue dummy character */
 			if (a & 0x80)
 				Term_putch(x, y + vert, 255, -1);


### PR DESCRIPTION
…tile_height box skipping the upper left corner rather than (tile_width + 1) x (tile_height + 1) box skipping the upper left corner.  Doesn't fix any known display issues.