### PR TITLE
Change monster.txt's comments for specific drops; include count of them in monster lore

### DIFF
--- a/lib/gamedata/monster.txt
+++ b/lib/gamedata/monster.txt
@@ -150,9 +150,10 @@
 # describe the monster. Leading whitespace will be removed, and a single space
 # will be added between desc: lines.
 
-# 'drop' lines create possible drops for specific monsters. If any drop lines
-# are present, the monster will drop *only* items from its drop lines.
-# Each item has its percent chance rolled for individually.
+# 'drop' lines create possible drops for specific monsters.  Each item
+# has its percent chance rolled for individually.  Any specified drops are in
+# addition to those that are possible due to the flags set.  Specific drops
+# can be affected by the DROP_GREAT and DROP_GOOD flags.
 
 # 'drop-base' lines work as for drops, but only the object tval is specified.
 

--- a/src/mon-make.h
+++ b/src/mon-make.h
@@ -29,7 +29,8 @@ void wipe_mon_list(struct chunk *c, struct player *p);
 s16b mon_pop(struct chunk *c);
 void get_mon_num_prep(bool (*get_mon_num_hook)(struct monster_race *race));
 struct monster_race *get_mon_num(int level);
-int mon_create_drop_count(const struct monster_race *race, bool maximize);
+int mon_create_drop_count(const struct monster_race *race, bool maximize,
+	bool specific, int *specific_count);
 void mon_create_mimicked_object(struct chunk *c, struct monster *mon,
 								int index);
 s16b place_monster(struct chunk *c, struct loc grid, struct monster *mon,


### PR DESCRIPTION
Resolves https://github.com/angband/angband/issues/4808 unless the monster lore should include details about the types of specific drops.

There's a bit of oddness with the interaction between specific drops and the the theft counts for uniques:  if someone steals a mushroom from Farmer Maggot, then he or she won't be able to kill Farmer Maggot and get a good item (other than mushrooms).  I figure that's not worth worrying about a resolution for that.