### PR TITLE
Add PU_MONSTERS to the player update flags when monsters with light move

### DIFF
--- a/src/mon-make.c
+++ b/src/mon-make.c
@@ -324,7 +324,8 @@ void delete_monster_idx(int m_idx)
 	}
 
 	/* Affect light? */
-	if (mon->race->light != 0) player->upkeep->update |= PU_UPDATE_VIEW;
+	if (mon->race->light != 0)
+		player->upkeep->update |= PU_UPDATE_VIEW | PU_MONSTERS;
 
 	/* Hack -- remove target monster */
 	if (target_get_monster() == mon)
@@ -1157,7 +1158,7 @@ static bool place_new_monster_one(struct chunk *c, struct loc grid,
 
 	/* Affect light? */
 	if (mon->race->light != 0)
-		player->upkeep->update |= PU_UPDATE_VIEW;
+		player->upkeep->update |= PU_UPDATE_VIEW | PU_MONSTERS;
 
 	/* Is this obviously a monster? (Mimics etc. aren't) */
 	if (rf_has(race->flags, RF_UNAWARE))

--- a/src/mon-util.c
+++ b/src/mon-util.c
@@ -601,7 +601,7 @@ void monster_swap(struct loc grid1, struct loc grid2)
 
 		/* Affect light? */
 		if (mon->race->light != 0)
-			player->upkeep->update |= PU_UPDATE_VIEW;
+			player->upkeep->update |= PU_UPDATE_VIEW | PU_MONSTERS;
 
 		/* Redraw monster list */
 		player->upkeep->redraw |= (PR_MONLIST);
@@ -650,7 +650,7 @@ void monster_swap(struct loc grid1, struct loc grid2)
 
 		/* Affect light? */
 		if (mon->race->light != 0)
-			player->upkeep->update |= PU_UPDATE_VIEW;
+			player->upkeep->update |= PU_UPDATE_VIEW | PU_MONSTERS;
 
 		/* Redraw monster list */
 		player->upkeep->redraw |= (PR_MONLIST);


### PR DESCRIPTION
Or when they leave or enter the map. Currently this appears to be redundant with the addition of PU_MONSTERS to the update flags at the end of process_monsters() but could allow that to be removed while retaining correct behavior.  Because of that redundancy, I suspect it'll have no impact on the sporadic invisibility problem, https://github.com/NickMcConnell/FirstAgeAngband/issues/175 .