### PR TITLE
Use a suitable working directory when invoking version.sh to get the tag for "make dist"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CLEAN = config.status config.log *.dll *.exe
 tests:
 	$(MAKE) -C src tests
 
-TAG = angband-`scripts/version.sh`
+TAG = angband-`cd scripts && ./version.sh`
 OUT = $(TAG).tar.gz
 
 manual:

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -2,6 +2,11 @@
 #
 # This scripts adds local version information from git.
 #
+# Because of the assumed path to the version stamp file in the top-level
+# directory of the source tree and because it needs access to the git
+# repository, the working directory when this script is invoked should be
+# an immediate subdirectory of the top-level directory of the source tree.
+#
 # Copied from Linux 2.6.32 scripts/setlocalversion and modified
 # slightly to work better for OpenOCD, then taken and ripped to
 # pieces for angband


### PR DESCRIPTION
Will only have an effect if "git rev-parse" fails and version.sh tries to access the version stamp file to get the version.