### PR TITLE
Modify the test cases to avoid compiler warnings if compiled with stricter warning settings

### DIFF
--- a/src/Makefile.osx
+++ b/src/Makefile.osx
@@ -211,7 +211,7 @@ dist: install
 	rm -rf disttemp*
 
 tests: $(EXE).o
-	$(MAKE) -C tests all CFLAGS='-I.. -DDEFAULT_CONFIG_PATH=\"../../lib\" -DDEFAULT_LIB_PATH=\"../../lib\" -DDEFAULT_DATA_PATH=\"../../lib\" $(CFLAGS)' LDFLAGS="$(LIBS)"
+	$(MAKE) -C tests all CFLAGS='-I.. -DDEFAULT_CONFIG_PATH=\"../../lib\" -DDEFAULT_LIB_PATH=\"../../lib\" -DDEFAULT_DATA_PATH=\"../../lib\" $(CFLAGS) -Wno-write-strings' LDFLAGS="$(LIBS)"
 
 test-clean:
 	$(MAKE) -C tests clean

--- a/src/tests/artifact/name.c
+++ b/src/tests/artifact/name.c
@@ -39,7 +39,7 @@ const char *names[] = {
 
 const char **p[] = { names, names };
 
-int test_names(void *state) {
+static int test_names(void *state) {
 	struct artifact a;
 	char *n;
 	int i;

--- a/src/tests/command/lookup.c
+++ b/src/tests/command/lookup.c
@@ -28,7 +28,7 @@ int teardown_tests(void *state) {
 }
 
 /* Regression test for #1330 */
-int test_cmd_lookup_orig(void *state) {
+static int test_cmd_lookup_orig(void *state) {
 	require(cmd_lookup('Z', KEYMAP_MODE_ORIG) == CMD_NULL);
 	require(cmd_lookup('{', KEYMAP_MODE_ORIG) == CMD_INSCRIBE);
 	require(cmd_lookup('u', KEYMAP_MODE_ORIG) == CMD_USE_STAFF);
@@ -41,7 +41,7 @@ int test_cmd_lookup_orig(void *state) {
 }
 
 /* Introduced after commit 8871070 added modes to cmd_lookup() calls */
-int test_cmd_lookup_rogue(void *state) {
+static int test_cmd_lookup_rogue(void *state) {
 	require(cmd_lookup('{', KEYMAP_MODE_ROGUE) == CMD_INSCRIBE);
 	require(cmd_lookup('Z', KEYMAP_MODE_ROGUE) == CMD_USE_STAFF);
 	require(cmd_lookup(KTRL('T'), KEYMAP_MODE_ROGUE) == CMD_TUNNEL);

--- a/src/tests/game/basic.c
+++ b/src/tests/game/basic.c
@@ -45,7 +45,7 @@ int teardown_tests(void *state) {
 	return 0;
 }
 
-int test_newgame(void *state) {
+static int test_newgame(void *state) {
 
 	/* Try making a new game */
 	eq(player_make_simple(NULL, NULL, "Tester"), true);
@@ -66,7 +66,7 @@ int test_newgame(void *state) {
 	ok;
 }
 
-int test_loadgame(void *state) {
+static int test_loadgame(void *state) {
 
 	/* Try loading the just-saved game */
 	eq(savefile_load("Test1", false), true);
@@ -79,7 +79,7 @@ int test_loadgame(void *state) {
 	ok;
 }
 
-int test_stairs1(void *state) {
+static int test_stairs1(void *state) {
 
 	/* Load the saved game */
 	eq(savefile_load("Test1", false), true);
@@ -91,7 +91,7 @@ int test_stairs1(void *state) {
 	ok;
 }
 
-int test_stairs2(void *state) {
+static int test_stairs2(void *state) {
 
 	/* Load the saved game */
 	eq(savefile_load("Test1", false), true);
@@ -109,7 +109,7 @@ int test_stairs2(void *state) {
 	ok;
 }
 
-int test_drop_pickup(void *state) {
+static int test_drop_pickup(void *state) {
 
 	/* Load the saved game */
 	eq(savefile_load("Test1", false), true);
@@ -131,7 +131,7 @@ int test_drop_pickup(void *state) {
 	ok;
 }
 
-int test_drop_eat(void *state) {
+static int test_drop_eat(void *state) {
 	int num = 0;
 
 	/* Load the saved game */

--- a/src/tests/game/mage.c
+++ b/src/tests/game/mage.c
@@ -47,7 +47,7 @@ int teardown_tests(void *state) {
 	return 0;
 }
 
-int test_magic_missile(void *state) {
+static int test_magic_missile(void *state) {
 
 	/* Try making a new game */
 	eq(player_make_simple("Gnome", "Mage", "Tyrion"), true);

--- a/src/tests/message/message.c
+++ b/src/tests/message/message.c
@@ -43,7 +43,7 @@ int teardown_tests(void *state) {
 	return 0;
 }
 
-int test_empty(void *state) {
+static int test_empty(void *state) {
 	const char *txt;
 	u16b n, mtype;
 	byte color;
@@ -73,7 +73,7 @@ int test_empty(void *state) {
 	ok;
 }
 
-int test_add(void *state) {
+static int test_add(void *state) {
 	const char *m1 = "msg1";
 	u16b t1 = MSG_GENERIC;
 	const char *m2 = "msg2";
@@ -201,7 +201,7 @@ int test_add(void *state) {
 	ok;
 }
 
-int test_fill(void *state) {
+static int test_fill(void *state) {
 	int i = 0;
 	const char *txt;
 	char buf[16];
@@ -249,7 +249,7 @@ int test_fill(void *state) {
 	ok;
 }
 
-int test_many_repeat(void *state)
+static int test_many_repeat(void *state)
 {
 	int i = 0;
 	const char *txt;
@@ -293,7 +293,7 @@ int test_many_repeat(void *state)
 	ok;
 }
 
-int test_color(void *state) {
+static int test_color(void *state) {
 	byte color;
 
 	messages_free();
@@ -325,7 +325,7 @@ int test_color(void *state) {
 	ok;
 }
 
-int test_msg(void *state) {
+static int test_msg(void *state) {
 	struct test_message_event_state *st = state;
 	const char expected1[] = "%   abcde   1  +2  3 4  ";
 	const char expected2[] = "ab      -7";
@@ -371,7 +371,7 @@ int test_msg(void *state) {
 	ok;
 }
 
-int test_sound(void *state) {
+static int test_sound(void *state) {
 	struct test_message_event_state *st = state;
 
 	reset_event_counters(st);
@@ -395,7 +395,7 @@ int test_sound(void *state) {
 	ok;
 }
 
-int test_bell(void *state) {
+static int test_bell(void *state) {
 	struct test_message_event_state *st = state;
 	const char expected1[] = "msg1";
 	const char expected2[] = "msg2";
@@ -447,7 +447,7 @@ int test_bell(void *state) {
 	ok;
 }
 
-int test_msgt(void *state)
+static int test_msgt(void *state)
 {
 	struct test_message_event_state *st = state;
 	const char expected1[] = "msg1";
@@ -497,7 +497,7 @@ int test_msgt(void *state)
 	ok;
 }
 
-int test_lookup(void *state)
+static int test_lookup(void *state)
 {
 	char buffer[16];
 	int i, j;
@@ -537,7 +537,7 @@ int test_lookup(void *state)
 	ok;
 }
 
-int test_sound_lookup(void *state)
+static int test_sound_lookup(void *state)
 {
 	int i;
 

--- a/src/tests/monster/attack.c
+++ b/src/tests/monster/attack.c
@@ -99,7 +99,7 @@ static int test_effects(void *state) {
 }
 
 const char *suite_name = "monster/attack";
-const struct test tests[] = {
+struct test tests[] = {
 	{ "blows", test_blows },
 	{ "effects", test_effects },
 	{ NULL, NULL },

--- a/src/tests/monster/monster.c
+++ b/src/tests/monster/monster.c
@@ -23,7 +23,7 @@ int teardown_tests(void *state) {
 }
 
 /* Regression test for #1409 */
-int test_match_monster_bases(void *state) {
+static int test_match_monster_bases(void *state) {
 	struct monster_base *base;
 
 	/* Scruffy little dog */

--- a/src/tests/object/alloc.c
+++ b/src/tests/object/alloc.c
@@ -214,7 +214,7 @@ static void compute_obj_num_expected(int level, bool good, int tval,
  * below that can get more than one kind of object) but can happen even if
  * get_obj_num() performs correctly.
  */
-int test_get_obj_num_basic(void *state) {
+static int test_get_obj_num_basic(void *state) {
 	struct {
 		int level, tval;
 		bool good;

--- a/src/tests/object/alloc.c
+++ b/src/tests/object/alloc.c
@@ -218,7 +218,7 @@ int test_get_obj_num_basic(void *state) {
 	struct {
 		int level, tval;
 		bool good;
-	} tests[] = {
+	} cases[] = {
 		{ 0, 0, false },
 		{ 1, 0, false },
 		{ 2, 0, false },
@@ -245,7 +245,7 @@ int test_get_obj_num_basic(void *state) {
 	}
 	ntrials *= 30;
 
-	for (i = 0; i < (int)N_ELEMENTS(tests); ++i) {
+	for (i = 0; i < (int)N_ELEMENTS(cases); ++i) {
 		int j, nnonzero;
 
 		for (j = 0; j < z_info->k_max; ++j) {
@@ -253,8 +253,8 @@ int test_get_obj_num_basic(void *state) {
 		}
 		for (j = 0; j < ntrials; ++j) {
 			const struct object_kind *kind =
-				get_obj_num(tests[i].level, tests[i].good,
-					tests[i].tval);
+				get_obj_num(cases[i].level, cases[i].good,
+					cases[i].tval);
 			int k;
 
 			/*
@@ -273,12 +273,12 @@ int test_get_obj_num_basic(void *state) {
 					 * because of the possibility of level
 					 * boosting.
 					 */
-					require(tests[i].level >= kind->alloc_min);
-					if (tests[i].good) {
+					require(cases[i].level >= kind->alloc_min);
+					if (cases[i].good) {
 						require(kf_has(kind->kind_flags, KF_GOOD));
 					}
-					if (tests[i].tval != 0) {
-						eq(kind->tval, tests[i].tval);
+					if (cases[i].tval != 0) {
+						eq(kind->tval, cases[i].tval);
 					}
 					++st->histogram[k];
 					break;
@@ -287,8 +287,8 @@ int test_get_obj_num_basic(void *state) {
 			}
 		}
 
-		compute_obj_num_expected(tests[i].level, tests[i].good,
-			tests[i].tval, st->expected, &nnonzero);
+		compute_obj_num_expected(cases[i].level, cases[i].good,
+			cases[i].tval, st->expected, &nnonzero);
 		require(nnonzero >= 1);
 		if (nnonzero == 1) {
 			require(histogram_max(st->histogram, z_info->k_max) == ntrials);

--- a/src/tests/object/attack.c
+++ b/src/tests/object/attack.c
@@ -10,7 +10,7 @@
 NOSETUP
 NOTEARDOWN
 
-int test_breakage_chance(void *state) {
+static int test_breakage_chance(void *state) {
 	struct object obj;
 	int c;
 

--- a/src/tests/object/pile.c
+++ b/src/tests/object/pile.c
@@ -15,7 +15,7 @@ int setup_tests(void **state) {
 NOTEARDOWN
 
 /* Testing the linked list functions in obj-pile.c */
-int test_obj_piles(void *state) {
+static int test_obj_piles(void *state) {
 	struct object *pile = NULL;
 
 	struct object *o1 = object_new();

--- a/src/tests/object/util.c
+++ b/src/tests/object/util.c
@@ -28,7 +28,7 @@ int teardown_tests(void *state) {
 }
 
 /* Regression test for #1661 */
-int test_obj_can_refill(void *state) {
+static int test_obj_can_refill(void *state) {
     struct object obj_torch, obj_lantern, obj_candidate;
 
     /* Torches cannot be refilled */
@@ -64,7 +64,7 @@ int test_obj_can_refill(void *state) {
 }
 
 /* Test basic functionality of check_for_inscrip_with_int(). */
-int test_basic_check_for_inscrip_with_int(void *state) {
+static int test_basic_check_for_inscrip_with_int(void *state) {
     struct object obj;
     int dummy = 8974;
     int inarg;

--- a/src/tests/parse/a-info.c
+++ b/src/tests/parse/a-info.c
@@ -21,7 +21,7 @@ int teardown_tests(void *state) {
 	return 0;
 }
 
-int test_name0(void *state) {
+static int test_name0(void *state) {
 	enum parser_error r = parser_parse(state, "name:of Thrain");
 	struct artifact *a;
 
@@ -32,19 +32,19 @@ int test_name0(void *state) {
 	ok;
 }
 
-int test_badtval0(void *state) {
+static int test_badtval0(void *state) {
 	enum parser_error r = parser_parse(state, "base-object:badtval:Junk");
 	eq(r, PARSE_ERROR_UNRECOGNISED_TVAL);
 	ok;
 }
 
-int test_badtval1(void *state) {
+static int test_badtval1(void *state) {
 	enum parser_error r = parser_parse(state, "base-object:-1:Junk");
 	eq(r, PARSE_ERROR_UNRECOGNISED_TVAL);
 	ok;
 }
 
-int test_base_object0(void *state) {
+static int test_base_object0(void *state) {
 	enum parser_error r = parser_parse(state, "base-object:light:6");
 	struct artifact *a;
 
@@ -56,7 +56,7 @@ int test_base_object0(void *state) {
 	ok;
 }
 
-int test_level0(void *state) {
+static int test_level0(void *state) {
 	enum parser_error r = parser_parse(state, "level:3");
 	struct artifact *a;
 
@@ -79,7 +79,7 @@ int test_weight0(void *state) {
 	ok;
 }
 
-int test_cost0(void *state) {
+static int test_cost0(void *state) {
 	enum parser_error r = parser_parse(state, "cost:200");
 	struct artifact *a;
 
@@ -90,19 +90,19 @@ int test_cost0(void *state) {
 	ok;
 }
 
-int test_alloc0(void *state) {
+static int test_alloc0(void *state) {
 	enum parser_error r = parser_parse(state, "alloc:3:5");
 	eq(r, PARSE_ERROR_INVALID_ALLOCATION);
 	ok;
 }
 
-int test_alloc1(void *state) {
+static int test_alloc1(void *state) {
 	enum parser_error r = parser_parse(state, "alloc:3:5 to 300");
 	eq(r, PARSE_ERROR_OUT_OF_BOUNDS);
 	ok;
 }
 
-int test_alloc2(void *state) {
+static int test_alloc2(void *state) {
 	enum parser_error r = parser_parse(state, "alloc:3:5 to 10");
 	struct artifact *a;
 
@@ -115,7 +115,7 @@ int test_alloc2(void *state) {
 	ok;
 }
 
-int test_attack0(void *state) {
+static int test_attack0(void *state) {
 	enum parser_error r = parser_parse(state, "attack:4d5:8:2");
 	struct artifact *a;
 
@@ -129,7 +129,7 @@ int test_attack0(void *state) {
 	ok;
 }
 
-int test_armor0(void *state) {
+static int test_armor0(void *state) {
 	enum parser_error r = parser_parse(state, "armor:3:1");
 	struct artifact *a;
 
@@ -141,7 +141,7 @@ int test_armor0(void *state) {
 	ok;
 }
 
-int test_flags0(void *state) {
+static int test_flags0(void *state) {
 	enum parser_error r = parser_parse(state, "flags:SEE_INVIS | HOLD_LIFE");
 	struct artifact *a;
 
@@ -152,7 +152,7 @@ int test_flags0(void *state) {
 	ok;
 }
 
-int test_values0(void *state) {
+static int test_values0(void *state) {
 	enum parser_error r = parser_parse(state, "values:STR[1] | CON[1]");
 	struct artifact *a;
 
@@ -176,7 +176,7 @@ int test_time0(void *state) {
 	ok;
 }
 
-int test_msg0(void *state) {
+static int test_msg0(void *state) {
 	enum parser_error r = parser_parse(state, "msg:foo");
 	struct artifact *a;
 
@@ -190,7 +190,7 @@ int test_msg0(void *state) {
 }
 
 
-int test_desc0(void *state) {
+static int test_desc0(void *state) {
 	enum parser_error r = parser_parse(state, "desc:baz");
 	struct artifact *a;
 

--- a/src/tests/parse/c-info.c
+++ b/src/tests/parse/c-info.c
@@ -38,7 +38,7 @@ int teardown_tests(void *state) {
 	return 0;
 }
 
-int test_name0(void *state) {
+static int test_name0(void *state) {
 	enum parser_error r = parser_parse(state, "name:Ranger");
 	struct player_class *c;
 
@@ -49,7 +49,7 @@ int test_name0(void *state) {
 	ok;
 }
 
-int test_stats0(void *state) {
+static int test_stats0(void *state) {
 	enum parser_error r = parser_parse(state, "stats:3:-3:2:-2:1");
 	struct player_class *c;
 
@@ -64,7 +64,7 @@ int test_stats0(void *state) {
 	ok;
 }
 
-int test_skill_disarm0(void *state) {
+static int test_skill_disarm0(void *state) {
 	enum parser_error r = parser_parse(state, "skill-disarm-phys:30:8");
 	struct player_class *c;
 
@@ -76,7 +76,7 @@ int test_skill_disarm0(void *state) {
 	ok;
 }
 
-int test_skill_device0(void *state) {
+static int test_skill_device0(void *state) {
 	enum parser_error r = parser_parse(state, "skill-device:32:10");
 	struct player_class *c;
 
@@ -88,7 +88,7 @@ int test_skill_device0(void *state) {
 	ok;
 }
 
-int test_skill_save0(void *state) {
+static int test_skill_save0(void *state) {
 	enum parser_error r = parser_parse(state, "skill-save:28:10");
 	struct player_class *c;
 
@@ -100,7 +100,7 @@ int test_skill_save0(void *state) {
 	ok;
 }
 
-int test_skill_stealth0(void *state) {
+static int test_skill_stealth0(void *state) {
 	enum parser_error r = parser_parse(state, "skill-stealth:3:0");
 	struct player_class *c;
 
@@ -112,7 +112,7 @@ int test_skill_stealth0(void *state) {
 	ok;
 }
 
-int test_skill_search0(void *state) {
+static int test_skill_search0(void *state) {
 	enum parser_error r = parser_parse(state, "skill-search:24:0");
 	struct player_class *c;
 
@@ -124,7 +124,7 @@ int test_skill_search0(void *state) {
 	ok;
 }
 
-int test_skill_melee0(void *state) {
+static int test_skill_melee0(void *state) {
 	enum parser_error r = parser_parse(state, "skill-melee:56:30");
 	struct player_class *c;
 
@@ -136,7 +136,7 @@ int test_skill_melee0(void *state) {
 	ok;
 }
 
-int test_skill_shoot0(void *state) {
+static int test_skill_shoot0(void *state) {
 	enum parser_error r = parser_parse(state, "skill-shoot:72:45");
 	struct player_class *c;
 
@@ -148,7 +148,7 @@ int test_skill_shoot0(void *state) {
 	ok;
 }
 
-int test_skill_throw0(void *state) {
+static int test_skill_throw0(void *state) {
 	enum parser_error r = parser_parse(state, "skill-throw:72:45");
 	struct player_class *c;
 
@@ -160,7 +160,7 @@ int test_skill_throw0(void *state) {
 	ok;
 }
 
-int test_skill_dig0(void *state) {
+static int test_skill_dig0(void *state) {
 	enum parser_error r = parser_parse(state, "skill-dig:0:0");
 	struct player_class *c;
 
@@ -172,7 +172,7 @@ int test_skill_dig0(void *state) {
 	ok;
 }
 
-int test_hitdie0(void *state) {
+static int test_hitdie0(void *state) {
 	enum parser_error r = parser_parse(state, "hitdie:4");
 	struct player_class *c;
 
@@ -183,7 +183,7 @@ int test_hitdie0(void *state) {
 	ok;
 }
 
-int test_max_attacks0(void *state) {
+static int test_max_attacks0(void *state) {
 	enum parser_error r = parser_parse(state, "max-attacks:5");
 	struct player_class *c;
 
@@ -194,7 +194,7 @@ int test_max_attacks0(void *state) {
 	ok;
 }
 
-int test_min_weight0(void *state) {
+static int test_min_weight0(void *state) {
 	enum parser_error r = parser_parse(state, "min-weight:35");
 	struct player_class *c;
 
@@ -205,7 +205,7 @@ int test_min_weight0(void *state) {
 	ok;
 }
 
-int test_strength_multiplier0(void *state) {
+static int test_strength_multiplier0(void *state) {
 	enum parser_error r = parser_parse(state, "strength-multiplier:4");
 	struct player_class *c;
 
@@ -216,7 +216,7 @@ int test_strength_multiplier0(void *state) {
 	ok;
 }
 
-int test_title0(void *state) {
+static int test_title0(void *state) {
 	enum parser_error r0 = parser_parse(state, "title:Runner");
 	enum parser_error r1 = parser_parse(state, "title:Strider");
 	struct player_class *c;
@@ -230,7 +230,7 @@ int test_title0(void *state) {
 	ok;
 }
 
-int test_equip0(void *state) {
+static int test_equip0(void *state) {
 	enum parser_error r = parser_parse(state, "equip:magic book:2:2:5:none");
 	struct player_class *c;
 
@@ -245,7 +245,7 @@ int test_equip0(void *state) {
 	ok;
 }
 
-int test_flags0(void *state) {
+static int test_flags0(void *state) {
 	enum parser_error r = parser_parse(state, "player-flags:BLESS_WEAPON | CHOOSE_SPELLS");
 	struct player_class *c;
 
@@ -256,7 +256,7 @@ int test_flags0(void *state) {
 	ok;
 }
 
-int test_flags1(void *state) {
+static int test_flags1(void *state) {
 	enum parser_error r = parser_parse(state, "obj-flags:SEE_INVIS | IMPAIR_HP");
 	struct player_class *c;
 
@@ -267,7 +267,7 @@ int test_flags1(void *state) {
 	ok;
 }
 
-int test_magic0(void *state) {
+static int test_magic0(void *state) {
 	enum parser_error r = parser_parse(state, "magic:3:400:9");
 	struct player_class *c;
 

--- a/src/tests/parse/e-info.c
+++ b/src/tests/parse/e-info.c
@@ -21,13 +21,13 @@ int teardown_tests(void *state) {
 	return 0;
 }
 
-int test_order(void *state) {
+static int test_order(void *state) {
 	enum parser_error r = parser_parse(state, "info:4");
 	eq(r, PARSE_ERROR_MISSING_FIELD);
 	ok;
 }
 
-int test_name0(void *state) {
+static int test_name0(void *state) {
 	enum parser_error r = parser_parse(state, "name:of Resist Lightning");
 	struct ego_item *e;
 
@@ -38,7 +38,7 @@ int test_name0(void *state) {
 	ok;
 }
 
-int test_info0(void *state) {
+static int test_info0(void *state) {
 	enum parser_error r = parser_parse(state, "info:6:8");
 	struct ego_item *e;
 
@@ -50,7 +50,7 @@ int test_info0(void *state) {
 	ok;
 }
 
-int test_combat0(void *state) {
+static int test_combat0(void *state) {
 	enum parser_error r = parser_parse(state, "combat:1d2:3d4:5d6");
 	struct ego_item *e;
 
@@ -66,7 +66,7 @@ int test_combat0(void *state) {
 	ok;
 }
 
-int test_min0(void *state) {
+static int test_min0(void *state) {
 	enum parser_error r = parser_parse(state, "min-combat:10:13:4");
 	struct ego_item *e;
 
@@ -79,7 +79,7 @@ int test_min0(void *state) {
 	ok;
 }
 
-int test_flags0(void *state) {
+static int test_flags0(void *state) {
 	enum parser_error r = parser_parse(state, "flags:SEE_INVIS");
 	struct ego_item *e;
 
@@ -90,7 +90,7 @@ int test_flags0(void *state) {
 	ok;
 }
 
-int test_desc0(void *state) {
+static int test_desc0(void *state) {
 	enum parser_error r = parser_parse(state, "desc:foo");
 	struct ego_item *e;
 	eq(r, PARSE_ERROR_NONE);

--- a/src/tests/parse/f-info.c
+++ b/src/tests/parse/f-info.c
@@ -24,7 +24,7 @@ int teardown_tests(void *state) {
 	return 0;
 }
 
-int test_name0(void *state) {
+static int test_name0(void *state) {
 	enum parser_error r = parser_parse(state, "name:Test Feature");
 	struct feature *f;
 
@@ -35,7 +35,7 @@ int test_name0(void *state) {
 	ok;
 }
 
-int test_graphics0(void *state) {
+static int test_graphics0(void *state) {
 	enum parser_error r = parser_parse(state, "graphics:::red");
 	struct feature *f;
 
@@ -47,7 +47,7 @@ int test_graphics0(void *state) {
 	ok;
 }
 
-int test_mimic0(void *state) {
+static int test_mimic0(void *state) {
 	enum parser_error r = parser_parse(state, "mimic:marshmallow");
 	struct feature *f;
 
@@ -58,7 +58,7 @@ int test_mimic0(void *state) {
 	ok;
 }
 
-int test_priority0(void *state) {
+static int test_priority0(void *state) {
 	enum parser_error r = parser_parse(state, "priority:2");
 	struct feature *f;
 
@@ -69,7 +69,7 @@ int test_priority0(void *state) {
 	ok;
 }
 
-int test_flags0(void *state) {
+static int test_flags0(void *state) {
 	enum parser_error r = parser_parse(state, "flags:LOS | PERMANENT | DOWNSTAIR");
 	struct feature *f;
 
@@ -80,7 +80,7 @@ int test_flags0(void *state) {
 	ok;
 }
 
-int test_info0(void *state) {
+static int test_info0(void *state) {
 	enum parser_error r = parser_parse(state, "info:9:2");
 	struct feature *f;
 
@@ -92,7 +92,7 @@ int test_info0(void *state) {
 	ok;
 }
 
-int test_walk_msg0(void *state) {
+static int test_walk_msg0(void *state) {
 	enum parser_error r = parser_parse(state, "walk-msg:lookout ");
 	struct feature *f;
 
@@ -103,7 +103,7 @@ int test_walk_msg0(void *state) {
 	ok;
 }
 
-int test_run_msg0(void *state) {
+static int test_run_msg0(void *state) {
 	enum parser_error r = parser_parse(state, "run-msg:lookout! ");
 	struct feature *f;
 
@@ -114,7 +114,7 @@ int test_run_msg0(void *state) {
 	ok;
 }
 
-int test_hurt_msg0(void *state) {
+static int test_hurt_msg0(void *state) {
 	enum parser_error r = parser_parse(state, "hurt-msg:ow!");
 	struct feature *f;
 
@@ -125,7 +125,7 @@ int test_hurt_msg0(void *state) {
 	ok;
 }
 
-int test_die_msg0(void *state) {
+static int test_die_msg0(void *state) {
 	enum parser_error r = parser_parse(state, "die-msg:aargh");
 	struct feature *f;
 
@@ -136,7 +136,7 @@ int test_die_msg0(void *state) {
 	ok;
 }
 
-int test_resist_flag0(void *state) {
+static int test_resist_flag0(void *state) {
 	enum parser_error r = parser_parse(state, "resist-flag:IM_POIS");
 	struct feature *f;
 

--- a/src/tests/parse/flavor.c
+++ b/src/tests/parse/flavor.c
@@ -21,14 +21,14 @@ int teardown_tests(void *state) {
 	return 0;
 }
 
-int test_kind0(void *state) {
+static int test_kind0(void *state) {
 	enum parser_error r = parser_parse(state, "kind:light:&");
 
 	eq(r, PARSE_ERROR_NONE);
 	ok;
 }
 
-int test_flavor0(void *state) {
+static int test_flavor0(void *state) {
 	enum parser_error r = parser_parse(state, "flavor:2:blue:Fishy");
 	struct flavor *f;
 

--- a/src/tests/parse/graphics.c
+++ b/src/tests/parse/graphics.c
@@ -38,7 +38,7 @@ static void getmsg(game_event_type type, game_event_data *data, void *user) {
 	*error = true;
 }
 
-int test_prefs(void *state) {
+static int test_prefs(void *state) {
 	bool error = false;
 	graphics_mode *mode;
 
@@ -64,7 +64,7 @@ int test_prefs(void *state) {
 	ok;
 }
 
-int test_defaults(void *state) {
+static int test_defaults(void *state) {
 	size_t i;
 	struct monster_base *mb = lookup_monster_base("giant");
 	int tval = tval_find_idx("sword");

--- a/src/tests/parse/h-info.c
+++ b/src/tests/parse/h-info.c
@@ -19,7 +19,7 @@ int teardown_tests(void *state) {
 	return 0;
 }
 
-int test_chart0(void *state) {
+static int test_chart0(void *state) {
 	enum parser_error r = parser_parse(state, "chart:1:3:5");
 	struct history_chart *c;
 	struct history_entry *e;
@@ -36,7 +36,7 @@ int test_chart0(void *state) {
 	ok;
 }
 
-int test_phrase0(void *state) {
+static int test_phrase0(void *state) {
 	enum parser_error r = parser_parse(state, "phrase:hello there");
 	struct history_chart *h;
 

--- a/src/tests/parse/k-info.c
+++ b/src/tests/parse/k-info.c
@@ -21,7 +21,7 @@ int teardown_tests(void *state) {
 	return 0;
 }
 
-int test_name0(void *state) {
+static int test_name0(void *state) {
 	errr r = parser_parse(state, "name:Test Object Kind");
 	struct object_kind *k;
 
@@ -32,7 +32,7 @@ int test_name0(void *state) {
 	ok;
 }
 
-int test_graphics0(void *state) {
+static int test_graphics0(void *state) {
 	errr r = parser_parse(state, "graphics:~:red");
 	struct object_kind *k;
 
@@ -44,7 +44,7 @@ int test_graphics0(void *state) {
 	ok;
 }
 
-int test_graphics1(void *state) {
+static int test_graphics1(void *state) {
 	errr r = parser_parse(state, "graphics:!:W");
 	struct object_kind *k;
 
@@ -68,7 +68,7 @@ int test_type0(void *state) {
 	ok;
 }
 
-int test_level0(void *state) {
+static int test_level0(void *state) {
 	errr r = parser_parse(state, "level:10");
 	struct object_kind *k;
 
@@ -79,7 +79,7 @@ int test_level0(void *state) {
 	ok;
 }
 
-int test_weight0(void *state) {
+static int test_weight0(void *state) {
 	errr r = parser_parse(state, "weight:5");
 	struct object_kind *k;
 
@@ -90,7 +90,7 @@ int test_weight0(void *state) {
 	ok;
 }
 
-int test_cost0(void *state) {
+static int test_cost0(void *state) {
 	errr r = parser_parse(state, "cost:120");
 	struct object_kind *k;
 
@@ -101,7 +101,7 @@ int test_cost0(void *state) {
 	ok;
 }
 
-int test_alloc0(void *state) {
+static int test_alloc0(void *state) {
 	errr r = parser_parse(state, "alloc:3:4 to 6");
 	struct object_kind *k;
 
@@ -114,7 +114,7 @@ int test_alloc0(void *state) {
 	ok;
 }
 
-int test_attack0(void *state) {
+static int test_attack0(void *state) {
 	errr r = parser_parse(state, "attack:4d8:1d4:2d5");
 	struct object_kind *k;
 
@@ -130,7 +130,7 @@ int test_attack0(void *state) {
 	ok;
 }
 
-int test_armor0(void *state) {
+static int test_armor0(void *state) {
 	errr r = parser_parse(state, "armor:3:7d6");
 	struct object_kind *k;
 
@@ -143,7 +143,7 @@ int test_armor0(void *state) {
 	ok;
 }
 
-int test_charges0(void *state) {
+static int test_charges0(void *state) {
 	errr r = parser_parse(state, "charges:2d8");
 	struct object_kind *k;
 
@@ -155,7 +155,7 @@ int test_charges0(void *state) {
 	ok;
 }
 
-int test_pile0(void *state) {
+static int test_pile0(void *state) {
 	errr r = parser_parse(state, "pile:4:3d6");
 	struct object_kind *k;
 
@@ -168,7 +168,7 @@ int test_pile0(void *state) {
 	ok;
 }
 
-int test_flags0(void *state) {
+static int test_flags0(void *state) {
 	errr r = parser_parse(state, "flags:EASY_KNOW | FEATHER");
 	struct object_kind *k;
 
@@ -184,7 +184,7 @@ int test_flags0(void *state) {
 	ok;
 }
 
-int test_pval0(void *state) {
+static int test_pval0(void *state) {
 	errr r = parser_parse(state, "pval:1+2d3M4");
 	struct object_kind *k;
 
@@ -198,7 +198,7 @@ int test_pval0(void *state) {
 	ok;
 }
 
-int test_time0(void *state) {
+static int test_time0(void *state) {
 	errr r = parser_parse(state, "time:4d5");
 	struct object_kind *k;
 
@@ -210,7 +210,7 @@ int test_time0(void *state) {
 	ok;
 }
 
-int test_desc0(void *state) {
+static int test_desc0(void *state) {
 	errr r = parser_parse(state, "desc:foo bar");
 	struct object_kind *k;
 

--- a/src/tests/parse/k-info.c
+++ b/src/tests/parse/k-info.c
@@ -56,6 +56,7 @@ int test_graphics1(void *state) {
 	ok;
 }
 
+/* Without an initialization for the kb_info array, this crashes; so not run. */
 int test_type0(void *state) {
 	errr r = parser_parse(state, "type:food");
 	struct object_kind *k;
@@ -230,6 +231,7 @@ struct test tests[] = {
 	{ "name0", test_name0 },
 	{ "graphics0", test_graphics0 },
 	{ "graphics1", test_graphics1 },
+	/* { "type0", test_type0 }, */
 	{ "level0", test_level0 },
 	{ "weight0", test_weight0 },
 	{ "cost0", test_cost0 },

--- a/src/tests/parse/lore.c
+++ b/src/tests/parse/lore.c
@@ -23,7 +23,7 @@ static errr run_parse_monster(struct parser *p) {
 	return parse_file(p, "monster");
 }
 
-int test_lore_parse_monster_text(void *state) {
+static int test_lore_parse_monster_text(void *state) {
 
 	struct file_parser test_lore_perser = lore_parser;
 	test_lore_perser.run = run_parse_monster;

--- a/src/tests/parse/names.c
+++ b/src/tests/parse/names.c
@@ -27,13 +27,13 @@ int teardown_tests(void *state) {
 	return 0;
 }
 
-int test_section0(void *state) {
+static int test_section0(void *state) {
 	errr r = parser_parse(state, "section:1");
 	eq(r, 0);
 	ok;
 }
 
-int test_word0(void *state) {
+static int test_word0(void *state) {
 	errr r = parser_parse(state, "word:foo");
 	struct names_parse *s = parser_priv(state);
 	eq(r, 0);
@@ -47,13 +47,13 @@ int test_word0(void *state) {
 	ok;
 }
 
-int test_section1(void *state) {
+static int test_section1(void *state) {
 	errr r = parser_parse(state, "section:2");
 	eq(r, 0);
 	ok;
 }
 
-int test_word1(void *state) {
+static int test_word1(void *state) {
 	errr r = parser_parse(state, "word:baz");
 	struct names_parse *s = parser_priv(state);
 	eq(r, 0);

--- a/src/tests/parse/p-info.c
+++ b/src/tests/parse/p-info.c
@@ -18,7 +18,7 @@ int teardown_tests(void *state) {
 	return 0;
 }
 
-int test_name0(void *state) {
+static int test_name0(void *state) {
 	enum parser_error r = parser_parse(state, "name:Half-Elf");
 	struct player_race *pr;
 
@@ -29,7 +29,7 @@ int test_name0(void *state) {
 	ok;
 }
 
-int test_stats0(void *state) {
+static int test_stats0(void *state) {
 	enum parser_error r = parser_parse(state, "stats:1:-1:2:-2:3");
 	struct player_race *pr;
 
@@ -44,7 +44,7 @@ int test_stats0(void *state) {
 	ok;
 }
 
-int test_skill_disarm0(void *state) {
+static int test_skill_disarm0(void *state) {
 	enum parser_error r = parser_parse(state, "skill-disarm-magic:1");
 	struct player_race *pr;
 
@@ -55,7 +55,7 @@ int test_skill_disarm0(void *state) {
 	ok;
 }
 
-int test_skill_device0(void *state) {
+static int test_skill_device0(void *state) {
 	enum parser_error r = parser_parse(state, "skill-device:3");
 	struct player_race *pr;
 
@@ -66,7 +66,7 @@ int test_skill_device0(void *state) {
 	ok;
 }
 
-int test_skill_save0(void *state) {
+static int test_skill_save0(void *state) {
 	enum parser_error r = parser_parse(state, "skill-save:5");
 	struct player_race *pr;
 
@@ -77,7 +77,7 @@ int test_skill_save0(void *state) {
 	ok;
 }
 
-int test_skill_stealth0(void *state) {
+static int test_skill_stealth0(void *state) {
 	enum parser_error r = parser_parse(state, "skill-stealth:7");
 	struct player_race *pr;
 
@@ -88,7 +88,7 @@ int test_skill_stealth0(void *state) {
 	ok;
 }
 
-int test_skill_search0(void *state) {
+static int test_skill_search0(void *state) {
 	enum parser_error r = parser_parse(state, "skill-search:9");
 	struct player_race *pr;
 
@@ -99,7 +99,7 @@ int test_skill_search0(void *state) {
 	ok;
 }
 
-int test_skill_melee0(void *state) {
+static int test_skill_melee0(void *state) {
 	enum parser_error r = parser_parse(state, "skill-melee:4");
 	struct player_race *pr;
 
@@ -110,7 +110,7 @@ int test_skill_melee0(void *state) {
 	ok;
 }
 
-int test_skill_shoot0(void *state) {
+static int test_skill_shoot0(void *state) {
 	enum parser_error r = parser_parse(state, "skill-shoot:6");
 	struct player_race *pr;
 
@@ -121,7 +121,7 @@ int test_skill_shoot0(void *state) {
 	ok;
 }
 
-int test_skill_throw0(void *state) {
+static int test_skill_throw0(void *state) {
 	enum parser_error r = parser_parse(state, "skill-throw:8");
 	struct player_race *pr;
 
@@ -132,7 +132,7 @@ int test_skill_throw0(void *state) {
 	ok;
 }
 
-int test_skill_dig0(void *state) {
+static int test_skill_dig0(void *state) {
 	enum parser_error r = parser_parse(state, "skill-dig:10");
 	struct player_race *pr;
 
@@ -143,7 +143,7 @@ int test_skill_dig0(void *state) {
 	ok;
 }
 
-int test_hitdie0(void *state) {
+static int test_hitdie0(void *state) {
 	enum parser_error r = parser_parse(state, "hitdie:10");
 	struct player_race *pr;
 
@@ -154,7 +154,7 @@ int test_hitdie0(void *state) {
 	ok;
 }
 
-int test_exp0(void *state) {
+static int test_exp0(void *state) {
 	enum parser_error r = parser_parse(state, "exp:20");
 	struct player_race *pr;
 
@@ -165,7 +165,7 @@ int test_exp0(void *state) {
 	ok;
 }
 
-int test_infravision0(void *state) {
+static int test_infravision0(void *state) {
 	enum parser_error r = parser_parse(state, "infravision:80");
 	struct player_race *pr;
 
@@ -176,7 +176,7 @@ int test_infravision0(void *state) {
 	ok;
 }
 
-int test_history0(void *state) {
+static int test_history0(void *state) {
 	enum parser_error r = parser_parse(state, "history:0");
 	struct player_race *pr;
 
@@ -187,7 +187,7 @@ int test_history0(void *state) {
 	ok;
 }
 
-int test_age0(void *state) {
+static int test_age0(void *state) {
 	enum parser_error r = parser_parse(state, "age:10:3");
 	struct player_race *pr;
 
@@ -199,7 +199,7 @@ int test_age0(void *state) {
 	ok;
 }
 
-int test_height0(void *state) {
+static int test_height0(void *state) {
 	enum parser_error r = parser_parse(state, "height:10:2");
 	struct player_race *pr;
 
@@ -211,7 +211,7 @@ int test_height0(void *state) {
 	ok;
 }
 
-int test_weight0(void *state) {
+static int test_weight0(void *state) {
 	enum parser_error r = parser_parse(state, "weight:80:10");
 	struct player_race *pr;
 
@@ -223,7 +223,7 @@ int test_weight0(void *state) {
 	ok;
 }
 
-int test_obj_flags0(void *state) {
+static int test_obj_flags0(void *state) {
 	enum parser_error r = parser_parse(state, "obj-flags:SUST_DEX");
 	struct player_race *pr;
 
@@ -234,7 +234,7 @@ int test_obj_flags0(void *state) {
 	ok;
 }
 
-int test_play_flags0(void *state) {
+static int test_play_flags0(void *state) {
 	enum parser_error r = parser_parse(state, "player-flags:KNOW_ZAPPER");
 	struct player_race *pr;
 

--- a/src/tests/parse/parse.c
+++ b/src/tests/parse/parse.c
@@ -18,82 +18,82 @@ int teardown_tests(void *state) {
 	return 0;
 }
 
-int test_blank(void *state) {
+static int test_blank(void *state) {
 	eq(parser_parse(state, ""), PARSE_ERROR_NONE);
 	ok;
 }
 
-int test_spaces(void *state) {
+static int test_spaces(void *state) {
 	eq(parser_parse(state, "   "), PARSE_ERROR_NONE);
 	ok;
 }
 
-int test_comment0(void *state) {
+static int test_comment0(void *state) {
 	eq(parser_parse(state, "# foo"), PARSE_ERROR_NONE);
 	ok;
 }
 
-int test_comment1(void *state) {
+static int test_comment1(void *state) {
 	eq(parser_parse(state, "  # bar"), PARSE_ERROR_NONE);
 	ok;
 }
 
-int test_priv(void *state) {
+static int test_priv(void *state) {
 	ptreq(parser_priv(state), 0);
 	parser_setpriv(state, (void*)0x42);
 	ptreq(parser_priv(state), (void*)0x42);
 	ok;
 }
 
-int test_reg0(void *state) {
+static int test_reg0(void *state) {
 	errr r = parser_reg(state, "", ignored);
 	eq(r, -EINVAL);
 	ok;
 }
 
-int test_reg1(void *state) {
+static int test_reg1(void *state) {
 	errr r = parser_reg(state, " ", ignored);
 	eq(r, -EINVAL);
 	ok;
 }
 
-int test_reg2(void *state) {
+static int test_reg2(void *state) {
 	errr r = parser_reg(state, "abc int", ignored);
 	eq(r, -EINVAL);
 	ok;
 }
 
-int test_reg3(void *state) {
+static int test_reg3(void *state) {
 	errr r = parser_reg(state, "abc notype name", ignored);
 	eq(r, -EINVAL);
 	ok;
 }
 
-int test_reg4(void *state) {
+static int test_reg4(void *state) {
 	errr r = parser_reg(state, "abc int a ?int b int c", ignored);
 	eq(r, -EINVAL);
 	ok;
 }
 
-int test_reg5(void *state) {
+static int test_reg5(void *state) {
 	errr r = parser_reg(state, "abc str foo int bar", ignored);
 	eq(r, -EINVAL);
 	ok;
 }
 
-int test_reg_int(void *state) {
+static int test_reg_int(void *state) {
 	errr r = parser_reg(state, "test-reg-int int foo", ignored);
 	eq(r, 0);
 	ok;
 }
 
-int test_reg_sym(void *state) {
+static int test_reg_sym(void *state) {
 	errr r = parser_reg(state, "test-reg-sym sym bar", ignored);
 	eq(r, 0);
 	ok;
 }
 
-int test_reg_str(void *state) {
+static int test_reg_str(void *state) {
 	errr r = parser_reg(state, "test-reg-str str baz", ignored);
 	eq(r, 0);
 	ok;
@@ -108,7 +108,7 @@ static enum parser_error helper_sym0(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
-int test_sym0(void *state) {
+static int test_sym0(void *state) {
 	int wasok = 0;
 	errr r = parser_reg(state, "test-sym0 sym foo", helper_sym0);
 	eq(r, 0);
@@ -129,7 +129,7 @@ static enum parser_error helper_sym1(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
-int test_sym1(void *state) {
+static int test_sym1(void *state) {
 	int wasok = 0;
 	errr r = parser_reg(state, "test-sym1 sym foo sym baz", helper_sym1);
 	eq(r, 0);
@@ -148,7 +148,7 @@ static enum parser_error helper_int0(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
-int test_int0(void *state) {
+static int test_int0(void *state) {
 	int wasok = 0;
 	errr r = parser_reg(state, "test-int0 int i0 int i1", helper_int0);
 	eq(r, 0);
@@ -166,7 +166,7 @@ static enum parser_error helper_int1(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
-int test_int1(void *state) {
+static int test_int1(void *state) {
 	int wasok = 0;
 	errr r = parser_reg(state, "test-int1 int i0", helper_int1);
 	eq(r, 0);
@@ -186,7 +186,7 @@ static enum parser_error helper_str0(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
-int test_str0(void *state) {
+static int test_str0(void *state) {
 	int wasok = 0;
 	errr r = parser_reg(state, "test-str0 str s0", helper_str0);
 	eq(r, 0);
@@ -197,7 +197,7 @@ int test_str0(void *state) {
 	ok;
 }
 
-int test_syntax0(void *state) {
+static int test_syntax0(void *state) {
 	struct parser_state s;
 	int v;
 	errr r = parser_reg(state, "test-syntax0 str s0", ignored);
@@ -211,7 +211,7 @@ int test_syntax0(void *state) {
 	ok;
 }
 
-int test_syntax1(void *state) {
+static int test_syntax1(void *state) {
 	struct parser_state s;
 	int v;
 	errr r = parser_reg(state, "test-syntax1 int i0", ignored);
@@ -225,7 +225,7 @@ int test_syntax1(void *state) {
 	ok;
 }
 
-int test_syntax2(void *state) {
+static int test_syntax2(void *state) {
 	struct parser_state s;
 	int v;
 	errr r = parser_reg(state, "test-syntax2 int i0 sym s1", ignored);
@@ -239,7 +239,7 @@ int test_syntax2(void *state) {
 	ok;
 }
 
-int test_baddir(void *state) {
+static int test_baddir(void *state) {
 	errr r = parser_parse(state, "test-baddir");
 	eq(r, PARSE_ERROR_UNDEFINED_DIRECTIVE);
 	ok;
@@ -254,7 +254,7 @@ static enum parser_error helper_rand0(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
-int test_rand0(void *state) {
+static int test_rand0(void *state) {
 	int wasok = 0;
 	errr r = parser_reg(state, "test-rand0 rand r0", helper_rand0);
 	eq(r, 0);
@@ -275,7 +275,7 @@ static enum parser_error helper_rand1(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
-int test_rand1(void *state) {
+static int test_rand1(void *state) {
 	int wasok = 0;
 	errr r = parser_reg(state, "test-rand1 rand r0 rand r1", helper_rand1);
 	eq(r, 0);
@@ -299,7 +299,7 @@ static enum parser_error helper_opt0(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
-int test_opt0(void *state) {
+static int test_opt0(void *state) {
 	int wasok = 0;
 	errr r = parser_reg(state, "test-opt0 sym s0 ?sym s1", helper_opt0);
 	eq(r, 0);
@@ -326,7 +326,7 @@ static enum parser_error helper_uint0(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
-int test_uint0(void *state) {
+static int test_uint0(void *state) {
 	int wasok = 0;
 	errr r = parser_reg(state, "test-uint0 uint u0", helper_uint0);
 	enum parser_error e;
@@ -339,7 +339,7 @@ int test_uint0(void *state) {
 
 }
 
-int test_uint1(void *state) {
+static int test_uint1(void *state) {
 	errr r = parser_reg(state, "test-uint1 uint u0", ignored);
 	enum parser_error e = parser_parse(state, "test-uint1:-2");
 	eq(r, 0);
@@ -357,7 +357,7 @@ static enum parser_error helper_char0(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
-int test_char0(void *state) {
+static int test_char0(void *state) {
 	int wasok = 0;
 	errr r = parser_reg(state, "test-char0 char c", helper_char0);
 	enum parser_error e;
@@ -382,7 +382,7 @@ static enum parser_error helper_char1(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
-int test_char1(void *state) {
+static int test_char1(void *state) {
 	int wasok = 0;
 	errr r = parser_reg(state, "test-char1 char c0 int i0 char c1 str s", helper_char1);
 	enum parser_error e;

--- a/src/tests/parse/r-info.c
+++ b/src/tests/parse/r-info.c
@@ -156,6 +156,7 @@ int test_mexp0(void *state) {
 	ok;
 }
 
+/* Without initialization of the blow_methods array, this crashes so not run. */
 int test_blow0(void *state) {
 	enum parser_error r = parser_parse(state, "blow:CLAW:FIRE:9d12");
 	struct monster_race *mr;
@@ -170,6 +171,7 @@ int test_blow0(void *state) {
 	ok;
 }
 
+/* Without initialization of the blow_methods array, this crashes so not run. */
 int test_blow1(void *state) {
 	enum parser_error r = parser_parse(state, "blow:BITE:FIRE:6d8:0");
 	struct monster_race *mr;

--- a/src/tests/parse/r-info.c
+++ b/src/tests/parse/r-info.c
@@ -22,7 +22,7 @@ int teardown_tests(void *state) {
 	return 0;
 }
 
-int test_name0(void *state) {
+static int test_name0(void *state) {
 	enum parser_error r = parser_parse(state, "name:Carcharoth, the Jaws of Thirst");
 	struct monster_race *mr;
 
@@ -33,7 +33,7 @@ int test_name0(void *state) {
 	ok;
 }
 
-int test_base0(void *state) {
+static int test_base0(void *state) {
 	enum parser_error r;
 	struct monster_race *mr;
 
@@ -46,7 +46,7 @@ int test_base0(void *state) {
 	ok;
 }
 
-int test_color0(void *state) {
+static int test_color0(void *state) {
 	enum parser_error r = parser_parse(state, "color:v");
 	struct monster_race *mr;
 
@@ -57,7 +57,7 @@ int test_color0(void *state) {
 	ok;
 }
 
-int test_speed0(void *state) {
+static int test_speed0(void *state) {
 	enum parser_error r = parser_parse(state, "speed:7");
 	struct monster_race *mr;
 
@@ -68,7 +68,7 @@ int test_speed0(void *state) {
 	ok;
 }
 
-int test_hp0(void *state) {
+static int test_hp0(void *state) {
 	enum parser_error r = parser_parse(state, "hit-points:500");
 	struct monster_race *mr;
 
@@ -79,7 +79,7 @@ int test_hp0(void *state) {
 	ok;
 }
 
-int test_hearing0(void *state) {
+static int test_hearing0(void *state) {
 	enum parser_error r = parser_parse(state, "hearing:80");
 	struct monster_race *mr;
 
@@ -90,7 +90,7 @@ int test_hearing0(void *state) {
 	ok;
 }
 
-int test_smell0(void *state) {
+static int test_smell0(void *state) {
 	enum parser_error r = parser_parse(state, "smell:30");
 	struct monster_race *mr;
 
@@ -101,7 +101,7 @@ int test_smell0(void *state) {
 	ok;
 }
 
-int test_ac0(void *state) {
+static int test_ac0(void *state) {
 	enum parser_error r = parser_parse(state, "armor-class:22");
 	struct monster_race *mr;
 
@@ -112,7 +112,7 @@ int test_ac0(void *state) {
 	ok;
 }
 
-int test_sleep0(void *state) {
+static int test_sleep0(void *state) {
 	enum parser_error r = parser_parse(state, "sleepiness:3");
 	struct monster_race *mr;
 
@@ -123,7 +123,7 @@ int test_sleep0(void *state) {
 	ok;
 }
 
-int test_depth0(void *state) {
+static int test_depth0(void *state) {
 	enum parser_error r = parser_parse(state, "depth:42");
 	struct monster_race *mr;
 
@@ -134,7 +134,7 @@ int test_depth0(void *state) {
 	ok;
 }
 
-int test_rarity0(void *state) {
+static int test_rarity0(void *state) {
 	enum parser_error r = parser_parse(state, "rarity:11");
 	struct monster_race *mr;
 
@@ -145,7 +145,7 @@ int test_rarity0(void *state) {
 	ok;
 }
 
-int test_mexp0(void *state) {
+static int test_mexp0(void *state) {
 	enum parser_error r = parser_parse(state, "experience:4");
 	struct monster_race *mr;
 
@@ -186,7 +186,7 @@ int test_blow1(void *state) {
 	ok;
 }
 
-int test_flags0(void *state) {
+static int test_flags0(void *state) {
 	enum parser_error r = parser_parse(state, "flags:UNIQUE | MALE");
 	struct monster_race *mr;
 
@@ -197,7 +197,7 @@ int test_flags0(void *state) {
 	ok;
 }
 
-int test_desc0(void *state) {
+static int test_desc0(void *state) {
 	enum parser_error r = parser_parse(state, "desc:foo bar ");
 	enum parser_error s = parser_parse(state, "desc: baz");
 	struct monster_race *mr;
@@ -210,7 +210,7 @@ int test_desc0(void *state) {
 	ok;
 }
 
-int test_innate_freq0(void *state) {
+static int test_innate_freq0(void *state) {
 	enum parser_error r = parser_parse(state, "innate-freq:10");
 	struct monster_race *mr;
 
@@ -221,7 +221,7 @@ int test_innate_freq0(void *state) {
 	ok;
 }
 
-int test_spell_freq0(void *state) {
+static int test_spell_freq0(void *state) {
 	enum parser_error r = parser_parse(state, "spell-freq:4");
 	struct monster_race *mr;
 
@@ -232,7 +232,7 @@ int test_spell_freq0(void *state) {
 	ok;
 }
 
-int test_spells0(void *state) {
+static int test_spells0(void *state) {
 	enum parser_error r = parser_parse(state, "spells:BR_DARK | S_HOUND");
 	struct monster_race *mr;
 

--- a/src/tests/parse/readstore.c
+++ b/src/tests/parse/readstore.c
@@ -63,7 +63,7 @@ int test_owner0(void *state) {
 	ok;
 }
 
-/* Causes segfault: lookup_name() requires z_info/k_info */
+/* Without initialization of the svals, fails with an unrecognised sval. */
 int test_i0(void *state) {
 	enum parser_error r = parser_parse(state, "normal:3:5");
 	struct store *s;

--- a/src/tests/parse/readstore.c
+++ b/src/tests/parse/readstore.c
@@ -28,7 +28,7 @@ int teardown_tests(void *state) {
 	return 0;
 }
 
-int test_store0(void *state) {
+static int test_store0(void *state) {
 	enum parser_error r = parser_parse(state, "store:1:foobar");
 	struct store *s;
 
@@ -40,7 +40,7 @@ int test_store0(void *state) {
 	ok;
 }
 
-int test_slots0(void *state) {
+static int test_slots0(void *state) {
 	enum parser_error r = parser_parse(state, "slots:2:33");
 	struct store *s;
 
@@ -52,7 +52,7 @@ int test_slots0(void *state) {
 	ok;
 }
 
-int test_owner0(void *state) {
+static int test_owner0(void *state) {
 	enum parser_error r = parser_parse(state, "owner:5000:Foo");
 	struct store *s;
 

--- a/src/tests/parse/v-info.c
+++ b/src/tests/parse/v-info.c
@@ -22,7 +22,7 @@ int teardown_tests(void *state) {
 	return 0;
 }
 
-int test_name0(void *state) {
+static int test_name0(void *state) {
 	enum parser_error r = parser_parse(state, "name:round");
 	struct vault *v;
 
@@ -33,7 +33,7 @@ int test_name0(void *state) {
 	ok;
 }
 
-int test_typ0(void *state) {
+static int test_typ0(void *state) {
 	enum parser_error r = parser_parse(state, "type:Lesser vault");
 	struct vault *v;
 
@@ -44,7 +44,7 @@ int test_typ0(void *state) {
 	ok;
 }
 
-int test_rat0(void *state) {
+static int test_rat0(void *state) {
 	enum parser_error r = parser_parse(state, "rating:5");
 	struct vault *v;
 
@@ -55,7 +55,7 @@ int test_rat0(void *state) {
 	ok;
 }
 
-int test_hgt0(void *state) {
+static int test_hgt0(void *state) {
 	enum parser_error r = parser_parse(state, "rows:12");
 	struct vault *v;
 
@@ -66,7 +66,7 @@ int test_hgt0(void *state) {
 	ok;
 }
 
-int test_wid0(void *state) {
+static int test_wid0(void *state) {
 	enum parser_error r = parser_parse(state, "columns:6");
 	struct vault *v;
 
@@ -77,7 +77,7 @@ int test_wid0(void *state) {
 	ok;
 }
 
-int test_min_lev0(void *state) {
+static int test_min_lev0(void *state) {
 	enum parser_error r = parser_parse(state, "min-depth:15");
 	struct vault *v;
 
@@ -88,7 +88,7 @@ int test_min_lev0(void *state) {
 	ok;
 }
 
-int test_max_lev0(void *state) {
+static int test_max_lev0(void *state) {
 	enum parser_error r = parser_parse(state, "max-depth:25");
 	struct vault *v;
 
@@ -99,7 +99,7 @@ int test_max_lev0(void *state) {
 	ok;
 }
 
-int test_d0(void *state) {
+static int test_d0(void *state) {
 	enum parser_error r0 = parser_parse(state, "D:  %%  ");
 	enum parser_error r1 = parser_parse(state, "D: %  % ");
 	struct vault *v;

--- a/src/tests/parse/z-info.c
+++ b/src/tests/parse/z-info.c
@@ -18,20 +18,20 @@ int teardown_tests(void *state) {
 	return 0;
 }
 
-int test_negative(void *state) {
+static int test_negative(void *state) {
 	errr r = parser_parse(state, "level-max:F:-1");
 	eq(r, PARSE_ERROR_INVALID_VALUE);
 	ok;
 }
 
-int test_badmax(void *state) {
+static int test_badmax(void *state) {
 	errr r = parser_parse(state, "level-max:D:1");
 	eq(r, PARSE_ERROR_UNDEFINED_DIRECTIVE);
 	ok;
 }
 
 #define TEST_MAX(l,u) \
-	int test_##l(void *s) { \
+	static int test_##l(void *s) { \
 		struct angband_constants *m = parser_priv(s); \
 		char buf[64]; \
 		errr r; \
@@ -45,7 +45,7 @@ int test_badmax(void *state) {
 TEST_MAX(level_monster_max, "monsters")
 
 #define TEST_MON(l,u) \
-	int test_##l(void *s) { \
+	static int test_##l(void *s) { \
 		struct angband_constants *m = parser_priv(s); \
 		char buf[64]; \
 		errr r; \

--- a/src/tests/player/birth.c
+++ b/src/tests/player/birth.c
@@ -33,7 +33,7 @@ int teardown_tests(void *state) {
 	return 0;
 }
 
-int test_generate0(void *state) {
+static int test_generate0(void *state) {
 	struct player *p = state;
 	player_generate(p, &test_race, &test_class, false);
 	eq(p->lev, 1);

--- a/src/tests/player/calc-inventory.c
+++ b/src/tests/player/calc-inventory.c
@@ -487,7 +487,7 @@ static int test_calc_inventory_oversubscribed_quiver(void *state) {
 			{ TV_SHOT, 1, 25, true, false },
 			{ TV_BOLT, 2, 12, true, false },
 			{ TV_SHOT, 3, 17, true, false },
-			{ -1, -1, -1 }
+			{ -1, -1, -1, false, false }
 		},
 		{
 			{ TV_SHOT, 2, 40 },
@@ -601,8 +601,8 @@ static int test_calc_inventory_oversubscribed_quiver_slot(void *state) {
 static int test_calc_inventory_quiver_split_pile(void *state) {
 	struct simple_test_case this_test_case = {
 		{
-			{ TV_FLASK, 1, 10 },
-			{ -1, -1, -1 }
+			{ TV_FLASK, 1, 10, false, false },
+			{ -1, -1, -1, false, false }
 		},
 		{
 			{ TV_FLASK, 1, 2 },

--- a/src/tests/player/history.c
+++ b/src/tests/player/history.c
@@ -55,7 +55,7 @@ int setup_tests(void **state) {
 	return 0;
 }
 
-int test_0(void *state) {
+static int test_0(void *state) {
 	int i;
 	for (i = 0; i < 100; i++) {
 		char *h = get_history(&ca);

--- a/src/tests/player/pathfind.c
+++ b/src/tests/player/pathfind.c
@@ -7,7 +7,7 @@
 NOSETUP
 NOTEARDOWN
 
-int test_dir_to(void *state) {
+static int test_dir_to(void *state) {
 	eq(pathfind_direction_to(loc(0,0), loc(0,1)), DIR_S);
 	eq(pathfind_direction_to(loc(0,0), loc(1,0)), DIR_E);
 	eq(pathfind_direction_to(loc(0,0), loc(1,1)), DIR_SE);

--- a/src/tests/player/playerstat.c
+++ b/src/tests/player/playerstat.c
@@ -31,7 +31,7 @@ int teardown_tests(void *state) {
 	return 0;
 }
 
-int test_stat_inc(void *state) {
+static int test_stat_inc(void *state) {
 	struct player *p = state;
 	int v;
 
@@ -50,7 +50,7 @@ int test_stat_inc(void *state) {
 	ok;
 }
 
-int test_stat_dec(void *state) {
+static int test_stat_dec(void *state) {
 	struct player *p = state;
 	int v;
 

--- a/src/tests/test-utils.c
+++ b/src/tests/test-utils.c
@@ -9,6 +9,7 @@
 #include "h-basic.h"
 #include "config.h"
 #include "init.h"
+#include "test-utils.h"
 #include "z-util.h"
 
 #ifdef SOUND_SDL

--- a/src/tests/trivial/trivial.c
+++ b/src/tests/trivial/trivial.c
@@ -5,11 +5,11 @@
 NOSETUP
 NOTEARDOWN
 
-int test_empty(void *state) {
+static int test_empty(void *state) {
 	ok;
 }
 
-int test_require(void *state) {
+static int test_require(void *state) {
 	require(1);
 	ok;
 }

--- a/src/tests/unit-test.c
+++ b/src/tests/unit-test.c
@@ -6,15 +6,10 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include "unit-test-types.h"
+#include "unit-test.h"
 #include "z-util.h"
 
 int verbose = 0;
-
-extern const char *suite_name;
-extern struct test tests[];
-extern int setup_tests(void **data);
-extern int teardown_tests(void *data);
 
 int main(int argc, char *argv[]) {
 	void *state;

--- a/src/tests/unit-test.h
+++ b/src/tests/unit-test.h
@@ -13,11 +13,22 @@ extern int verbose;
 extern int showpass(void);
 extern int showfail(void);
 
-/* Forward declaration, since suite_names may be at the end of the test
- * file.
+/* Forward declaration for string provided by the test case but expected by
+ * unit-test.c and the macros declared here.
  */
-const char *suite_name; 
+extern const char *suite_name;
 
+/* Forward declaration for the test case array provided by the test case but
+ * expected by unit-test.c.
+ */
+extern struct test tests[];
+
+/* Provided by the test case and called by unit-test.c.  If a test case
+ * does not need setup or teardown use the NOSETUP or NOTEARDOWN macros
+ * in the test case to provide the functions unit-test.c wants.
+ */
+extern int setup_tests(void **data);
+extern int teardown_tests(void *data);
 #define NOSETUP int setup_tests(void **data) { return 0; }
 #define NOTEARDOWN int teardown_tests(void *data) { return 0; }
 

--- a/src/tests/z-dice/dice.c
+++ b/src/tests/z-dice/dice.c
@@ -6,7 +6,7 @@
 NOSETUP
 NOTEARDOWN
 
-int test_alloc(void *state)
+static int test_alloc(void *state)
 {
 	dice_t *new = dice_new();
 	require(new != NULL);
@@ -14,7 +14,7 @@ int test_alloc(void *state)
 	ok;
 }
 
-int test_parse_success(void *state)
+static int test_parse_success(void *state)
 {
 	dice_t *new = dice_new();
 
@@ -122,7 +122,7 @@ int test_parse_success(void *state)
 	ok;
 }
 
-int test_parse_failure(void *state)
+static int test_parse_failure(void *state)
 {
 	dice_t *new = dice_new();
 
@@ -160,12 +160,12 @@ int test_parse_failure(void *state)
 	ok;
 }
 
-s32b test_evaluate_base(void)
+static s32b test_evaluate_base(void)
 {
 	return 3;
 }
 
-int test_evaluate(void *state)
+static int test_evaluate(void *state)
 {
 	int value = 0;
 	expression_t *expression = expression_new();

--- a/src/tests/z-expression/expression.c
+++ b/src/tests/z-expression/expression.c
@@ -6,7 +6,7 @@
 NOSETUP
 NOTEARDOWN
 
-int test_alloc(void *state)
+static int test_alloc(void *state)
 {
 	expression_t *new = expression_new();
 	expression_t *copy;
@@ -21,7 +21,7 @@ int test_alloc(void *state)
 	ok;
 }
 
-int test_parse_success(void *state)
+static int test_parse_success(void *state)
 {
 	int result = 0;
 	expression_t *new = expression_new()	;
@@ -74,7 +74,7 @@ int test_parse_success(void *state)
 	ok;
 }
 
-int test_parse_failure(void *state)
+static int test_parse_failure(void *state)
 {
 	int result = 0;
 	expression_t *new = expression_new();
@@ -126,7 +126,7 @@ static s32b base_value_2(void)
 	return 9;
 }
 
-int test_evaluate(void *state)
+static int test_evaluate(void *state)
 {
 	expression_t *new = expression_new();
 

--- a/src/tests/z-quark/quark.c
+++ b/src/tests/z-quark/quark.c
@@ -13,7 +13,7 @@ int teardown_tests(void *state) {
 	return 0;
 }
 
-int test_alloc(void *state) {
+static int test_alloc(void *state) {
 	quark_t q1 = quark_add("0-foo");
 	quark_t q2 = quark_add("0-bar");
 	quark_t q3 = quark_add("0-baz");
@@ -29,7 +29,7 @@ int test_alloc(void *state) {
 	ok;
 }
 
-int test_dedup(void *state) {
+static int test_dedup(void *state) {
 	quark_t q1 = quark_add("1-foo");
 	quark_t q2 = quark_add("1-foo");
 	quark_t q3 = quark_add("1-bar");

--- a/src/tests/z-textblock/textblock.c
+++ b/src/tests/z-textblock/textblock.c
@@ -12,7 +12,7 @@ int teardown_tests(void *state) {
 	ok;
 }
 
-int test_alloc(void *state) {
+static int test_alloc(void *state) {
 	textblock *tb = textblock_new();
 
 	require(tb);
@@ -22,7 +22,7 @@ int test_alloc(void *state) {
 	ok;
 }
 
-int test_append(void *state) {
+static int test_append(void *state) {
 	textblock *tb = textblock_new();
 
 	require(!wcscmp(textblock_text(tb), L""));
@@ -38,7 +38,7 @@ int test_append(void *state) {
 	ok;
 }
 
-int test_colour(void *state) {
+static int test_colour(void *state) {
 	textblock *tb = textblock_new();
 
 	const char text[] = "two";
@@ -53,7 +53,7 @@ int test_colour(void *state) {
 	ok;
 }
 
-int test_length(void *state) {
+static int test_length(void *state) {
 	textblock *tb = textblock_new();
 
 	const char text[] = "1234567";
@@ -81,7 +81,7 @@ int test_length(void *state) {
 	ok;
 }
 
-int test_append_textblock(void *state) {
+static int test_append_textblock(void *state) {
 	const byte attrs[] = { COLOUR_L_BLUE, COLOUR_L_BLUE, COLOUR_L_BLUE,
 		COLOUR_L_GREEN, COLOUR_L_GREEN, COLOUR_L_GREEN, COLOUR_L_GREEN };
 	textblock *tb1 = textblock_new();

--- a/src/tests/z-util/util.c
+++ b/src/tests/z-util/util.c
@@ -11,7 +11,7 @@ int teardown_tests(void *state) {
 	return 0;
 }
 
-int test_alloc(void *state) {
+static int test_alloc(void *state) {
 	char buffer[64];
 
 	/* Check it functions at all */
@@ -41,7 +41,7 @@ int test_alloc(void *state) {
 	ok;
 }
 
-int test_utf8_fskip(void *state) {
+static int test_utf8_fskip(void *state) {
 	/*
 	 * dollar sign (U+0024; 1 byte as UTF-8), cent sign (U+00A2; 2 bytes
 	 * as UTF-8)), euro sign (U+20AC; 3 bytes as UTF-8), gothic letter
@@ -83,7 +83,7 @@ int test_utf8_fskip(void *state) {
 	ok;
 }
 
-int test_utf8_rskip(void *state) {
+static int test_utf8_rskip(void *state) {
 	/*
 	 * dollar sign (U+0024; 1 byte as UTF-8), cent sign (U+00A2; 2 bytes
 	 * as UTF-8)), euro sign (U+20AC; 3 bytes as UTF-8), gothic letter
@@ -117,7 +117,7 @@ int test_utf8_rskip(void *state) {
 	ok;
 }
 
-int test_utf32_to_utf8(void *state) {
+static int test_utf32_to_utf8(void *state) {
 	/*
 	 * dollar sign (U+0024; 1 byte as UTF-8), cent sign (U+00A2; 2 bytes
 	 * as UTF-8)), euro sign (U+20AC; 3 bytes as UTF-8), gothic letter

--- a/src/tests/z-virt/mem.c
+++ b/src/tests/z-virt/mem.c
@@ -6,7 +6,7 @@
 NOSETUP
 NOTEARDOWN
 
-int test_alloc(void *state) {
+static int test_alloc(void *state) {
 	void *p1 = mem_alloc(16);
 	void *p2 = mem_alloc(16);
 	require(p1 != p2);
@@ -17,7 +17,7 @@ int test_alloc(void *state) {
 	return 0;
 }
 
-int test_realloc(void *state) {
+static int test_realloc(void *state) {
 	void *p1 = mem_realloc(NULL, 32);
 	void *p2 = mem_realloc(p1, 64);
 	memset(p2, 0x3, 64);

--- a/src/tests/z-virt/string.c
+++ b/src/tests/z-virt/string.c
@@ -6,7 +6,7 @@
 NOSETUP
 NOTEARDOWN
 
-int test_string_make(void *state) {
+static int test_string_make(void *state) {
 	char *s1 = string_make("foo");
 	require(s1);
 	require(!strcmp(s1, "foo"));
@@ -14,18 +14,18 @@ int test_string_make(void *state) {
 	ok;
 }
 
-int test_string_make_null(void *state) {
+static int test_string_make_null(void *state) {
 	char *s1 = string_make(NULL);
 	require(!s1);
 	ok;
 }
 
-int test_string_free_null(void *state) {
+static int test_string_free_null(void *state) {
 	string_free(NULL);
 	ok;
 }
 
-int test_string_append(void *state) {
+static int test_string_append(void *state) {
 	char *s1 = string_make("foo");
 	char *s3 = string_append(s1, "bar");
 
@@ -36,7 +36,7 @@ int test_string_append(void *state) {
 	ok;
 }
 
-int test_string_append_null0(void *state) {
+static int test_string_append_null0(void *state) {
 	char *r = string_append(NULL, "foo");
 	require(r);
 	require(!strcmp(r, "foo"));
@@ -44,7 +44,7 @@ int test_string_append_null0(void *state) {
 	ok;
 }
 
-int test_string_append_null1(void *state) {
+static int test_string_append_null1(void *state) {
 	char *s = string_make("bar");
 	char *r = string_append(s, NULL);
 	require(r);
@@ -53,7 +53,7 @@ int test_string_append_null1(void *state) {
 	ok;
 }
 
-int test_string_append_null2(void *state) {
+static int test_string_append_null2(void *state) {
 	char *r = string_append(NULL, NULL);
 	require(!r);
 	ok;


### PR DESCRIPTION
Most of those changes are to get rid of warnings if -Wmissing-prototypes is used.