### PR TITLE
Make panel handling consistent for big tiles

### DIFF
--- a/src/ui-knowledge.c
+++ b/src/ui-knowledge.c
@@ -3697,18 +3697,25 @@ void do_cmd_look(void)
 }
 
 
-
-/**
- * Number of basic grids per panel, vertically and horizontally
- */
-#define PANEL_SIZE	11
-
 /**
  * Allow the player to examine other sectors on the map
  */
 void do_cmd_locate(void)
 {
+	int panel_hgt, panel_wid;
 	int y1, x1;
+
+	/* Use dimensions that match those in ui-output.c. */
+	if (Term == term_screen) {
+		panel_hgt = SCREEN_HGT;
+		panel_wid = SCREEN_WID;
+	} else {
+		panel_hgt = Term->hgt / tile_height;
+		panel_wid = Term->wid / tile_width;
+	}
+	/* Bound below to avoid division by zero. */
+	panel_hgt = MAX(panel_hgt, 1);
+	panel_wid = MAX(panel_wid, 1);
 
 	/* Start at current panel */
 	y1 = Term->offset_y;
@@ -3726,10 +3733,6 @@ void do_cmd_locate(void)
 		int y2 = Term->offset_y;
 		int x2 = Term->offset_x;
 		
-		/* Adjust for tiles */
-		int panel_hgt = (int)(PANEL_SIZE / tile_height);
-		int panel_wid = (int)(PANEL_SIZE / tile_width);
-
 		/* Describe the location */
 		if ((y2 == y1) && (x2 == x1)) {
 			tmp_val[0] = '\0';
@@ -3742,14 +3745,14 @@ void do_cmd_locate(void)
 		/* Prepare to ask which way to look */
 		strnfmt(out_val, sizeof(out_val),
 		        "Map sector [%d,%d], which is%s your sector.  Direction?",
-		        (y2 / panel_hgt), (x2 / panel_wid), tmp_val);
+		        (2 * y2) / panel_hgt, (2 * x2) / panel_wid, tmp_val);
 
 		/* More detail */
 		if (OPT(player, center_player)) {
 			strnfmt(out_val, sizeof(out_val),
 		        	"Map sector [%d(%02d),%d(%02d)], which is%s your sector.  Direction?",
-					(y2 / panel_hgt), (y2 % panel_hgt),
-					(x2 / panel_wid), (x2 % panel_wid), tmp_val);
+					(2 * y2) / panel_hgt, (2 * y2) % panel_hgt,
+					(2 * x2) / panel_wid, (2 * x2) % panel_wid, tmp_val);
 		}
 
 		/* Get a direction */

--- a/src/ui-output.c
+++ b/src/ui-output.c
@@ -484,8 +484,10 @@ bool panel_should_modify(term *t, int wy, int wx)
 {
 	int dungeon_hgt = cave->height;
 	int dungeon_wid = cave->width;
-	int screen_hgt = (t == angband_term[0]) ? SCREEN_HGT : t->hgt;
-	int screen_wid = (t == angband_term[0]) ? SCREEN_WID : t->wid;
+	int screen_hgt = (t == angband_term[0]) ?
+		SCREEN_HGT : t->hgt / tile_height;
+	int screen_wid = (t == angband_term[0]) ?
+		SCREEN_WID : t->wid / tile_width;
 
 	/* Verify wy, adjust if needed */
 	if (wy > dungeon_hgt - screen_hgt) wy = dungeon_hgt - screen_hgt;
@@ -514,8 +516,10 @@ bool modify_panel(term *t, int wy, int wx)
 {
 	int dungeon_hgt = cave->height;
 	int dungeon_wid = cave->width;
-	int screen_hgt = (t == angband_term[0]) ? SCREEN_HGT : t->hgt;
-	int screen_wid = (t == angband_term[0]) ? SCREEN_WID : t->wid;
+	int screen_hgt = (t == angband_term[0]) ?
+		SCREEN_HGT : t->hgt / tile_height;
+	int screen_wid = (t == angband_term[0]) ?
+		SCREEN_WID : t->wid / tile_width;
 
 	/* Verify wy, adjust if needed */
 	if (wy > dungeon_hgt - screen_hgt) wy = dungeon_hgt - screen_hgt;
@@ -677,7 +681,12 @@ bool textui_panel_contains(unsigned int y, unsigned int x)
 	unsigned int wid;
 	if (!Term)
 		return true;
-	hgt = SCREEN_HGT;
-	wid = SCREEN_WID;
+	if (Term == term_screen) {
+		hgt = SCREEN_HGT;
+		wid = SCREEN_WID;
+	} else {
+		hgt = Term->hgt / tile_height;
+		wid = Term->wid / tile_width;
+	}
 	return (y - Term->offset_y) < hgt && (x - Term->offset_x) < wid;
 }


### PR DESCRIPTION
1. In panel_should_modify(), modify_panel(), and textui_get_panel(), use dimensions that are consistent with verify_panel_int() and change_panel().
2. Do that as well for do_cmd_locate() but also impose a lower bound so there's no division by zero.  Since the panel dimensions are one half the displayed size, multiply by two when printing the panel coordinates to there's a change in the printed coordinates with each move.  Should resolve PowerWyrm's report, http://angband.oook.cz/forum/showpost.php?p=152675&postcount=43 , of tile size multipliers greater than 11 causing crashes in the locate command.