### PR TITLE
Add lore-color-immune entry for monster's poison breaths, bolts, and balls

### DIFF
--- a/lib/gamedata/monster_spell.txt
+++ b/lib/gamedata/monster_spell.txt
@@ -183,7 +183,8 @@ hit:100
 effect:BREATH:POIS:0:30
 lore:poison
 lore-color-base:Orange
-lore-color-resist:Light Green
+lore-color-resist:Yellow
+lore-color-immune:Light Green
 message-vis:{name} breathes poison.
 message-invis:You hear a sickening roar.
 
@@ -413,7 +414,8 @@ dice:$Dd4
 expr:D:SPELL_POWER:/ 2 + 3
 lore:produce poison balls
 lore-color-base:Orange
-lore-color-resist:Light Green
+lore-color-resist:Yellow
+lore-color-immune:Light Green
 message-vis:{name} casts a venomous cloud.
 message-invis:Something mumbles.
 power-cutoff:60
@@ -687,7 +689,8 @@ dice:$B+9d8
 expr:B:SPELL_POWER:/ 3
 lore:produce poison bolts
 lore-color-base:Orange
-lore-color-resist:Light Green
+lore-color-resist:Yellow
+lore-color-immune:Light Green
 message-vis:{name} spews a stream of poison.
 message-invis:Something retches.
 


### PR DESCRIPTION
Do that since the Pukel-man shape (and, in FirstAgeAngband, the green dragon shape) grant poison immunity,.  Use the same color scheme as is used for the four basic elements.  May resolve Chud's reported issue in https://github.com/angband/angband/issues/4189 (monster was a great swamp wyrm) and Mitze's reported issue in https://github.com/NickMcConnell/FirstAgeAngband/issues/163 (was lore entry for blacklock mages' poison ball) though it's not clear if the player had poison immunity in those cases.  Should not resolve Arralen's follow up to Mitze's report (priests don't have a poison attack).