### PR TITLE
Move the logic from monster_death() to delete_monster_idx() for …

### DIFF
--- a/src/mon-make.c
+++ b/src/mon-make.c
@@ -323,6 +323,9 @@ void delete_monster_idx(int m_idx)
 		cave->num_repro--;
 	}
 
+	/* Affect light? */
+	if (mon->race->light != 0) player->upkeep->update |= PU_UPDATE_VIEW;
+
 	/* Hack -- remove target monster */
 	if (target_get_monster() == mon)
 		target_set_monster(NULL);

--- a/src/mon-util.c
+++ b/src/mon-util.c
@@ -996,10 +996,6 @@ void monster_death(struct monster *mon, bool stats)
 	/* Update monster list window */
 	player->upkeep->redraw |= PR_MONLIST;
 
-	/* Affect light? */
-	if (mon->race->light != 0)
-		player->upkeep->update |= PU_UPDATE_VIEW;
-
 	/* Check if we finished a quest */
 	quest_check(mon);
 }


### PR DESCRIPTION
…triggering view updates when a light-affecting monster goes away.  That way it happens for cases (banishment, trampling, polymorph, teleport level) that don't use monster_death().

It's likely that FirstAgeAngband's sporadic invisibility issue, https://github.com/NickMcConnell/FirstAgeAngband/issues/175 , is in Angband as well (had a high-elf warrior that couldn't see a vortex in one of horizontal neighboring grids; the character had a light source and wasn't blind).  Noticed the above issue in the code while trying to track down what might cause the problems with visibility.  As far as I know, this change wouldn't have fixed what I saw or what's been reported for FirstAgeAngband.