### PR TITLE
Be more consistent with the geometry in the tests for rendering upper halves of double-height tiles

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -1852,6 +1852,13 @@ static void draw_image_tile(
  */
 @property TerminalChanges *changes;
 
+/*
+ * Record first possible row and column for tiles for double-height tile
+ * handling.
+ */
+@property int firstTileRow;
+@property int firstTileCol;
+
 @property (nonatomic, assign) BOOL hasSubwindowFlags;
 @property (nonatomic, assign) BOOL windowVisibilityChecked;
 
@@ -2574,7 +2581,9 @@ static int compare_advances(const void *ap, const void *bp)
 	self->lastRefreshTime = CFAbsoluteTimeGetCurrent();
 	self->inFullscreenTransition = NO;
 
-        self->_windowVisibilityChecked = NO;
+	self->_firstTileRow = 0;
+	self->_firstTileCol = 0;
+	self->_windowVisibilityChecked = NO;
     }
     return self;
 }
@@ -3040,10 +3049,10 @@ static int compare_nsrect_yorigin_greater(const void *ap, const void *bp)
 			   pcell->voff_n / (1.0 * pcell->voff_d)),
 	    graf_width * pcell->hscl / (1.0 * pcell->hoff_d),
 	    graf_height * pcell->vscl / (1.0 * pcell->voff_d));
-	int dbl_height_bck = overdraw_row && (irow > 2) &&
+	int dbl_height_bck = overdraw_row && (irow > self.firstTileRow + 1) &&
 	    (pcell->v.ti.bckRow >= overdraw_row &&
 	     pcell->v.ti.bckRow <= overdraw_max);
-	int dbl_height_fgd = overdraw_row && (irow > 2) &&
+	int dbl_height_fgd = overdraw_row && (irow > self.firstTileRow + 1) &&
 	    (pcell->v.ti.fgdRow >= overdraw_row) &&
 	    (pcell->v.ti.fgdRow <= overdraw_max);
 	int aligned_row = 0, aligned_col = 0;
@@ -3051,14 +3060,10 @@ static int compare_nsrect_yorigin_greater(const void *ap, const void *bp)
 
 	/* Initialize stuff for handling a double-height tile. */
 	if (dbl_height_bck || dbl_height_fgd) {
-	    if (self->terminal == angband_term[0]) {
-		aligned_col = ((icol0 - COL_MAP) / pcell->hoff_d) *
-		    pcell->hoff_d + COL_MAP;
-	    } else {
-		aligned_col = (icol0 / pcell->hoff_d) * pcell->hoff_d;
-	    }
-	    aligned_row = ((irow - ROW_MAP) / pcell->voff_d) *
-		pcell->voff_d + ROW_MAP;
+	    aligned_col = ((icol0 - self.firstTileCol) / pcell->hoff_d) *
+		    pcell->hoff_d + self.firstTileCol;
+	    aligned_row = ((irow - self.firstTileRow) / pcell->voff_d) *
+		pcell->voff_d + self.firstTileRow;
 
 	    /*
 	     * If the lower half has been broken into multiple pieces, only
@@ -4779,10 +4784,24 @@ static errr Term_pict_cocoa(int x, int y, int n, const int *ap,
 	overdraw_max = current_graphics_mode->overdrawMax;
 	alphablend = (ainfo & (kCGImageAlphaPremultipliedFirst |
 			       kCGImageAlphaPremultipliedLast)) ? 1 : 0;
+	if (overdraw_row) {
+	    if (Term == angband_term[0]) {
+		angbandContext.firstTileRow = ROW_MAP;
+		angbandContext.firstTileCol = COL_MAP;
+	    } else {
+		angbandContext.firstTileRow = 0;
+		angbandContext.firstTileCol = 0;
+	    }
+	} else {
+	    angbandContext.firstTileRow = 0;
+	    angbandContext.firstTileCol = 0;
+	}
     } else {
 	overdraw_row = 0;
 	overdraw_max = 0;
 	alphablend = 0;
+	angbandContext.firstTileRow = 0;
+	angbandContext.firstTileCol = 0;
     }
 
     for (int i = x; i < x + n * tile_width; i += tile_width) {
@@ -4818,7 +4837,7 @@ static errr Term_pict_cocoa(int x, int y, int n, const int *ap,
 			   backgroundRow:bckRow
 			   tileWidth:tile_width
 			   tileHeight:tile_height];
-	    if (overdraw_row && y > ROW_MAP + 1 &&
+	    if (overdraw_row && y > angbandContext.firstTileRow + 1 &&
 		((bckRow >= overdraw_row && bckRow <= overdraw_max) ||
 		 (fgdRow >= overdraw_row && fgdRow <= overdraw_max))) {
 		[angbandContext.changes markChangedBlockAtColumn:i

--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -3049,10 +3049,12 @@ static int compare_nsrect_yorigin_greater(const void *ap, const void *bp)
 			   pcell->voff_n / (1.0 * pcell->voff_d)),
 	    graf_width * pcell->hscl / (1.0 * pcell->hoff_d),
 	    graf_height * pcell->vscl / (1.0 * pcell->voff_d));
-	int dbl_height_bck = overdraw_row && (irow > self.firstTileRow + 1) &&
+	int dbl_height_bck = overdraw_row &&
+	    irow >= self.firstTileRow + pcell->hoff_d &&
 	    (pcell->v.ti.bckRow >= overdraw_row &&
 	     pcell->v.ti.bckRow <= overdraw_max);
-	int dbl_height_fgd = overdraw_row && (irow > self.firstTileRow + 1) &&
+	int dbl_height_fgd = overdraw_row &&
+	    irow >= self.firstTileRow + pcell->hoff_d &&
 	    (pcell->v.ti.fgdRow >= overdraw_row) &&
 	    (pcell->v.ti.fgdRow <= overdraw_max);
 	int aligned_row = 0, aligned_col = 0;
@@ -4785,13 +4787,9 @@ static errr Term_pict_cocoa(int x, int y, int n, const int *ap,
 	alphablend = (ainfo & (kCGImageAlphaPremultipliedFirst |
 			       kCGImageAlphaPremultipliedLast)) ? 1 : 0;
 	if (overdraw_row) {
-	    if (Term == angband_term[0]) {
-		angbandContext.firstTileRow = ROW_MAP;
-		angbandContext.firstTileCol = COL_MAP;
-	    } else {
-		angbandContext.firstTileRow = 0;
-		angbandContext.firstTileCol = 0;
-	    }
+	    angbandContext.firstTileRow = Term_get_first_tile_row(Term);
+	    angbandContext.firstTileCol = (Term == angband_term[0]) ?
+		COL_MAP : 0;
 	} else {
 	    angbandContext.firstTileRow = 0;
 	    angbandContext.firstTileCol = 0;
@@ -4837,7 +4835,8 @@ static errr Term_pict_cocoa(int x, int y, int n, const int *ap,
 			   backgroundRow:bckRow
 			   tileWidth:tile_width
 			   tileHeight:tile_height];
-	    if (overdraw_row && y > angbandContext.firstTileRow + 1 &&
+	    if (overdraw_row &&
+		y > angbandContext.firstTileRow + tile_height - 1 &&
 		((bckRow >= overdraw_row && bckRow <= overdraw_max) ||
 		 (fgdRow >= overdraw_row && fgdRow <= overdraw_max))) {
 		[angbandContext.changes markChangedBlockAtColumn:i

--- a/src/main-sdl.c
+++ b/src/main-sdl.c
@@ -3038,11 +3038,26 @@ static errr Term_pict_sdl(int col, int row, int n, const int *ap,
 	SDL_Rect rc, src, ur;
 	int i, j;
 	bool haddbl = false;
+	int dhrclip;
 
 	/* First time a pict is requested we load the tileset in */
 	if (!win->tiles) {
 		sdl_BuildTileset(win);
 		if (!win->tiles) return (1);
+	}
+
+	/*
+	 * Set exclusive lower bound in y for rendering upper halves of
+	 * double-height tiles.
+	 */
+	if (overdraw) {
+		dhrclip = Term_get_first_tile_row(Term) + tile_height - 1;
+	} else {
+		/*
+		 * There's no double-height tiles so the value does not
+		 * matter.
+		 */
+		dhrclip = 0;
 	}
 
 	/* Make the destination rectangle */
@@ -3077,7 +3092,7 @@ static errr Term_pict_sdl(int col, int row, int n, const int *ap,
 		src.y = j * src.h;
 		
 		/* if we are using overdraw, draw the top rectangle */
-		if (overdraw && row > ROW_MAP + 1 &&
+		if (overdraw && row > dhrclip &&
 				 j >= overdraw && j <= overdraw_max) {
 			src.y -= rc.h;
 			rc.y -= rc.h;
@@ -3099,7 +3114,7 @@ static errr Term_pict_sdl(int col, int row, int n, const int *ap,
 		src.y = j * src.h;
 		
 		/* if we are using overdraw, draw the top rectangle */
-		if (overdraw && row > ROW_MAP + 1 &&
+		if (overdraw && row > dhrclip &&
 				j >= overdraw && j <= overdraw_max) {
 			src.y -= rc.h;
 			rc.y -= rc.h;

--- a/src/main-win.c
+++ b/src/main-win.c
@@ -2343,7 +2343,8 @@ static errr Term_pict_win_alpha(int x, int y, int n,
 								const int *tap, const wchar_t *tcp)
 {
 	term_data *td = (term_data*)(Term->data);
-
+	int dhrclip = (overdraw) ?
+		Term_get_first_tile_row(Term) + tile_height - 1 : 0;
 	int i;
 	int mw, mh;
 	int x1, y1, w1, h1;
@@ -2418,7 +2419,7 @@ static errr Term_pict_win_alpha(int x, int y, int n,
 			StretchBlt(hdc, x2, y2, tw2, th2, hdcSrc, x3, y3, w1, h1, SRCCOPY);
 		}
 
-		if (overdraw && trow >= overdraw && y > ROW_MAP + 1 &&
+		if (overdraw && trow >= overdraw && y > dhrclip &&
 				trow <= overdrawmax) {
 			AlphaBlend(hdc, x2, y2-th2, tw2, th2, hdcSrc, x3, y3-h1, w1, h1,
 					   blendfn);
@@ -2428,7 +2429,7 @@ static errr Term_pict_win_alpha(int x, int y, int n,
 		if ((x1 != x3) || (y1 != y3))
 		{
 			/* Copy the picture from the bitmap to the window */
-			if (overdraw && row >= overdraw && y > ROW_MAP + 1 &&
+			if (overdraw && row >= overdraw && y > dhrclip &&
 					row <= overdrawmax) {
 				AlphaBlend(hdc, x2, y2-th2, tw2, th2*2, hdcSrc, x1, y1-h1, w1,
 						   h1*2, blendfn);

--- a/src/ui-term.c
+++ b/src/ui-term.c
@@ -3107,3 +3107,54 @@ int big_pad(int col, int row, byte a, wchar_t c)
 
 	return tile_width;
 }
+
+/**
+ * For the given terminal, return the first row where tiles may be rendered.
+ * \param t Is the terminal to be queried.
+ */
+int Term_get_first_tile_row(term *t)
+{
+	int result;
+
+	if (t == angband_term[0]) {
+		/*
+		 * In the main window, there's no tiles in the top bar, does
+		 * not account for the case where the main window is used as
+		 * the target for display_map() or displays tiles in the
+		 * knowledge menus.
+		 */
+		result = ROW_MAP;
+	} else {
+		/* In other windows, have to check the flags. */
+		int i = 1;
+
+		while (1) {
+			if (i >= ANGBAND_TERM_MAX) {
+				/*
+				 * Don't know the flags.  Err on the side of
+				 * drawing too few tiles.
+				 */
+				result = 1;
+				break;
+			}
+			if (t == angband_term[i]) {
+				if (window_flag[i] & PW_OVERHEAD) {
+					/*
+					 * All rows are valid targets for
+					 * tiles.
+					 */
+					result = 0;
+				} else {
+					/*
+					 * It's presumably a minimap view where
+					 * the first row has a non-tile border.
+					 */
+					result = 1;
+				}
+				break;
+			}
+			++i;
+		}
+	}
+	return result;
+}

--- a/src/ui-term.h
+++ b/src/ui-term.h
@@ -413,4 +413,6 @@ extern errr term_init(term *t, int w, int h, int k);
 
 extern int big_pad(int col, int row, byte a, wchar_t c);
 
+extern int Term_get_first_tile_row(term *t);
+
 #endif /* INCLUDED_Z_TERM_H */


### PR DESCRIPTION
The previous test was that the row be greater than ROW_MAP + 1.  The new test is row greater than "first possible row for tile in terminal" + tile_height - 1, which for the main window is equivalent to ROW_MAP + tile_height - 1.  Put the "first possible row for tile in terminal" in ui-term.c since it uses the angband_term and window_flag arrays.  It isn't fully general (for one, it doesn't account for the main window being used to draw the overview map or for tile display in the knowledge menus; the old test didn't account for those either).

Does avoid some unnecessary dropping of upper halves, but the conditions for seeing that aren't particularly common (use a tile_height of one and have a double-height tile in the second row of the map in the main window; have a double-height tile in the second row of what's displayed in a PW_OVERHEAD window).