### PR TITLE
Add workflow checks to include SDL/SDL2 sound and statistics front end

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -71,7 +71,7 @@ jobs:
       - name: Install Build Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install gcc make cmake libsdl-image1.2-dev libsdl-ttf2.0-dev
+          sudo apt-get install gcc make cmake libsdl-image1.2-dev libsdl-ttf2.0-dev libsdl-mixer1.2-dev
 
       - name: Clone Project
         uses: actions/checkout@v2
@@ -80,7 +80,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DSUPPORT_SDL_FRONTEND=ON ..
+          cmake -DSUPPORT_SDL_FRONTEND=ON -DSUPPORT_SDL_SOUND=ON ..
           make
 
   sdl2:
@@ -98,5 +98,5 @@ jobs:
       - name: Build
         run: |
           ./autogen.sh
-          ./configure --with-no-install --enable-sdl2
+          ./configure --with-no-install --enable-sdl2 --enable-sdl2-mixer
           make

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -100,3 +100,25 @@ jobs:
           ./autogen.sh
           ./configure --with-no-install --enable-sdl2 --enable-sdl2-mixer
           make
+
+  statbuild:
+    name: Statistics Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Build Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc autoconf automake make libsqlite3-dev
+
+      - name: Clone Project
+        uses: actions/checkout@v2
+
+      # Build with some extra warnings.  Others that could be good additions
+      # are -Wwrite-strings, -Wshadow, and disabling how configure currently
+      # turns off -Wmissing-field-initializers, but, for now, those generate
+      # a lot of warnings to wade through.
+      - name: Build
+        run: |
+          ./autogen.sh
+          env CFLAGS="-Wvla -Wnested-externs -Wno-multichar -Wstrict-prototypes -Wlogical-op -Wbad-function-cast" ./configure --with-no-install --enable-stats
+          make


### PR DESCRIPTION
Gets closer to covering what's desired in https://github.com/angband/angband/issues/3788 but implemented with Github's workflows rather than the buildbot.

As I see it, what's still missing is:

1. More extra warning flags in the build for the statistics front end.  Likely would want some option in the configure script to disable it's current disabling of -Wmissing-field-specifiers.  Also would likely want to change code so there's fewer warnings with the extra warning flags on.
2. Add workflows which exercise "make dist" (can what that produces be used to compile a working distribution), "make install", "make clean", and "make distclean".  Strictly speaking, those don't need to run with every push/pull request to the repository, just those that add, move, or remove files or that make a change to the build system.