### PR TITLE
Simplify shared system-wide installation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -191,6 +191,9 @@ AC_DEFINE_UNQUOTED([DEFAULT_DATA_PATH], "${vardatadir}", [Path to the game's var
 
 NOINSTALL="$with_noinstall"; AC_SUBST(NOINSTALL)
 SETEGID="$with_setgid";      AC_SUBST(SETEGID)
+if test "x$wsetgid" == "xyes"; then
+	AC_DEFINE(SETGID, 1, [Define if running as a central install on a multiuser system that has setresgid or setegid support.])
+fi
 
 dnl Frontends
 AC_ARG_ENABLE(curses,

--- a/configure.ac
+++ b/configure.ac
@@ -178,11 +178,17 @@ case "/$varpath" in
 	*/) MY_EXPAND_DIR(vardatadir, "$varpath")  ;;
 	*)  MY_EXPAND_DIR(vardatadir, "$varpath/") ;;
 esac
+if test "x$with_private_dirs" != "x"; then
+	varshareddatadir="${vardatadir}user/"
+else
+	varshareddatadir="${vardatadir}"
+fi
 
 
 AC_SUBST([configdir])
 AC_SUBST([libdatadir])
 AC_SUBST([vardatadir])
+AC_SUBST([varshareddatadir])
 AC_SUBST([docdatadir])
 
 AC_DEFINE_UNQUOTED([DEFAULT_CONFIG_PATH], "${configdir}", [Path to the game's configuration data])

--- a/lib/user/Makefile
+++ b/lib/user/Makefile
@@ -1,6 +1,6 @@
 MKPATH=../../mk/
 include $(MKPATH)buildsys.mk
 
-SUBDIRS = save scores info
+SUBDIRS = archive save scores info
 PACKAGE = user
 

--- a/lib/user/archive/Makefile
+++ b/lib/user/archive/Makefile
@@ -8,6 +8,6 @@ install-extra:
 		if [ "x$(DRY)" = "x" ]; then \
 			${MKDIR_P} ${DESTDIR}${varshareddatadir}${PACKAGE}; \
 			chown root:${SETEGID} ${DESTDIR}${varshareddatadir}${PACKAGE}; \
-			chmod 070 ${DESTDIR}${varshareddatadir}${PACKAGE}; \
+			chmod 171 ${DESTDIR}${varshareddatadir}${PACKAGE}; \
 		fi; \
 	fi

--- a/lib/user/archive/Makefile
+++ b/lib/user/archive/Makefile
@@ -1,13 +1,13 @@
 MKPATH=../../../mk/
 include $(MKPATH)buildsys.mk
 
-PACKAGE = user/archive
+PACKAGE = archive
 
 install-extra:
 	if [ "x$(SETEGID)" != "x" ]; then \
 		if [ "x$(DRY)" = "x" ]; then \
-			${MKDIR_P} ${DESTDIR}${vardatadir}${PACKAGE}; \
-			chown root:${SETEGID} ${DESTDIR}${vardatadir}${PACKAGE}; \
-			chmod 070 ${DESTDIR}${vardatadir}${PACKAGE}; \
+			${MKDIR_P} ${DESTDIR}${varshareddatadir}${PACKAGE}; \
+			chown root:${SETEGID} ${DESTDIR}${varshareddatadir}${PACKAGE}; \
+			chmod 070 ${DESTDIR}${varshareddatadir}${PACKAGE}; \
 		fi; \
 	fi

--- a/lib/user/save/Makefile
+++ b/lib/user/save/Makefile
@@ -8,6 +8,6 @@ install-extra:
 		if [ "x$(DRY)" = "x" ]; then \
 			${MKDIR_P} ${DESTDIR}${varshareddatadir}${PACKAGE}; \
 			chown root:${SETEGID} ${DESTDIR}${varshareddatadir}${PACKAGE}; \
-			chmod 070 ${DESTDIR}${varshareddatadir}${PACKAGE}; \
+			chmod 171 ${DESTDIR}${varshareddatadir}${PACKAGE}; \
 		fi; \
 	fi

--- a/lib/user/save/Makefile
+++ b/lib/user/save/Makefile
@@ -1,13 +1,13 @@
 MKPATH=../../../mk/
 include $(MKPATH)buildsys.mk
 
-PACKAGE = user/save
+PACKAGE = save
 
 install-extra:
 	if [ "x$(SETEGID)" != "x" ]; then \
 		if [ "x$(DRY)" = "x" ]; then \
-			${MKDIR_P} ${DESTDIR}${vardatadir}${PACKAGE}; \
-			chown root:${SETEGID} ${DESTDIR}${vardatadir}${PACKAGE}; \
-			chmod 070 ${DESTDIR}${vardatadir}${PACKAGE}; \
+			${MKDIR_P} ${DESTDIR}${varshareddatadir}${PACKAGE}; \
+			chown root:${SETEGID} ${DESTDIR}${varshareddatadir}${PACKAGE}; \
+			chmod 070 ${DESTDIR}${varshareddatadir}${PACKAGE}; \
 		fi; \
 	fi

--- a/lib/user/scores/Makefile
+++ b/lib/user/scores/Makefile
@@ -1,14 +1,14 @@
 MKPATH=../../../mk/
 include $(MKPATH)buildsys.mk
 
-PACKAGE = user/scores
+PACKAGE = scores
 
 install-extra:
 	if [ "x$(SETEGID)" != "x" ]; then \
 		if [ "x$(DRY)" = "x" ]; then \
-			${MKDIR_P} ${DESTDIR}${vardatadir}${PACKAGE}; \
-			touch ${DESTDIR}${vardatadir}${PACKAGE}/scores.raw; \
-			chown -R root:${SETEGID} ${DESTDIR}${vardatadir}${PACKAGE}; \
-			chmod -R g+w ${DESTDIR}${vardatadir}${PACKAGE}; \
+			${MKDIR_P} ${DESTDIR}${varshareddatadir}${PACKAGE}; \
+			touch ${DESTDIR}${varshareddatadir}${PACKAGE}/scores.raw; \
+			chown -R root:${SETEGID} ${DESTDIR}${varshareddatadir}${PACKAGE}; \
+			chmod -R g+w ${DESTDIR}${varshareddatadir}${PACKAGE}; \
 		fi; \
 	fi

--- a/mk/buildsys.mk.in
+++ b/mk/buildsys.mk.in
@@ -104,7 +104,7 @@ MO_FILES = ${LOCALES:.po=.mo}
 .SILENT:
 .SUFFIXES:
 .SUFFIXES: .beam .c .c.dep .cc .cc.dep .class .cxx .cxx.dep .d .erl .lib.o .java .mo .m .m.dep .mm .mm.dep .o .plugin.o .po .py .pyc .rc .S .S.dep .xpm
-.PHONY: all subdirs pre-depend depend install install-extra uninstall uninstall-extra clean distclean locales
+.PHONY: all subdirs pre-depend depend install install-extra post-install uninstall uninstall-extra clean distclean locales
 
 all:
 	${MAKE} ${MFLAGS} subdirs
@@ -430,6 +430,7 @@ install: ${SHARED_LIB} ${STATIC_LIB} ${STATIC_PIC_LIB} ${PLUGIN} ${PROG} install
 	for i in ${SUBDIRS}; do \
 		${DIR_ENTER}; \
 		${MAKE} ${MFLAGS} install || exit $$?; \
+		${MAKE} ${MFLAGS} post-install || exit $$?; \
 		${DIR_LEAVE}; \
 	done
 
@@ -527,7 +528,11 @@ install: ${SHARED_LIB} ${STATIC_LIB} ${STATIC_PIC_LIB} ${PLUGIN} ${PROG} install
 		fi \
 	done
 
+	${MAKE} ${MFLAGS} post-install
+
 install-extra:
+
+post-install:
 
 uninstall: uninstall-extra
 	for i in ${SUBDIRS}; do \

--- a/mk/extra.mk.in
+++ b/mk/extra.mk.in
@@ -3,6 +3,7 @@ SETEGID = @SETEGID@
 LIBDIR = ${libdir}
 libdatadir = @libdatadir@
 vardatadir = @vardatadir@
+varshareddatadir = @varshareddatadir@
 docdatadir = @docdatadir@
 configdir = @configdir@
 pdfdir ?= @pdfdir@

--- a/src/Makefile
+++ b/src/Makefile
@@ -64,4 +64,16 @@ gen-covs: tests/ran-already $(GCOVS)
 %.gcov: %
 	(gcov -o $(dir $^) -p $^ >/dev/null)
 
+post-install:
+	# For a shared installation, set appropriate owner for executable
+	# and mark it as setgid.
+	if [ "x$(SETEGID)" != "x" ]; then \
+		${INSTALL_STATUS}; \
+		if chown root:${SETEGID} ${DESTDIR}${bindir}/${PROG} && chmod g+s ${DESTDIR}${bindir}/${PROG} ; then \
+			${INSTALL_OK}; \
+		else \
+			${INSTALL_FAILED}; \
+		fi \
+	fi
+
 .PHONY : tests coverage clean-coverage tests/ran-already

--- a/src/datafile.h
+++ b/src/datafile.h
@@ -56,6 +56,7 @@ void write_flags(ang_file *fff, const char *intro_text, bitflag *flags,
 				 int flag_size, const char *names[]);
 void write_mods(ang_file *fff, const int values[]);
 void write_elements(ang_file *fff, const struct element_info *el_info);
+void set_archive_user_prefix(const char *pfx);
 void file_archive(char *fname, char *append);
 void activate_randart_file(void);
 void deactivate_randart_file(void);

--- a/src/h-basic.h
+++ b/src/h-basic.h
@@ -73,13 +73,6 @@
 #endif
 
 /**
- * Define SETGID if we are running as a central install on a multiuser
- * system that has setgid support.
- */
-/* #define SETGID */
-
-
-/**
  * Every system seems to use its own symbol as a path separator.
  *
  * Default to the standard Unix slash, but attempt to change this

--- a/src/ui-game.c
+++ b/src/ui-game.c
@@ -711,6 +711,7 @@ void savefile_set_name(const char *fname, bool make_safe, bool strip_suffix)
 	strnfmt(path, pathlen, "%d.", player_uid);
 	off = strlen(path);
 	pathlen -= off;
+	set_archive_user_prefix(path);
 #endif
 
 	if (make_safe) {


### PR DESCRIPTION
Have it so "./autogen.sh; ./configure --with-setgid=games; make; sudo make install" is sufficient.  Most of the changes are only in the build system.  The exceptions are to remove the mention of SETGID in h-basic.h (since for a build using configure it's being set in autoconf.h) and to adjust the handling of the randart files to include grabbing/dropping privileges and incorporation of a per-user prefix when putting a file in a shared archive directory.

This indirectly resolves https://github.com/angband/angband/issues/3594 : in a shared system-wide install the proper directories will be created during installation so create_needed_dirs() will normally succeed without having to create anything (the exceptions would be if the installation is damaged or the names of the directories have been set with -d command line options).

There's a couple of somewhat related problems that haven't been addressed:

1. In a shared system-wide installation, the -l command line option doesn't work.  Having the shared save directory be readable for user/other would fix that.
2. Similarly, if someone wanted to share their randart file with someone else (or use it for another game of their own) while using a shared system-wide install, that's not readily doable.  Making the shared archive directory readable for user/other would fix that.
3. In a --with-no-install installation, the preexisting lib/user/archive, lib/user/save, and lib/user/scores directories  are not used.  Instead, lib/archive, lib/save and lib/scores are used which might be confusing.  That happens even without the changes made here.