### PR TITLE
Make changes prompted by auditing strnfmt/textblock_append/file_putf

### DIFF
--- a/src/effects-info.c
+++ b/src/effects-info.c
@@ -538,7 +538,7 @@ textblock *effect_describe(const struct effect *e, const char *prefix,
 			break;
 
 		case EFINFO_NONE:
-			strnfmt(desc, sizeof(desc), edesc);
+			strnfmt(desc, sizeof(desc), "%s", edesc);
 			break;
 
 		default:
@@ -596,7 +596,7 @@ size_t effect_get_menu_name(char *buf, size_t max, const struct effect *e)
 	case EFINFO_CONST:
 	case EFINFO_QUAKE:
 	case EFINFO_NONE:
-		len = strnfmt(buf, max, fmt);
+		len = strnfmt(buf, max, "%s", fmt);
 		break;
 
 	case EFINFO_FOOD:

--- a/src/mon-lore.c
+++ b/src/mon-lore.c
@@ -1151,7 +1151,8 @@ void lore_append_exp(textblock *tb, const struct monster_race *race,
 
 	/* Mention the experience */
 	textblock_append(tb, " is worth ");
-	textblock_append_c(tb, COLOUR_BLUE, format("%s point%s", buf, PLURAL((exp_integer == 1) && (exp_fraction == 0))));
+	textblock_append_c(tb, COLOUR_BLUE, "%s point%s", buf,
+		PLURAL((exp_integer == 1) && (exp_fraction == 0)));
 
 	/* Take account of annoying English */
 	ordinal = "th";

--- a/src/obj-info.c
+++ b/src/obj-info.c
@@ -1811,7 +1811,7 @@ static bool describe_origin(textblock *tb, const struct object *obj, bool terse)
 	switch (origins[origin].args)
 	{
 		case -1: return false;
-		case 0: textblock_append(tb, origins[origin].desc); break;
+		case 0: textblock_append(tb, "%s", origins[origin].desc); break;
 		case 1: textblock_append(tb, origins[origin].desc, loot_spot);
 				break;
 		case 2:

--- a/src/obj-info.c
+++ b/src/obj-info.c
@@ -1382,7 +1382,7 @@ static bool describe_combat(textblock *tb, const struct object *obj)
 
 	if (ammo) {
 		textblock_append(tb, "When fired, hits targets up to ");
-		textblock_append_c(tb, COLOUR_L_GREEN, format("%d", range));
+		textblock_append_c(tb, COLOUR_L_GREEN, "%d", range);
 		textblock_append(tb, " feet away.\n");
 	}
 
@@ -1568,7 +1568,7 @@ static bool describe_light(textblock *tb, const struct object *obj,
 
 	if (tval_is_light(obj)) {
 		textblock_append(tb, "Intensity ");
-		textblock_append_c(tb, COLOUR_L_GREEN, format("%d", intensity));
+		textblock_append_c(tb, COLOUR_L_GREEN, "%d", intensity);
 		textblock_append(tb, " light.");
 
 		if (!obj->artifact && !uses_fuel)

--- a/src/ui-command.c
+++ b/src/ui-command.c
@@ -320,7 +320,7 @@ void html_screenshot(const char *path, int mode)
 	const char *change_color_fmt = (mode == 0) ?
 					"</font><font color=\"#%02X%02X%02X\" style=\"background-color: #%02X%02X%02X\">"
 					: "[/COLOR][COLOR=\"#%02X%02X%02X\"]";
-	const char *close_color_fmt = mode ==  0 ? "</font>" : "[/COLOR]";
+	const char *close_color_str = mode ==  0 ? "</font>" : "[/COLOR]";
 
 	char *mbbuf;
 	ang_file *fp;
@@ -386,7 +386,7 @@ void html_screenshot(const char *path, int mode)
 				} else if (fg_colour == COLOUR_WHITE &&
 						   bg_colour == COLOUR_DARK) {
 					/* From another color to the default white */
-					file_putf(fp, close_color_fmt);
+					file_putf(fp, "%s", close_color_str);
 				} else {
 					/* Change colors */
 					file_putf(fp, change_color_fmt,
@@ -422,7 +422,7 @@ void html_screenshot(const char *path, int mode)
 	}
 
 	/* Close the last font-color tag if necessary */
-	if (oa != COLOUR_WHITE) file_putf(fp, close_color_fmt);
+	if (oa != COLOUR_WHITE) file_putf(fp, "%s", close_color_str);
 
 	if (mode == 0) {
 		file_putf(fp, "</pre>\n");


### PR DESCRIPTION
- Pass some internal strings through "%s" anyways when formatting to avoid raising false alarms about format string security and, for effect or origin descriptions that are expected to take no arguments, provide a bit of protection against programmer mistakes.
- Skip some calls to format() and let textblock_append_c() handle the formatting.