### PR TITLE
Mac: be consistent with typical Mac behavior - require click to change focus

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -5137,7 +5137,8 @@ static void AngbandHandleEventMouseDown( NSEvent *event )
 	AngbandContext *mainAngbandContext =
 	    (__bridge AngbandContext*) (angband_term[0]->data);
 
-	if (mainAngbandContext.primaryWindow &&
+	if ([[event window] isKeyWindow] &&
+	    mainAngbandContext.primaryWindow &&
 	    [[event window] windowNumber] ==
 	    [mainAngbandContext.primaryWindow windowNumber])
 	{


### PR DESCRIPTION
Check for isKeyWindow set to true on [event window] before processing mouse events.  That way the initial click in the main window when some other window has focus only changes focus and does not trigger any other actions.  Resolves https://github.com/angband/angband/issues/4782 .