### PR TITLE
Remove flagging for full view update in the disable trap projection

### DIFF
--- a/src/project-feat.c
+++ b/src/project-feat.c
@@ -226,9 +226,6 @@ static void project_feature_handler_KILL_TRAP(project_feature_handler_context_t 
 
 		/* Disable the trap */
 		square_disable_trap(cave, grid);
-
-		/* Visibility change */
-		player->upkeep->update |= (PU_UPDATE_VIEW);
 	} else if (square_islockeddoor(cave, grid)) {
 		/* Unlock the door */
 		square_unlock_door(cave, grid);


### PR DESCRIPTION
The disabling doesn't affect the line of sight so a full view updated isn't necessary, and the update to the map happens via a square_light_spot() call from square_disable_trap() or the functions it calls.