### PR TITLE
Fix instances of potential format string security holes with msg() and msgt()

### DIFF
--- a/src/cmd-obj.c
+++ b/src/cmd-obj.c
@@ -459,9 +459,9 @@ static void use_aux(struct command *cmd, struct object *obj, enum use use,
 			msgt(snd, "You activate it.");
 			activation_message(obj);
 		} else if (obj->kind->effect_msg) {
-			msgt(snd, obj->kind->effect_msg);
+			msgt(snd, "%s", obj->kind->effect_msg);
 		} else if (obj->kind->vis_msg && !player->timed[TMD_BLIND]) {
-			msgt(snd, obj->kind->vis_msg);
+			msgt(snd, "%s", obj->kind->vis_msg);
 		} else {
 			/* Make a noise! */
 			sound(snd);

--- a/src/cmd-wizard.c
+++ b/src/cmd-wizard.c
@@ -1179,7 +1179,7 @@ void do_cmd_wiz_dump_level_map(struct command *cmd)
 	if (fo) {
 		dump_level(fo, title, cave, NULL);
 		if (file_close(fo)) {
-			msg(format("Level dumped to %s.", path));
+			msg("Level dumped to %s.", path);
 		}
 	}
 }

--- a/src/cmd-wizard.c
+++ b/src/cmd-wizard.c
@@ -1905,7 +1905,7 @@ void do_cmd_wiz_play_item(struct command *cmd)
 
 		/* Provide some feedback. */
 		if (done_msg) {
-			msg(done_msg);
+			msg("%s", done_msg);
 		}
 	}
 }

--- a/src/gen-util.c
+++ b/src/gen-util.c
@@ -845,8 +845,8 @@ void dump_level_simple(const char *basefilename, const char *title,
 	if (fo) {
 		dump_level(fo, (title) ? title : "Dumped Level", c, NULL);
 		if (file_close(fo)) {
-			msg(format("Level dumped to %s.html",
-				(basefilename) ? basefilename : "dumpedlevel"));
+			msg("Level dumped to %s.html",
+				(basefilename) ? basefilename : "dumpedlevel");
 		}
 	}
 }

--- a/src/obj-curse.c
+++ b/src/obj-curse.c
@@ -318,7 +318,7 @@ bool do_curse_effect(int i, struct object *obj)
 		dir++;
 	}
 	if (curse->obj->effect_msg) {
-		msgt(MSG_GENERIC, curse->obj->effect_msg);
+		msgt(MSG_GENERIC, "%s", curse->obj->effect_msg);
 	}
 	effect_do(effect, source_object(obj), NULL, &ident, was_aware, dir, 0, 0, NULL);
 	curse->obj->known->effect = curse->obj->effect;

--- a/src/trap.c
+++ b/src/trap.c
@@ -516,7 +516,7 @@ extern void hit_trap(struct loc grid, int delayed)
 
 		/* Give a message */
 		if (trap->kind->msg)
-			msg(trap->kind->msg);
+			msg("%s", trap->kind->msg);
 
 		/* Test for save due to flag */
 		for (flag = of_next(trap->kind->save_flags, FLAG_START);
@@ -539,10 +539,10 @@ extern void hit_trap(struct loc grid, int delayed)
 		/* Save, or fire off the trap */
 		if (saved) {
 			if (trap->kind->msg_good)
-				msg(trap->kind->msg_good);
+				msg("%s", trap->kind->msg_good);
 		} else {
 			if (trap->kind->msg_bad)
-				msg(trap->kind->msg_bad);
+				msg("%s", trap->kind->msg_bad);
 			effect = trap->kind->effect;
 			effect_do(effect, source_trap(trap), NULL, &ident, false, 0, 0, 0, NULL);
 
@@ -552,7 +552,7 @@ extern void hit_trap(struct loc grid, int delayed)
 			/* Do any extra effects */
 			if (trap->kind->effect_xtra && one_in_(2)) {
 				if (trap->kind->msg_xtra)
-					msg(trap->kind->msg_xtra);
+					msg("%s", trap->kind->msg_xtra);
 				effect = trap->kind->effect_xtra;
 				effect_do(effect, source_trap(trap), NULL, &ident, false,
 						  0, 0, 0, NULL);

--- a/src/ui-game.c
+++ b/src/ui-game.c
@@ -527,7 +527,7 @@ void textui_process_command(void)
 
 						cmd = nested_lists[cmd->nested_keymap - 1][(unsigned char) nestkey];
 						if (!cmd) {
-							msg(em ? em : "That is not a valid nested command.");
+							msg("%s", em ? em : "That is not a valid nested command.");
 						}
 					} else {
 						cmd = NULL;


### PR DESCRIPTION
For two instances where the strings are internally sourced but variable, also process them through "%s" so they won't raise false alarms about security issues.

Related to https://github.com/angband/angband/issues/2950 .

Remove two unnecessary calls to format() that turned when auditing the calls to msg() and msgt().