### PR TITLE
Call wipe_mon_list() during test teardown if the test setup used …

### DIFF
--- a/src/tests/effects/chain.c
+++ b/src/tests/effects/chain.c
@@ -12,6 +12,7 @@
 #include "effects-info.h"
 #include "game-world.h"
 #include "init.h"
+#include "mon-make.h"
 #include "player.h"
 #include "player-birth.h"
 #include "player-calcs.h"
@@ -39,6 +40,7 @@ int setup_tests(void **state) {
 }
 
 int teardown_tests(void *state) {
+	wipe_mon_list(cave, player);
 	cleanup_angband();
 	return 0;
 }

--- a/src/tests/player/calc-inventory.c
+++ b/src/tests/player/calc-inventory.c
@@ -6,6 +6,7 @@
 #include "cave.h"
 #include "game-world.h"
 #include "init.h"
+#include "mon-make.h"
 #include "obj-gear.h"
 #include "obj-knowledge.h"
 #include "obj-make.h"
@@ -48,6 +49,7 @@ int setup_tests(void **state) {
 }
 
 int teardown_tests(void *state) {
+	wipe_mon_list(cave, player);
 	cleanup_angband();
 
 	return 0;

--- a/src/tests/player/inven-wield.c
+++ b/src/tests/player/inven-wield.c
@@ -7,6 +7,7 @@
 #include "effects.h"
 #include "game-world.h"
 #include "init.h"
+#include "mon-make.h"
 #include "obj-curse.h"
 #include "obj-gear.h"
 #include "obj-knowledge.h"
@@ -201,6 +202,7 @@ int setup_tests(void **state) {
 }
 
 int teardown_tests(void *state) {
+	wipe_mon_list(cave, player);
 	cleanup_angband();
 
 	return 0;


### PR DESCRIPTION
…prepare_next_level().  That avoids valgrind complaining about leaks of monster group information.