### PR TITLE
Allow targeting the closest to pick up a target outside the current panel

### DIFF
--- a/src/target.c
+++ b/src/target.c
@@ -20,6 +20,7 @@
 #include "cave.h"
 #include "cmd-core.h"
 #include "game-input.h"
+#include "init.h"
 #include "mon-desc.h"
 #include "mon-util.h"
 #include "monster.h"
@@ -424,14 +425,22 @@ bool target_sighted(void)
 /**
  * Return a target set of target_able monsters.
  */
-struct point_set *target_get_monsters(int mode, monster_predicate pred)
+struct point_set *target_get_monsters(int mode, monster_predicate pred,
+		bool restrict_to_panel)
 {
 	int y, x;
 	int min_y, min_x, max_y, max_x;
 	struct point_set *targets = point_set_new(TS_INITIAL_SIZE);
 
-	/* Get the current panel */
-	get_panel(&min_y, &min_x, &max_y, &max_x);
+	if (restrict_to_panel) {
+		/* Get the current panel */
+		get_panel(&min_y, &min_x, &max_y, &max_x);
+	} else {
+		min_y = player->grid.y - z_info->max_range;
+		max_y = player->grid.y + z_info->max_range + 1;
+		min_x = player->grid.x - z_info->max_range;
+		max_x = player->grid.x + z_info->max_range + 1;
+	}
 
 	/* Scan for targets */
 	for (y = min_y; y < max_y; y++) {
@@ -482,7 +491,7 @@ bool target_set_closest(int mode, monster_predicate pred)
 	target_set_monster(NULL);
 
 	/* Get ready to do targetting */
-	targets = target_get_monsters(mode, pred);
+	targets = target_get_monsters(mode, pred, false);
 
 	/* If nothing was prepared, then return */
 	if (point_set_size(targets) < 1) {

--- a/src/target.h
+++ b/src/target.h
@@ -56,7 +56,8 @@ void coords_desc(char *buf, int size, int y, int x);
 void target_get(struct loc *grid);
 struct monster *target_get_monster(void);
 bool target_sighted(void);
-struct point_set *target_get_monsters(int mode, monster_predicate pred);
+struct point_set *target_get_monsters(int mode, monster_predicate pred,
+	bool restrict_to_panel);
 bool target_set_closest(int mode, monster_predicate pred);
 
 #endif /* !TARGET_H */

--- a/src/ui-target.c
+++ b/src/ui-target.c
@@ -978,7 +978,7 @@ bool target_set_interactive(int mode, int x, int y)
 	prt("Press '?' for help.", help_prompt_loc, 0);
 
 	/* Prepare the target set */
-	targets = target_get_monsters(mode, NULL);
+	targets = target_get_monsters(mode, NULL, true);
 
 	/* Start near the player */
 	m = 0;
@@ -1211,7 +1211,7 @@ bool target_set_interactive(int mode, int x, int y)
 					if (change_panel(d)) {
 						/* Recalculate interesting grids */
 						point_set_dispose(targets);
-						targets = target_get_monsters(mode, NULL);
+						targets = target_get_monsters(mode, NULL, true);
 
 						/* Find a new monster */
 						i = target_pick(old_y, old_x, ddy[d], ddx[d], targets);
@@ -1220,7 +1220,7 @@ bool target_set_interactive(int mode, int x, int y)
 						if ((i < 0) && modify_panel(Term, old_wy, old_wx)) {
 							/* Recalculate interesting grids */
 							point_set_dispose(targets);
-							targets = target_get_monsters(mode, NULL);
+							targets = target_get_monsters(mode, NULL, true);
 						}
 
 						/* Handle stuff */
@@ -1323,7 +1323,7 @@ bool target_set_interactive(int mode, int x, int y)
 
 						/* Recalculate interesting grids */
 						point_set_dispose(targets);
-						targets = target_get_monsters(mode, NULL);
+						targets = target_get_monsters(mode, NULL, true);
 					}
 
 					if (square_monster(cave, loc(x, y)) ||
@@ -1469,7 +1469,7 @@ bool target_set_interactive(int mode, int x, int y)
 
 					/* Recalculate interesting grids */
 					point_set_dispose(targets);
-					targets = target_get_monsters(mode, NULL);
+					targets = target_get_monsters(mode, NULL, true);
 				}
 			}
 		}


### PR DESCRIPTION
Addresses Sky's request here, http://angband.oook.cz/forum/showthread.php?t=10742 .  Doesn't address whether that can be applied in target_set_interactive():  since it's already refreshing the target list after a panel change it still limits the target list to the current panel.