### PR TITLE
Allow classic, cavern, and lair levels when using persistent levels

### DIFF
--- a/lib/gamedata/dungeon_profile.txt
+++ b/lib/gamedata/dungeon_profile.txt
@@ -106,6 +106,10 @@ room:room template:3:11:33:30:0:1:100
 # Normal rooms (rarity = 0)
 room:simple room:0:11:33:1:0:0:100
 
+# Staircase rooms - rarity 99 to prevent random occurrence
+# these rooms are specially generated to join persistent levels
+room:staircase room:0:3:3:1:0:99:0
+
 ## Modified
 name:modified
 params:1:50:300:2
@@ -139,7 +143,7 @@ room:simple room:0:11:33:1:0:0:100
 
 # Staircase rooms - rarity 99 to prevent random occurrence
 # these rooms are specially generated to join persistent levels
-room:staircase room:0:1:1:1:0:99:0
+room:staircase room:0:3:3:1:0:99:0
 
 ## Moria - these have alloc -1, but still appear after other checks
 ## To completely turn them off, set alloc to zero
@@ -162,6 +166,10 @@ room:Interesting room:0:44:55:0:0:2:100
 
 # Normal moria-style rooms (rarity = 0)
 room:moria room:0:11:33:1:0:0:100
+
+# Staircase rooms - rarity 99 to prevent random occurrence
+# these rooms are specially generated to join persistent levels
+room:staircase room:0:3:3:1:0:99:0
 
 ## Lair
 name:lair

--- a/lib/gamedata/dungeon_profile.txt
+++ b/lib/gamedata/dungeon_profile.txt
@@ -203,6 +203,10 @@ room:room template:3:11:33:30:0:1:100
 # Normal rooms (rarity = 0)
 room:simple room:0:11:33:1:0:0:100
 
+# Staircase rooms - rarity 99 to prevent random occurrence
+# these rooms are specially generated to join persistent levels
+room:staircase room:0:3:3:1:0:99:0
+
 ## Gauntlet
 name:gauntlet
 params:1:0:200:0

--- a/lib/gamedata/dungeon_profile.txt
+++ b/lib/gamedata/dungeon_profile.txt
@@ -10,7 +10,8 @@
 # The dungeon is divided into non-overlapping square blocks of block_size by
 # block_size grids.  When rooms are placed, each is assigned a rectangular
 # chunk of blocks, and those assignments won't leave a block assigned to more
-# than one room.  So, block_size affects how densely the rooms can be packed
+# than one room (the staircase rooms for persistent levels are an exception
+# to that rule).  So, block_size affects how densely the rooms can be packed
 # and the maximum number of rooms possible.  rooms is the number of rooms to
 # aim for.  unusual is a measure of how likely high rarity roooms are to
 # appear - higher values make the rare rooms rarer.  rarity is the maximum

--- a/src/cave.c
+++ b/src/cave.c
@@ -382,17 +382,26 @@ struct chunk *cave_new(int height, int width) {
 }
 
 /**
+ * Free a linked list of cave connections.
+ */
+void cave_connectors_free(struct connector *join)
+{
+	while (join) {
+		struct connector *current = join;
+
+		join = current->next;
+		mem_free(current->info);
+		mem_free(current);
+	}
+}
+
+/**
  * Free a chunk
  */
 void cave_free(struct chunk *c) {
 	int y, x, i;
 
-	while (c->join) {
-		struct connector *current = c->join;
-		mem_free(current->info);
-		c->join = current->next;
-		mem_free(current);
-	}
+	cave_connectors_free(c->join);
 
 	/* Look for orphaned objects and delete them. */
 	for (i = 1; i < c->obj_max; i++) {

--- a/src/cave.h
+++ b/src/cave.h
@@ -447,6 +447,7 @@ struct loc next_grid(struct loc grid, int dir);
 int lookup_feat(const char *name);
 void set_terrain(void);
 struct chunk *cave_new(int height, int width);
+void cave_connectors_free(struct connector *join);
 void cave_free(struct chunk *c);
 void list_object(struct chunk *c, struct object *obj);
 void delist_object(struct chunk *c, struct object *obj);

--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -944,11 +944,13 @@ static void handle_level_stairs(struct chunk *c, struct player *p,
 		persistent = true;
 		/*
 		 * For persistent levels, require that the stairs be at least
-		 * three grids (two for surrounding walls; one for a buffer
-		 * between the walls) apart so the staircase rooms in the
-		 * connecting level won't overlap.
+		 * four grids apart (two for surrounding walls; two for a
+		 * buffer between the walls; the buffer space could be one -
+		 * shared by the staircases - but the reservations in the
+		 * room map don't allow for that) so the staircase rooms in
+		 * the connecting level won't overlap.
 		 */
-		minsep = 3;
+		minsep = 4;
 	} else {
 		persistent = false;
 		/* Don't contrain the separation between the staircases. */

--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -1042,10 +1042,10 @@ struct chunk *classic_gen(struct player *p, int min_height, int min_width) {
 		build_streamer(c, FEAT_QUARTZ, dun->profile->str.qc);
 
 	/* Place 3 or 4 down stairs near some walls */
-	alloc_stairs(c, FEAT_MORE, rand_range(3, 4));
+	alloc_stairs(c, FEAT_MORE, rand_range(3, 4), 0, false);
 
 	/* Place 1 or 2 up stairs near some walls */
-	alloc_stairs(c, FEAT_LESS, rand_range(1, 2));
+	alloc_stairs(c, FEAT_LESS, rand_range(1, 2), 0, false);
 
 	/* General amount of rubble, traps and monsters */
 	k = MAX(MIN(c->depth / 3, 10), 2);
@@ -1303,11 +1303,11 @@ struct chunk *labyrinth_gen(struct player *p, int min_height, int min_width) {
 
 	/* Generate a single set of stairs up if necessary. */
 	if (!cave_find(c, &grid, square_isupstairs))
-		alloc_stairs(c, FEAT_LESS, 1);
+		alloc_stairs(c, FEAT_LESS, 1, 0, false);
 
 	/* Generate a single set of stairs down if necessary. */
 	if (!cave_find(c, &grid, square_isdownstairs))
-		alloc_stairs(c, FEAT_MORE, 1);
+		alloc_stairs(c, FEAT_MORE, 1, 0, false);
 
 	/* General some rubble, traps and monsters */
 	k = MAX(MIN(c->depth / 3, 10), 2);
@@ -1846,10 +1846,10 @@ struct chunk *cavern_gen(struct player *p, int min_height, int min_width) {
 	draw_rectangle(c, 0, 0, h - 1, w - 1, FEAT_PERM, SQUARE_NONE, true);
 
 	/* Place 2-3 down stairs near some walls */
-	alloc_stairs(c, FEAT_MORE, rand_range(1, 3));
+	alloc_stairs(c, FEAT_MORE, rand_range(1, 3), 0, false);
 
 	/* Place 1-2 up stairs near some walls */
-	alloc_stairs(c, FEAT_LESS, rand_range(1, 2));
+	alloc_stairs(c, FEAT_LESS, rand_range(1, 2), 0, false);
 
 	/* General some rubble, traps and monsters */
 	k = MAX(MIN(c->depth / 3, 10), 2);
@@ -2538,12 +2538,20 @@ struct chunk *modified_gen(struct player *p, int min_height, int min_width) {
 
 	/* Place 3 or 4 down stairs near some walls */
 	if (!OPT(p, birth_levels_persist) || !chunk_find_adjacent(p, false)) {
-		alloc_stairs(c, FEAT_MORE, rand_range(3, 4));
+		/*
+		 * For persistent levels, require that the stairs be at least
+		 * three grids (two for surrounding walls; one for a buffer
+		 * between the walls) apart so the staircase rooms in the
+		 * connecting level won't overlap.
+		 */
+		alloc_stairs(c, FEAT_MORE, rand_range(3, 4),
+			OPT(p, birth_levels_persist) ? 3 : 0, false);
 	}
 
 	/* Place 1 or 2 up stairs near some walls */
 	if (!OPT(p, birth_levels_persist) || !chunk_find_adjacent(p, true)) {
-		alloc_stairs(c, FEAT_LESS, rand_range(1, 2));
+		alloc_stairs(c, FEAT_LESS, rand_range(1, 2),
+			OPT(p, birth_levels_persist) ? 3 : 0, false);
 	}
 
 	/* General amount of rubble, traps and monsters */
@@ -2733,10 +2741,10 @@ struct chunk *moria_gen(struct player *p, int min_height, int min_width) {
 		build_streamer(c, FEAT_QUARTZ, dun->profile->str.qc);
 
 	/* Place 3 or 4 down stairs near some walls */
-	alloc_stairs(c, FEAT_MORE, rand_range(3, 4));
+	alloc_stairs(c, FEAT_MORE, rand_range(3, 4), 0, false);
 
 	/* Place 1 or 2 up stairs near some walls */
-	alloc_stairs(c, FEAT_LESS, rand_range(1, 2));
+	alloc_stairs(c, FEAT_LESS, rand_range(1, 2), 0, false);
 
 	/* General amount of rubble, traps and monsters */
 	k = MAX(MIN(c->depth / 3, 10), 2);
@@ -3011,10 +3019,10 @@ struct chunk *hard_centre_gen(struct player *p, int min_height, int min_width)
 		centre_cavern_wid * (upper_cavern_hgt + lower_cavern_hgt);
 
 	/* Place 2-3 down stairs near some walls */
-	alloc_stairs(c, FEAT_MORE, rand_range(1, 3));
+	alloc_stairs(c, FEAT_MORE, rand_range(1, 3), 0, false);
 
 	/* Place 1-2 up stairs near some walls */
-	alloc_stairs(c, FEAT_LESS, rand_range(1, 2));
+	alloc_stairs(c, FEAT_LESS, rand_range(1, 2), 0, false);
 
 	/* Generate some rubble, traps and monsters */
 	k = MAX(MIN(c->depth / 3, 10), 2);
@@ -3164,10 +3172,10 @@ struct chunk *lair_gen(struct player *p, int min_height, int min_width) {
 	ensure_connectedness(c, true);
 
 	/* Place 3 or 4 down stairs near some walls */
-	alloc_stairs(c, FEAT_MORE, rand_range(3, 4));
+	alloc_stairs(c, FEAT_MORE, rand_range(3, 4), 0, false);
 
 	/* Place 1 or 2 up stairs near some walls */
-	alloc_stairs(c, FEAT_LESS, rand_range(1, 2));
+	alloc_stairs(c, FEAT_LESS, rand_range(1, 2), 0, false);
 
 	/* Put some rubble in corridors */
 	alloc_objects(c, SET_CORR, TYP_RUBBLE, randint1(k), c->depth, 0);
@@ -3248,10 +3256,10 @@ struct chunk *gauntlet_gen(struct player *p, int min_height, int min_width) {
 		SQUARE_NO_TELEPORT);
 
 	/* Place down stairs in the right cavern */
-	alloc_stairs(right, FEAT_MORE, rand_range(2, 3));
+	alloc_stairs(right, FEAT_MORE, rand_range(2, 3), 0, false);
 
 	/* Place up stairs in the left cavern */
-	alloc_stairs(left, FEAT_LESS, rand_range(1, 3));
+	alloc_stairs(left, FEAT_LESS, rand_range(1, 3), 0, false);
 
 	/*
 	 * Open the ends of the gauntlet.  Make sure the opening is

--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -926,6 +926,7 @@ static void build_staircase_rooms(struct chunk *c, const char *label)
 				c->width), c);
 			quit("Failed to place stairs");
 		}
+		++dun->nstair_room;
 	}
 }
 

--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -955,10 +955,12 @@ static void handle_level_stairs(struct chunk *c, struct player *p,
 		minsep = 0;
 	}
 	if (!persistent || !chunk_find_adjacent(p, false)) {
-		alloc_stairs(c, FEAT_MORE, down_count, minsep, false);
+		alloc_stairs(c, FEAT_MORE, down_count, minsep, false,
+			dun->one_off_below);
 	}
 	if (!persistent || !chunk_find_adjacent(p, true)) {
-		alloc_stairs(c, FEAT_LESS, up_count, minsep, false);
+		alloc_stairs(c, FEAT_LESS, up_count, minsep, false,
+			dun->one_off_above);
 	}
 }
 
@@ -1368,11 +1370,11 @@ struct chunk *labyrinth_gen(struct player *p, int min_height, int min_width) {
 
 	/* Generate a single set of stairs up if necessary. */
 	if (!cave_find(c, &grid, square_isupstairs))
-		alloc_stairs(c, FEAT_LESS, 1, 0, false);
+		alloc_stairs(c, FEAT_LESS, 1, 0, false, NULL);
 
 	/* Generate a single set of stairs down if necessary. */
 	if (!cave_find(c, &grid, square_isdownstairs))
-		alloc_stairs(c, FEAT_MORE, 1, 0, false);
+		alloc_stairs(c, FEAT_MORE, 1, 0, false, NULL);
 
 	/* General some rubble, traps and monsters */
 	k = MAX(MIN(c->depth / 3, 10), 2);
@@ -1911,10 +1913,10 @@ struct chunk *cavern_gen(struct player *p, int min_height, int min_width) {
 	draw_rectangle(c, 0, 0, h - 1, w - 1, FEAT_PERM, SQUARE_NONE, true);
 
 	/* Place 2-3 down stairs near some walls */
-	alloc_stairs(c, FEAT_MORE, rand_range(1, 3), 0, false);
+	alloc_stairs(c, FEAT_MORE, rand_range(1, 3), 0, false, NULL);
 
 	/* Place 1-2 up stairs near some walls */
-	alloc_stairs(c, FEAT_LESS, rand_range(1, 2), 0, false);
+	alloc_stairs(c, FEAT_LESS, rand_range(1, 2), 0, false, NULL);
 
 	/* General some rubble, traps and monsters */
 	k = MAX(MIN(c->depth / 3, 10), 2);
@@ -3055,10 +3057,10 @@ struct chunk *hard_centre_gen(struct player *p, int min_height, int min_width)
 		centre_cavern_wid * (upper_cavern_hgt + lower_cavern_hgt);
 
 	/* Place 2-3 down stairs near some walls */
-	alloc_stairs(c, FEAT_MORE, rand_range(1, 3), 0, false);
+	alloc_stairs(c, FEAT_MORE, rand_range(1, 3), 0, false, NULL);
 
 	/* Place 1-2 up stairs near some walls */
-	alloc_stairs(c, FEAT_LESS, rand_range(1, 2), 0, false);
+	alloc_stairs(c, FEAT_LESS, rand_range(1, 2), 0, false, NULL);
 
 	/* Generate some rubble, traps and monsters */
 	k = MAX(MIN(c->depth / 3, 10), 2);
@@ -3208,10 +3210,10 @@ struct chunk *lair_gen(struct player *p, int min_height, int min_width) {
 	ensure_connectedness(c, true);
 
 	/* Place 3 or 4 down stairs near some walls */
-	alloc_stairs(c, FEAT_MORE, rand_range(3, 4), 0, false);
+	alloc_stairs(c, FEAT_MORE, rand_range(3, 4), 0, false, NULL);
 
 	/* Place 1 or 2 up stairs near some walls */
-	alloc_stairs(c, FEAT_LESS, rand_range(1, 2), 0, false);
+	alloc_stairs(c, FEAT_LESS, rand_range(1, 2), 0, false, NULL);
 
 	/* Put some rubble in corridors */
 	alloc_objects(c, SET_CORR, TYP_RUBBLE, randint1(k), c->depth, 0);
@@ -3292,10 +3294,10 @@ struct chunk *gauntlet_gen(struct player *p, int min_height, int min_width) {
 		SQUARE_NO_TELEPORT);
 
 	/* Place down stairs in the right cavern */
-	alloc_stairs(right, FEAT_MORE, rand_range(2, 3), 0, false);
+	alloc_stairs(right, FEAT_MORE, rand_range(2, 3), 0, false, NULL);
 
 	/* Place up stairs in the left cavern */
-	alloc_stairs(left, FEAT_LESS, rand_range(1, 3), 0, false);
+	alloc_stairs(left, FEAT_LESS, rand_range(1, 3), 0, false, NULL);
 
 	/*
 	 * Open the ends of the gauntlet.  Make sure the opening is

--- a/src/gen-room.c
+++ b/src/gen-room.c
@@ -95,7 +95,8 @@ struct vault *random_vault(int depth, const char *typ)
 /**
  * ------------------------------------------------------------------------
  * Helper functions to fill in information in the global dun (see also
- * find_space() and room_build() which set cent_n and cent in that structure)
+ * find_space(), room_build(), and build_staircase() which set cent_n and
+ * cent in that structure)
  * ------------------------------------------------------------------------
  */
 /**
@@ -978,6 +979,50 @@ void set_pit_type(int depth, int type)
 }
 
 /**
+ * Check that a rectangular range has not been reserved in the block map.
+ * \param by1 Is the y block coordinate for the top left corner of the range.
+ * \param bx1 Is the x block coordinate for the top left corner of the range.
+ * \param by2 Is the y block coordinate for the bottom right corner.
+ * \param bx2 Is the x block coordinate for the bottom right corner.
+ * \return Return true if the complete range has not been reserved and falls
+ * within the bounds of the map.  Otherwise, return false.
+ */
+static bool check_for_unreserved_blocks(int by1, int bx1, int by2, int bx2)
+{
+	int by, bx;
+
+	/* Never run off the screen */
+	if (by1 < 0 || by2 >= dun->row_blocks) return false;
+	if (bx1 < 0 || bx2 >= dun->col_blocks) return false;
+
+	/* Verify open space */
+	for (by = by1; by <= by2; by++) {
+		for (bx = bx1; bx <= bx2; bx++) {
+			if (dun->room_map[by][bx]) return false;
+		}
+	}
+	return true;
+}
+
+/**
+ * Reserve a rectangular range in the block map.
+ * \param by1 Is the y block coordinate for the top left corner of the range.
+ * \param bx1 Is the x block coordinate for the top left corner of the range.
+ * \param by2 Is the y block coordinate for the bottom right corner.
+ * \param bx2 Is the x block coordinate for the bottom right corner.
+ */
+static void reserve_blocks(int by1, int bx1, int by2, int bx2)
+{
+	int by, bx;
+
+	for (by = by1; by <= by2; by++) {
+		for (bx = bx1; bx <= bx2; bx++) {
+			dun->room_map[by][bx] = true;
+		}
+	}
+}
+
+/**
  * Find a good spot for the next room.
  *
  * \param y centre of the room
@@ -999,55 +1044,14 @@ void set_pit_type(int depth, int type)
 static bool find_space(struct loc *centre, int height, int width)
 {
 	int i;
-	int by, bx, by1, bx1, by2, bx2;
-
-	bool filled;
+	int by1, bx1, by2, bx2;
 
 	/* Find out how many blocks we need. */
 	int blocks_high = 1 + ((height - 1) / dun->block_hgt);
 	int blocks_wide = 1 + ((width - 1) / dun->block_wid);
 
-	/* Deal with staircase "rooms" */
-	if (OPT(player, birth_levels_persist) && (height * width == 1)) {
-		struct connector *join = dun->join;
-		bool found = false;
-
-		/* Acquire the location of the room */
-		int n = dun->cent_n;
-
-		while (n) {
-			join = join->next;
-			n--;
-		}
-		if (join) {
-			*centre = join->grid;
-			found = true;
-		}
-
-		/* Check we have found one */
-		if (found) {
-			/* Get the blocks */
-			by = (centre->y + 1) / dun->block_hgt;
-			bx = (centre->x + 1) / dun->block_wid;
-
-			/* Save the room location */
-			if (dun->cent_n < z_info->level_room_max) {
-				dun->cent[dun->cent_n] = *centre;
-				dun->cent_n++;
-			}
-
-			/* Reserve a block, marked with the room index */
-			dun->room_map[by][bx] = dun->cent_n;
-
-			/* Success. */
-			return (true);
-		}
-	}
-
 	/* We'll allow twenty-five guesses. */
 	for (i = 0; i < 25; i++) {
-		filled = false;
-
 		/* Pick a top left block at random */
 		by1 = randint0(dun->row_blocks);
 		bx1 = randint0(dun->col_blocks);
@@ -1056,20 +1060,7 @@ static bool find_space(struct loc *centre, int height, int width)
 		by2 = by1 + blocks_high - 1;
 		bx2 = bx1 + blocks_wide - 1;
 
-		/* Never run off the screen */
-		if (by1 < 0 || by2 >= dun->row_blocks) continue;
-		if (bx1 < 0 || bx2 >= dun->col_blocks) continue;
-
-		/* Verify open space */
-		for (by = by1; by <= by2; by++) {
-			for (bx = bx1; bx <= bx2; bx++) {
-				if (dun->room_map[by][bx])
-					filled = true;
-			}
-		}
-
-		/* If space filled, try again. */
-		if (filled)	continue;
+		if (!check_for_unreserved_blocks(by1, bx1, by2, bx2)) continue;
 
 		/* Get the location of the room */
 		centre->y = ((by1 + by2 + 1) * dun->block_hgt) / 2;
@@ -1081,12 +1072,7 @@ static bool find_space(struct loc *centre, int height, int width)
 			dun->cent_n++;
 		}
 
-		/* Reserve some blocks */
-		for (by = by1; by <= by2; by++) {
-			for (bx = bx1; bx <= bx2; bx++) {
-				dun->room_map[by][bx] = true;
-			}
-		}
+		reserve_blocks(by1, bx1, by2, bx2);
 
 		/* Success. */
 		return (true);
@@ -1870,11 +1856,59 @@ static void hollow_out_room(struct chunk *c, struct loc grid)
  */
 bool build_staircase(struct chunk *c, struct loc centre, int rating)
 {
-	struct connector *join = dun->join;
+	struct connector *join = dun->curr_join;
 
-	/* Find and reserve one grid in the dungeon */
-	if (!find_space(&centre, 1, 1))
+	if (!join) {
+		quit_fmt("build_staircase() called without dun->curr_join set");
+	}
+
+	if (centre.y >= c->height || centre.x >= c->width) {
+		/*
+		 * Verify that there's space for the 1 x 1 room at the
+		 * staircase location (3 x 3 including the walls; if not at
+		 * an edge also want a one grid buffer around the walls so
+		 * the wall piercings for tunneling will work).
+		 */
+		struct loc tl, br;
+		int by1, bx1, by2, bx2;
+
+		centre = join->grid;
+		if (centre.y < 1 || centre.y > c->height - 2 || centre.x < 1 ||
+			centre.x > c->width - 2) return false;
+		tl = loc(centre.x - ((centre.x > 1) ? 2 : 1),
+			centre.y - ((centre.y > 1) ? 2 : 1));
+		br = loc(centre.x + ((centre.x < c->width - 2) ? 2 : 1),
+			centre.y + ((centre.y < c->height - 2) ? 2 : 1));
+		by1 = tl.y / dun->block_hgt;
+		bx1 = tl.x / dun->block_wid;
+		by2 = br.y / dun->block_hgt;
+		bx2 = br.x / dun->block_wid;
+		/*
+		 * If the block size is greater than one, look for room flags
+		 * rather than check the block map.  It's less efficient, but
+		 * gives a better chance of success since multiple staircase
+		 * rooms could be placed in a block if they're far enough apart.
+		 */
+		if (dun->block_hgt > 1 || dun->block_wid > 1) {
+			struct loc rg;
+
+			if (cave_find_in_range(c, &rg, tl, br, square_isroom))
+				return false;
+		} else if (!check_for_unreserved_blocks(by1, bx1, by2, bx2)) {
+			return false;
+		}
+
+		reserve_blocks(by1, bx1, by2, bx2);
+
+		/* Save the room location */
+		if (dun->cent_n < z_info->level_room_max) {
+			dun->cent[dun->cent_n] = centre;
+			dun->cent_n++;
+		}
+	} else {
+		/* Never works for the caller to set the location. */
 		return false;
+	}
 
 	/* Generate new room and outer walls */
 	generate_room(c, centre.y - 1, centre.x - 1, centre.y + 1, centre.x + 1,
@@ -1883,16 +1917,7 @@ bool build_staircase(struct chunk *c, struct loc centre, int rating)
 		FEAT_GRANITE, SQUARE_WALL_OUTER, false);
 
 	/* Place the correct stair */
-	while (join) {
-		if (loc_eq(join->grid, centre)) {
-			square_set_feat(c, join->grid, join->feat);
-			break;
-		}
-		join = join->next;
-	}
-	if (!join) {
-		quit_fmt("Stair connect mismatch y=%d x=%d!", centre.y, centre.x);
-	}
+	square_set_feat(c, centre, join->feat);
 
 	/* Success */
 	return true;
@@ -3471,7 +3496,6 @@ bool room_build(struct chunk *c, int by0, int bx0, struct room_profile profile,
 	int bx2 = bx0 + profile.width / dun->block_wid;
 
 	struct loc centre;
-	int by, bx;
 
 	/* Enforce the room profile's minimum depth */
 	if (c->depth < profile.level) return false;
@@ -3489,17 +3513,8 @@ bool room_build(struct chunk *c, int by0, int bx0, struct room_profile profile,
 		if (!profile.builder(c, loc(c->width, c->height), profile.rating))
 			return false;
 	} else {
-		/* Never run off the screen */
-		if (by1 < 0 || by2 >= dun->row_blocks) return false;
-		if (bx1 < 0 || bx2 >= dun->col_blocks) return false;
-
-		/* Verify open space */
-		for (by = by1; by <= by2; by++) {
-			for (bx = bx1; bx <= bx2; bx++) {
-				/* previous rooms prevent new ones */
-				if (dun->room_map[by][bx]) return false;
-			}
-		}
+		if (!check_for_unreserved_blocks(by1, bx1, by2, bx2))
+			return false;
 
 		/* Get the location of the room */
 		centre = loc(((bx1 + bx2 + 1) * dun->block_wid) / 2,
@@ -3518,12 +3533,7 @@ bool room_build(struct chunk *c, int by0, int bx0, struct room_profile profile,
 			return false;
 		}
 
-		/* Reserve some blocks */
-		for (by = by1; by < by2; by++) {
-			for (bx = bx1; bx < bx2; bx++) {
-				dun->room_map[by][bx] = true;
-			}
-		}
+		reserve_blocks(by1, bx1, by2, bx2);
 	}
 
 	/* Count pit/nests rooms */

--- a/src/gen-room.c
+++ b/src/gen-room.c
@@ -2984,10 +2984,10 @@ bool build_greater_vault(struct chunk *c, struct loc centre, int rating)
 	int denominator = 3;
 	
 	/*
-	 * Only try to build a GV as the first room.  If not finding space,
-	 * cent_n has already been incremented.
+	 * Only try to build a GV as the first non-staircase room.  If not
+	 * finding space, cent_n has already been incremented.
 	 */
-	if (dun->cent_n > ((centre.y >= c->height ||
+	if (dun->cent_n - dun->nstair_room > ((centre.y >= c->height ||
 		centre.x >= c->width) ? 0 : 1)) return false;
 
 	/* Level 90+ has a 1/3 chance, level 80-89 has 2/9, ... */
@@ -3413,10 +3413,11 @@ bool build_huge(struct chunk *c, struct loc centre, int rating)
 	int width = 45 + randint0(50);
 
 	/*
-	 * Only try to build a huge room as the first room.  If not finding
-	 * space, cent_n has already been increment.
+	 * Only try to build a huge room as the first non-staircase room.  If
+	 * not finding space, cent_n has already been increment.
 	 */
-	if (dun->cent_n > ((finding_space) ? 0 : 1)) return false;
+	if (dun->cent_n - dun->nstair_room > ((finding_space) ? 0 : 1))
+		return false;
 
 	/* Flat 5% chance */
 	if (!one_in_(20)) return false;

--- a/src/gen-util.c
+++ b/src/gen-util.c
@@ -157,7 +157,7 @@ void shuffle(int *arr, int n)
  * \param pred square_predicate specifying what we're looking for
  * \return success
  */
-static bool cave_find_in_range(struct chunk *c, struct loc *grid,
+bool cave_find_in_range(struct chunk *c, struct loc *grid,
 	struct loc top_left, struct loc bottom_right,
 	square_predicate pred)
 {

--- a/src/generate.c
+++ b/src/generate.c
@@ -1084,6 +1084,7 @@ static struct chunk *cave_generate(struct player *p, int height, int width)
 		dun->wall = mem_zalloc(z_info->wall_pierce_max * sizeof(struct loc));
 		dun->tunn = mem_zalloc(z_info->tunn_grid_max * sizeof(struct loc));
 		dun->join = NULL;
+		dun->curr_join = NULL;
 
 		/* Get connector info for persistent levels */
 		if (OPT(p, birth_levels_persist)) {

--- a/src/generate.c
+++ b/src/generate.c
@@ -1047,28 +1047,10 @@ static void cave_clear(struct chunk *c, struct player *p)
 static void cleanup_dun_data(struct dun_data *dd)
 {
 	int i;
-	struct connector *join = dun->join;
 
-	while (join) {
-		struct connector *jtgt = join;
-
-		join = join->next;
-		mem_free(jtgt);
-	}
-	join = dun->one_off_above;
-	while (join) {
-		struct connector *jtgt = join;
-
-		join = join->next;
-		mem_free(jtgt);
-	}
-	join = dun->one_off_below;
-	while (join) {
-		struct connector *jtgt = join;
-
-		join = join->next;
-		mem_free(jtgt);
-	}
+	cave_connectors_free(dun->join);
+	cave_connectors_free(dun->one_off_above);
+	cave_connectors_free(dun->one_off_below);
 	mem_free(dun->cent);
 	mem_free(dun->ent_n);
 	for (i = 0; i < z_info->level_room_max; ++i) {

--- a/src/generate.c
+++ b/src/generate.c
@@ -919,6 +919,30 @@ static void get_join_info(struct player *p, struct dun_data *dd)
 				join = join->next;
 			}
 		}
+	} else if ((lev = level_by_depth(p->depth - 2))) {
+		/*
+		 * When there isn't a level above but there is one two levels
+		 * up, remember where the down staircases are so up staircases
+		 * on this level won't conflict with them if the level above is
+		 * ever generated.
+		 */
+		struct chunk *check = chunk_find_name(lev->name);
+
+		if (check) {
+			struct connector *join;
+
+			for (join = check->join; join; join = join->next) {
+				if (join->feat == FEAT_MORE) {
+					struct connector *nc =
+						mem_zalloc(sizeof(*nc));
+
+					nc->grid = join->grid;
+					nc->feat = FEAT_MORE;
+					nc->next = dd->one_off_above;
+					dd->one_off_above = nc;
+				}
+			}
+		}
 	}
 
 	/* Check level below */
@@ -937,6 +961,25 @@ static void get_join_info(struct player *p, struct dun_data *dd)
 					dd->join = new;
 				}
 				join = join->next;
+			}
+		}
+	} else if ((lev = level_by_depth(p->depth + 2))) {
+		/* Same logic as above for looking one past the next level */
+		struct chunk *check = chunk_find_name(lev->name);
+
+		if (check) {
+			struct connector *join;
+
+			for (join = check->join; join; join = join->next) {
+				if (join->feat == FEAT_LESS) {
+					struct connector *nc =
+						mem_zalloc(sizeof(*nc));
+
+					nc->grid = join->grid;
+					nc->feat = FEAT_LESS;
+					nc->next = dd->one_off_below;
+					dd->one_off_below = nc;
+				}
 			}
 		}
 	}
@@ -1006,6 +1049,20 @@ static void cleanup_dun_data(struct dun_data *dd)
 	int i;
 	struct connector *join = dun->join;
 
+	while (join) {
+		struct connector *jtgt = join;
+
+		join = join->next;
+		mem_free(jtgt);
+	}
+	join = dun->one_off_above;
+	while (join) {
+		struct connector *jtgt = join;
+
+		join = join->next;
+		mem_free(jtgt);
+	}
+	join = dun->one_off_below;
 	while (join) {
 		struct connector *jtgt = join;
 
@@ -1084,6 +1141,8 @@ static struct chunk *cave_generate(struct player *p, int height, int width)
 		dun->wall = mem_zalloc(z_info->wall_pierce_max * sizeof(struct loc));
 		dun->tunn = mem_zalloc(z_info->tunn_grid_max * sizeof(struct loc));
 		dun->join = NULL;
+		dun->one_off_above = NULL;
+		dun->one_off_below = NULL;
 		dun->curr_join = NULL;
 
 		/* Get connector info for persistent levels */

--- a/src/generate.c
+++ b/src/generate.c
@@ -1144,6 +1144,7 @@ static struct chunk *cave_generate(struct player *p, int height, int width)
 		dun->one_off_above = NULL;
 		dun->one_off_below = NULL;
 		dun->curr_join = NULL;
+		dun->nstair_room = 0;
 
 		/* Get connector info for persistent levels */
 		if (OPT(p, birth_levels_persist)) {

--- a/src/generate.h
+++ b/src/generate.h
@@ -171,6 +171,10 @@ struct dun_data {
     /*!< Info for connecting to persistent levels */
     struct connector *join;
 
+    /*!< Info for avoiding conflicts with persistent levels two away */
+    struct connector *one_off_above;
+    struct connector *one_off_below;
+
     /*!< The connection information to use for the next staircase room */
     struct connector *curr_join;
 };
@@ -394,7 +398,8 @@ void place_secret_door(struct chunk *c, struct loc grid);
 void place_closed_door(struct chunk *c, struct loc grid);
 void place_random_door(struct chunk *c, struct loc grid);
 void place_random_stairs(struct chunk *c, struct loc grid);
-void alloc_stairs(struct chunk *c, int feat, int num, int minsep, bool sepany);
+void alloc_stairs(struct chunk *c, int feat, int num, int minsep, bool sepany,
+	const struct connector *avoid_list);
 void vault_objects(struct chunk *c, struct loc grid, int depth, int num);
 void vault_traps(struct chunk *c, struct loc grid, int yd, int xd, int num);
 void vault_monsters(struct chunk *c, struct loc grid, int depth, int num);

--- a/src/generate.h
+++ b/src/generate.h
@@ -170,6 +170,9 @@ struct dun_data {
 
     /*!< Info for connecting to persistent levels */
     struct connector *join;
+
+    /*!< The connection information to use for the next staircase room */
+    struct connector *curr_join;
 };
 
 
@@ -373,6 +376,8 @@ extern byte get_angle_to_grid[41][41];
 int grid_to_i(struct loc grid, int w);
 void i_to_grid(int i, int w, struct loc *grid);
 void shuffle(int *arr, int n);
+bool cave_find_in_range(struct chunk *c, struct loc *grid, struct loc top_left,
+	struct loc bottom_right, square_predicate pred);
 bool cave_find(struct chunk *c, struct loc *grid, square_predicate pred);
 bool find_empty(struct chunk *c, struct loc *grid);
 bool find_empty_range(struct chunk *c, struct loc *grid, struct loc top_left,

--- a/src/generate.h
+++ b/src/generate.h
@@ -389,7 +389,7 @@ void place_secret_door(struct chunk *c, struct loc grid);
 void place_closed_door(struct chunk *c, struct loc grid);
 void place_random_door(struct chunk *c, struct loc grid);
 void place_random_stairs(struct chunk *c, struct loc grid);
-void alloc_stairs(struct chunk *c, int feat, int num);
+void alloc_stairs(struct chunk *c, int feat, int num, int minsep, bool sepany);
 void vault_objects(struct chunk *c, struct loc grid, int depth, int num);
 void vault_traps(struct chunk *c, struct loc grid, int yd, int xd, int num);
 void vault_monsters(struct chunk *c, struct loc grid, int depth, int num);

--- a/src/generate.h
+++ b/src/generate.h
@@ -177,6 +177,9 @@ struct dun_data {
 
     /*!< The connection information to use for the next staircase room */
     struct connector *curr_join;
+
+    /*!< The number of staircase rooms */
+    int nstair_room;
 };
 
 


### PR DESCRIPTION
Also adjust the handling of Moria levels to match what's expected when using persistent levels.

Don't count staircase rooms when testing whether a greater vault or huge room is the first room on a level.  That way there's a chance those can be generated when using persistent levels and the level wasn't reach by a deep descent effect.