### PR TITLE
In vaults, automatically mark inner permanent walls with SQUARE_WALL_INNER

### DIFF
--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -542,7 +542,8 @@ static void build_tunnel(struct chunk *c, struct loc grid1, struct loc grid2)
 		}
 
 		/* Avoid obstacles */
-		if (square_isperm(c, tmp_grid) ||
+		if ((square_isperm(c, tmp_grid) && !sqinfo_has(square(c,
+				tmp_grid)->info, SQUARE_WALL_INNER)) ||
 				square_is_granite_with_flag(c, tmp_grid,
 				SQUARE_WALL_SOLID)) {
 			continue;

--- a/src/gen-room.c
+++ b/src/gen-room.c
@@ -1660,6 +1660,24 @@ bool build_vault(struct chunk *c, struct loc centre, struct vault *v)
 						sqinfo_on(square(c, grid)->info,
 							SQUARE_WALL_INNER);
 					}
+					break;
+				}
+					/* Permanent wall */
+				case '@': {
+					/* Check consistency with first pass. */
+					assert(square_isroom(c, grid) &&
+						square_isvault(c, grid) &&
+						square_isperm(c, grid));
+					/*
+					 * Mark as SQUARE_WALL_INNER if it does
+					 * not touch the outside of the vault.
+					 */
+					if (count_neighbors(NULL, c, grid,
+							square_isroom, false) == 8) {
+						sqinfo_on(square(c, grid)->info,
+							SQUARE_WALL_INNER);
+					}
+					break;
 				}
 				}
 		}


### PR DESCRIPTION
Modify the tunneling code so they get the same treatment as other features internal to rooms (skipped over easily without modification).  Allows tunnels that start with vaults like the Maltese Cross (not marked as FEW_ENTRANCES, center is surrounded by permanent rock that requires diagonal moves to avoid) can make progress.