### PR TITLE
Add configure option for more compiler warnings; use that in one workflow

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -108,17 +108,17 @@ jobs:
       - name: Install Build Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install gcc autoconf automake make libsqlite3-dev
+          sudo apt-get install gcc autoconf automake make libsqlite3-dev libsdl1.2-dev libsdl-mixer1.2-dev
 
       - name: Clone Project
         uses: actions/checkout@v2
 
-      # Build with some extra warnings.  Others that could be good additions
-      # are -Wwrite-strings, -Wshadow, and disabling how configure currently
-      # turns off -Wmissing-field-initializers, but, for now, those generate
-      # a lot of warnings to wade through.
+      # Build with some extra warnings.  Add some that are only supported in
+      # more recent versions of GCC that the configure script won't enable.
+      # Also turn on sound and the test front end so more of the basic
+      # infrastructure is compiled.
       - name: Build
         run: |
           ./autogen.sh
-          env CFLAGS="-Wvla -Wnested-externs -Wno-multichar -Wstrict-prototypes -Wlogical-op -Wbad-function-cast" ./configure --with-no-install --enable-stats
+          env CFLAGS="-Wvla -Wlogical-op" ./configure --enable-more-gcc-warnings --with-no-install --enable-stats --enable-test --enable-sdl-mixer
           make

--- a/configure.ac
+++ b/configure.ac
@@ -98,16 +98,25 @@ dnl needed because h-basic.h checks for this define for autoconf support.
 CPPFLAGS="$CPPFLAGS -DHAVE_CONFIG_H"
 CPPFLAGS="$CPPFLAGS -I." 
 
+AC_ARG_ENABLE(more-gcc-warnings,
+	[  --enable-more-gcc-warnings       enable more warnings if using GCC],
+	[ more_gcc_warnings=yes],
+	[ more_gcc_warnings=no])
+
 if test "$GCC" = "yes"; then
 	CFLAGS="$CFLAGS -W -Wall -Wextra -Wno-unused-parameter -pedantic"
-	AC_MSG_CHECKING([if gcc supports -Wno-missing-field-initializers])
-	_gcc_cflags_save=$CFLAGS
-	CFLAGS="-Wno-missing-field-initializers"
-	AC_COMPILE_IFELSE([AC_LANG_SOURCE([])],_gcc_wopt=yes,_gcc_wopt=no)
-	AC_MSG_RESULT($_gcc_wopt)
-	CFLAGS=$_gcc_cflags_save;
-	if test x"$_gcc_wopt" = xyes ; then
-		CFLAGS="$CFLAGS -Wno-missing-field-initializers"
+	if test x"$more_gcc_warnings" = xyes ; then
+		CFLAGS="$CFLAGS -Wstrict-prototypes -Wmissing-prototypes -Wwrite-strings -Wbad-function-cast -Wnested-externs -Wshadow"
+	else
+		AC_MSG_CHECKING([if gcc supports -Wno-missing-field-initializers])
+		_gcc_cflags_save=$CFLAGS
+		CFLAGS="-Wno-missing-field-initializers"
+		AC_COMPILE_IFELSE([AC_LANG_SOURCE([])],_gcc_wopt=yes,_gcc_wopt=no)
+		AC_MSG_RESULT($_gcc_wopt)
+		CFLAGS=$_gcc_cflags_save;
+		if test x"$_gcc_wopt" = xyes ; then
+			CFLAGS="$CFLAGS -Wno-missing-field-initializers"
+		fi
 	fi
 fi
 


### PR DESCRIPTION
Do it as an option (--enable-more-gcc-warnings) rather simply setting CFLAGS when calling configure so that it's easier to skip how the configure script adds -Wno-missing-field-initializers to the compiler options.

In the workflow output, the build with the extra warnings is "Statistics Build" in the Linux runs.  Also enabled sound and the test front end in that build to cover more of the code.