### PR TITLE
Run 'apt-get update' before running 'apt-get install'

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -11,7 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Build Dependencies
-        run: sudo apt-get install gcc automake autoconf make libx11-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc automake autoconf make libx11-dev
 
       - name: Clone Project
         uses: actions/checkout@v2
@@ -29,7 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Build Dependencies
-        run: sudo apt-get install gcc make cmake libx11-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc make cmake libx11-dev
 
       - name: Clone Project
         uses: actions/checkout@v2
@@ -46,7 +50,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Build Dependencies
-        run: sudo apt-get install gcc make cmake libncursesw5-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc make cmake libncursesw5-dev
 
       - name: Clone Project
         uses: actions/checkout@v2
@@ -63,7 +69,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Build Dependencies
-        run: sudo apt-get install gcc make cmake libsdl-image1.2-dev libsdl-ttf2.0-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc make cmake libsdl-image1.2-dev libsdl-ttf2.0-dev
 
       - name: Clone Project
         uses: actions/checkout@v2

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -11,7 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Build Dependencies
-        run: sudo apt-get install gcc-mingw-w64 automake autoconf make
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc-mingw-w64 automake autoconf make
 
       - name: Clone Project
         uses: actions/checkout@v2


### PR DESCRIPTION
Hopefully, the transient failures avoided because the host system's package list is out-of-date with the package repository exceed the transient failures introduced because of the extra action invoked on the package repository.