### PR TITLE
Protect against artifact duplication in specified drops

### DIFF
--- a/src/mon-make.c
+++ b/src/mon-make.c
@@ -810,7 +810,8 @@ static bool mon_create_drop(struct chunk *c, struct monster *mon, byte origin)
 		obj->origin = origin;
 		obj->origin_depth = player->depth;
 		obj->origin_race = mon->race;
-		obj->number = randint0(drop->max - drop->min) + drop->min;
+		obj->number = (obj->artifact) ?
+			1 : randint0(drop->max - drop->min) + drop->min;
 
 		/* Try to carry */
 		if (monster_carry(c, mon, obj)) {


### PR DESCRIPTION
There's no reported instances of that happening, but all current specified drops are for scrolls, books, or mushrooms.