### PR TITLE
Add game events for peeking into cave generation; use those to gather statistics with 'D' debugging

### DIFF
--- a/docs/hacking/debug.rst
+++ b/docs/hacking/debug.rst
@@ -140,7 +140,8 @@ Collect disconnection stats ``D``
   Generates several levels to collect statistics about how often all
   down staircases are inaccessible to the player and about how often
   a level has non-vault areas that are inaccessible to the player.  The
-  results are written to the message window.
+  results are written to the message window.  Also collects general
+  statistics about the generated levels and writes them to a file.
 
 Collect pit stats ``P``
   Generates several pits of the room type you specify (pit, nest, or

--- a/src/game-event.c
+++ b/src/game-event.c
@@ -248,3 +248,26 @@ void event_signal_missile(game_event_type type,
 
 	game_event_dispatch(type, &data);
 }
+
+void event_signal_size(game_event_type type, int h, int w)
+{
+	game_event_data data;
+
+	data.size.h = h;
+	data.size.w = w;
+	game_event_dispatch(type, &data);
+}
+
+void event_signal_tunnel(game_event_type type, int nstep, int npierce, int ndug,
+		int dstart, int dend, bool early)
+{
+	game_event_data data;
+
+	data.tunnel.nstep = nstep;
+	data.tunnel.npierce = npierce;
+	data.tunnel.ndug = ndug;
+	data.tunnel.dstart = dstart;
+	data.tunnel.dend = dend;
+	data.tunnel.early = early;
+	game_event_dispatch(type, &data);
+}

--- a/src/game-event.h
+++ b/src/game-event.h
@@ -91,6 +91,15 @@ typedef enum game_event_type
 	EVENT_ENTER_DEATH,
 	EVENT_LEAVE_DEATH,
 
+	/* Events for introspection into dungeon generation */
+	EVENT_GEN_LEVEL_START, /* has string in event data for profile name */
+	EVENT_GEN_LEVEL_END, /* has flag in event data indicating success */
+	EVENT_GEN_ROOM_START, /* has string in event data for room type */
+	EVENT_GEN_ROOM_CHOOSE_SIZE, /* has size in event data with name */
+	EVENT_GEN_ROOM_CHOOSE_SUBTYPE, /* has string in event data with name */
+	EVENT_GEN_ROOM_END, /* has flag in event data indicating success */
+	EVENT_GEN_TUNNEL_FINISHED, /* has tunnel in event data with results */
+
 	EVENT_END  /* Can be sent at the end of a series of events */
 } game_event_type;
 
@@ -157,6 +166,35 @@ typedef union
 		int x;
 	} missile;
 
+	struct
+	{
+		int h, w;
+	} size;
+
+	struct
+	{
+		/*
+		 * "nstep" is the total number of tunneling steps made,
+		 * "npierce" is the total number of wall piercings for rooms,
+		 * and "ndug" is the number of tiles excavated (excluding wall
+		 * piercings).
+		 */
+		int nstep, npierce, ndug;
+		/*
+		 * "dstart" is the city block distance, in grids, (i.e.
+		 * ABS(start.x - end.x) + ABS(start.y - end.y)) between the
+		 * startng point and the goal for the tunnel.  "dend" is the
+		 * city block distance between the final point in the tunnel
+		 * and the goal:  "dend" equal to zero indicates that the
+		 * tunnel reached its goal.
+		 */
+		int dstart, dend;
+		/*
+		 * "early" is true if the tunnel was terminated by the random
+		 * early termination criteria.
+		 */
+		bool early;
+	} tunnel;
 } game_event_data;
 
 
@@ -204,5 +242,8 @@ void event_signal_missile(game_event_type type,
 						  bool seen,
 						  int y,
 						  int x);
+void event_signal_size(game_event_type type, int h, int w);
+void event_signal_tunnel(game_event_type type, int nstep, int npierce, int ndug,
+	int dstart, int dend, bool early);
 
 #endif /* INCLUDED_GAME_EVENT_H */

--- a/src/generate.c
+++ b/src/generate.c
@@ -1521,6 +1521,66 @@ void prepare_next_level(struct chunk **c, struct player *p)
 }
 
 /**
+ * Return the number of room builders available.
+ */
+int get_room_builder_count(void)
+{
+	return (int) N_ELEMENTS(room_builders);
+}
+
+/**
+ * Convert the name of a room builder into its index.  Return -1 if the
+ * name does not match any of the room builders.
+ */
+int get_room_builder_index_from_name(const char *name)
+{
+	int i = 0;
+
+	while (1) {
+		if (i >= (int) N_ELEMENTS(room_builders)) {
+			return -1;
+		}
+		if (streq(name, room_builders[i].name)) {
+			return i;
+		}
+		++i;
+	}
+}
+
+/**
+ * Get the name of a room builder given its index.  Return NULL if the index
+ * is out of bounds (less than one or greater than or equal to
+ * get_room_builder_count()).
+ */
+const char *get_room_builder_name_from_index(int i)
+{
+	return (i >= 0 && i < (int) get_room_builder_count()) ?
+		room_builders[i].name : NULL;
+}
+
+/**
+ * Convert the name of a level profile into its index in the cave_profiles
+ * list.  Return -1 if the name does not match any of the profiles.
+ */
+int get_level_profile_index_from_name(const char *name)
+{
+	const struct cave_profile *p = find_cave_profile(name);
+
+	return (p) ? (int) (p - cave_profiles) : -1;
+}
+
+/**
+ * Get the name of a level profile given its index.  Return NULL if the index
+ * is out of bounds (less than one or greater than or equal to
+ * z_info->profile_max).
+ */
+const char *get_level_profile_name_from_index(int i)
+{
+	return (i >= 0 && i < z_info->profile_max) ?
+		cave_profiles[i].name : NULL;
+}
+
+/**
  * The generate module, which initialises template rooms and vaults
  * Should it clean up?
  */

--- a/src/generate.h
+++ b/src/generate.h
@@ -309,6 +309,13 @@ extern struct dun_data *dun;
 extern struct vault *vaults;
 extern struct room_template *room_templates;
 
+/* generate.c */
+int get_room_builder_count(void);
+int get_room_builder_index_from_name(const char *name);
+const char *get_room_builder_name_from_index(int i);
+int get_level_profile_index_from_name(const char *name);
+const char *get_level_profile_name_from_index(int i);
+
 /* gen-cave.c */
 struct chunk *town_gen(struct player *p, int min_height, int min_width);
 struct chunk *classic_gen(struct player *p, int min_height, int min_width);

--- a/src/wiz-stats.c
+++ b/src/wiz-stats.c
@@ -1910,7 +1910,7 @@ static double compute_covar(const struct covar_n *cv, int i, int j)
 		j = i;
 		i = t;
 	}
-	assert(i >= 0 && i < cv->n && j >= 0 && cv->count >= 0);
+	assert(i >= 0 && i < cv->n && j >= 0);
 	if (cv->count <= 1) return 0.0;
 	result = cv->c[(i * (i + 1)) / 2 + j] - cv->s[i] * cv->s[i] / cv->count;
 	return (i != j || result > 0.0) ? result / (cv->count - 1) : 0.0;

--- a/src/wiz-stats.c
+++ b/src/wiz-stats.c
@@ -1819,6 +1819,922 @@ void pit_stats(int nsim, int pittype, int depth)
 	return;
 }
 
+struct tunnel_instance {
+	int nstep, npierce, ndug, dstart, dend;
+	bool early;
+};
+
+struct covar_n {
+	/* Is an n element array with the sum of each component. */
+	double *s;
+	/*
+	 * Is a (n * (n + 1)) / 2 element array.  c[(i * (i + 1)) / 2 + j]]
+	 * for 0 <= i < n and 0 <= j <= i is the sum of the product of the
+	 * ith and jth components.
+	 */
+	double *c;
+	/* Is the number of terms added to the sums. */
+	u32b count;
+	/* Is the number of components. */
+	int n;
+};
+
+static void initialize_covar(struct covar_n *cv, int n)
+{
+	int i;
+
+	assert(n >= 1);
+	cv->count = 0;
+	cv->n = n;
+	cv->s = mem_alloc(n * sizeof(*cv->s));
+	for (i = 0; i < n; ++i) {
+		cv->s[i] = 0.0;
+	}
+	cv->c = mem_alloc(((n * (n + 1)) / 2) * sizeof(*cv->c));
+	for (i = 0; i < (n * (n + 1)) / 2; ++i) {
+		cv->c[i] = 0.0;
+	}
+}
+
+static void cleanup_covar(struct covar_n *cv)
+{
+	mem_free(cv->c);
+	mem_free(cv->s);
+}
+
+static void add_to_covar(struct covar_n *cv, ...)
+{
+	/*
+	 * This is temporary space to hold the values so the cross terms can
+	 * be computed.
+	 */
+	double *hs;
+	va_list vp;
+	int i, ij;
+
+	assert(cv->n >= 1);
+	hs = mem_alloc(cv->n * sizeof(*hs));
+
+	/*
+	 * Get the component values from the variable arguments.  Add to
+	 * to the single component sums.
+	 */
+	va_start(vp, cv);
+	for (i = 0; i < cv->n; ++i) {
+		hs[i] = va_arg(vp, double);
+		cv->s[i] += hs[i];
+	}
+	va_end(vp);
+
+	/* Compute the cross terms. */
+	for (i = 0, ij = 0; i < cv->n; ++i) {
+		int j;
+
+		for (j = 0; j <= i; ++j, ++ij) {
+			cv->c[ij] += hs[i] * hs[j];
+		}
+	}
+
+	++cv->count;
+
+	mem_free(hs);
+}
+
+static double compute_covar(const struct covar_n *cv, int i, int j)
+{
+	double result;
+
+	if (j > i) {
+		int t = j;
+
+		j = i;
+		i = t;
+	}
+	assert(i >= 0 && i < cv->n && j >= 0 && cv->count >= 0);
+	if (cv->count <= 1) return 0.0;
+	result = cv->c[(i * (i + 1)) / 2 + j] - cv->s[i] * cv->s[i] / cv->count;
+	return (i != j || result > 0.0) ? result / (cv->count - 1) : 0.0;
+}
+
+static void dump_covar_averages(const struct covar_n *cv, ang_file* fo)
+{
+	int i;
+
+	for (i = 0; i < cv->n; ++i) {
+		if (i != 0) file_put(fo, "\t");
+		file_putf(fo, "%.4f", (cv->count > 0) ?
+			cv->s[i] / cv->count : 0.0);
+	}
+}
+
+static void dump_covar_var(const struct covar_n *cv, ang_file* fo)
+{
+	int i;
+
+	for (i = 0; i < cv->n; ++i) {
+		int j;
+
+		for (j = 0; j <= i; ++j) {
+			if (j != 0) file_put(fo, "\t");
+			file_putf(fo, "%+.6f", compute_covar(cv, i, j));
+		}
+		file_put(fo, "\n");
+	}
+}
+
+/* Assumes the count of terms in the sum is maintained elsewhere. */
+struct i_sum_sum2 {
+	u32b sum, sum2_lo, sum2_hi;
+};
+
+static void add_to_i_sum_sum2(struct i_sum_sum2 *s, int v)
+{
+	u32b v2 = v * v;
+
+	s->sum += v;
+	if (v2 > 4294967295UL - s->sum2_lo) {
+		++s->sum2_hi;
+	}
+	s->sum2_lo += v2;
+}
+
+static double stddev_i_sum_sum2(struct i_sum_sum2 s, int count)
+{
+	double var;
+
+	if (count <= 1) return 0.0;
+	var = s.sum2_hi * 4294967296.0 + s.sum2_lo -
+		s.sum * ((double) s.sum / count);
+	return (var > 0.0) ? sqrt(var / (count - 1)) : 0.0;
+}
+
+/* Assumes the count of terms in the sum is maintained elsewhere. */
+struct d_sum_sum2 {
+	double sum, sum2;
+};
+
+static void initialize_d_sum_sum2(struct d_sum_sum2 *s)
+{
+	s->sum = 0.0;
+	s->sum2 = 0.0;
+}
+
+static void add_to_d_sum_sum2(struct d_sum_sum2 *s, double v)
+{
+	s->sum += v;
+	s->sum2 += v * v;
+}
+
+static double stddev_d_sum_sum2(struct d_sum_sum2 s, int count)
+{
+	double var;
+
+	if (count <= 1) return 0.0;
+	var = s.sum2 - s.sum * s.sum / count;
+	return (var > 0.0) ? sqrt(var / (count - 1)) : 0.0;
+}
+
+struct tunnel_aggregate {
+	/*
+	 * Hold the sums for for the normalized number of steps, number of
+	 * wall piercings, normalized number of grids excavated, normalized
+	 * starting distance, and normalized final distance.  The first
+	 * includes all tunnels, the second only those that had early
+	 * terminations, the third only those without early termination, and
+	 * the fourth only those that did not reach their destination.
+	 */
+	struct covar_n cv_all, cv_early, cv_noearly, cv_fail;
+	/*
+	 * As above but drops the normalized final distance since that is
+	 * always zero for tunnels that reach their destinations.
+	 */
+	struct covar_n cv_success;
+	/*
+	 * Hold the sums for the fraction of tunnels with early termination
+	 * and successful termination.
+	 */
+	struct d_sum_sum2 early_frac, success_frac;
+};
+
+static void initialize_tunnel_aggregate(struct tunnel_aggregate *ta)
+{
+	initialize_covar(&ta->cv_all, 5);
+	initialize_covar(&ta->cv_early, 5);
+	initialize_covar(&ta->cv_noearly, 5);
+	initialize_covar(&ta->cv_fail, 5);
+	initialize_covar(&ta->cv_success, 4);
+	initialize_d_sum_sum2(&ta->early_frac);
+	initialize_d_sum_sum2(&ta->success_frac);
+}
+
+static void cleanup_tunnel_aggregate(struct tunnel_aggregate *ta)
+{
+	cleanup_covar(&ta->cv_success);
+	cleanup_covar(&ta->cv_fail);
+	cleanup_covar(&ta->cv_noearly);
+	cleanup_covar(&ta->cv_early);
+	cleanup_covar(&ta->cv_all);
+}
+
+static void add_to_tunnel_aggregate(struct tunnel_aggregate *ta,
+		const struct tunnel_instance *ti, int ntunnel,
+		const struct chunk *c)
+{
+	/*
+	 * Normalize the number of steps taken, number of grids excavated,
+	 * starting distance, and final distance by the sum of the dimensions
+	 * of the cave - that has the correct units (grids) and should allow
+	 * reasonable aggregation of tunneling results from caves with
+	 * different sizes.
+	 */
+	double length_norm = c->width + c->height;
+	int early_count = 0, success_count = 0, i;
+
+	assert(c->width > 0 && c->height > 0);
+
+	for (i = 0; i < ntunnel; ++i) {
+		double normed[5] = {
+			ti[i].nstep / length_norm,
+			ti[i].npierce,
+			ti[i].ndug / length_norm,
+			ti[i].dstart / length_norm,
+			ti[i].dend / length_norm
+		};
+
+		add_to_covar(&ta->cv_all, normed[0], normed[1], normed[2],
+			normed[3], normed[4]);
+
+		if (ti[i].early) {
+			add_to_covar(&ta->cv_early, normed[0], normed[1],
+				normed[2], normed[3], normed[4]);
+			++early_count;
+		} else {
+			add_to_covar(&ta->cv_noearly, normed[0], normed[1],
+				normed[2], normed[3], normed[4]);
+		}
+
+		if (ti[i].dend == 0) {
+			add_to_covar(&ta->cv_success, normed[0], normed[1],
+				normed[2], normed[3]);
+			++success_count;
+		} else {
+			add_to_covar(&ta->cv_fail, normed[0], normed[1],
+				normed[2], normed[3], normed[4]);
+		}
+	}
+
+	if (ntunnel > 0) {
+		add_to_d_sum_sum2(&ta->early_frac,
+			early_count / (double) ntunnel);
+		add_to_d_sum_sum2(&ta->success_frac,
+			success_count / (double) ntunnel);
+	}
+}
+
+struct grid_count_aggregate {
+	/*
+	 * For everything but the stairs, accumulate the counts normalized by
+	 * the area (in grids) for the cave.  For the stairs, accumulate the
+	 * unnormalized counts since the number of stairs is typically
+	 * independent of the size of the cave.
+	 */
+	struct d_sum_sum2 floor;
+	struct i_sum_sum2 upstair;
+	struct i_sum_sum2 downstair;
+	struct d_sum_sum2 trap;
+	struct d_sum_sum2 lava;
+	struct d_sum_sum2 impass_rubble;
+	struct d_sum_sum2 pass_rubble;
+	struct d_sum_sum2 magma_treasure;
+	struct d_sum_sum2 quartz_treasure;
+	struct d_sum_sum2 open_door;
+	struct d_sum_sum2 closed_door;
+	struct d_sum_sum2 broken_door;
+	struct d_sum_sum2 secret_door;
+	struct d_sum_sum2 traversable_neighbor_histogram[9];
+};
+
+static void initialize_grid_count_aggregate(struct grid_count_aggregate *ga)
+{
+	int i;
+
+	ga->floor.sum = 0.0;
+	ga->floor.sum2 = 0.0;
+	ga->upstair.sum = 0;
+	ga->upstair.sum2_lo = 0;
+	ga->upstair.sum2_hi = 0;
+	ga->downstair.sum = 0;
+	ga->downstair.sum2_lo = 0;
+	ga->downstair.sum2_hi = 0;
+	ga->trap.sum = 0.0;
+	ga->trap.sum2 = 0.0;
+	ga->lava.sum = 0.0;
+	ga->lava.sum2 = 0.0;
+	ga->impass_rubble.sum = 0.0;
+	ga->impass_rubble.sum2 = 0.0;
+	ga->pass_rubble.sum = 0.0;
+	ga->pass_rubble.sum2 = 0.0;
+	ga->magma_treasure.sum = 0.0;
+	ga->magma_treasure.sum2 = 0.0;
+	ga->quartz_treasure.sum = 0.0;
+	ga->quartz_treasure.sum2 = 0.0;
+	ga->open_door.sum = 0.0;
+	ga->open_door.sum2 = 0.0;
+	ga->closed_door.sum = 0.0;
+	ga->closed_door.sum2 = 0.0;
+	ga->broken_door.sum = 0.0;
+	ga->broken_door.sum2 = 0.0;
+	ga->secret_door.sum = 0.0;
+	ga->secret_door.sum2 = 0.0;
+	for (i = 0; i < 9; ++i) {
+		ga->traversable_neighbor_histogram[i].sum = 0.0;
+		ga->traversable_neighbor_histogram[i].sum2 = 0.0;
+	}
+}
+
+static void add_to_grid_count_aggregate(struct grid_count_aggregate *ga,
+		const struct grid_counts *gi, const struct chunk *c)
+{
+	double area = c->width * c->height;
+	int i;
+
+	assert(c->width > 0 && c->height > 0);
+	add_to_d_sum_sum2(&ga->floor, gi->floor / area);
+	add_to_i_sum_sum2(&ga->upstair, gi->upstair);
+	add_to_i_sum_sum2(&ga->downstair, gi->downstair);
+	add_to_d_sum_sum2(&ga->trap, gi->trap / area);
+	add_to_d_sum_sum2(&ga->lava, gi->lava / area);
+	add_to_d_sum_sum2(&ga->impass_rubble, gi->impass_rubble / area);
+	add_to_d_sum_sum2(&ga->pass_rubble, gi->pass_rubble / area);
+	add_to_d_sum_sum2(&ga->magma_treasure, gi->magma_treasure / area);
+	add_to_d_sum_sum2(&ga->quartz_treasure, gi->quartz_treasure / area);
+	add_to_d_sum_sum2(&ga->open_door, gi->open_door / area);
+	add_to_d_sum_sum2(&ga->closed_door, gi->closed_door / area);
+	add_to_d_sum_sum2(&ga->broken_door, gi->broken_door / area);
+	add_to_d_sum_sum2(&ga->secret_door, gi->secret_door / area);
+	for (i = 0; i < 9; ++i) {
+		add_to_d_sum_sum2(&ga->traversable_neighbor_histogram[i],
+			gi->traversable_neighbor_histogram[i] / area);
+	}
+}
+
+struct cgen_stats {
+	/*
+	 * This is effectively a 2 x z_info->profile_max array where
+	 * level_counts[0][i] element is the number of successful builds of
+	 * the ith level type and level_counts[1][i] is the number of
+	 * unsuccessful builds of the ith level type.
+	 */
+	u32b* level_counts[2];
+	/*
+	 * This is a z_info->profile_max element array where total_rooms[i] has
+	 * the results for the total number of rooms per successful level in
+	 * the ith level type.
+	 */
+	struct i_sum_sum2* total_rooms;
+	/*
+	 * This is effectively a z_info->profile_max x 2 x room_type_count array
+	 * where room_counts[i][0][j] has the results for the number of
+	 * successful rooms of the jth type in the ith level type and
+	 * room_counts[i][1][j] has the results for number of unsuccessful
+	 * rooms of the jth type in the ith level type.
+	 */
+	struct i_sum_sum2*** room_counts;
+	/*
+	 * This is a z_info_profile_max element array of the aggregate results,
+	 * by level profile, for tunneling.
+	 */
+	struct tunnel_aggregate *ta;
+	/*
+	 * This is a z_info_profile_max x 3 element array of the aggregate
+	 * results, by level profile, for grid types.
+	 */
+	struct grid_count_aggregate **ga;
+	/*
+	 * This is a 2 x room_type_count array for the room counts of the
+	 * current level so they can be reverted upon a level failure.
+	 */
+	u32b* curr_room_counts[2];
+	/*
+	 * This is a flat array of the tunneling results for the current level.
+	 */
+	struct tunnel_instance *curr_tunn;
+	int n_curr_tunn, alloc_curr_tunn;
+	/*
+	 * disarea_counts[i] is the number of levels of type i that had at
+	 * least one disconnected area that wasn't in a vault.
+	 */
+	u32b* disarea_counts;
+	/*
+	 * disdstair_counts[i] is the number of levels of type i where the
+	 * player is disconnected from all down staircases.
+	 */
+	u32b* disdstair_counts;
+	/* Is the number of successfully generated levels. */
+	int nsuccess;
+	/* Is the number of failed levels. */
+	int nfail;
+	/*
+	 * Are the type indices for the most recently initiated level and room.
+	 */
+	int level_type, room_type;
+	/*
+	 * Is the number of possible room types; caches the result of
+	 * get_room_builder_count().
+	 */
+	int room_type_count;
+};
+
+static void cgenstat_handle_new_level(game_event_type et, game_event_data *ed,
+		void *ud)
+{
+	struct cgen_stats *gs;
+	int i;
+
+	assert(et == EVENT_GEN_LEVEL_START && ud);
+	gs = (struct cgen_stats*) ud;
+	gs->level_type = (ed->string) ?
+		get_level_profile_index_from_name(ed->string) : -1;
+	assert(gs->level_type >= 0 && gs->level_type < z_info->profile_max);
+
+	/* Reset counters for the current level. */
+	for (i = 0; i < gs->room_type_count; ++i) {
+		gs->curr_room_counts[0][i] = 0;
+		gs->curr_room_counts[1][i] = 0;
+	}
+	gs->n_curr_tunn = 0;
+}
+
+static void cgenstat_handle_level_end(game_event_type et, game_event_data *ed,
+		void *ud)
+{
+	struct cgen_stats *gs;
+
+	assert(et == EVENT_GEN_LEVEL_END && ud);
+	gs = (struct cgen_stats*) ud;
+	assert(gs->level_type >= 0 && gs->level_type < z_info->profile_max);
+	if (ed->flag) {
+		int room_count = 0;
+		struct grid_counts gcounts[3];
+		int i;
+
+		/* Successfully created.  Transfer room counts. */
+		for (i = 0; i < gs->room_type_count; ++i) {
+			add_to_i_sum_sum2(
+				&gs->room_counts[gs->level_type][0][i],
+				gs->curr_room_counts[0][i]);
+			room_count += gs->curr_room_counts[0][i];
+			add_to_i_sum_sum2(
+				&gs->room_counts[gs->level_type][1][i],
+				gs->curr_room_counts[1][i]);
+		}
+		add_to_i_sum_sum2(&gs->total_rooms[gs->level_type], room_count);
+
+		/* Aggregate tunneling results. */
+		add_to_tunnel_aggregate(&gs->ta[gs->level_type],
+			gs->curr_tunn, gs->n_curr_tunn, cave);
+
+		/*
+		 * Summarize what's in the cave and add it to the running
+		 * totals.
+		 */
+		stat_grid_counter_simple(cave, gcounts);
+		for (i = 0; i < 3; ++i) {
+			add_to_grid_count_aggregate(&gs->ga[gs->level_type][i],
+				&gcounts[i], cave);
+		}
+
+		/* Update level success count. */
+		++gs->level_counts[0][gs->level_type];
+		++gs->nsuccess;
+	} else {
+		/* Creation failed.  Update level failure count. */
+		++gs->level_counts[1][gs->level_type];
+		++gs->nfail;
+	}
+}
+
+static void cgenstat_handle_new_room(game_event_type et, game_event_data *ed,
+		void *ud)
+{
+	struct cgen_stats *gs;
+
+	assert(et == EVENT_GEN_ROOM_START && ud);
+	gs = (struct cgen_stats*) ud;
+	assert(gs->level_type >= 0 && gs->level_type < z_info->profile_max);
+	gs->room_type = (ed->string) ?
+		get_room_builder_index_from_name(ed->string) : -1;
+	assert(gs->room_type >= 0 && gs->room_type < gs->room_type_count);
+}
+
+static void cgenstat_handle_room_end(game_event_type et, game_event_data *ed,
+		void *ud)
+{
+	struct cgen_stats *gs;
+
+	assert(et == EVENT_GEN_ROOM_END && ud);
+	gs = (struct cgen_stats*) ud;
+	assert(gs->level_type >= 0 && gs->level_type < z_info->profile_max);
+	assert(gs->room_type >= 0 && gs->room_type < gs->room_type_count);
+
+	/* Update room count for the current level. */
+	++gs->curr_room_counts[(ed->flag) ? 0 : 1][gs->room_type];
+}
+
+static void cgenstat_handle_tunnel(game_event_type et, game_event_data *ed,
+		void *ud)
+{
+	struct cgen_stats *gs;
+
+	assert(et == EVENT_GEN_TUNNEL_FINISHED && ud);
+	gs = (struct cgen_stats*) ud;
+	assert(gs->level_type >= 0 && gs->level_type < z_info->profile_max);
+
+	/* Add to the tunneling records. */
+	assert(gs->n_curr_tunn >= 0 && gs->n_curr_tunn <= gs->alloc_curr_tunn);
+	if (gs->n_curr_tunn == gs->alloc_curr_tunn) {
+		gs->alloc_curr_tunn = (gs->alloc_curr_tunn) ?
+			gs->alloc_curr_tunn + gs->alloc_curr_tunn : 8;
+		gs->curr_tunn = mem_realloc(gs->curr_tunn,
+			gs->alloc_curr_tunn * sizeof(*gs->curr_tunn));
+	}
+	gs->curr_tunn[gs->n_curr_tunn].nstep = ed->tunnel.nstep;
+	gs->curr_tunn[gs->n_curr_tunn].npierce = ed->tunnel.npierce;
+	gs->curr_tunn[gs->n_curr_tunn].ndug = ed->tunnel.ndug;
+	gs->curr_tunn[gs->n_curr_tunn].dstart = ed->tunnel.dstart;
+	gs->curr_tunn[gs->n_curr_tunn].dend = ed->tunnel.dend;
+	gs->curr_tunn[gs->n_curr_tunn].early = ed->tunnel.early;
+	++gs->n_curr_tunn;
+}
+
+static void initialize_generation_stats(struct cgen_stats *gs)
+{
+	int i;
+
+	gs->nsuccess = 0;
+	gs->nfail = 0;
+	gs->level_type = -1;
+	gs->room_type = -1;
+	gs->room_type_count = get_room_builder_count();
+
+	gs->level_counts[0] = mem_zalloc(z_info->profile_max *
+		sizeof(*gs->level_counts[0]));
+	gs->level_counts[1] = mem_zalloc(z_info->profile_max *
+		sizeof(*gs->level_counts[1]));
+
+	gs->total_rooms = mem_zalloc(z_info->profile_max *
+		sizeof(*gs->total_rooms));
+
+	gs->room_counts = mem_alloc(z_info->profile_max *
+		sizeof(*gs->room_counts));
+	for (i = 0; i < z_info->profile_max; ++i) {
+		gs->room_counts[i] = mem_alloc(2 * sizeof(*gs->room_counts[i]));
+		gs->room_counts[i][0] = mem_zalloc(gs->room_type_count *
+			sizeof(*gs->room_counts[i][0]));
+		gs->room_counts[i][1] = mem_zalloc(gs->room_type_count *
+			sizeof(*gs->room_counts[i][1]));
+	}
+
+	gs->ta = mem_alloc(z_info->profile_max * sizeof(*gs->ta));
+	for (i = 0; i < z_info->profile_max; ++i) {
+		initialize_tunnel_aggregate(&gs->ta[i]);
+	}
+
+	gs->ga = mem_alloc(z_info->profile_max * sizeof(*gs->ga));
+	for (i = 0; i < z_info->profile_max; ++i) {
+		gs->ga[i] = mem_alloc(3 * sizeof(*gs->ga[i]));
+		initialize_grid_count_aggregate(&gs->ga[i][0]);
+		initialize_grid_count_aggregate(&gs->ga[i][1]);
+		initialize_grid_count_aggregate(&gs->ga[i][2]);
+	}
+
+	gs->curr_room_counts[0] = mem_alloc(gs->room_type_count *
+		sizeof(*gs->curr_room_counts[0]));
+	gs->curr_room_counts[1] = mem_alloc(gs->room_type_count *
+		sizeof(*gs->curr_room_counts[1]));
+
+	gs->curr_tunn = NULL;
+	gs->n_curr_tunn = 0;
+	gs->alloc_curr_tunn = 0;
+
+	gs->disarea_counts = mem_zalloc(z_info->profile_max *
+		sizeof(*gs->disarea_counts));
+	gs->disdstair_counts = mem_zalloc(z_info->profile_max *
+		sizeof(*gs->disdstair_counts));
+
+	event_add_handler(EVENT_GEN_LEVEL_START, cgenstat_handle_new_level, gs);
+	event_add_handler(EVENT_GEN_LEVEL_END, cgenstat_handle_level_end, gs);
+	event_add_handler(EVENT_GEN_ROOM_START, cgenstat_handle_new_room, gs);
+	event_add_handler(EVENT_GEN_ROOM_END, cgenstat_handle_room_end, gs);
+	event_add_handler(EVENT_GEN_TUNNEL_FINISHED, cgenstat_handle_tunnel, gs);
+}
+
+static void cleanup_generation_stats(struct cgen_stats *gs)
+{
+	int i;
+
+	event_remove_handler(EVENT_GEN_LEVEL_START,
+		cgenstat_handle_new_level, gs);
+	event_remove_handler(EVENT_GEN_LEVEL_END,
+		cgenstat_handle_level_end, gs);
+	event_remove_handler(EVENT_GEN_ROOM_START,
+		cgenstat_handle_new_room, gs);
+	event_remove_handler(EVENT_GEN_ROOM_END,
+		cgenstat_handle_room_end, gs);
+	event_remove_handler(EVENT_GEN_TUNNEL_FINISHED,
+		cgenstat_handle_tunnel, gs);
+
+	mem_free(gs->disdstair_counts);
+	mem_free(gs->disarea_counts);
+
+	mem_free(gs->curr_tunn);
+
+	mem_free(gs->curr_room_counts[1]);
+	mem_free(gs->curr_room_counts[0]);
+
+	for (i = 0; i < z_info->profile_max; ++i) {
+		mem_free(gs->ga[i]);
+	}
+	mem_free(gs->ga);
+
+	for (i = 0; i < z_info->profile_max; ++i) {
+		cleanup_tunnel_aggregate(&gs->ta[i]);
+	}
+	mem_free(gs->ta);
+
+	for (i = 0; i < z_info->profile_max; ++i) {
+		mem_free(gs->room_counts[i][1]);
+		mem_free(gs->room_counts[i][0]);
+		mem_free(gs->room_counts[i]);
+	}
+	mem_free(gs->room_counts);
+
+	mem_free(gs->total_rooms);
+
+	mem_free(gs->level_counts[1]);
+	mem_free(gs->level_counts[0]);
+}
+
+static void dump_generation_stats(ang_file *fo, const struct cgen_stats *gs)
+{
+	int i;
+
+	file_put(fo, "Number of Successful Levels::\n");
+	file_putf(fo, "%d\n\n", (unsigned long) gs->nsuccess);
+
+	file_put(fo, "Level Builder Success Count, Probability, and Failure Rate Per Successful Level::\n");
+	for (i = 0; i < z_info->profile_max; ++i) {
+		file_putf(fo, "\"%s\"\t%lu\t%.6f\t%.6f\n",
+			get_level_profile_name_from_index(i),
+			(unsigned long) gs->level_counts[0][i],
+			(double) gs->level_counts[0][i] / gs->nsuccess,
+			(double) gs->level_counts[1][i] / gs->nsuccess);
+	}
+	file_put(fo, "\n");
+
+	file_put(fo, "Average and Std. Deviation of Room Counts by Level Type::\n");
+	for (i = 0; i < z_info->profile_max; ++i) {
+		file_putf(fo, "\"%s\"\t%.4f\t%.4f\n",
+			get_level_profile_name_from_index(i),
+			(gs->level_counts[0][i] > 0) ?
+				(double) gs->total_rooms[i].sum /
+				gs->level_counts[0][i] : 0.0,
+			stddev_i_sum_sum2(gs->total_rooms[i],
+				gs->level_counts[0][i]));
+	}
+	file_put(fo, "\n");
+
+	for (i = 0; i < z_info->profile_max; ++i) {
+		int j;
+		const char *name;
+
+		/* Skip profiles that were not used. */
+		if (!gs->level_counts[0][i]) continue;
+
+		name = get_level_profile_name_from_index(i);
+
+		file_putf(fo, "\"%s\" Mean and Std. Deviation For Room Counts::\n", name);
+		for (j = 0; j < gs->room_type_count; ++j) {
+			file_putf(fo, "\"%s\"\t%.4f\t%.4f\n",
+				get_room_builder_name_from_index(j),
+				(double) gs->room_counts[i][0][j].sum /
+					gs->level_counts[0][i],
+				stddev_i_sum_sum2(gs->room_counts[i][0][j],
+					gs->level_counts[0][i]));
+		}
+		file_put(fo, "\n");
+
+		file_putf(fo, "\"%s\" Mean and Std. Deviation for Room Failure Rates::\n", name);
+		for (j = 0; j < gs->room_type_count; ++j) {
+			file_putf(fo, "\"%s\"\t%.6f\t%.6f\n",
+				get_room_builder_name_from_index(j),
+				(double) gs->room_counts[i][1][j].sum /
+					gs->level_counts[0][i],
+				stddev_i_sum_sum2(gs->room_counts[i][1][j],
+					gs->level_counts[0][i]));
+		}
+		file_put(fo, "\n");
+
+		file_putf(fo, "\"%s\" Grid Fractions (Vault, Room, Other)::\n", name);
+		file_put(fo, "floor");
+		for (j = 0; j < 3; ++j) {
+			file_putf(fo, "\t%.6f\t%.6f",
+				gs->ga[i][j].floor.sum / gs->level_counts[0][i],
+				stddev_d_sum_sum2(gs->ga[i][j].floor,
+					gs->level_counts[0][i]));
+		}
+		file_put(fo, "\n");
+		file_put(fo, "trap");
+		for (j = 0; j < 3; ++j) {
+			file_putf(fo, "\t%.6f\t%.6f",
+				gs->ga[i][j].trap.sum / gs->level_counts[0][i],
+				stddev_d_sum_sum2(gs->ga[i][j].trap,
+					gs->level_counts[0][i]));
+		}
+		file_put(fo, "\n");
+		file_put(fo, "lava");
+		for (j = 0; j < 3; ++j) {
+			file_putf(fo, "\t%.6f\t%.6f",
+				gs->ga[i][j].lava.sum / gs->level_counts[0][i],
+				stddev_d_sum_sum2(gs->ga[i][j].lava,
+					gs->level_counts[0][i]));
+		}
+		file_put(fo, "\n");
+		file_put(fo, "imrubb");
+		for (j = 0; j < 3; ++j) {
+			file_putf(fo, "\t%.6f\t%.6f",
+				gs->ga[i][j].impass_rubble.sum /
+					gs->level_counts[0][i],
+				stddev_d_sum_sum2(gs->ga[i][j].impass_rubble,
+					gs->level_counts[0][i]));
+		}
+		file_put(fo, "\n");
+		file_put(fo, "parubb");
+		for (j = 0; j < 3; ++j) {
+			file_putf(fo, "\t%.6f\t%.6f",
+				gs->ga[i][j].pass_rubble.sum /
+					gs->level_counts[0][i],
+				stddev_d_sum_sum2(gs->ga[i][j].pass_rubble,
+					gs->level_counts[0][i]));
+		}
+		file_put(fo, "\n");
+		file_put(fo, "mgmvein");
+		for (j = 0; j < 3; ++j) {
+			file_putf(fo, "\t%.6f\t%.6f",
+				gs->ga[i][j].magma_treasure.sum /
+					gs->level_counts[0][i],
+				stddev_d_sum_sum2(gs->ga[i][j].magma_treasure,
+					gs->level_counts[0][i]));
+		}
+		file_put(fo, "\n");
+		file_put(fo, "qtzvein");
+		for (j = 0; j < 3; ++j) {
+			file_putf(fo, "\t%.6f\t%.6f",
+				gs->ga[i][j].quartz_treasure.sum /
+					gs->level_counts[0][i],
+				stddev_d_sum_sum2(gs->ga[i][j].quartz_treasure,
+					gs->level_counts[0][i]));
+		}
+		file_put(fo, "\n");
+		file_put(fo, "opdoor");
+		for (j = 0; j < 3; ++j) {
+			file_putf(fo, "\t%.6f\t%.6f",
+				gs->ga[i][j].open_door.sum /
+					gs->level_counts[0][i],
+				stddev_d_sum_sum2(gs->ga[i][j].open_door,
+					gs->level_counts[0][i]));
+		}
+		file_put(fo, "\n");
+		file_put(fo, "cldoor");
+		for (j = 0; j < 3; ++j) {
+			file_putf(fo, "\t%.6f\t%.6f",
+				gs->ga[i][j].closed_door.sum /
+					gs->level_counts[0][i],
+				stddev_d_sum_sum2(gs->ga[i][j].closed_door,
+					gs->level_counts[0][i]));
+		}
+		file_put(fo, "\n");
+		file_put(fo, "brdoor");
+		for (j = 0; j < 3; ++j) {
+			file_putf(fo, "\t%.6f\t%.6f",
+				gs->ga[i][j].broken_door.sum /
+					gs->level_counts[0][i],
+				stddev_d_sum_sum2(gs->ga[i][j].broken_door,
+					gs->level_counts[0][i]));
+		}
+		file_put(fo, "\n");
+		file_put(fo, "scdoor");
+		for (j = 0; j < 3; ++j) {
+			file_putf(fo, "\t%.6f\t%.6f",
+				gs->ga[i][j].secret_door.sum /
+					gs->level_counts[0][i],
+				stddev_d_sum_sum2(gs->ga[i][j].secret_door,
+					gs->level_counts[0][i]));
+		}
+		file_put(fo, "\n\n");
+
+		file_putf(fo, "\"%s\" Stair Average Counts (Vault, Room, Other)::\n", name);
+		file_put(fo, "up");
+		for (j = 0; j < 3; ++j) {
+			file_putf(fo, "\t%.6f\t%.6f",
+				gs->ga[i][j].upstair.sum /
+					(double) gs->level_counts[0][i],
+				stddev_i_sum_sum2(gs->ga[i][j].upstair,
+					gs->level_counts[0][i]));
+		}
+		file_put(fo, "\n");
+		file_put(fo, "down");
+		for (j = 0; j < 3; ++j) {
+			file_putf(fo, "\t%.6f\t%.6f",
+				gs->ga[i][j].downstair.sum /
+					(double) gs->level_counts[0][i],
+				stddev_i_sum_sum2(gs->ga[i][j].downstair,
+					gs->level_counts[0][i]));
+		}
+		file_put(fo, "\n\n");
+
+		file_putf(fo, "\"%s\" Traversable Neighbor Histogram (Vault, Room, Other)::\n", name);
+		for (j = 0; j < 9; ++j) {
+			int k;
+
+			file_putf(fo, "%d", j);
+			for (k = 0; k < 3; ++k) {
+				file_putf(fo, "\t%.6f\t%.6f",
+					gs->ga[i][k].traversable_neighbor_histogram[j].sum /
+						gs->level_counts[0][i],
+					stddev_d_sum_sum2(gs->ga[i][k].traversable_neighbor_histogram[j],
+						gs->level_counts[0][i]));
+			}
+			file_put(fo, "\n");
+		}
+		file_put(fo, "\n");
+
+		file_putf(fo, "\"%s\" Tunneling Total Number, Success Rate, Early Termination Rate::\n", name);
+		file_putf(fo, "%lu\t%.6f\t%.6f\t%.6f\t%.6f\n\n",
+			gs->ta[i].cv_all.count,
+			gs->ta[i].success_frac.sum /
+			gs->level_counts[0][i], stddev_d_sum_sum2(
+			gs->ta[i].success_frac, gs->level_counts[0][i]),
+			gs->ta[i].early_frac.sum /
+			gs->level_counts[0][i], stddev_d_sum_sum2(
+			gs->ta[i].early_frac, gs->level_counts[0][i]));
+
+		file_putf(fo, "\"%s\" Tunneling Scaled Averages (all tunnels; steps, wall piercings, excavated, start distance, final distance)::\n", name);
+		dump_covar_averages(&gs->ta[i].cv_all, fo);
+		file_put(fo, "\n\n");
+
+		file_putf(fo, "\"%s\" Tunneling Scaled Covariances (all tunnels; steps, wall piercings, excavated, start distance, final distance)::\n", name);
+		dump_covar_var(&gs->ta[i].cv_all, fo);
+		file_put(fo, "\n");
+
+		file_putf(fo, "\"%s\" Tunneling Scaled Averages (tunnels terminated early; steps, wall piercings, excavated, start distance, final distance)::\n", name);
+		dump_covar_averages(&gs->ta[i].cv_early, fo);
+		file_put(fo, "\n\n");
+
+		file_putf(fo, "\"%s\" Tunneling Scaled Covariances (tunnels terminated early; steps, wall piercings, excavated, start distance, final distance)::\n", name);
+		dump_covar_var(&gs->ta[i].cv_early, fo);
+		file_put(fo, "\n");
+
+		file_putf(fo, "\"%s\" Tunneling Scaled Averages (tunnels not terminated early; steps, wall piercings, excavated, start distance, final distance)::\n", name);
+		dump_covar_averages(&gs->ta[i].cv_noearly, fo);
+		file_put(fo, "\n\n");
+
+		file_putf(fo, "\"%s\" Tunneling Scaled Covariances (tunnels not terminated early; steps, wall piercings, excavated, start distance, final distance)::\n", name);
+		dump_covar_var(&gs->ta[i].cv_noearly, fo);
+		file_put(fo, "\n");
+
+		file_putf(fo, "\"%s\" Tunneling Scaled Averages (tunnels that reached their destinations; steps, wall piercings, excavated, start distance)::\n", name);
+		dump_covar_averages(&gs->ta[i].cv_success, fo);
+		file_put(fo, "\n\n");
+
+		file_putf(fo, "\"%s\" Tunneling Scaled Covariances (tunnels that reached their destinations; steps, wall piercings, excavated, start distance)::\n", name);
+		dump_covar_var(&gs->ta[i].cv_success, fo);
+		file_put(fo, "\n");
+
+		file_putf(fo, "\"%s\" Tunneling Scaled Averages (tunnels that did not reach their destinations; steps, wall piercings, excavated, start distance, final distance)::\n", name);
+		dump_covar_averages(&gs->ta[i].cv_fail, fo);
+		file_put(fo, "\n\n");
+
+		file_putf(fo, "\"%s\" Tunneling Scaled Covariances (tunnels that did not reach their destinations; steps, wall piercings, excavated, start distance, final distance)::\n", name);
+		dump_covar_var(&gs->ta[i].cv_fail, fo);
+		file_put(fo, "\n");
+	}
+
+	file_put(fo, "Counts of Levels with Disconnected Non-vault Areas::\n");
+	for (i = 0; i < z_info->profile_max; ++i) {
+		file_putf(fo, "\"%s\"\t%lu\n",
+			get_level_profile_name_from_index(i),
+			(unsigned long) gs->disarea_counts[i]);
+	}
+	file_put(fo, "\n");
+
+	file_put(fo, "Counts of Levels with Player Disconnected from Down Stairs::\n");
+	for (i = 0; i < z_info->profile_max; ++i) {
+		file_putf(fo, "\"%s\"\t%lu\n",
+			get_level_profile_name_from_index(i),
+			(unsigned long) gs->disdstair_counts[i]);
+	}
+}
 
 /**
  * Gather whether the dungeon has disconnects in it and whether the player
@@ -1835,12 +2751,24 @@ void disconnect_stats(int nsim, bool stop_on_disconnect)
 	long dsc_area = 0, dsc_from_stairs = 0;
 	char path[1024];
 	ang_file *disfile;
+	struct cgen_stats gs;
+	ang_file *gstfile;
 
 	path_build(path, sizeof(path), ANGBAND_DIR_USER, "disconnect.html");
 	disfile = file_open(path, MODE_WRITE, FTYPE_TEXT);
 	if (disfile) {
 		dump_level_header(disfile, "Disconnected Levels");
 	}
+
+	path_build(path, sizeof(path), ANGBAND_DIR_USER,
+		"disconnect_gstat.txt");
+	gstfile = file_open(path, MODE_WRITE, FTYPE_TEXT);
+
+	/*
+	 * Set up to collect some statistics about level types, room types,
+	 * and tunneling as well.
+	 */
+	initialize_generation_stats(&gs);
 
 	for (i = 1; i <= nsim; i++) {
 		/* Assume no disconnected areas */
@@ -1901,9 +2829,19 @@ void disconnect_stats(int nsim, bool stop_on_disconnect)
 			}
 		}
 
-		if (has_dsc_from_stairs) dsc_from_stairs++;
+		if (has_dsc_from_stairs) {
+			dsc_from_stairs++;
+			if (gs.level_type >= 0) {
+				++gs.disdstair_counts[gs.level_type];
+			}
+		}
 
-		if (has_dsc) dsc_area++;
+		if (has_dsc) {
+			dsc_area++;
+			if (gs.level_type >= 0) {
+				++gs.disarea_counts[gs.level_type];
+			}
+		}
 
 		if (has_dsc || has_dsc_from_stairs) {
 			if (disfile) {
@@ -1927,6 +2865,14 @@ void disconnect_stats(int nsim, bool stop_on_disconnect)
 			msg("Map is in disconnect.html.");
 		}
 	}
+	if (gstfile) {
+		dump_generation_stats(gstfile, &gs);
+		if (file_close(gstfile)) {
+			msg("Level generation statistics are in disconnect_gstat.txt");
+		}
+	}
+
+	cleanup_generation_stats(&gs);
 
 	/* Redraw the level */
 	do_cmd_redraw();
@@ -1953,3 +2899,230 @@ void pit_stats(int nsim, int pittype, int depth)
 {
 }
 #endif /* USE_STATS */
+
+/**
+ * Visit all grids in a chunk and report requested counts.
+ * \param c Is the chunk to use.
+ * \param gpreds Is a n_gpred element array.  For each element in the array,
+ * the in_vault_count, in_room_count, and in_other_count fields are set to
+ * zero at the start of this function.  Then for each grid in the chunk where
+ * the pred field evaluates to be true, the following is done: if
+ * square_isvault() is also true for that grid, in_vault_count is incremented;
+ * if square_isvault() is not true but square_isroom() is true for that grid,
+ * in_room_count is incremented; if both square_isvault() and square_isroom()
+ * ar false for that grid, in_other_count is incremented.
+ * \param n_gpred Is the number of elements in gpreds.
+ * \param npreds Is a n_npred element array.  For each element in the array,
+ * all elmeents of vault_histogram, room_histogram, and other_histogram are
+ * set to zero as the start of this function.  Then for each grid in the chunk
+ * where the pred field evaluates to be true, count the number of immediate
+ * neighbors where the neigh field evaluates to be true.  If square_isvault()
+ * is true for the grid, increment the vault_histogram element corresponding to
+ * that count; if square_isvault() is not true but square_isroom() is true for
+ * the grid, increment the room_histogram element correspoding to that count;
+ * if both square_isvault() and square_isroom() are false for the grid,
+ * increment the other_histogram element corresponding to that count.
+ * \param n_npred Is the number of elements in npreds.
+ */
+void stat_grid_counter(struct chunk *c, struct grid_counter_pred *gpreds,
+		int n_gpred, struct neighbor_counter_pred *npreds, int n_npred)
+{
+	int i;
+	struct loc grid;
+
+	/* Initialize counts. */
+	for (i = 0; i < n_gpred; ++i) {
+		gpreds[i].in_vault_count = 0;
+		gpreds[i].in_room_count = 0;
+		gpreds[i].in_other_count = 0;
+	}
+	for (i = 0; i < n_npred; ++i) {
+		int j;
+
+		for (j = 0; j < 9; ++j) {
+			npreds[i].vault_histogram[j] = 0;
+			npreds[i].room_histogram[j] = 0;
+			npreds[i].other_histogram[j] = 0;
+		}
+	}
+
+	/* Visit every grid. */
+	for (grid.y = 0; grid.y < c->height; ++grid.y) {
+		for (grid.x = 0; grid.x < c->width; ++grid.x) {
+			if (square_isvault(c, grid)) {
+				for (i = 0; i < n_gpred; ++i) {
+					if ((*gpreds[i].pred)(c, grid)) {
+						++gpreds[i].in_vault_count;
+					}
+				}
+				for (i = 0; i < n_npred; ++i) {
+					if ((npreds[i].pred)(c, grid)) {
+						int count = count_neighbors(
+							NULL, c, grid,
+							npreds[i].neigh, false);
+
+						assert(count >= 0 &&
+							count <= 8);
+						++npreds[i].vault_histogram[count];
+					}
+				}
+			} else if (square_isroom(c, grid)) {
+				for (i = 0; i < n_gpred; ++i) {
+					if ((*gpreds[i].pred)(c, grid)) {
+						++gpreds[i].in_room_count;
+					}
+				}
+				for (i = 0; i < n_npred; ++i) {
+					if ((npreds[i].pred)(c, grid)) {
+						int count = count_neighbors(
+							NULL, c, grid,
+							npreds[i].neigh, false);
+
+						assert(count >= 0 &&
+							count <= 8);
+						++npreds[i].room_histogram[count];
+					}
+				}
+			} else {
+				for (i = 0; i < n_gpred; ++i) {
+					if ((*gpreds[i].pred)(c, grid)) {
+						++gpreds[i].in_other_count;
+					}
+				}
+				for (i = 0; i < n_npred; ++i) {
+					if ((npreds[i].pred)(c, grid)) {
+						int count = count_neighbors(
+							NULL, c, grid,
+							npreds[i].neigh, false);
+
+						assert(count >= 0 &&
+							count <= 8);
+						++npreds[i].other_histogram[count];
+					}
+				}
+			}
+		}
+	}
+}
+
+static bool is_easily_traversed(struct chunk *c, struct loc grid)
+{
+	return square_ispassable(c, grid) || square_isdoor(c, grid) ||
+		square_isrubble(c, grid);
+}
+
+static bool is_impassable_rubble(struct chunk *c, struct loc grid)
+{
+	return !square_ispassable(c, grid) && square_isrubble(c, grid);
+}
+
+static bool is_passable_rubble(struct chunk *c, struct loc grid)
+{
+	return square_ispassable(c, grid) && square_isrubble(c, grid);
+}
+
+static bool is_magma_treasure(struct chunk *c, struct loc grid)
+{
+	return square_ismagma(c, grid) && square_hasgoldvein(c, grid);
+}
+
+static bool is_quartz_treasure(struct chunk *c, struct loc grid)
+{
+	return square_isquartz(c, grid) && square_hasgoldvein(c, grid);
+}
+
+/**
+ * Use stat_grid_counter() to get the grid counts and immediate neighborhood
+ * characteristics most likely to be useful for assessing map quality and
+ * balance.
+ * \param c Is the chunk to use.
+ * \param counts Is a three element array of the count structures.  The first
+ * element will hold the count of the features in vaults.  The second element
+ * will hold the count of the features in rooms that are not also vaults.  The
+ * third element will hold the count of features that are neither in vaults nor
+ * rooms.  For all three, the traversable_neighbor_histogram field has the
+ * histogram of the number of immediate neighbors that are fairly easily
+ * traversed by the player (square_ispassable(), square_isdoor(), or
+ * square_isrubble()) for all easily traversable grids in the respective
+ * category (vault, room, other).  For the other category, that's a measure of
+ * how often corridors bend, intersect, or bunch up into wide corridors.
+ */
+void stat_grid_counter_simple(struct chunk *c, struct grid_counts counts[3])
+{
+	struct grid_counter_pred gpreds[] = {
+		{ square_isfloor, 0, 0, 0 },
+		{ square_isupstairs, 0, 0, 0 },
+		{ square_isdownstairs, 0, 0, 0 },
+		{ square_istrap, 0, 0, 0 },
+		{ square_isfiery, 0, 0, 0 },
+		{ is_impassable_rubble, 0, 0, 0 },
+		{ is_passable_rubble, 0, 0, 0 },
+		{ is_magma_treasure, 0, 0, 0 },
+		{ is_quartz_treasure, 0, 0, 0 },
+		{ square_isopendoor, 0, 0, 0 },
+		{ square_iscloseddoor, 0, 0, 0 },
+		{ square_isbrokendoor, 0, 0, 0 },
+		{ square_issecretdoor, 0, 0, 0 },
+	};
+	struct neighbor_counter_pred npreds[] = {
+		{ is_easily_traversed, is_easily_traversed,
+			{ 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+			{ 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+			{ 0, 0, 0, 0, 0, 0, 0, 0, 0 } },
+	};
+	int i;
+
+	stat_grid_counter(c, gpreds, (int) N_ELEMENTS(gpreds),
+		npreds, (int) N_ELEMENTS(npreds));
+	counts[0].floor = gpreds[0].in_vault_count;
+	counts[0].upstair = gpreds[1].in_vault_count;
+	counts[0].downstair = gpreds[2].in_vault_count;
+	counts[0].trap = gpreds[3].in_vault_count;
+	counts[0].lava = gpreds[4].in_vault_count;
+	counts[0].impass_rubble = gpreds[5].in_vault_count;
+	counts[0].pass_rubble = gpreds[6].in_vault_count;
+	counts[0].magma_treasure = gpreds[7].in_vault_count;
+	counts[0].quartz_treasure = gpreds[8].in_vault_count;
+	counts[0].open_door = gpreds[9].in_vault_count;
+	counts[0].closed_door = gpreds[10].in_vault_count;
+	counts[0].broken_door = gpreds[11].in_vault_count;
+	counts[0].secret_door = gpreds[12].in_vault_count;
+	for (i = 0; i < 9; ++i) {
+		counts[0].traversable_neighbor_histogram[i] =
+			npreds[0].vault_histogram[i];
+	}
+	counts[1].floor = gpreds[0].in_room_count;
+	counts[1].upstair = gpreds[1].in_room_count;
+	counts[1].downstair = gpreds[2].in_room_count;
+	counts[1].trap = gpreds[3].in_room_count;
+	counts[1].lava = gpreds[4].in_room_count;
+	counts[1].impass_rubble = gpreds[5].in_room_count;
+	counts[1].pass_rubble = gpreds[6].in_room_count;
+	counts[1].magma_treasure = gpreds[7].in_room_count;
+	counts[1].quartz_treasure = gpreds[8].in_room_count;
+	counts[1].open_door = gpreds[9].in_room_count;
+	counts[1].closed_door = gpreds[10].in_room_count;
+	counts[1].broken_door = gpreds[11].in_room_count;
+	counts[1].secret_door = gpreds[12].in_room_count;
+	for (i = 0; i < 9; ++i) {
+		counts[1].traversable_neighbor_histogram[i] =
+			npreds[0].room_histogram[i];
+	}
+	counts[2].floor = gpreds[0].in_other_count;
+	counts[2].upstair = gpreds[1].in_other_count;
+	counts[2].downstair = gpreds[2].in_other_count;
+	counts[2].trap = gpreds[3].in_other_count;
+	counts[2].lava = gpreds[4].in_other_count;
+	counts[2].impass_rubble = gpreds[5].in_other_count;
+	counts[2].pass_rubble = gpreds[6].in_other_count;
+	counts[2].magma_treasure = gpreds[7].in_other_count;
+	counts[2].quartz_treasure = gpreds[8].in_other_count;
+	counts[2].open_door = gpreds[9].in_other_count;
+	counts[2].closed_door = gpreds[10].in_other_count;
+	counts[2].broken_door = gpreds[11].in_other_count;
+	counts[2].secret_door = gpreds[12].in_other_count;
+	for (i = 0; i < 9; ++i) {
+		counts[2].traversable_neighbor_histogram[i] =
+			npreds[0].other_histogram[i];
+	}
+}

--- a/src/wizard.h
+++ b/src/wizard.h
@@ -19,6 +19,51 @@
 #ifndef INCLUDED_WIZARD_H
 #define INCLUDED_WIZARD_H
 
+#include "cave.h"
+
+/* For stat_grid_counter() */
+struct chunk;
+struct grid_counter_pred {
+	square_predicate pred;
+	/* Hold the number of grids that match pred and are in vaults. */
+	int in_vault_count;
+	/*
+	 * Hold the number of grids that match pred and are in rooms (but not
+	 * in vaults).
+	 */
+	int in_room_count;
+	/*
+	 * Hold the number of grids that match pred and are neither in vaults
+	 * nor rooms.
+	 */
+	int in_other_count;
+};
+struct neighbor_counter_pred {
+	square_predicate pred;
+	square_predicate neigh;
+	int vault_histogram[9];
+	int room_histogram[9];
+	int other_histogram[9];
+};
+
+/* For stat_grid_counter_simple() */
+struct grid_counts {
+	int floor;
+	int upstair;
+	int downstair;
+	int trap;
+	int lava;
+	int impass_rubble;
+	int pass_rubble;
+	int magma_treasure;
+	int quartz_treasure;
+	int open_door;
+	int closed_door;
+	int broken_door;
+	int secret_door;
+	int traversable_neighbor_histogram[9];
+};
+
 /* wiz-debug.c */
 void wiz_cheat_death(void);
 
@@ -27,6 +72,9 @@ bool stats_are_enabled(void);
 void stats_collect(int nsim, int simtype);
 void disconnect_stats(int nsim, bool stop_on_disconnect);
 void pit_stats(int nsim, int pittype, int depth);
+void stat_grid_counter(struct chunk *c, struct grid_counter_pred *gpreds,
+	int n_gpred, struct neighbor_counter_pred *npreds, int n_npred);
+void stat_grid_counter_simple(struct chunk *c, struct grid_counts counts[3]);
 
 /* wiz-spoil.c */
 void spoil_artifact(const char *fname);


### PR DESCRIPTION
The game events are a partial step for implementing https://github.com/angband/angband/issues/2850 .  The design here is different than what magnate outlined in the comment there.  There isn't a single event signaling statistics versus normal mode; instead there's events that are always fired to signal start of level generation, completion of level generation, start of generating a room, completion of generating a room, and completion of a tunnel.

Add collection of statistics about cave generation using those events to the disconnection statistics debugging command, 'D', since it is already generating a bunch of levels at the same depth.  That might serve as a prototype for what cave generation data could be useful in main-stats.c.

Left main-stats.c as it is:  probably want to gain some experience with what's in the 'D' command to see what's really useful before settling on what the database tables should be for cave generation.