### PR TITLE
For SDL and Windows, reduce number of graphics calls to clear big tiles

### DIFF
--- a/src/main-sdl.c
+++ b/src/main-sdl.c
@@ -2772,9 +2772,10 @@ static errr Term_xtra_sdl(int n, int v)
 	return (1);
 }
 
-
-
-static errr Term_wipe_sdl(int col, int row, int n)
+/**
+ * Erase a nc x nr block of characters whose upper left corner is at (col, row).
+ */
+static errr Term_wipe_sdl_helper(int col, int row, int nc, int nr)
 {
 	term_window *win = (term_window*)(Term->data);
 
@@ -2783,8 +2784,8 @@ static errr Term_wipe_sdl(int col, int row, int n)
 	/* Build the area to black out */
 	rc.x = col * win->tile_wid;
 	rc.y = row * win->tile_hgt;
-	rc.w = win->tile_wid * n;
-	rc.h = win->tile_hgt;
+	rc.w = win->tile_wid * nc;
+	rc.h = win->tile_hgt * nr;
 
 	/* Translate it */
 	rc.x += win->border;
@@ -2797,6 +2798,11 @@ static errr Term_wipe_sdl(int col, int row, int n)
 	set_update_rect(win, &rc);
 
 	return (0);
+}
+
+static errr Term_wipe_sdl(int col, int row, int n)
+{
+	return Term_wipe_sdl_helper(col, row, n, 1);
 }
 
 /**
@@ -2821,7 +2827,7 @@ static errr Term_text_sdl(int col, int row, int n, int a, const wchar_t *s)
 	if (!win->visible) return (0);
 
 	/* Clear the way */
-	Term_wipe_sdl(col, row, n);
+	Term_wipe_sdl_helper(col, row, n, 1);
 
 	/* Take a copy of the incoming string, but truncate it at n chars */
 	wcsncpy(src, s, n);
@@ -3082,8 +3088,7 @@ static errr Term_pict_sdl(int col, int row, int n, const int *ap,
 	ur.w *= n;
 
 	/* Clear the way */
-	for (j = 0; j < tile_height; j++)
-		Term_wipe_sdl(col, row + j, n * tile_width);
+	Term_wipe_sdl_helper(col, row, n * tile_width, tile_height);
 
 	/* Blit 'em! (it) */
 	for (i = 0; i < n; i++) {

--- a/src/main-win.c
+++ b/src/main-win.c
@@ -1955,11 +1955,11 @@ static errr Term_bigcurs_win(int x, int y)
 
 
 /**
- * Low level graphics (Assumes valid input).
- *
- * Erase a "block" of "n" characters starting at (x,y).
+ * Help Term_wipe_win(), Term_pict_win(), and Term_pict_win_alpha():
+ * erase a nc x nr block of characters where the upper left corner
+ * of the block is at (x,y).
  */
-static errr Term_wipe_win(int x, int y, int n)
+static errr Term_wipe_win_helper(int x, int y, int nc, int nr)
 {
 	term_data *td = (term_data*)(Term->data);
 
@@ -1968,9 +1968,9 @@ static errr Term_wipe_win(int x, int y, int n)
 
 	/* Rectangle to erase in client coords */
 	rc.left = x * td->tile_wid + td->size_ow1;
-	rc.right = rc.left + n * td->tile_wid;
+	rc.right = rc.left + nc * td->tile_wid;
 	rc.top = y * td->tile_hgt + td->size_oh1;
-	rc.bottom = rc.top + td->tile_hgt;
+	rc.bottom = rc.top + nr * td->tile_hgt;
 
 	hdc = GetDC(td->w);
 	SetBkColor(hdc, RGB(0, 0, 0));
@@ -1980,6 +1980,17 @@ static errr Term_wipe_win(int x, int y, int n)
 
 	/* Success */
 	return 0;
+}
+
+
+/**
+ * Low level graphics (Assumes valid input).
+ *
+ * Erase a "block" of "n" characters starting at (x,y).
+ */
+static errr Term_wipe_win(int x, int y, int n)
+{
+	return Term_wipe_win_helper(x, y, n, 1);
 }
 
 
@@ -2133,7 +2144,7 @@ static errr Term_pict_win(int x, int y, int n,
 	th2 = mh * h2;
 
 	/* Erase the grids */
-	for (i = 0; i < mh; ++i) Term_wipe_win(x, y + i, n * mw);
+	Term_wipe_win_helper(x, y, n * mw, mh);
 
 	/* Location of window cell */
 	x2 = x * w2 + td->size_ow1;
@@ -2377,7 +2388,7 @@ static errr Term_pict_win_alpha(int x, int y, int n,
 	th2 = mh * h2;
 
 	/* Erase the grids */
-	for (i = 0; i < mh; ++i) Term_wipe_win(x, y + i, n * mw);
+	Term_wipe_win_helper(x, y, n * mw, mh);
 
 	/* Location of window cell */
 	x2 = x * w2 + td->size_ow1;


### PR DESCRIPTION
Do so by refactoring Term_wipe_win() and Term_wipe_sdl().