### PR TITLE
Add to the core game's cleanup to avoid valgrind warnings when running some test cases

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -3991,4 +3991,5 @@ void cleanup_angband(void)
 	string_free(ANGBAND_DIR_SAVE);
 	string_free(ANGBAND_DIR_SCORES);
 	string_free(ANGBAND_DIR_INFO);
+	string_free(ANGBAND_DIR_ARCHIVE);
 }

--- a/src/player-birth.c
+++ b/src/player-birth.c
@@ -1282,6 +1282,12 @@ void do_cmd_accept_character(struct command *cmd)
 	/* Disable repeat command, so we don't try to be born again */
 	cmd_disable_repeat();
 
+	/* No longer need the cached history. */
+	string_free(prev.history);
+	prev.history = NULL;
+	string_free(quickstart_prev.history);
+	quickstart_prev.history = NULL;
+
 	/* Now we're really done.. */
 	event_signal(EVENT_LEAVE_BIRTH);
 }


### PR DESCRIPTION
1. Free ANGBAND_DIR_ARCHIVE in cleanup_angband().
2. Release cached player histories from the birth process when the character is accepted.