### PR TITLE
Drop forced redraw_stuff() when big tiles are in use and there's a panel change

### DIFF
--- a/src/ui-output.c
+++ b/src/ui-output.c
@@ -538,9 +538,6 @@ bool modify_panel(term *t, int wy, int wx)
 		/* Redraw map */
 		player->upkeep->redraw |= (PR_MAP);
 
-		/* Redraw for big graphics */
-		if ((tile_width > 1) || (tile_height > 1)) redraw_stuff(player);
-
 		/* Changed */
 		return (true);
 	}


### PR DESCRIPTION
Changes to big tile handling in ui-term.c and in the subwindows appear to have rendered it unnecessary.