### PR TITLE
Add configure warning message if there's no player frontends enabled

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -69,7 +69,7 @@ if test X`uname` = XOpenBSD ; then
             export AUTOMAKE_VERSION
         fi
     fi
-    echo "OpenBSD; using AUTOCONF_VERSION=$AUTOCONF_VERSION AUTOMAKE_VERSION=$AUTOMAKE_VERSION"
+    echo "*info* OpenBSD; using AUTOCONF_VERSION=$AUTOCONF_VERSION AUTOMAKE_VERSION=$AUTOMAKE_VERSION"
 fi
 
 cd $TOP_DIR

--- a/configure.ac
+++ b/configure.ac
@@ -517,11 +517,13 @@ fi
 
 echo
 echo "-- Frontends --"
+local_player_frontends=""
 if test "$enable_curses" = "yes"; then
 	if test "$with_curses" = "no"; then
 		echo "- Curses                                  No; missing libraries"
 	else
 		echo "- Curses                                  Yes"
+		local_player_frontends="$local_player_frontends"+
 	fi
 else
 	echo "- Curses                                  Disabled"
@@ -531,6 +533,7 @@ if test "$enable_x11" = "yes"; then
 		echo "- X11                                     No; missing libraries"
 	else
 		echo "- X11                                     Yes"
+		local_player_frontends="$local_player_frontends"+
 	fi
 else
 	echo "- X11                                     Disabled"
@@ -540,6 +543,7 @@ if test "$enable_sdl2" = "yes"; then
 		echo "- SDL2                                    No; missing libraries"
 	else
 		echo "- SDL2                                    Yes"
+		local_player_frontends="$local_player_frontends"+
 	fi
 else
 	echo "- SDL2                                    Disabled"
@@ -549,6 +553,7 @@ if test "$enable_sdl" = "yes"; then
 		echo "- SDL                                     No; missing libraries"
 	else
 		echo "- SDL                                     Yes"
+		local_player_frontends="$local_player_frontends"+
 	fi
 else
 	echo "- SDL                                     Disabled"
@@ -559,6 +564,7 @@ if test "$enable_win" = "yes"; then
 		echo "- Windows                                 No; missing libraries"
 	else
 		echo "- Windows                                 Yes"
+		local_player_frontends="$local_player_frontends"+
 	fi
 else
 	echo "- Windows                                 Disabled"
@@ -601,4 +607,8 @@ if test "$enable_sdl_mixer" = "yes"; then
 	fi
 else
 	echo "- SDL sound                               Disabled"
+fi
+
+if test x"$local_player_frontends" = "x" ; then
+	AC_MSG_WARN([No player frontends are enabled.  Check your --enable options and prerequisites for the frontends.])
 fi


### PR DESCRIPTION
That's to help avoid situations like this, http://angband.oook.cz/forum/showpost.php?p=154273&postcount=1 .

Also adjust a message from autogen.sh about OpenBSD so that it has the same "*info*" prefix as the other informational messages.