### PR TITLE
In the game/basic test add cleanup before reloads and a call to wipe_mon_list() in the teardown

### DIFF
--- a/src/tests/game/basic.c
+++ b/src/tests/game/basic.c
@@ -10,6 +10,7 @@
 #include "game-event.h"
 #include "game-world.h"
 #include "init.h"
+#include "mon-make.h"
 #include "savefile.h"
 #include "player.h"
 #include "player-birth.h"
@@ -22,6 +23,15 @@ static void event_message(game_event_type type, game_event_data *data, void *use
 
 static void println(const char *str) {
 	printf("%s\n", str);
+}
+
+static void reset_before_load(void) {
+	play_again = true;
+	wipe_mon_list(cave, player);
+	cleanup_angband();
+	chunk_list_max = 0;
+	init_angband();
+	play_again = false;
 }
 
 int setup_tests(void **state) {
@@ -41,6 +51,7 @@ int setup_tests(void **state) {
 
 int teardown_tests(void *state) {
 	file_delete("Test1");
+	wipe_mon_list(cave, player);
 	cleanup_angband();
 	return 0;
 }
@@ -67,6 +78,7 @@ static int test_newgame(void *state) {
 }
 
 static int test_loadgame(void *state) {
+	reset_before_load();
 
 	/* Try loading the just-saved game */
 	eq(savefile_load("Test1", false), true);
@@ -80,6 +92,7 @@ static int test_loadgame(void *state) {
 }
 
 static int test_stairs1(void *state) {
+	reset_before_load();
 
 	/* Load the saved game */
 	eq(savefile_load("Test1", false), true);
@@ -92,6 +105,7 @@ static int test_stairs1(void *state) {
 }
 
 static int test_stairs2(void *state) {
+	reset_before_load();
 
 	/* Load the saved game */
 	eq(savefile_load("Test1", false), true);
@@ -110,6 +124,7 @@ static int test_stairs2(void *state) {
 }
 
 static int test_drop_pickup(void *state) {
+	reset_before_load();
 
 	/* Load the saved game */
 	eq(savefile_load("Test1", false), true);
@@ -133,6 +148,8 @@ static int test_drop_pickup(void *state) {
 
 static int test_drop_eat(void *state) {
 	int num = 0;
+
+	reset_before_load();
 
 	/* Load the saved game */
 	eq(savefile_load("Test1", false), true);


### PR DESCRIPTION
That's to avoid memory leak warnings when run under valgrind.