### PR TITLE
Fix some runtime issues with statistics mode, main-stats.c

### DIFF
--- a/src/main-stats.c
+++ b/src/main-stats.c
@@ -814,7 +814,7 @@ static int stats_dump_lists(void)
 	if (err) return err;
 
 	for (idx = 0; idx < OF_MAX; idx++) {
-		err = stats_db_bind_ints(sql_stmt, 1, idx);
+		err = sqlite3_bind_int(sql_stmt, 1, idx);
 		if (err) return err;
 		err = sqlite3_bind_text(sql_stmt, 2, object_flag_names[idx],
 			strlen(object_flag_names[idx]), SQLITE_STATIC);
@@ -829,7 +829,7 @@ static int stats_dump_lists(void)
 	if (err) return err;
 
 	for (idx = 0; object_mods[idx] != NULL; idx++) {
-		err = stats_db_bind_ints(sql_stmt, 1, idx);
+		err = sqlite3_bind_int(sql_stmt, 1, idx);
 		if (err) return err;
 		err = sqlite3_bind_text(sql_stmt, 2, object_mods[idx],
 			strlen(object_mods[idx]), SQLITE_STATIC);
@@ -1027,10 +1027,10 @@ static bool stats_prep_db(void)
 	err = stats_db_exec("CREATE TABLE monster_spell_flags_list(idx INT PRIMARY KEY, cap INT, div INT, name TEXT);");
 	if (err) return false;
 
-	err = stats_db_exec("CREATE TABLE object_flags_list(idx INT PRIMARY KEY, type INT, power INT, name TEXT);");
+	err = stats_db_exec("CREATE TABLE object_flags_list(idx INT PRIMARY KEY, name TEXT);");
 	if (err) return false;
 
-	err = stats_db_exec("CREATE TABLE object_mods_list(idx INT PRIMARY KEY, type INT, power INT, mod_mult INT, name TEXT);");
+	err = stats_db_exec("CREATE TABLE object_mods_list(idx INT PRIMARY KEY, name TEXT);");
 	if (err) return false;
 
 	err = stats_db_exec("CREATE TABLE origin_flags_list(idx INT PRIMARY KEY, name TEXT);");

--- a/src/main-stats.c
+++ b/src/main-stats.c
@@ -1477,6 +1477,18 @@ static void progress_bar(u32b run, time_t start) {
 
 static void stats_cleanup_angband_run(void)
 {
+	if (character_dungeon) {
+		wipe_mon_list(cave, player);
+		if (player->cave) {
+			cave_free(player->cave);
+			player->cave = NULL;
+		}
+		if (cave) {
+			cave_free(cave);
+			cave = NULL;
+		}
+		character_dungeon = false;
+	}
 	mem_free(player->history);
 	player->history = NULL;
 }

--- a/src/main-stats.c
+++ b/src/main-stats.c
@@ -179,6 +179,9 @@ static void free_stats_memory(void)
 /* Copied from birth.c:generate_player() */
 static void generate_player_for_stats(void)
 {
+	char buf[80];
+	int i;
+
 	OPT(player, birth_randarts) = randarts;
 	OPT(player, birth_no_selling) = no_selling;
 	OPT(player, birth_stacking) = true;
@@ -188,6 +191,21 @@ static void generate_player_for_stats(void)
 
 	player->race = races;  /* Human   */
 	player->class = classes; /* Warrior */
+
+	/* Needs a body; duplicates logic from the private player_embody(). */
+	memcpy(&player->body, &bodies[player->race->body],
+		sizeof(player->body));
+	my_strcpy(buf, bodies[player->race->body].name, sizeof(buf));
+	player->body.name = string_make(buf);
+	player->body.slots = mem_zalloc(player->body.count *
+		sizeof(*(player->body.slots)));
+	for (i = 0; i < player->body.count; ++i) {
+		player->body.slots[i].type =
+			bodies[player->race->body].slots[i].type;
+		my_strcpy(buf, bodies[player->race->body].slots[i].name,
+			sizeof(buf));
+		player->body.slots[i].name = string_make(buf);
+	}
 
 	/* Level 1 */
 	player->max_lev = player->lev = 1;

--- a/src/main-stats.c
+++ b/src/main-stats.c
@@ -268,6 +268,9 @@ static void kill_all_monsters(int level)
 	for (i = cave_monster_max(cave) - 1; i >= 1; i--) {
 		struct monster *mon = cave_monster(cave, i);
 
+		/* Skip the ones that are already dead. */
+		if (!mon->race) continue;
+
 		level_data[level].monsters[mon->race->ridx]++;
 
 		monster_death(mon, true);

--- a/src/main-stats.c
+++ b/src/main-stats.c
@@ -1477,7 +1477,8 @@ static void progress_bar(u32b run, time_t start) {
 
 static void stats_cleanup_angband_run(void)
 {
-	if (player->history) mem_free(player->history);
+	mem_free(player->history);
+	player->history = NULL;
 }
 
 static errr run_stats(void)


### PR DESCRIPTION
- The setup of the object_flags_list and object_mods_list tables was triggering "Couldn't prepare database!" failures at startup.
- The initialization of the player didn't set up the body triggering later assertions (in slot_by_name() called from the object power calculations).
- Skip already dead monsters in kill_all_monsters() to avoid crashes.
- After freeing the player history, set it to NULL to avoid double frees.
- Add cleanup for the cave to stats_cleanup_angband_run() so using more than one run doesn't trigger an assertion in prepare_next_level().
- Use list-origins.h so the table of origins is consistent with the rest of Angband.