### PR TITLE
Add tests for some aspects of effects; fix some issues the tests turned up

### DIFF
--- a/src/effects-info.c
+++ b/src/effects-info.c
@@ -590,7 +590,7 @@ size_t effect_get_menu_name(char *buf, size_t max, const struct effect *e)
 			switch (e->subtype) {
 			case 0: /* INC_BY */
 				actstr = "feed";
-				actarg = "yourelf";
+				actarg = "yourself";
 				break;
 			case 1: /* DEC_BY */
 				actstr = "increase";

--- a/src/effects-info.c
+++ b/src/effects-info.c
@@ -755,14 +755,16 @@ int effect_avg_damage(const struct effect *effect)
 		// accumulate damage
 		int total = 0;
 		struct effect *e = effect->next;
-		int num_subeffects = dice_evaluate(effect->dice, 0, AVERAGE, NULL);
-		if (num_subeffects <= 0) return 0;
-		for (int i = 0; e != NULL && i < num_subeffects; i++) {
+		int n_stated = dice_evaluate(effect->dice, 0, AVERAGE, NULL);
+		int n_actual = 0;
+
+		for (int i = 0; e != NULL && i < n_stated; i++) {
 			total += effect_avg_damage(e);
+			++n_actual;
 			e = e->next;
 		}
 		// Return an average of the sub-effects' average damages
-		return total / num_subeffects;
+		return (n_actual > 0) ? total / n_actual : 0;
 	} else {
 		// Non-random effect, calculate the average damage
 		return effect_damages(effect) ?

--- a/src/effects.c
+++ b/src/effects.c
@@ -5799,6 +5799,16 @@ bool effect_do(struct effect *effect,
 			int choice;
 
 			/*
+			 * If it has no subeffects, act as if it completed
+			 * successfully and go to the next effect.
+			 */
+			if (choice_count <= 0) {
+				completed = true;
+				effect = effect->next;
+				continue;
+			}
+
+			/*
 			 * Treat select effects like random ones if they
 			 * aren't from a player or if there's really no choice
 			 * to be made.

--- a/src/effects.c
+++ b/src/effects.c
@@ -5850,8 +5850,16 @@ bool effect_do(struct effect *effect,
 
 			/* Skip to the chosen effect */
 			effect = effect->next;
-			while (choice--)
+			while (choice-- && effect)
 				effect = effect->next;
+			if (!effect) {
+				/*
+				 * There's fewer subeffects than expected.  Act
+				 * as if it ran successfully.
+				 */
+				completed = true;
+				break;
+			}
 
 			/* Roll the damage, if needed */
 			if (effect->dice != NULL)
@@ -5885,7 +5893,7 @@ bool effect_do(struct effect *effect,
 		}
 
 		/* Get the next effect, if there is one */
-		while (leftover--)
+		while (leftover-- && effect)
 			effect = effect->next;
 	} while (effect);
 

--- a/src/list-effects.h
+++ b/src/list-effects.h
@@ -96,7 +96,7 @@ EFFECT(BOLT_OR_BEAM,				true,	"dam",		2,		EFINFO_BOLTD,	"casts a bolt or beam of
 EFFECT(LINE,						true,	"dam",		2,		EFINFO_BOLTD,	"creates a line of %s dealing %s damage",	"create a line of %s")
 EFFECT(ALTER,						true,	NULL,		1,		EFINFO_BOLT,	"creates a line which %s",	"create a line which %s")
 EFFECT(BOLT_STATUS,					true,	NULL,		1,		EFINFO_BOLT,	"casts a bolt which %s",	"cast a bolt which %s")
-EFFECT(BOLT_STATUS_DAM,				true,	"dam",		2,		EFINFO_BOLTD,	"casts a bolt which %s, dealing %s damage",	"cast a bolt which %s and damages")
+EFFECT(BOLT_STATUS_DAM,				true,	"dam",		2,		EFINFO_BOLTD,	"casts a bolt which %s, dealing %s damage",	"cast a bolt which %s")
 EFFECT(BOLT_AWARE,					true,	NULL,		1,		EFINFO_BOLT,	"creates a bolt which %s",	"create a bolt which %s")
 EFFECT(TOUCH,						false,	NULL,		1,		EFINFO_TOUCH,	"%s on all adjacent squares",	"%s all adjacent")
 EFFECT(TOUCH_AWARE,					false,	NULL,		1,		EFINFO_TOUCH,	"%s on all adjacent squares",	"%s all adjacent")

--- a/src/tests/effects/chain.c
+++ b/src/tests/effects/chain.c
@@ -1,0 +1,697 @@
+/*
+ * effects/chain
+ * Test handling of effect chains and the container (RANDOM and SELECT) or
+ * logic operation effects (BREAK, SKIP, BREAK_IF, and SKIP_IF) that are used
+ * in chains.
+ */
+
+#include "unit-test.h"
+#include "test-utils.h"
+#include "cave.h"
+#include "effects.h"
+#include "effects-info.h"
+#include "game-world.h"
+#include "init.h"
+#include "player.h"
+#include "player-birth.h"
+#include "player-calcs.h"
+#include "player-timed.h"
+#include "source.h"
+#include "z-dice.h"
+
+struct simple_effect {
+	int t_index, radius, other;
+	const char *st_str;
+	const char *d_str;
+};
+
+int setup_tests(void **state) {
+	set_file_paths();
+	init_angband();
+	/* Set up the player so there's a target available for the effects. */
+	if (!player_make_simple(NULL, NULL, "Tester")) {
+		cleanup_angband();
+		return 1;
+	}
+	prepare_next_level(&cave, player);
+	on_new_level();
+	return 0;
+}
+
+int teardown_tests(void *state) {
+	cleanup_angband();
+	return 0;
+}
+
+static void restore_to_full_health(void)
+{
+	player->chp = player->mhp;
+	if (player->upkeep) player->upkeep->redraw |= (PR_HP);
+}
+
+static struct effect *build_effect_chain(const struct simple_effect *earr,
+	int count)
+{
+	struct effect *prev = NULL;
+	int i = count;
+
+	/* Work backwards to make building the linked list easier. */
+	while (i > 0) {
+		struct effect *curr = mem_zalloc(sizeof(*curr));
+
+		--i;
+		curr->next = prev;
+		curr->index = earr[i].t_index;
+		if (earr[i].d_str) {
+			curr->dice = dice_new();
+			if (!dice_parse_string(curr->dice, earr[i].d_str)) {
+				free_effect(curr);
+				return NULL;
+			}
+		}
+		curr->subtype = effect_subtype(curr->index, earr[i].st_str);
+		if (curr->subtype == -1) {
+			free_effect(curr);
+			return NULL;
+		}
+		curr->radius = earr[i].radius;
+		curr->other = earr[i].other;
+		prev = curr;
+	}
+	return prev;
+}
+
+static int test_chain1_execute(void *state) {
+	struct simple_effect ea[] = {
+		{ EF_DAMAGE, 0, 0, "NONE", "1" },
+	};
+	struct effect *ec = build_effect_chain(ea, (int)N_ELEMENTS(ea));
+	bool completed = false, ident = true;
+
+	if (ec) {
+		restore_to_full_health();
+		completed = effect_do(ec, source_player(), NULL, &ident, true,
+			0, 0, false, NULL);
+		free_effect(ec);
+	}
+	noteq(ec, NULL);
+	require(completed);
+	require(ident);
+	require(player->chp == player->mhp - 1);
+	ok;
+}
+
+static int test_chain2_execute(void *state) {
+	struct simple_effect ea[] = {
+		{ EF_DAMAGE, 0, 0, "NONE", "2" },
+		{ EF_HEAL_HP, 0, 0, "NONE", "1" },
+	};
+	struct effect *ec = build_effect_chain(ea, (int)N_ELEMENTS(ea));
+	bool completed = false, ident = true;
+
+	if (ec) {
+		restore_to_full_health();
+		completed = effect_do(ec, source_player(), NULL, &ident, true,
+			0, 0, false, NULL);
+		free_effect(ec);
+	}
+	noteq(ec, NULL);
+	require(completed);
+	require(ident);
+	require(player->chp == player->mhp - 1);
+	ok;
+}
+
+static int test_chain3_execute(void *state) {
+	struct simple_effect ea[] = {
+		{ EF_DAMAGE, 0, 0, "NONE", "5" },
+		{ EF_HEAL_HP, 0, 0, "NONE", "4" },
+		{ EF_DAMAGE, 0, 0, "NONE", "2" },
+	};
+	struct effect *ec = build_effect_chain(ea, (int)N_ELEMENTS(ea));
+	bool completed = false, ident = true;
+
+	if (ec) {
+		restore_to_full_health();
+		completed = effect_do(ec, source_player(), NULL, &ident, true,
+			0, 0, false, NULL);
+		free_effect(ec);
+	}
+	noteq(ec, NULL);
+	require(completed);
+	require(ident);
+	require(player->chp == player->mhp - 3);
+	ok;
+}
+
+/*
+ * A RANDOM effect with a negative number of subeffects should do nothing
+ * successfully.
+ */
+static int test_randomneg_execute(void *state) {
+	struct simple_effect ea[] = {
+		{ EF_RANDOM, 0, 0, "NONE", "-4+1d2" },
+	};
+	struct effect *ec = build_effect_chain(ea, (int)N_ELEMENTS(ea));
+	bool completed = false, ident = true;
+
+	if (ec) {
+		completed = effect_do(ec, source_player(), NULL, &ident, true,
+			0, 0, false, NULL);
+		free_effect(ec);
+	}
+	noteq(ec, NULL);
+	require(completed);
+	require(ident);
+	ok;
+}
+
+/* A RANDOM effect with zero subeffects should do nothing successfully.  */
+static int test_random0_execute(void *state) {
+	struct simple_effect ea[] = {
+		{ EF_RANDOM, 0, 0, "NONE", "0" },
+	};
+	struct effect *ec = build_effect_chain(ea, (int)N_ELEMENTS(ea));
+	bool completed = false, ident = true;
+
+	if (ec) {
+		completed = effect_do(ec, source_player(), NULL, &ident, true,
+			0, 0, false, NULL);
+		free_effect(ec);
+	}
+	noteq(ec, NULL);
+	require(completed);
+	require(ident);
+	ok;
+}
+
+static int test_random1_execute(void *state) {
+	struct simple_effect ea[] = {
+		{ EF_RANDOM, 0, 0, "NONE", "1" },
+		{ EF_DAMAGE, 0, 0, "NONE", "1" },
+	};
+	struct effect *ec = build_effect_chain(ea, (int)N_ELEMENTS(ea));
+	bool completed = false, ident = true;
+
+	if (ec) {
+		restore_to_full_health();
+		completed = effect_do(ec, source_player(), NULL, &ident, true,
+			0, 0, false, NULL);
+		free_effect(ec);
+	}
+	noteq(ec, NULL);
+	require(completed);
+	require(ident);
+	require(player->chp == player->mhp - 1);
+	ok;
+}
+
+static int test_random2_execute(void *state) {
+	struct simple_effect ea[] = {
+		{ EF_RANDOM, 0, 0, "NONE", "2" },
+		{ EF_DAMAGE, 0, 0, "NONE", "1" },
+		{ EF_TIMED_INC, 0, 0, "BOLD", "10" },
+	};
+	struct effect *ec = build_effect_chain(ea, (int)N_ELEMENTS(ea));
+	bool completed = false, ident = true;
+
+	if (ec) {
+		restore_to_full_health();
+		player_clear_timed(player, TMD_BOLD, false);
+		completed = effect_do(ec, source_player(), NULL, &ident, true,
+			0, 0, false, NULL);
+		free_effect(ec);
+	}
+	noteq(ec, NULL);
+	require(completed);
+	require(ident);
+	require((player->chp == player->mhp - 1 || player->timed[TMD_BOLD]) &&
+		!(player->chp == player->mhp - 1 && player->timed[TMD_BOLD]));
+	ok;
+}
+
+/*
+ * Check that a RANDOM effect which says it has more subeffects than it does
+ * is handled gracefully.
+ */
+static int test_randomover_execute(void *state) {
+	struct simple_effect ea[] = {
+		{ EF_RANDOM, 0, 0, "NONE", "10" },
+	};
+	struct effect *ec = build_effect_chain(ea, (int)N_ELEMENTS(ea));
+	bool completed = false, ident = true;
+
+	if (ec) {
+		completed = effect_do(ec, source_player(), NULL, &ident, true,
+			0, 0, false, NULL);
+		free_effect(ec);
+	}
+	noteq(ec, NULL);
+	require(completed);
+	require(ident);
+	ok;
+}
+
+/*
+ * There's a non-deterministic aspect to this test.  It could fail (about .01%
+ * of the time) even if random selection is working correctly.
+ */
+static int test_random_stats(void *state) {
+	struct simple_effect ea[] = {
+		{ EF_RANDOM, 0, 0, "NONE", "2" },
+		{ EF_DAMAGE, 0, 0, "NONE", "1" },
+		{ EF_DAMAGE, 0, 0, "NONE", "2" },
+	};
+	struct effect *ec = build_effect_chain(ea, (int)N_ELEMENTS(ea));
+	int nsim = 1000, i = 0;
+	int bins[2] = { 0, 0 };
+
+	if (ec) {
+		while (1) {
+			bool completed = false, ident = true;
+
+			if (i >= nsim) break;
+			restore_to_full_health();
+			player_clear_timed(player, TMD_BOLD, false);
+			completed = effect_do(ec, source_player(), NULL,
+				&ident, true, 0, 0, false, NULL);
+			if (!completed) break;
+			if (player->mhp - player->chp == 1) {
+				++bins[0];
+			} else if (player->mhp - player->chp == 2) {
+				++bins[1];
+			} else {
+				break;
+			}
+			++i;
+		}
+		free_effect(ec);
+	}
+	require(i == nsim && (bins[0] + bins[1]) == nsim);
+	/*
+         * By my calculation of the Chernoff upper bound for the cumulative
+	 * distribution function of the binomial distribution,
+	 * https://en.wikipedia.org/wiki/Binomial_distribution#Tail_bounds
+	 * , with n = 1000 and p = 0.5, 432 is the closest point to where the
+	 * upper bound crosses a probability of .0001.
+	 */
+	require(bins[0] >= 432 && bins[0] <= 568);
+	ok;
+}
+
+/*
+ * In the current implementation, a SELECT effect nested in another RANDOM
+ * (or SELECT) effect is treated as a do-nothing effect with no subeffects.
+ * This test exercises that.  If the implementation changes to allow proper
+ * nesting of SELECT effects, this test will have to be changed.
+ */
+static int test_nested_random_execute(void *state) {
+	struct simple_effect ea[] = {
+		{ EF_RANDOM, 0, 0, "NONE", "3" },
+		{ EF_DAMAGE, 0, 0, "NONE", "1" },
+		{ EF_RANDOM, 0, 0, "NONE", "5" },
+		{ EF_TIMED_INC, 0, 0, "BOLD", "10" },
+	};
+	struct effect *ec = build_effect_chain(ea, (int)N_ELEMENTS(ea));
+	bool completed = false, ident = true;
+
+	if (ec) {
+		restore_to_full_health();
+		player_clear_timed(player, TMD_BOLD, false);
+		completed = effect_do(ec, source_player(), NULL, &ident, true,
+			0, 0, false, NULL);
+		free_effect(ec);
+	}
+	noteq(ec, NULL);
+	require(completed);
+	require(ident);
+	require((player->chp == player->mhp - 1 || player->timed[TMD_BOLD] ||
+		(player->chp == player->mhp && !player->timed[TMD_BOLD])) &&
+		!(player->chp == player->mhp - 1 && player->timed[TMD_BOLD]));
+	ok;
+}
+
+/*
+ * A SELECT effect with a negative number of subeffects should do nothing
+ * successfully.
+ */
+static int test_selectneg_execute(void *state) {
+	struct simple_effect ea[] = {
+		{ EF_SELECT, 0, 0, "NONE", "-4+1d2" },
+	};
+	struct effect *ec = build_effect_chain(ea, (int)N_ELEMENTS(ea));
+	bool completed = false, ident = true;
+
+	if (ec) {
+		completed = effect_do(ec, source_player(), NULL, &ident, true,
+			0, 0, false, NULL);
+		free_effect(ec);
+	}
+	noteq(ec, NULL);
+	require(completed);
+	require(ident);
+	ok;
+}
+
+/* A SELECT effect with zero subeffects should do nothing successfully.  */
+static int test_select0_execute(void *state) {
+	struct simple_effect ea[] = {
+		{ EF_SELECT, 0, 0, "NONE", "0" },
+	};
+	struct effect *ec = build_effect_chain(ea, (int)N_ELEMENTS(ea));
+	bool completed = false, ident = true;
+
+	if (ec) {
+		completed = effect_do(ec, source_player(), NULL, &ident, true,
+			0, 0, false, NULL);
+		free_effect(ec);
+	}
+	noteq(ec, NULL);
+	require(completed);
+	require(ident);
+	ok;
+}
+
+/*
+ * A SELECT effect with only one choice should not prompt so this test should
+ * run without special steps to avoid the prompt.
+ */
+static int test_select1_execute(void *state) {
+	struct simple_effect ea[] = {
+		{ EF_SELECT, 0, 0, "NONE", "1" },
+		{ EF_DAMAGE, 0, 0, "NONE", "1" },
+	};
+	struct effect *ec = build_effect_chain(ea, (int)N_ELEMENTS(ea));
+	bool completed = false, ident = true;
+
+	if (ec) {
+		restore_to_full_health();
+		completed = effect_do(ec, source_player(), NULL, &ident, true,
+			0, 0, false, NULL);
+		free_effect(ec);
+	}
+	noteq(ec, NULL);
+	require(completed);
+	require(ident);
+	require(player->chp == player->mhp - 1);
+	ok;
+}
+
+/*
+ * A SELECT with more than one subeffect will prompt so provide a command object
+ * with a preselected choice to bypass the prompt.
+ */
+static int test_select2_execute(void *state) {
+	struct simple_effect ea[] = {
+		{ EF_SELECT, 0, 0, "NONE", "2" },
+		{ EF_DAMAGE, 0, 0, "NONE", "1" },
+		{ EF_TIMED_INC, 0, 0, "BOLD", "10" },
+	};
+	struct effect *ec = build_effect_chain(ea, (int)N_ELEMENTS(ea));
+	bool completed = false, ident = true;
+	int choice = randint0(2);
+
+	if (ec) {
+		struct command cmd;
+
+		restore_to_full_health();
+		player_clear_timed(player, TMD_BOLD, false);
+		memset(&cmd, 0, sizeof(cmd));
+		cmd_set_arg_choice(&cmd, "list_index", choice);
+		completed = effect_do(ec, source_player(), NULL, &ident, true,
+			0, 0, false, &cmd);
+		free_effect(ec);
+	}
+	noteq(ec, NULL);
+	require(completed);
+	require(ident);
+	require(choice == 0 || choice == 1);
+	if (choice == 0) {
+		require(player->chp == player->mhp - 1 &&
+			!player->timed[TMD_BOLD]);
+	} else {
+		require(player->chp == player->mhp && player->timed[TMD_BOLD]);
+	}
+	ok;
+}
+
+/*
+ * Check that a SELECT effect which says it has more subeffects than it does
+ * is handled gracefully.
+ */
+static int test_selectover_execute(void *state) {
+	struct simple_effect ea[] = {
+		{ EF_SELECT, 0, 0, "NONE", "5" },
+	};
+	struct effect *ec = build_effect_chain(ea, (int)N_ELEMENTS(ea));
+	bool completed = false, ident = true;
+	int choice = randint0(5);
+
+	if (ec) {
+		struct command cmd;
+
+		memset(&cmd, 0, sizeof(cmd));
+		cmd_set_arg_choice(&cmd, "list_index", choice);
+		completed = effect_do(ec, source_player(), NULL, &ident, true,
+			0, 0, false, &cmd);
+		free_effect(ec);
+	}
+	noteq(ec, NULL);
+	require(completed);
+	require(ident);
+	ok;
+}
+
+/*
+ * In the current implementation, a SELECT effect nested in another SELECT
+ * (or RANDOM) effect is treated as a do-nothing effect with no subeffects.
+ * This test exercises that.  If the implementation changes to allow proper
+ * nesting of SELECT effects, this test will have to be changed.
+ */
+static int test_nested_select_execute(void *state) {
+	struct simple_effect ea[] = {
+		{ EF_RANDOM, 0, 0, "NONE", "3" },
+		{ EF_DAMAGE, 0, 0, "NONE", "1" },
+		{ EF_SELECT, 0, 0, "NONE", "5" },
+		{ EF_TIMED_INC, 0, 0, "BOLD", "10" },
+	};
+	struct effect *ec = build_effect_chain(ea, (int)N_ELEMENTS(ea));
+	bool completed = false, ident = true;
+
+	if (ec) {
+		restore_to_full_health();
+		player_clear_timed(player, TMD_BOLD, false);
+		completed = effect_do(ec, source_player(), NULL, &ident, true,
+			0, 0, false, NULL);
+		free_effect(ec);
+	}
+	noteq(ec, NULL);
+	require(completed);
+	require(ident);
+	require((player->chp == player->mhp - 1 || player->timed[TMD_BOLD] ||
+		(player->chp == player->mhp && !player->timed[TMD_BOLD])) &&
+		!(player->chp == player->mhp - 1 && player->timed[TMD_BOLD]));
+	ok;
+}
+
+static int test_random_select_damages(void *state)
+{
+	struct simple_effect ea1[] = {
+		{ EF_RANDOM, 0, 0, "NONE", "3" },
+		{ EF_HEAL_HP, 0, 0, "NONE", "5" },
+		{ EF_BOLT, 0, 0, "ACID", "1" },
+		{ EF_TIMED_INC, 0, 0, "BOLD", "10" },
+	};
+	struct simple_effect ea2[] = {
+		{ EF_RANDOM, 0, 0, "NONE", "3" },
+		{ EF_HEAL_HP, 0, 0, "NONE", "5" },
+		{ EF_TIMED_INC, 0, 0, "FAST", "8" },
+		{ EF_TIMED_INC, 0, 0, "BOLD", "10" },
+	};
+	struct effect *ec1 = build_effect_chain(ea1, (int)N_ELEMENTS(ea1));
+	struct effect *ec2 = build_effect_chain(ea2, (int)N_ELEMENTS(ea2));
+	const bool expected[4] = { true, true, false, false };
+	bool results[4] = { false, false, false, false };
+
+	if (ec1) {
+		results[0] = effect_damages(ec1);
+		ec1->index = EF_SELECT;
+		results[1] = effect_damages(ec1);
+		free_effect(ec1);
+	}
+	if (ec2) {
+		results[2] = effect_damages(ec2);
+		ec2->index = EF_SELECT;
+		results[3] = effect_damages(ec2);
+		free_effect(ec2);
+	}
+	require(ec1 && ec2);
+	require(results[0] == expected[0] && results[1] == expected[1] &&
+		results[2] == expected[2] && results[3] == expected[3]);
+	ok;
+}
+
+static int test_random_select_avg_damage(void *state)
+{
+	struct simple_effect ea1[] = {
+		{ EF_RANDOM, 0, 0, "NONE", "3" },
+		{ EF_HEAL_HP, 0, 0, "NONE", "5" },
+		{ EF_BOLT, 0, 0, "ACID", "3d5" },
+		{ EF_TIMED_INC, 0, 0, "BOLD", "10" },
+	};
+	struct simple_effect ea2[] = {
+		{ EF_RANDOM, 0, 0, "NONE", "3" },
+		{ EF_BOLT, 0, 0, "FIRE", "1d7" },
+		{ EF_ARC, 0, 0, "COLD", "3+1d3" },
+		{ EF_BOLT_OR_BEAM, 0, 0, "POIS", "6" },
+	};
+	struct effect *ec1 = build_effect_chain(ea1, (int)N_ELEMENTS(ea1));
+	struct effect *ec2 = build_effect_chain(ea2, (int)N_ELEMENTS(ea2));
+	const int expected[4] = { 3, 3, 5, 5 };
+	int results[4] = { -1, -1, -1, -1 };
+
+	if (ec1) {
+		results[0] = effect_avg_damage(ec1);
+		ec1->index = EF_SELECT;
+		results[1] = effect_avg_damage(ec1);
+		free_effect(ec1);
+	}
+	if (ec2) {
+		results[2] = effect_avg_damage(ec2);
+		ec2->index = EF_SELECT;
+		results[3] = effect_avg_damage(ec2);
+		free_effect(ec2);
+	}
+	require(results[0] == expected[0] && results[1] == expected[1] &&
+		results[2] == expected[2] && results[3] == expected[3]);
+	ok;
+}
+
+static int test_random_select_projection(void *state)
+{
+	struct simple_effect ea1[] = {
+		{ EF_RANDOM, 0, 0, "NONE", "3" },
+		{ EF_BALL, 3, 0, "ACID", "5" },
+		{ EF_BOLT, 0, 0, "ACID", "1" },
+		{ EF_ARC, 0, 0, "ACID", "10" },
+	};
+	struct simple_effect ea2[] = {
+		{ EF_RANDOM, 0, 0, "NONE", "3" },
+		{ EF_BOLT, 0, 0, "FIRE", "5" },
+		{ EF_BREATH, 0, 0, "ELEC", "8" },
+		{ EF_LASH, 0, 0, "POIS", "10" },
+	};
+	struct effect *ec1 = build_effect_chain(ea1, (int)N_ELEMENTS(ea1));
+	struct effect *ec2 = build_effect_chain(ea2, (int)N_ELEMENTS(ea2));
+	const char *expected[4] = { "acid", "acid", "", "" };
+	bool results[4] = { false, false, false, false };
+	const char* result;
+
+	if (ec1) {
+		result = effect_projection(ec1);
+		results[0] = streq(result, expected[0]);
+		ec1->index = EF_SELECT;
+		result = effect_projection(ec1);
+		results[1] = streq(result, expected[1]);
+		free_effect(ec1);
+	}
+	if (ec2) {
+		result = effect_projection(ec2);
+		results[2] = streq(result, expected[2]);
+		ec2->index = EF_SELECT;
+		result = effect_projection(ec2);
+		results[3] = streq(result, expected[3]);
+		free_effect(ec2);
+	}
+	require(results[0] && results[1] && results[2] && results[3]);
+	ok;
+}
+
+static int test_iterate1(void *state)
+{
+	struct simple_effect ea[] = {
+		{ EF_DAMAGE, 0, 0, "NONE", "0" },
+		{ EF_RANDOM, 0, 0, "NONE", "3" },
+		{ EF_DAMAGE, 0, 0, "NONE", "1" },
+		{ EF_HEAL_HP, 0, 0, "NONE", "2" },
+		{ EF_TIMED_INC, 0, 0, "BOLD", "10" },
+		{ EF_DAMAGE, 0, 0, "NONE", "1" },
+		{ EF_SELECT, 0, 0, "NONE", "2" },
+		{ EF_TIMED_INC, 0, 0, "STUN", "5" },
+		{ EF_TIMED_INC, 0, 0, "FAST", "5" },
+		{ EF_HEAL_HP, 0, 0, "NONE", "2" },
+	};
+	struct effect *ec = build_effect_chain(ea, (int)N_ELEMENTS(ea));
+	/* This is a flat array for the effect addresses in the chain. */
+	int namax = 10, nacurr = 0;
+	struct effect **a = mem_alloc(namax * sizeof(*a));
+	/* This is a flat array for the effect address from iteration. */
+	int naimax = 10, naicurr = 0;
+	struct effect **ai = mem_alloc(naimax * sizeof(*ai));
+	/* These as are the expected results as indices into a. */
+	const int expected[] = { 0, 1, 5, 6, 9 };
+	int i, nmatch;
+
+	if (ec) {
+		struct effect *e = ec;
+
+		/* Build up a. */
+		while (e) {
+			if (nacurr >= namax) {
+				namax *= 2;
+				a = mem_realloc(a, namax * sizeof(*a));
+			}
+			a[nacurr] = e;
+			++nacurr;
+			e = e->next;
+		}
+
+		/* Get the iteration results. */
+		e = ec;
+		while (e) {
+			if (naicurr >= naimax) {
+				naimax *= 2;
+				ai = mem_realloc(ai, naimax * sizeof(*ai));
+			}
+			ai[naicurr] = e;
+			++naicurr;
+			e = effect_next(e);
+		}
+		free_effect(ec);
+	}
+	for (i = 0, nmatch = 0;
+			i < naicurr && i < (int)N_ELEMENTS(expected); ++i) {
+		if (ai[i] == a[expected[i]]) {
+			++nmatch;
+		}
+	}
+	mem_free(ai);
+	mem_free(a);
+	require(nmatch == naicurr && nmatch == (int)N_ELEMENTS(expected));
+	ok;
+}
+
+const char *suite_name = "effects/chain";
+struct test tests[] = {
+	{ "chain1_execute", test_chain1_execute },
+	{ "chain2_execute", test_chain2_execute },
+	{ "chain3_execute", test_chain3_execute },
+	{ "randomneg_execute", test_randomneg_execute },
+	{ "random0_execute", test_random0_execute },
+	{ "random1_execute", test_random1_execute },
+	{ "random2_execute", test_random2_execute },
+	{ "randomover_execute", test_randomover_execute },
+	{ "nested_random_execute", test_nested_random_execute },
+	{ "test_random_stats", test_random_stats },
+	{ "selectneg_execute", test_selectneg_execute },
+	{ "select0_execute", test_select0_execute },
+	{ "select1_execute", test_select1_execute },
+	{ "select2_execute", test_select2_execute },
+	{ "selectover_execute", test_selectover_execute },
+	{ "nested_select_execute", test_nested_select_execute },
+	{ "random_select_damages", test_random_select_damages },
+	{ "random_select_avg_damage", test_random_select_avg_damage },
+	{ "random_select_projection", test_random_select_projection },
+	{ "iterate1", test_iterate1 },
+	{ NULL, NULL }
+};

--- a/src/tests/effects/info.c
+++ b/src/tests/effects/info.c
@@ -1,0 +1,257 @@
+/*
+ * effects/info
+ * Test functions from effects-info.c for single effects; tests for chains are
+ * in chain.c.
+ */
+
+#include "unit-test.h"
+#include "test-utils.h"
+#include "effects.h"
+#include "effects-info.h"
+#include "init.h"
+#include "z-dice.h"
+
+struct test_effects {
+	struct effect *acid_bolt;
+	struct effect *fire_arc;
+	struct effect *cold_sphere;
+	struct effect *lightning_ball;
+	struct effect *drain_bolt;
+	struct effect *curse_mon;
+	struct effect *slow_bolt;
+	struct effect *heal;
+	struct effect *food;
+	struct effect *cure_stun;
+	struct effect *inc_fear;
+	struct effect *inc_nores_blind;
+	struct effect *dec_fast;
+	struct effect *detect_gold;
+	int avgd_acid_bolt;
+	int avgd_fire_arc;
+	int avgd_cold_sphere;
+	int avgd_lightning_ball;
+	int avgd_drain_bolt;
+	int avgd_curse_mon;
+};
+
+static struct effect *build_effect(int index, const char *st_str,
+		const char *d_str, int radius, int other) {
+	struct effect *e = mem_zalloc(sizeof(*e));
+
+	e->index = index;
+	if (d_str) {
+		e->dice = dice_new();
+		if (!dice_parse_string(e->dice, d_str)) {
+			free_effect(e);
+			return NULL;
+		}
+	}
+	e->subtype = effect_subtype(e->index, st_str);
+	if (e->subtype == -1) {
+		free_effect(e);
+		return NULL;
+	}
+	e->radius = radius;
+	e->other = other;
+	return e;
+}
+
+int teardown_tests(void *state) {
+	struct test_effects *te = state;
+
+	if (te) {
+		free_effect(te->detect_gold);
+		free_effect(te->dec_fast);
+		free_effect(te->inc_nores_blind);
+		free_effect(te->inc_fear);
+		free_effect(te->cure_stun);
+		free_effect(te->food);
+		free_effect(te->heal);
+		free_effect(te->slow_bolt);
+		free_effect(te->curse_mon);
+		free_effect(te->drain_bolt);
+		free_effect(te->lightning_ball);
+		free_effect(te->cold_sphere);
+		free_effect(te->fire_arc);
+		free_effect(te->acid_bolt);
+		mem_free(te);
+	}
+	cleanup_angband();
+	return 0;
+}
+
+int setup_tests(void **state) {
+	struct test_effects *te;
+	bool failed;
+
+	set_file_paths();
+	init_angband();
+
+	/* Set up some effects.  Remember expected average damage. */
+	failed = false;
+	te = mem_zalloc(sizeof(*te));
+	te->acid_bolt = build_effect(EF_BOLT, "ACID", "2d8", 0, 0);
+	te->avgd_acid_bolt = 9;
+	if (!te->acid_bolt) failed = true;
+	te->fire_arc = build_effect(EF_ARC, "FIRE", "4+1d5", 0, 0);
+	te->avgd_fire_arc = 7;
+	if (!te->fire_arc) failed = true;
+	te->cold_sphere = build_effect(EF_SPHERE, "COLD", "2+3d1", 5, 0);
+	te->avgd_cold_sphere = 5;
+	if (!te->cold_sphere) failed = true;
+	te->lightning_ball = build_effect(EF_BALL, "ELEC", "5+8d3", 3, 0);
+	te->avgd_lightning_ball = 21;
+	if (!te->lightning_ball) failed = true;
+	te->drain_bolt = build_effect(EF_BOLT_STATUS_DAM, "MON_DRAIN",
+		"10", 0, 0);
+	te->avgd_drain_bolt = 10;
+	if (!te->drain_bolt) failed = true;
+	te->curse_mon = build_effect(EF_CURSE, "NONE", "6d4", 0, 0);
+	te->avgd_curse_mon = 15;
+	if (!te->curse_mon) failed = true;
+	te->slow_bolt = build_effect(EF_BOLT_STATUS, "MON_SLOW", "15+1d5", 0, 0);
+	if (!te->slow_bolt) failed = true;
+	te->heal = build_effect(EF_HEAL_HP, "NONE", "13", 0, 0);
+	if (!te->heal) failed = true;
+	te->food = build_effect(EF_NOURISH, "INC_BY", "5", 0, 0);
+	if (!te->food) failed = true;
+	te->cure_stun = build_effect(EF_CURE, "STUN", NULL, 0, 0);
+	if (!te->cure_stun) failed = true;
+	te->inc_fear = build_effect(EF_TIMED_INC, "AFRAID", "30+1d10", 0, 0);
+	if (!te->inc_fear) failed = true;
+	te->inc_nores_blind = build_effect(EF_TIMED_INC_NO_RES, "BLIND",
+		"40", 0, 0);
+	if (!te->inc_nores_blind) failed = true;
+	te->dec_fast = build_effect(EF_TIMED_DEC, "FAST", "15", 0, 0);
+	if (!te->dec_fast) failed = true;
+	te->detect_gold = build_effect(EF_DETECT_GOLD, "NONE", NULL, 0, 0);
+	if (!te->detect_gold) failed = true;
+
+	if (failed) {
+		teardown_tests(te);
+		return 1;
+	}
+
+	*state = te;
+	return 0;
+}
+
+static int test_damages(void *state)
+{
+	struct test_effects *te = state;
+
+	require(effect_damages(te->acid_bolt));
+	require(effect_damages(te->fire_arc));
+	require(effect_damages(te->cold_sphere));
+	require(effect_damages(te->lightning_ball));
+	require(effect_damages(te->drain_bolt));
+	require(effect_damages(te->curse_mon));
+	require(!effect_damages(te->slow_bolt));
+	require(!effect_damages(te->heal));
+	require(!effect_damages(te->food));
+	require(!effect_damages(te->cure_stun));
+	require(!effect_damages(te->inc_fear));
+	require(!effect_damages(te->inc_nores_blind));
+	require(!effect_damages(te->dec_fast));
+	require(!effect_damages(te->detect_gold));
+	ok;
+}
+
+static int test_avg_damage(void *state) {
+	struct test_effects *te = state;
+
+	eq(effect_avg_damage(te->acid_bolt), te->avgd_acid_bolt);
+	eq(effect_avg_damage(te->fire_arc), te->avgd_fire_arc);
+	eq(effect_avg_damage(te->cold_sphere), te->avgd_cold_sphere);
+	eq(effect_avg_damage(te->lightning_ball), te->avgd_lightning_ball);
+	eq(effect_avg_damage(te->drain_bolt), te->avgd_drain_bolt);
+	eq(effect_avg_damage(te->curse_mon), te->avgd_curse_mon);
+	eq(effect_avg_damage(te->slow_bolt), 0);
+	eq(effect_avg_damage(te->heal), 0);
+	eq(effect_avg_damage(te->food), 0);
+	eq(effect_avg_damage(te->cure_stun), 0);
+	eq(effect_avg_damage(te->inc_fear), 0);
+	eq(effect_avg_damage(te->inc_nores_blind), 0);
+	eq(effect_avg_damage(te->dec_fast), 0);
+	eq(effect_avg_damage(te->detect_gold), 0);
+	ok;
+}
+
+static int test_projection(void *state) {
+	struct test_effects *te = state;
+
+	require(streq(effect_projection(te->acid_bolt), "acid"));
+	require(streq(effect_projection(te->fire_arc), "fire"));
+	require(streq(effect_projection(te->cold_sphere), "frost"));
+	require(streq(effect_projection(te->lightning_ball), "lightning"));
+	require(streq(effect_projection(te->drain_bolt), ""));
+	require(streq(effect_projection(te->curse_mon), ""));
+	require(streq(effect_projection(te->slow_bolt), ""));
+	require(streq(effect_projection(te->heal), ""));
+	require(streq(effect_projection(te->food), ""));
+	require(streq(effect_projection(te->cure_stun), ""));
+	require(streq(effect_projection(te->inc_fear), ""));
+	require(streq(effect_projection(te->inc_nores_blind), ""));
+	require(streq(effect_projection(te->dec_fast), ""));
+	require(streq(effect_projection(te->detect_gold), ""));
+	ok;
+}
+
+static int test_menu_name(void *state) {
+	struct test_effects *te = state;
+	char buf[80];
+	size_t n;
+
+	n = effect_get_menu_name(buf, sizeof(buf), te->acid_bolt);
+	eq(n, strlen(buf));
+	require(streq(buf, "cast a bolt of acid"));
+	n = effect_get_menu_name(buf, sizeof(buf), te->fire_arc);
+	eq(n, strlen(buf));
+	require(streq(buf, "produce a cone of fire"));
+	n = effect_get_menu_name(buf, sizeof(buf), te->cold_sphere);
+	eq(n, strlen(buf));
+	require(streq(buf, "project frost"));
+	n = effect_get_menu_name(buf, sizeof(buf), te->lightning_ball);
+	eq(n, strlen(buf));
+	require(streq(buf, "fire a ball of lightning"));
+	n = effect_get_menu_name(buf, sizeof(buf), te->drain_bolt);
+	eq(n, strlen(buf));
+	require(streq(buf, "cast a bolt which damages living monsters"));
+	n = effect_get_menu_name(buf, sizeof(buf), te->curse_mon);
+	eq(n, strlen(buf));
+	require(streq(buf, "curse"));
+	n = effect_get_menu_name(buf, sizeof(buf), te->slow_bolt);
+	eq(n, strlen(buf));
+	require(streq(buf, "cast a bolt which attempts to slow monsters"));
+	n = effect_get_menu_name(buf, sizeof(buf), te->heal);
+	eq(n, strlen(buf));
+	require(streq(buf, "heal self"));
+	n = effect_get_menu_name(buf, sizeof(buf), te->food);
+	eq(n, strlen(buf));
+	require(streq(buf, "feed yourself"));
+	n = effect_get_menu_name(buf, sizeof(buf), te->cure_stun);
+	eq(n, strlen(buf));
+	require(streq(buf, "cure stunning"));
+	n = effect_get_menu_name(buf, sizeof(buf), te->inc_fear);
+	eq(n, strlen(buf));
+	require(streq(buf, "extend fear"));
+	n = effect_get_menu_name(buf, sizeof(buf), te->inc_nores_blind);
+	eq(n, strlen(buf));
+	require(streq(buf, "extend blindness"));
+	n = effect_get_menu_name(buf, sizeof(buf), te->dec_fast);
+	eq(n, strlen(buf));
+	require(streq(buf, "reduce haste"));
+	n = effect_get_menu_name(buf, sizeof(buf), te->detect_gold);
+	eq(n, strlen(buf));
+	require(streq(buf, "detect gold"));
+	ok;
+}
+
+const char *suite_name = "effects/info";
+struct test tests[] = {
+	{ "damages", test_damages },
+	{ "average damage", test_avg_damage },
+	{ "projection", test_projection },
+	{ "menu name", test_menu_name },
+	{ NULL, NULL }
+};

--- a/src/tests/effects/suite.mk
+++ b/src/tests/effects/suite.mk
@@ -1,0 +1,1 @@
+TESTPROGS += effects/chain effects/info


### PR DESCRIPTION
The issues are:

1. Handling of RANDOM/SELECT in a chain when the number of sub-effects is less than or equal to zero
2. Handling of RANDOM/SELECT in a chain when the number of sub-effects is more than what was actually supplied
3. Typo for one case in effect_get_menu_name()
4. Awkward name from effect_get_menu_name() for BOLT_STATUS_DAM effects

The tests added don't try to exhaust executing all the effect types.  They try to cover the execution of chains and then handling of effect_next(), effect_get_menu_name(), effect_damages(), effect_avg_damage(), and effect_projection().
