### PR TITLE
Remove 'p' as a casting command in the documentation

### DIFF
--- a/docs/command.rst
+++ b/docs/command.rst
@@ -238,7 +238,7 @@ Gain new spells (``G``)
   only cast from two or three of these.  Higher level books are normally found
   only in the dungeon. This command takes some energy.
 
-Cast a spell (``m`` and ``p`` in both keysets)
+Cast a spell (``m`` in both keysets)
   To cast a spell, you must have previously learned the spell and must have
   in your inventory a book from which the spell can be read. Each spell has
   a chance of failure which starts out fairly large but decreases as you

--- a/docs/playing.rst
+++ b/docs/playing.rst
@@ -101,7 +101,7 @@ Original Keyset Command Summary
  ``m``  Cast a spell                  ``M``  Full dungeon map
  ``n``  Repeat previous command       ``N``  (unused)
  ``o``  Open a door or chest          ``O``  (unused)
- ``p``  Cast a spell                  ``P``  (unused)
+ ``p``  (unused)                      ``P``  (unused)
  ``q``  Quaff a potion                ``Q``  End character & quit
  ``r``  Read a scroll                 ``R``  Rest for a period
  ``s``  Steal (rogues only)           ``S``  (unused)
@@ -163,7 +163,7 @@ Roguelike Keyset Command Summary
   m    Cast a spell                    M    Full dungeon map
   n    (walk - south east)             N    (run - south east)
   o    Open a door or chest            O    Toggle ignore
-  p    Cast a spell                    P    Browse a book
+  p    (unused)                        P    Browse a book
   q    Quaff a potion                  Q    End character & quit
   r    Read a scroll                   R    Rest for a period
   s    Steal (rogues only)             S    (unused)


### PR DESCRIPTION
That follows up on the changes in https://github.com/angband/angband/commit/6e7f4e891aee60259187f5446e824f5642901eb8 .