### PR TITLE
Always initialize second argument passed to scatter()

### DIFF
--- a/src/cmd-wizard.c
+++ b/src/cmd-wizard.c
@@ -2649,7 +2649,7 @@ void do_cmd_wiz_summon_named(struct command *cmd)
 
 	/* Try 10 times */
 	while (1) {
-		struct loc grid;
+		struct loc grid = player->grid;
 
 		if (i >= 10) {
 			msg("Could not place monster.");

--- a/src/gen-util.c
+++ b/src/gen-util.c
@@ -807,7 +807,7 @@ void vault_monsters(struct chunk *c, struct loc grid, int depth, int num)
 	for (k = 0; k < num; k++) {
 		/* Try nine locations */
 		for (i = 0; i < 9; i++) {
-			struct loc near;
+			struct loc near = grid;
 
 			/* Pick a nearby location */
 			scatter(c, &near, grid, 1, true);

--- a/src/mon-make.c
+++ b/src/mon-make.c
@@ -1307,7 +1307,7 @@ static bool place_friends(struct chunk *c, struct loc grid, struct monster_race 
 										   total, origin);
 		} else {
 			int j;
-			struct loc new;
+			struct loc new = grid;
 
 			/* Find a nearby place to put the other groups */
 			for (j = 0; j < 50; j++) {

--- a/src/mon-move.c
+++ b/src/mon-move.c
@@ -983,7 +983,7 @@ static bool get_move(struct chunk *c, struct monster *mon, int *dir, bool *good)
  */
 bool multiply_monster(struct chunk *c, const struct monster *mon)
 {
-	struct loc grid;
+	struct loc grid = mon->grid;
 	int i;
 	bool result = false;
 	struct monster_group_info info = { 0, 0 };

--- a/src/mon-summon.c
+++ b/src/mon-summon.c
@@ -400,7 +400,7 @@ static int call_monster(struct loc grid)
 int summon_specific(struct loc grid, int lev, int type, bool delay, bool call)
 {
 	int i;
-	struct loc near;
+	struct loc near = grid;
 	struct monster *mon;
 	struct monster_race *race;
 	struct monster_group_info info = { 0, 0 };

--- a/src/obj-pile.c
+++ b/src/obj-pile.c
@@ -1216,7 +1216,7 @@ void push_object(struct loc grid)
 			mimic->mimicked_obj = NULL;
 
 			while (1) {
-				struct loc newgrid;
+				struct loc newgrid = grid;
 
 				if (ntry > 150) {
 					/*

--- a/src/obj-pile.c
+++ b/src/obj-pile.c
@@ -1200,9 +1200,8 @@ void push_object(struct loc grid)
 			 * Try to find a location; there's 49 positions in
 			 * the 7 x 7 square so make at most a small multiple
 			 * of that number in attempts to find an appropriate
-			 * one that doesn't already have a monster or the
-			 * player.  If scatter accepted a predicate argument,
-			 * could avoid the multiple attempts.
+			 * one that's empty.  If scatter accepted a predicate
+			 * argument, could avoid the multiple attempts.
 			 */
 			struct monster *mimic =
 				cave_monster(cave, obj->mimicking_m_idx);
@@ -1231,7 +1230,7 @@ void push_object(struct loc grid)
 					break;
 				}
 				scatter(cave, &newgrid, grid, 3, true);
-				if (square(cave, newgrid)->mon == 0) {
+				if (square_isempty(cave, newgrid)) {
 					bool dummy = true;
 
 					if (floor_carry(cave, newgrid, obj, &dummy)) {


### PR DESCRIPTION
That's to handle the unlikely event (given that scatter() currently does up to 1000 tries internally) that all of scatter()'s attempts fail and the passed in value is never modified.

Also, adjust the logic for handling unrevealed mimics in push_object():  require an empty square for them rather than merely no player or monster.  Noticed that when checking the uses of scatter().