### PR TITLE
Tidy src/Makefile.osx

### DIFF
--- a/src/Makefile.osx
+++ b/src/Makefile.osx
@@ -19,7 +19,7 @@ OSXVERSFLAGS = -mmacosx-version-min=10.9
 WARNINGS = -W -Wall -Wno-unused-parameter -Wno-missing-field-initializers \
 	-Wunused-macros
 JUST_C = -std=c99
-OBJ_CFLAGS = -std=c99 -x objective-c -fobjc-arc $(OSXVERSFLAGS)
+OBJ_CFLAGS = -std=c99 -x objective-c -fobjc-arc
 CFLAGS = -g -I. $(WARNINGS) $(OPT) -DMACH_O_CARBON -DHAVE_MKSTEMP \
 	-fno-stack-protector $(OSXVERSFLAGS) $(ARCHFLAGS)
 LIBS = -framework Cocoa

--- a/src/Makefile.osx
+++ b/src/Makefile.osx
@@ -212,7 +212,7 @@ dist: install
 
 	rm -rf disttemp*
 
-tests:
+tests: $(EXE).o
 	$(MAKE) -C tests all CFLAGS='-I.. -DDEFAULT_CONFIG_PATH=\"../../lib\" -DDEFAULT_LIB_PATH=\"../../lib\" -DDEFAULT_DATA_PATH=\"../../lib\" $(CFLAGS)' LDFLAGS="$(LIBS)"
 
 test-clean:

--- a/src/Makefile.osx
+++ b/src/Makefile.osx
@@ -71,8 +71,6 @@ $(EXE).o: $(OBJS)
 	done; \
 	lipo $$LIPO_ARGS -create -output $@
 
-izzywizzy: $(OBJS) izzywizzy.o
-
 $(EXE): $(EXE).o $(OSX_OBJS)
 	$(DEPLOYMENT_TARGET) $(CC) $(CFLAGS) $(LDFLAGS) -o $(EXE) $(EXE).o $(OSX_OBJS) $(LIBS) 
 

--- a/src/Makefile.osx
+++ b/src/Makefile.osx
@@ -16,8 +16,9 @@ BUNDLE_IDENTIFIER = org.rephial.angband
 ARCHS = x86_64 arm64
 ARCHFLAGS = $(addprefix -arch ,$(ARCHS))
 OSXVERSFLAGS = -mmacosx-version-min=10.9
-WARNINGS = -W -Wall -Wno-unused-parameter -Wno-missing-field-initializers \
-	-Wunused-macros
+WARNINGS = -W -Wall -Wextra -Wno-unused-parameter \
+	-Wno-missing-field-initializers -Wwrite-strings -Wmissing-prototypes \
+	-Wnested-externs -Wshadow -Wunused-macros
 JUST_C = -std=c99
 OBJ_CFLAGS = -std=c99 -x objective-c -fobjc-arc
 CFLAGS = -g -I. $(WARNINGS) $(OPT) -DMACH_O_CARBON -DHAVE_MKSTEMP \


### PR DESCRIPTION
- Since compiling Objective-C uses both CFLAGS and OBJC_FLAGS, only need the minimum OS version in the former.
- Extend to set of default warning flags to be closer to what builds with configure use.
- Add $(EXE).o as a prerequisite for the tests rule so it works more reliably.
- Remove reference to the unused izzywizzy.