### PR TITLE
Fix easily avoided leaks in the teardown for two test cases

### DIFF
--- a/src/tests/parse/graphics.c
+++ b/src/tests/parse/graphics.c
@@ -26,6 +26,8 @@ int setup_tests(void **state) {
 
 int teardown_tests(void *state) {
 	textui_prefs_free();
+	close_graphics_modes();
+	cleanup_angband();
 	return 0;
 }
 

--- a/src/tests/parse/readstore.c
+++ b/src/tests/parse/readstore.c
@@ -24,6 +24,7 @@ int teardown_tests(void *state) {
 	string_free((char *)s->name);
 	mem_free(s);
 	parser_destroy(state);
+	mem_free(z_info);
 	return 0;
 }
 


### PR DESCRIPTION
That ways there's less to wade through if one runs the tests under valgrind to look for potential issues.