### PR TITLE
Fix knowledge spacing after periods

### DIFF
--- a/lib/gamedata/artifact.txt
+++ b/lib/gamedata/artifact.txt
@@ -66,7 +66,7 @@
 # list-mon-race-flags.h or monster bases in monster_base.txt) and resistances
 # (based on list-elements.h).
 
-# 'desc' is for the artifact description.  These appear when the item is 
+# 'desc' is for the artifact description.  These appear when the item is
 # identified.  Special thanks to J.R.R Tolkien, without whom the words would
 # be unwritten, the images unconceived, the deed undone. -LM-
 # Contributors: Jeff Butler, Neal Hackler, Ethan Sicotte, Pat Tracy,
@@ -153,8 +153,8 @@ desc: sparks of white radiance shot with glints of the rainbow.
 #time:50+d50
 #msg:The {kind} glow{s} a deep green...
 #values:INT[2] | WIS[2] | INFRA[3] |  SEARCH[3] | LIGHT[3] | RES_CHAOS[1]
-#desc:A great globe with a heart of fire, the Palantír provides the wearer with 
-#desc:sight of far places - at a cost, for those espied upon are aware of it.
+#desc:A great globe with a heart of fire, the Palantír provides the wearer with
+#desc: sight of far places - at a cost, for those espied upon are aware of it.
 
 
 ### Swords and Daggers ###
@@ -437,7 +437,7 @@ values:RES_ELEC[1] | RES_LIGHT[1] | RES_DARK[1]
 brand:POIS_3
 slay:EVIL_2
 slay:DEMON_3
-desc:This black blade was forged of meteoric iron by Eöl the Dark Elf. It is
+desc:This black blade was forged of meteoric iron by Eöl the Dark Elf.  It is
 desc: imbued with the malice of its maker; as dangerous to its wielder as it is
 desc: deadly to his foes.
 
@@ -800,8 +800,8 @@ brand:ELEC_3
 slay:DRAGON_5
 act:HASTE1
 time:100+d100
-desc:A great ridged mace that surrounds you with a nimbus of living lightning.  
-desc:You remain utterly untouched, even as fat sparks crackle around your
+desc:A great ridged mace that surrounds you with a nimbus of living lightning.
+desc:  You remain utterly untouched, even as fat sparks crackle around your
 desc: fingers and eyebrows.
 
 name:'Nar-i-vagil'
@@ -873,8 +873,8 @@ slay:DRAGON_5
 slay:EVIL_2
 slay:UNDEAD_3
 slay:DEMON_3
-desc:The wondrous hammer of Aulë, creator of the wise Dwarven lords of old.  
-desc: It bears demolishing magics that no serpent or demon can withstand, and
+desc:The wondrous hammer of Aulë, creator of the wise Dwarven lords of old.
+desc:  It bears demolishing magics that no serpent or demon can withstand, and
 desc: invokes the strength of mountains to ward off the tumult of the elements.
 
 name:'Deathwreaker'
@@ -1295,8 +1295,8 @@ alloc:5:40 to 127
 attack:0d0:20:22
 armor:0:0
 values:DEX[3] | SPEED[1] | STEALTH[1] | SHOTS[10] | RES_DISEN[1]
-desc:The great bow of Beleg Cúthalion, the most famous archer of the Elves. 
-desc: Its backbone of black yew holds strings of bear sinew, and of old, only
+desc:The great bow of Beleg Cúthalion, the most famous archer of the Elves.
+desc:  Its backbone of black yew holds strings of bear sinew, and of old, only
 desc: Beleg himself could draw them.
 
 name:of Bard
@@ -1471,8 +1471,8 @@ values:SPEED[6] | RES_ELEC[3] | RES_SOUND[1]
 act:BERSERKER
 time:100
 desc:And they hewed off Gelmir's hands and feet, and his head last, within
-desc: sight of the Elves, and left him. By ill chance there stood Gwindor
-desc: of Nargothrond, the brother of Gelmir. Now his wrath was kindled to
+desc: sight of the Elves, and left him.  By ill chance there stood Gwindor
+desc: of Nargothrond, the brother of Gelmir.  Now his wrath was kindled to
 desc: madness, and he leapt forth on horseback, and many riders with him;
 desc: and they pursued the heralds and slew them, and drove on deep into
 desc: the main host.
@@ -1580,7 +1580,7 @@ values:RES_ACID[1] | RES_NEXUS[1] | RES_COLD[1] | RES_DARK[1]
 desc:A great helm, as steady and as distinctive as the hero of the Westdike.
 desc:  Many long months was Helm Hammerhand besieged in the Hornburg, yet he
 desc: strode out time and again among his foes and slew many.  Although they
-desc: knew of his coming, none could stand against him. 
+desc: knew of his coming, none could stand against him.
 
 name:of Berúthiel
 base-object:crown:Iron Crown
@@ -1767,7 +1767,7 @@ values:RES_DARK[1] | RES_DISEN[1]
 act:BANISHMENT
 time:500
 desc:A shimmering suit of true-silver, forged long ago by dwarven smiths of
-desc: legend. It gleams with purest white as you gaze upon it, and mighty are
+desc: legend.  It gleams with purest white as you gaze upon it, and mighty are
 desc: its powers to protect and banish.
 
 name:'Soulkeeper'
@@ -2037,7 +2037,7 @@ attack:1d1:0:0
 armor:2:20
 flags:PROT_CONF | HOLD_LIFE
 values:CON[4] | WIS[1] | INT[1] | RES_ELEC[1] | RES_SHARD[1]
-desc:The shield of Elros Tar-Minyatur, founder of Númenor. Granted long
+desc:The shield of Elros Tar-Minyatur, founder of Númenor.  Granted long
 desc: life by the Valar, even his shield became imbued with power.
 
 name:of Thorin
@@ -2080,8 +2080,8 @@ flags:SUST_STR | SUST_CON | PROT_FEAR | PROT_BLIND
 values:STR[2] | CON[2] | STEALTH[-2] | RES_POIS[1]
 act:BERSERKER
 time:50
-desc:The painted shield of a chieftain of Far Harad, gaudy and barbaric. 
-desc: Its wielder will fear nothing and fight with unnatural strength, but
+desc:The painted shield of a chieftain of Far Harad, gaudy and barbaric.
+desc:  Its wielder will fear nothing and fight with unnatural strength, but
 desc: also draw attention to himself.
 
 name:of Anárion
@@ -2327,7 +2327,7 @@ desc: return to the Shire.
 #flags:PROT_FEAR | PROT_BLIND | PROT_STUN | PROT_CONF
 #values:SEARCH[4] | SPEED[2] | RES_ELEC[1] | RES_COLD[1]
 #desc:The pendant of Amandil, the last Lord of Andúnië, and mighty
-#desc: ship-captain of Númenor. First among Númenóreans to see
+#desc: ship-captain of Númenor.  First among Númenóreans to see
 #desc: Sauron for what he was.
 
 
@@ -2346,8 +2346,8 @@ values:LIGHT[1] | RES_ELEC[3] | RES_DISEN[1] | RES_ACID[1] | RES_FIRE[1]
 values:RES_COLD[1] | RES_POIS[1] | RES_LIGHT[1] | RES_DARK[1]
 act:STAR_BALL
 time:50
-desc:A massive suit of heavy dragon scales deeply saturated with many colors.  
-desc: It throbs with angry energies, and you feel the raw elemental might of
+desc:A massive suit of heavy dragon scales deeply saturated with many colors.
+desc:  It throbs with angry energies, and you feel the raw elemental might of
 desc: untamed Lightning as you put it on.
 
 name:'Mediator'

--- a/lib/gamedata/class.txt
+++ b/lib/gamedata/class.txt
@@ -326,7 +326,7 @@ effect:BOLT_STATUS:AWAY_ALL
 dice:$B
 expr:B:PLAYER_LEVEL:* 3
 desc:Produces a bolt that teleports away the first monster in its path.
-desc: Distance teleported increases with player level.
+desc:  Distance teleported increases with player level.
 
 spell:Resistance:20:20:65:20
 effect:SET_VALUE
@@ -557,7 +557,7 @@ effect:SHORT_BEAM:SHARD:4:5
 dice:$Dd6
 expr:D:PLAYER_LEVEL:/ 3 + 2
 desc:Causes shards to explode in a line out of the earth, striking objects and
-desc: monsters. Length of the line increases with player level.
+desc: monsters.  Length of the line increases with player level.
 
 book:nature book:dungeon:[Creature Dominion]:5:nature
 book-graphics:?:o
@@ -1182,7 +1182,7 @@ effect:SHAPECHANGE:vampire
 effect:JUMP_AND_BITE
 dice:$B
 expr:B:PLAYER_LEVEL:+ 0
-desc:Allows you to assume the form of a vampire at the cost of half your 
+desc:Allows you to assume the form of a vampire at the cost of half your
 desc: current hitpoints, than teleports you to the nearest living monster
 desc: and drains a level-dependent number of hitpoints, healing and nourishing
 desc: you.  When first transformed you will temporarily be able
@@ -1462,7 +1462,7 @@ effect:BOLT_STATUS:AWAY_ALL
 dice:$B
 expr:B:PLAYER_LEVEL:* 3
 desc:Produces a bolt that teleports away the first monster in its path.
-desc: Distance teleported increases with player level.
+desc:  Distance teleported increases with player level.
 
 spell:Teleport Level:35:17:65:80
 effect:TELEPORT_LEVEL
@@ -1700,7 +1700,7 @@ desc:Coats all your melee weapons with poison for 18+d18 turns.
 spell:Werewolf Form:32:30:40:100
 effect:SHAPECHANGE:werewolf
 desc:With a blood-curdling cry you change into a half-man half-wolf!
-desc: In this form you move, attack, and heal faster.
+desc:  In this form you move, attack, and heal faster.
 
 book:shadow book:dungeon:[Deadly Powers]:4:shadow
 
@@ -1708,7 +1708,7 @@ spell:Bloodlust:30:25:37:80
 effect:TIMED_INC:BLOODLUST:0:-1
 dice:10
 desc:Gives you a powerful desire to kill, increased every time you satisfy it.
-desc: Gives you extra melee damage and extra blows, but comes
+desc:  Gives you extra melee damage and extra blows, but comes
 desc: with dangerous side-effects.
 
 spell:Unholy Reprieve:34:45:60:120

--- a/lib/gamedata/monster.txt
+++ b/lib/gamedata/monster.txt
@@ -147,8 +147,9 @@
 # 'spells' is for spell flags, which work just like regular flags.
 
 # 'desc' is for description. As many desc: lines may be used as are needed to
-# describe the monster. Leading whitespace will be removed, and a single space
-# will be added between desc: lines.
+# describe the monster. Note that lines will need spaces at their
+# ends or the beginning of the next line to prevent words from running
+# together.
 
 # 'drop' lines create possible drops for specific monsters.  Each item
 # has its percent chance rolled for individually.  Any specified drops are in
@@ -4858,7 +4859,7 @@ flags:IM_POIS | IM_ACID
 flags:DROP_1 | DROP_GOOD | ONLY_ITEM
 spell-freq:10
 spells:TELE_TO | HOLD
-desc:The ancient grey willow tree, ruler of the Old Forest. He despises
+desc:The ancient grey willow tree, ruler of the Old Forest.  He despises
 desc: trespassers in his territory.  "...a huge willow-tree, old and hoary.
 desc:  Enormous it looked, its sprawling branches going up like racing arms
 desc: with many long-fingered hands, its knotted and twisted trunk gaping in
@@ -4885,9 +4886,9 @@ blow:CLAW:HURT:2d10
 blow:CLAW:HURT:2d10
 blow:BITE:HURT:3d8
 flags:NO_FEAR
-desc:A blinding whirlwind of fear and feathers. Its razor sharp beak and talons
-desc: fill its foes with terror as it seeks to rend flesh from bone with
-desc: unbridled ferocity.
+desc:A blinding whirlwind of fear and feathers.  Its razor sharp beak and
+desc: talons fill its foes with terror as it seeks to rend flesh from bone
+desc: with unbridled ferocity.
 
 name:Mirkwood spider
 base:spider
@@ -6053,7 +6054,7 @@ blow:CRAWL:EXP_10:1d5
 flags:EVIL | WEIRD_MIND | MULTIPLY | STUPID
 flags:RAND_25 | RAND_50 | BASH_DOOR | KILL_WALL
 flags:HURT_LIGHT | NO_FEAR | COLD_BLOOD | INVISIBLE
-desc:A writhing wormlike shimmer of blackness, large as your arm. It squirms
+desc:A writhing wormlike shimmer of blackness, large as your arm.  It squirms
 desc: through air and walls with equal facility, leaving void in its wake.
 
 name:giant firefly
@@ -6380,7 +6381,7 @@ innate-freq:5
 spells:BR_NEXU
 friends:100:2d7:Same
 desc:A locus of conflicting points coalesce to form the vague shape of a huge
-desc: hound. Or is it just your imagination?
+desc: hound.  Or is it just your imagination?
 
 name:vampire
 base:vampire
@@ -9929,7 +9930,7 @@ spells:WOUND
 spells:BO_MANA | BO_WATE
 desc:This sad creature - once a mighty warrior - betrayed his former friends to
 desc: Morgoth's army in return for, he thought, safety for himself and his
-desc: wife.   And so he fell under Morgoth's power and became little more than
+desc: wife.  And so he fell under Morgoth's power and became little more than
 desc: a mindless servant of evil, even though the other side of his "bargain"
 desc: was not kept.
 
@@ -11706,7 +11707,7 @@ spell-freq:12
 spells:CONF | SCARE
 spells:BR_COLD | BR_NETH
 desc:The skeletal form of a once-great dragon, enchanted by magic most
-desc: perilous.   Its animated form strikes with speed and drains life from its
+desc: perilous.  Its animated form strikes with speed and drains life from its
 desc: prey to satisfy its hunger.
 
 name:dracolisk
@@ -12711,7 +12712,7 @@ spell-freq:10
 spells:WOUND
 spells:BR_CHAO
 desc:"Beware the Jabberwock, my son!  The jaws that bite, the claws that catch!"
-desc: Run and run quickly, for death incarnate chases behind you!
+desc:  Run and run quickly, for death incarnate chases behind you!
 
 name:Tselakus, the Dreadlord
 base:ghost
@@ -12823,7 +12824,7 @@ spells:BOULDER
 spells:BO_PLAS | BA_FIRE
 spells:S_MONSTERS
 desc:Known as the giant of summer and the south, he towers above you
-desc: like a great elm. In his right hand, he holds the longest
+desc: like a great elm.  In his right hand, he holds the longest
 desc: sword you have ever beheld.
 
 name:nightcrawler
@@ -13155,7 +13156,7 @@ spells:S_AINU
 desc:Encrusted with barnacles, slimy and dripping, the Maia of the untamed
 desc: sea has dragged himself down into Angband to send you to a watery grave.
 desc: Ossë is the most powerful and heartless of Ulmo's servants and embodies
-desc: the untamed power of the ocean. Terror grows in your heart with each
+desc: the untamed power of the ocean.  Terror grows in your heart with each
 desc: squelching step of his approach.
 
 
@@ -13187,7 +13188,7 @@ spells:BLIND | CONF | SCARE
 spells:BR_FIRE
 color-cycle:fancy:hell
 desc:A vast dragon of immense power.  Fire leaps continuously from its huge
-desc: form. The air around it scalds you.  Its slightest glance burns you, and
+desc: form.  The air around it scalds you.  Its slightest glance burns you, and
 desc: you truly realize how insignificant you are.
 
 name:great bile wyrm
@@ -13477,7 +13478,7 @@ spells:S_KIN
 desc:This enormous, hideous spirit of void is in the form of a spider of immense
 desc: proportions.  She is surrounded by a cloud of Unlight as she sucks in all
 desc: living light into her bloated body, and breathes out the blackest of
-desc: darkness. She is always ravenously hungry and would even eat herself to
+desc: darkness.  She is always ravenously hungry and would even eat herself to
 desc: avoid starvation.
 
 name:bronze golem

--- a/lib/gamedata/object.txt
+++ b/lib/gamedata/object.txt
@@ -1395,8 +1395,8 @@ cost:4
 alloc:20:1 to 100
 attack:1d1:0:0
 armor:1:0
-desc:A set of open-topped footgear with soft calfskin lacings and a sturdy 
-desc:cured leather base.
+desc:A set of open-topped footgear with soft calfskin lacings and a sturdy
+desc: cured leather base.
 
 name:& Pair~ of Leather Boots
 type:boots
@@ -1786,8 +1786,8 @@ alloc:8:40 to 100
 attack:0d0:0:0
 armor:6:0
 values:STEALTH[1] | SPEED[1]
-desc:A mantle made of curious silken material by the Galadrim that wondrously 
-desc:takes on the hues and shapes of its surroundings.
+desc:A mantle made of curious silken material by the Galadrim that wondrously
+desc: takes on the hues and shapes of its surroundings.
 
 name:& Ethereal Cloak~
 type:cloak
@@ -1799,8 +1799,8 @@ alloc:10:70 to 100
 attack:0d0:0:0
 armor:0:10
 flags:IGNORE_ACID | IGNORE_ELEC | IGNORE_FIRE | IGNORE_COLD 
-desc:This unearthly, completely transparent body mantle folds and drapes in 
-desc:iridescent patterns around you.  It weighs absolutely nothing.
+desc:This unearthly, completely transparent body mantle folds and drapes in
+desc: iridescent patterns around you.  It weighs absolutely nothing.
 
 
 ### Gloves ###

--- a/lib/gamedata/player_property.txt
+++ b/lib/gamedata/player_property.txt
@@ -128,11 +128,11 @@ code:COMBAT_REGEN
 bindui:imphp_ui_compact_0:0:1
 name:Combat Regeneration
 desc:You draw power from the thrill of combat, represented by
-desc: Spell Points (SP). You gain SP when damaged by an enemy or
-desc: when you attack in melee. As your blood cools your power fades;
+desc: Spell Points (SP).  You gain SP when damaged by an enemy or
+desc: when you attack in melee.  As your blood cools your power fades;
 desc: you lose SP at half the rate other classes gain them.
-desc: When you spend SP by casting a spell you regain some health, and
-desc: fading SP replenish your health more efficiently. The more damaged
+desc:  When you spend SP by casting a spell you regain some health, and
+desc: fading SP replenish your health more efficiently.  The more damaged
 desc: you are, the bigger these health gains will be.
 
 

--- a/lib/gamedata/terrain.txt
+++ b/lib/gamedata/terrain.txt
@@ -90,6 +90,11 @@
 # 'resist-flag' is the race flag a monster must have to be able to enter
 # damaging terrain
 
+# 'desc' is for description. As many desc: lines may be used as are needed
+# to describe the terrain. Note that lines will need spaces at their
+# ends or the beginning of the next line to prevent words from running
+# together.
+
 name:unknown grid
 graphics: :w
 priority:2
@@ -99,8 +104,8 @@ name:open floor
 graphics:.:w
 priority:5
 flags:LOS | PROJECT | PASSABLE | FLOOR | OBJECT | EASY | TRAP | TORCH
-desc:An open floor or bare ground.  Can be walked across by anything, and can 
-desc:hold traps or items.  Does not break line of sight.
+desc:An open floor or bare ground.  Can be walked across by anything, and can
+desc: hold traps or items.  Does not break line of sight.
 
 name:closed door
 graphics:+:U
@@ -108,19 +113,19 @@ priority:17
 flags:DOOR_ANY | DOOR_CLOSED | INTERESTING
 info:0:5
 confused-msg:bangs into a door
-desc:Doors may be locked; getting through them may not be easy.  Your 
-desc:disarming skill makes all the difference to your ability to handle locks, 
-desc:but you can also take a pickaxe to them, or blast them open 
-desc:with magic.  Monsters are also slowed down by doors; you can earn yourself 
-desc:valuable time by locking them.
+desc:Doors may be locked; getting through them may not be easy.  Your
+desc: disarming skill makes all the difference to your ability to handle locks,
+desc: but you can also take a pickaxe to them, or blast them open
+desc: with magic.  Monsters are also slowed down by doors; you can earn yourself
+desc: valuable time by locking them.
 
 name:open door
 graphics:':U
 priority:15
 flags:LOS | PROJECT | PASSABLE | DOOR_ANY | INTERESTING | CLOSABLE | EASY
 look-in-preposition:in
-desc:A door that is already open.  Player, monster, spell and missile can pass 
-desc:through as long as it stays open.
+desc:A door that is already open.  Player, monster, spell and missile can pass
+desc: through as long as it stays open.
 
 name:broken door
 graphics:':u
@@ -159,8 +164,8 @@ flags:SHOP | PROJECT | PASSABLE | PERMANENT | INTERESTING | EASY
 info:2:0
 look-prefix:the entrance to the
 look-in-preposition:at
-desc:The armour sold here will give you some protection against the blows of 
-desc:your enemies.
+desc:The armour sold here will give you some protection against the blows of
+desc: your enemies.
 
 name:Weapon Smiths
 graphics:3:w
@@ -169,8 +174,8 @@ flags:SHOP | PROJECT | PASSABLE | PERMANENT | INTERESTING | EASY
 info:3:0
 look-prefix:the entrance to the
 look-in-preposition:at
-desc:Weapons for hitting and shooting your enemies are forged in the hot, acrid 
-desc:backroom of this enticing shop.
+desc:Weapons for hitting and shooting your enemies are forged in the hot, acrid
+desc: backroom of this enticing shop.
 
 name:Bookseller
 graphics:4:g
@@ -179,8 +184,8 @@ flags:SHOP | PROJECT | PASSABLE | PERMANENT | INTERESTING | EASY
 info:4:0
 look-prefix:the entrance to the
 look-in-preposition:at
-desc:A quiet, reflective place of refuge, lined with shelves of 
-desc:mystical tomes.
+desc:A quiet, reflective place of refuge, lined with shelves of
+desc: mystical tomes.
 
 name:Alchemy Shop
 graphics:5:b
@@ -207,8 +212,8 @@ flags:SHOP | PROJECT | PASSABLE | PERMANENT | INTERESTING | EASY
 info:7:0
 look-prefix:the entrance to the
 look-in-preposition:at
-desc:Watch your back and hold onto your purse as you enter this disreputable 
-desc:haunt - and do not expect friendly service or good bargains.
+desc:Watch your back and hold onto your purse as you enter this disreputable
+desc: haunt - and do not expect friendly service or good bargains.
 
 name:Home
 graphics:8:y
@@ -217,8 +222,8 @@ flags:SHOP | PROJECT | PASSABLE | PERMANENT | INTERESTING | EASY
 info:8:0
 look-prefix:the entrance to the
 look-in-preposition:at
-desc:Your safe piece of Middle Earth, and the only place you can store goods 
-desc:apart from on your person.
+desc:Your safe piece of Middle Earth, and the only place you can store goods
+desc: apart from on your person.
 
 name:secret door
 graphics:#:w
@@ -234,8 +239,8 @@ priority:13
 flags:ROCK | NO_SCENT | NO_FLOW | INTERESTING | TORCH
 info:0:1
 confused-msg:bumps into some rocks
-desc:Ends LOS, stops missiles, bolts, and beams.  May dissolve or be tunnelled 
-desc:to normal floor.
+desc:Ends LOS, stops missiles, bolts, and beams.  May dissolve or be tunnelled
+desc: to normal floor.
 
 name:magma vein
 graphics:%:D
@@ -243,9 +248,9 @@ priority:12
 flags:WALL | ROCK | NO_SCENT | NO_FLOW | MAGMA | TORCH
 info:0:2
 confused-msg:bashes into a wall
-desc:A seam of soft rock.  It can be removed by digging or magic, and passed 
-desc:through by immaterial monsters.  It stops any spells, missiles or line of 
-desc:sight.
+desc:A seam of soft rock.  It can be removed by digging or magic, and passed
+desc: through by immaterial monsters.  It stops any spells, missiles or line of
+desc: sight.
 
 name:quartz vein
 graphics:%:s
@@ -253,9 +258,9 @@ priority:11
 flags:WALL | ROCK | NO_SCENT | NO_FLOW | QUARTZ | TORCH
 info:0:3
 confused-msg:bashes into a wall
-desc:A seam of hardish rock.  It can be removed by digging or magic, and passed 
-desc:through by immaterial monsters.  It stops any spells, missiles or line of 
-desc:sight.
+desc:A seam of hardish rock.  It can be removed by digging or magic, and passed
+desc: through by immaterial monsters.  It stops any spells, missiles or line of
+desc: sight.
 
 name:magma vein with treasure
 graphics:*:o
@@ -263,9 +268,9 @@ priority:19
 flags:WALL | ROCK | INTERESTING | NO_SCENT | NO_FLOW | GOLD | MAGMA
 info:0:2
 confused-msg:bashes into a wall
-desc:A seam of soft rock.  It can be removed by digging or magic, and passed 
-desc:through by immaterial monsters.  It stops any spells, missiles or line of 
-desc:sight.  It contains visible treasure.
+desc:A seam of soft rock.  It can be removed by digging or magic, and passed
+desc: through by immaterial monsters.  It stops any spells, missiles or line of
+desc: sight.  It contains visible treasure.
 
 name:quartz vein with treasure
 graphics:*:y
@@ -273,9 +278,9 @@ priority:19
 flags:WALL | ROCK | INTERESTING | NO_SCENT | NO_FLOW | GOLD | QUARTZ
 info:0:3
 confused-msg:bashes into a wall
-desc:A seam of hardish rock.  It can be removed by digging or magic, and passed 
-desc:through by immaterial monsters.  It stops any spells, missiles or line of 
-desc:sight.  It contains visible treasure.
+desc:A seam of hardish rock.  It can be removed by digging or magic, and passed
+desc: through by immaterial monsters.  It stops any spells, missiles or line of
+desc: sight.  It contains visible treasure.
 
 name:granite wall
 graphics:#:W
@@ -283,17 +288,17 @@ priority:10
 flags:WALL | ROCK | GRANITE | NO_SCENT | NO_FLOW | TORCH
 info:0:4
 confused-msg:bashes into a wall
-desc:A seam of hard rock.  It can be removed by digging or magic, and passed 
-desc:through by immaterial monsters.  It stops any spells, missiles or line of 
-desc:sight. 
+desc:A seam of hard rock.  It can be removed by digging or magic, and passed
+desc: through by immaterial monsters.  It stops any spells, missiles or line of
+desc: sight.
 
 name:permanent wall
 graphics:#:z
 priority:10
 flags:WALL | ROCK | PERMANENT | NO_SCENT | NO_FLOW
 confused-msg:bashes into a wall
-desc:You can dig through most walls but these are impenetrable.  The dungeon is 
-desc:surrounded by these kinds of walls and some special rooms are made of them.
+desc:You can dig through most walls but these are impenetrable.  The dungeon is
+desc: surrounded by these kinds of walls and some special rooms are made of them.
 
 ## New terrain
 
@@ -314,7 +319,7 @@ graphics:::u
 priority:13
 flags:ROCK | PASSABLE | INTERESTING | TORCH
 info:0:1
-desc:Ends LOS, stops missiles, bolts, and beams, and reduces the radius of ball 
-desc:spells.  May dissolve or be tunnelled to normal floor, and can be walked 
-desc:through by the player and monsters.
+desc:Ends LOS, stops missiles, bolts, and beams, and reduces the radius of ball
+desc: spells.  May dissolve or be tunnelled to normal floor, and can be walked
+desc: through by the player and monsters.
 


### PR DESCRIPTION
I noticed a monster entry with 3 spaces after a period, and when I went to fix it, I found a couple instances.

Angband has a pretty strong convention of using 2 spaces after periods, so I checked on 1 space and found a handful of those.

Description lines are joined directly, so need spaces at the end of previous lines, or the beginning of new lines. End-of-line spaces are poor form in software projects, so I converted end-of-life spaces to beginning-of-next-line spaces, which was the more common convention anyway. A few instances of 1 or 3 spaces were hidden across line breaks, so these were fixed as well.

The 'desc' field description in monster.txt said some processing was done on description lines when joining, but that appears to no longer be the case so I updated the help text to match the other files, and added the 'desc' field description to a file that was missing it.

~~Finally, the unique monster "the jaberwock" was not capitalized, which is unusual for a unique monster, and as far as I can tell, the poem and its wikipedia article always refer to the creature as the Jaberwock.~~

