### PR TITLE
Have inven_carry_num() return obj->number for any valid treasure type

### DIFF
--- a/src/obj-gear.c
+++ b/src/obj-gear.c
@@ -602,6 +602,11 @@ int inven_carry_num(const struct object *obj)
 	int n_free_slot = z_info->pack_size - pack_slots_used(player);
 	int num_to_quiver, num_left, i;
 
+	/* Treasure can always be picked up. */
+	if (tval_is_money(obj) && lookup_kind(obj->tval, obj->sval)) {
+		return obj->number;
+	}
+
 	/* Absorb as many as we can in the quiver. */
 	quiver_absorb_num(obj, &n_free_slot, &num_to_quiver);
 

--- a/src/tests/player/inven-carry-num.c
+++ b/src/tests/player/inven-carry-num.c
@@ -25,6 +25,7 @@ struct carry_num_state {
 	struct object *shot;
 	struct object *flask;
 	struct object *inscribed_flask;
+	struct object *treasure;
 };
 
 int setup_tests(void **state) {
@@ -79,6 +80,10 @@ int setup_tests(void **state) {
 	cns->inscribed_flask->known = object_new();
 	object_set_base_known(cns->inscribed_flask);
 	object_touch(cns->p, cns->inscribed_flask);
+	cns->treasure = make_gold(1, "any");
+	cns->treasure->known = object_new();
+	object_set_base_known(cns->treasure);
+	object_touch(cns->p, cns->treasure);
 	*state = cns;
 
 	return 0;
@@ -107,6 +112,10 @@ int teardown_tests(void *state) {
 		object_free(cns->inscribed_flask->known);
 	}
 	object_free(cns->inscribed_flask);
+	if (cns->treasure->known) {
+		object_free(cns->treasure->known);
+	}
+	object_free(cns->treasure);
 	mem_free(state);
 
 	cleanup_angband();
@@ -299,6 +308,7 @@ static int test_carry_num_empty_pack_empty_quiver(void *state) {
 		z_info->quiver_slot_size));
 	require(perform_one_test(cns, cns->inscribed_flask,
 		z_info->quiver_slot_size, z_info->quiver_slot_size));
+	require(perform_one_test(cns, cns->treasure, 10, 10));
 	ok;
 }
 
@@ -320,6 +330,7 @@ static int test_carry_num_partial_pack_empty_quiver(void *state) {
 	require(perform_one_test(cns, cns->inscribed_flask,
 		z_info->quiver_slot_size,
 		z_info->quiver_slot_size / z_info->thrown_quiver_mult));
+	require(perform_one_test(cns, cns->treasure, 8, 8));
 	ok;
 }
 
@@ -337,6 +348,7 @@ static int test_carry_num_full_pack_empty_quiver(void *state) {
 	require(perform_one_test(cns, cns->flask, z_info->quiver_slot_size, 0));
 	require(perform_one_test(cns, cns->inscribed_flask,
 		z_info->quiver_slot_size, 0));
+	require(perform_one_test(cns, cns->treasure, 15, 15));
 	ok;
 }
 
@@ -363,6 +375,7 @@ static int test_carry_num_empty_pack_partial_quiver(void *state) {
 	 */
 	require(perform_one_test(cns, cns->inscribed_flask,
 		z_info->quiver_slot_size, z_info->quiver_slot_size));
+	require(perform_one_test(cns, cns->treasure, 3, 3));
 
 	require(fill_pack_quiver(cns, 0,
 		z_info->quiver_slot_size - n_arrow_miss, 0,
@@ -386,6 +399,7 @@ static int test_carry_num_empty_pack_partial_quiver(void *state) {
 	 */
 	require(perform_one_test(cns, cns->inscribed_flask,
 		z_info->quiver_slot_size, z_info->quiver_slot_size));
+	require(perform_one_test(cns, cns->treasure, 30, 30));
 
 	require(fill_pack_quiver(cns, 0, 0,
 		z_info->quiver_slot_size - n_shot_miss,
@@ -409,6 +423,7 @@ static int test_carry_num_empty_pack_partial_quiver(void *state) {
 	 */
 	require(perform_one_test(cns, cns->inscribed_flask,
 		z_info->quiver_slot_size, z_info->quiver_slot_size));
+	require(perform_one_test(cns, cns->treasure, 1, 1));
 
 	/* Then do tests with all slots filled but with room in each stack. */
 	require(fill_pack_quiver(cns, 0,
@@ -441,6 +456,7 @@ static int test_carry_num_empty_pack_partial_quiver(void *state) {
 	 */
 	require(perform_one_test(cns, cns->inscribed_flask,
 		z_info->quiver_slot_size, z_info->quiver_slot_size));
+	require(perform_one_test(cns, cns->treasure, 25, 25));
 
 	ok;
 }
@@ -472,6 +488,7 @@ static int test_carry_num_partial_pack_partial_quiver(void *state) {
 	require(perform_one_test(cns, cns->inscribed_flask,
 		z_info->quiver_slot_size,
 		z_info->quiver_slot_size / z_info->thrown_quiver_mult));
+	require(perform_one_test(cns, cns->treasure, 13, 13));
 
 	require(fill_pack_quiver(cns, z_info->pack_size - 3,
 		z_info->quiver_slot_size - n_arrow_miss, 0,
@@ -494,6 +511,7 @@ static int test_carry_num_partial_pack_partial_quiver(void *state) {
 	require(perform_one_test(cns, cns->inscribed_flask,
 		z_info->quiver_slot_size,
 		z_info->quiver_slot_size / z_info->thrown_quiver_mult));
+	require(perform_one_test(cns, cns->treasure, 6, 6));
 
 	require(fill_pack_quiver(cns, z_info->pack_size - 3, 0,
 		z_info->quiver_slot_size - n_shot_miss,
@@ -516,6 +534,7 @@ static int test_carry_num_partial_pack_partial_quiver(void *state) {
 	require(perform_one_test(cns, cns->inscribed_flask,
 		z_info->quiver_slot_size,
 		z_info->quiver_slot_size / z_info->thrown_quiver_mult));
+	require(perform_one_test(cns, cns->treasure, 21, 21));
 
 	/* Then do tests with all slots filled but with room in each stack. */
 	require(fill_pack_quiver(cns, z_info->pack_size - 4,
@@ -539,6 +558,7 @@ static int test_carry_num_partial_pack_partial_quiver(void *state) {
 	 */
 	require(perform_one_test(cns, cns->inscribed_flask,
 		z_info->quiver_slot_size, z_info->quiver_slot_size));
+	require(perform_one_test(cns, cns->treasure, 9, 9));
 
 	ok;
 }
@@ -569,6 +589,7 @@ static int test_carry_num_full_pack_partial_quiver(void *state) {
 	require(perform_one_test(cns, cns->inscribed_flask,
 		z_info->quiver_slot_size,
 		(n_arrow_miss + n_shot_miss) / z_info->thrown_quiver_mult));
+	require(perform_one_test(cns, cns->treasure, 2, 2));
 
 	require(fill_pack_quiver(cns, z_info->pack_size - 2,
 		z_info->quiver_slot_size - n_arrow_miss, 0,
@@ -590,6 +611,7 @@ static int test_carry_num_full_pack_partial_quiver(void *state) {
 	require(perform_one_test(cns, cns->inscribed_flask,
 		z_info->quiver_slot_size,
 		n_arrow_miss / z_info->thrown_quiver_mult + n_flask_miss));
+	require(perform_one_test(cns, cns->treasure, 41, 41));
 
 	require(fill_pack_quiver(cns, z_info->pack_size - 2, 0,
 		z_info->quiver_slot_size - n_shot_miss,
@@ -606,6 +628,7 @@ static int test_carry_num_full_pack_partial_quiver(void *state) {
 	require(perform_one_test(cns, cns->inscribed_flask,
 		z_info->quiver_slot_size,
 		n_shot_miss / z_info->thrown_quiver_mult + n_flask_miss));
+	require(perform_one_test(cns, cns->treasure, 50, 50));
 
 	/* Then do tests with all slots filled but with room in each stack. */
 	require(fill_pack_quiver(cns, z_info->pack_size - 3,
@@ -622,6 +645,7 @@ static int test_carry_num_full_pack_partial_quiver(void *state) {
 		n_flask_miss));
 	require(perform_one_test(cns, cns->inscribed_flask,
 		z_info->quiver_slot_size, n_flask_miss));
+	require(perform_one_test(cns, cns->treasure, 5, 5));
 
 	ok;
 }
@@ -640,6 +664,7 @@ static int test_carry_num_empty_pack_full_quiver(void *state) {
 		z_info->quiver_slot_size));
 	require(perform_one_test(cns, cns->inscribed_flask,
 		z_info->quiver_slot_size, z_info->quiver_slot_size));
+	require(perform_one_test(cns, cns->treasure, 17, 17));
 	ok;
 }
 
@@ -658,6 +683,7 @@ static int test_carry_num_partial_pack_full_quiver(void *state) {
 		z_info->quiver_slot_size));
 	require(perform_one_test(cns, cns->inscribed_flask,
 		z_info->quiver_slot_size, z_info->quiver_slot_size));
+	require(perform_one_test(cns, cns->treasure, 36, 36));
 	ok;
 }
 
@@ -673,6 +699,7 @@ static int test_carry_num_full_pack_full_quiver(void *state) {
 	require(perform_one_test(cns, cns->flask, z_info->quiver_slot_size, 0));
 	require(perform_one_test(cns, cns->inscribed_flask,
 		z_info->quiver_slot_size, 0));
+	require(perform_one_test(cns, cns->treasure, 24, 24));
 	ok;
 }
 


### PR DESCRIPTION
That's to be consistent with player_pickup_item().  Should resolve this bug report, http://angband.oook.cz/forum/showpost.php?p=153115&postcount=305 , for FirstAgeAngband.