### PR TITLE
Tweak handling of minimap (PW_MAP) subwindows

### DIFF
--- a/src/ui-display.c
+++ b/src/ui-display.c
@@ -1947,7 +1947,7 @@ static void update_minimap_subwindow(game_event_type type,
 		Term_activate(t);
 
 		/* If whole-map redraw, clear window first. */
-		if (flags->needs_redraw	|| tile_width > 1 || tile_height > 1)
+		if (flags->needs_redraw)
 			Term_clear();
 
 		/* Redraw map */

--- a/src/ui-map.c
+++ b/src/ui-map.c
@@ -820,15 +820,21 @@ void display_map(int *cy, int *cx)
 	if (tile_height > 1)
 		row = row - (row % tile_height);
 
+	/* Get the terrain at the player's spot. */
+	map_info(player->grid, &g);
+	g.lighting = LIGHTING_LIT;
+	grid_data_as_text(&g, &a, &c, &ta, &tc);
+
 	/* Get the "player" tile */
-	ta = monster_x_attr[race->ridx];
-	tc = monster_x_char[race->ridx];
+	a = monster_x_attr[race->ridx];
+	c = monster_x_char[race->ridx];
 
 	/* Draw the player */
-	Term_putch(col + 1, row + 1, ta, tc);
+	Term_queue_char(Term, col + 1, row + 1, a, c, ta, tc);
 
 	if ((tile_width > 1) || (tile_height > 1))
-		Term_big_putch(col + 1, row + 1, ta, tc);
+		Term_big_queue_char(Term, col + 1, row + 1, Term->hgt - 1,
+			255, -1, 0, 0);
   
 	/* Return player location */
 	if (cy != NULL) (*cy) = row + 1;

--- a/src/ui-output.c
+++ b/src/ui-output.c
@@ -569,7 +569,7 @@ static void verify_panel_int(bool centered)
 		if (!t) continue;
 
 		/* No relevant flags */
-		if ((j > 0) && !(window_flag[j] & (PW_MAPS))) continue;
+		if ((j > 0) && !(window_flag[j] & (PW_OVERHEAD))) continue;
 
 		wy = t->offset_y;
 		wx = t->offset_x;
@@ -625,7 +625,7 @@ bool change_panel(int dir)
 		if (!t) continue;
 
 		/* No relevant flags */
-		if ((j > 0) && !(window_flag[j] & PW_MAPS)) continue;
+		if ((j > 0) && !(window_flag[j] & PW_OVERHEAD)) continue;
 
 		screen_hgt = (j == 0) ? SCREEN_HGT : t->hgt / tile_height;
 		screen_wid = (j == 0) ? SCREEN_WID : t->wid / tile_width;

--- a/src/ui-target.c
+++ b/src/ui-target.c
@@ -178,7 +178,7 @@ static bool adjust_panel_help(int y, int x, bool help)
 		if (!t) continue;
 
 		/* No relevant flags */
-		if ((j > 0) && !(window_flag[j] & PW_MAPS)) continue;
+		if ((j > 0) && !(window_flag[j] & PW_OVERHEAD)) continue;
 
 		wy = t->offset_y;
 		wx = t->offset_x;


### PR DESCRIPTION
1. move_cursor_relative_map(), print_rel_map(), and prt_map_aux() treated those windows as if they were overhead views.  Instead have those functions be consistent with what display_map() generates.
2. Since those windows show a full (possibly compressed) view of the level, they don't need panel change logic.
3. When displaying the character in display_map(), get the terrain under the player for display as well (only has an effect when using a  graphics mode that supports blending the foreground with the terrain).
4. Adjust the dimensions calculations for display_map() when big tiles are used to avoid worrying about partial tiles on the right or bottom or loss of information when the level is small enough that it can be displayed without compression.
5. Drop the forced clearing of the minimap when big tiles are used.  No longer seems to be necessary to avoid drawing artifacts.