### PR TITLE
Change handling of projections with unrevealed mimics

### DIFF
--- a/src/list-mon-message.h
+++ b/src/list-mon-message.h
@@ -60,6 +60,7 @@ MON_MSG(MANA_DRAIN,			MSG_GENERIC,	false,	"lose[s] some mana!")
 MON_MSG(BRIEF_PUZZLE,		MSG_GENERIC,	false,	"look[s] briefly puzzled.")
 MON_MSG(MAINTAIN_SHAPE,		MSG_GENERIC,	false,	"maintain[s] the same shape.")
 MON_MSG(UNHARMED,			MSG_GENERIC,	false,	"[is|are] unharmed.")
+MON_MSG(APPEAR,			MSG_GENERIC,	false,	"appear[s]!")
 /* Dummy messages for monster pain - we use edit file info instead. */
 MON_MSG(95,					MSG_GENERIC,	false,	"")
 MON_MSG(75,					MSG_GENERIC,	false,	"")

--- a/src/mon-move.c
+++ b/src/mon-move.c
@@ -1001,6 +1001,18 @@ bool multiply_monster(struct chunk *c, const struct monster *mon)
 		/* Create a new monster (awake, no groups) */
 		result = place_new_monster(c, grid, mon->race, false, false, info,
 								   ORIGIN_DROP_BREED);
+		/*
+		 * Fix so multiplying a revealed mimic creates another
+		 * revealed mimic.
+		 */
+		if (result) {
+			struct monster *child = square_monster(c, grid);
+
+			if (child && monster_is_mimicking(child)
+					&& !monster_is_mimicking(mon)) {
+				become_aware(child);
+			}
+		}
 
 		/* Done */
 		break;

--- a/src/mon-msg.c
+++ b/src/mon-msg.c
@@ -145,7 +145,7 @@ static int message_flags(const struct monster *mon)
 		flags |= MON_MSG_FLAG_OFFSCREEN;
 	}
 
-	if (!monster_is_visible(mon)) {
+	if (!monster_is_obvious(mon)) {
 		flags |= MON_MSG_FLAG_INVISIBLE;
 	}
 

--- a/src/mon-util.c
+++ b/src/mon-util.c
@@ -762,6 +762,9 @@ void become_aware(struct monster *mon)
 			 * done below outside of the if block.
 			 */
 			square_delete_object(cave, obj->grid, obj, false, false);
+
+			/* Since mimicry affects visibility, update that. */
+			update_mon(mon, cave, false);
 		}
 
 		/* Update monster and item lists */

--- a/src/player-attack.c
+++ b/src/player-attack.c
@@ -1009,7 +1009,7 @@ static void ranged_helper(struct player *p,	struct object *obj, int dir,
 		/* Try the attack on the monster at (x, y) if any */
 		mon = square_monster(cave, path_g[i]);
 		if (mon) {
-			int visible = monster_is_visible(mon);
+			int visible = monster_is_obvious(mon);
 
 			bool fear = false;
 			const char *note_dies = monster_is_destroyed(mon) ? 
@@ -1065,7 +1065,7 @@ static void ranged_helper(struct player *p,	struct object *obj, int dir,
 					}
 
 					/* Track this monster */
-					if (monster_is_visible(mon)) {
+					if (monster_is_obvious(mon)) {
 						monster_race_track(p->upkeep, mon->race);
 						health_track(p->upkeep, mon);
 					}
@@ -1074,7 +1074,7 @@ static void ranged_helper(struct player *p,	struct object *obj, int dir,
 				/* Hit the monster, check for death */
 				if (!mon_take_hit(mon, dmg, &fear, note_dies)) {
 					message_pain(mon, dmg);
-					if (fear && monster_is_visible(mon)) {
+					if (fear && monster_is_obvious(mon)) {
 						add_monster_message(mon, MON_MSG_FLEE_IN_TERROR, true);
 					}
 				}
@@ -1122,7 +1122,7 @@ static struct attack_result make_ranged_shot(struct player *p,
 	my_strcpy(hit_verb, "hits", 20);
 
 	/* Did we hit it (penalize distance travelled) */
-	if (!test_hit(chance, mon->race->ac, monster_is_visible(mon)))
+	if (!test_hit(chance, mon->race->ac, monster_is_obvious(mon)))
 		return result;
 
 	result.success = true;
@@ -1159,7 +1159,7 @@ static struct attack_result make_ranged_throw(struct player *p,
 	my_strcpy(hit_verb, "hits", 20);
 
 	/* If we missed then we're done */
-	if (!test_hit(chance, mon->race->ac, monster_is_visible(mon)))
+	if (!test_hit(chance, mon->race->ac, monster_is_obvious(mon)))
 		return result;
 
 	result.success = true;

--- a/src/project-mon.c
+++ b/src/project-mon.c
@@ -1375,6 +1375,11 @@ void project_m(struct source origin, int r, struct loc grid, int dam, int typ,
 	if ((flg & PROJECT_STOP) && monster_is_camouflaged(mon)
 			&& monster_is_in_view(mon)) {
 		become_aware(mon);
+		/* Reevaluate whether it's seen. */
+		if (monster_is_visible(mon)) {
+			seen = true;
+			context.seen = true;
+		}
 	}
 
 	/* Force obviousness for certain types if seen. */

--- a/src/project-mon.c
+++ b/src/project-mon.c
@@ -884,7 +884,7 @@ static void project_monster_handler_MON_CLONE(project_monster_handler_context_t 
 	mon_inc_timed(context->mon, MON_TMD_FAST, 50, MON_TMD_FLG_NOTIFY);
 
 	/* Attempt to clone. */
-	if (multiply_monster(cave, context->mon))
+	if (multiply_monster(cave, context->mon) && context->seen)
 		context->hurt_msg = MON_MSG_SPAWN;
 
 	/* No "real" damage */

--- a/src/project-mon.c
+++ b/src/project-mon.c
@@ -1357,6 +1357,12 @@ void project_m(struct source origin, int r, struct loc grid, int dam, int typ,
 	if (monster_is_destroyed(mon))
 		context.die_msg = MON_MSG_DESTROYED;
 
+	/* Reveal a camouflaged monster if in view and it stopped an effect. */
+	if ((flg & PROJECT_STOP) && monster_is_camouflaged(mon)
+			&& monster_is_in_view(mon)) {
+		become_aware(mon);
+	}
+
 	/* Force obviousness for certain types if seen. */
 	if (projections[typ].obvious && context.seen)
 		context.obvious = true;

--- a/src/project-mon.c
+++ b/src/project-mon.c
@@ -1346,7 +1346,12 @@ void project_m(struct source origin, int r, struct loc grid, int dam, int typ,
 	context.lore = lore;
 
 	/* See visible monsters */
-	if (monster_is_visible(mon)) {
+	if (monster_is_mimicking(mon)) {
+		if (monster_is_in_view(mon)) {
+			seen = true;
+			context.seen = true;
+		}
+	} else if (monster_is_visible(mon)) {
 		seen = true;
 		context.seen = seen;
 	}


### PR DESCRIPTION
These are an attempt to resolve #4902 .  The changes are essentially these things:

- When a camouflaged monster that's in view stops a projection, become aware of the camouflaged monster.
- Call update_mon() from become_aware() for revealed mimics since the mimicry influences visibility.
- Use monster_is_obvious() rather than monster_is_visible() in some places (deciding whether to flag a monster message as from an invisible source and within the handling of player missile or thrown attacks) since using monster_is_visible() with an unlit and unrevealed mimic whose mimicked object has a known position can lead to messages that reveal the mimics identity.
- When checking for whether the position of a monster is visible in project_m(), use monster_is_in_view() for unrevealed mimics rather than monster_is_visible() since the latter flags some unlit and unrevealed mimics as visible.
- For multiply_monster() on a revealed mimic, call become_aware() on the clone so it is also revealed.

In the process of checking the above, I also changed handling of the messages for polymorph and clone monster so most of those messages won't be added if context.seen is false.  The exception is the case where polymorph generates a visible monster from a lit but invisible one.  For that a new message type is used, MON_MSG_APPEAR, with the resulting visible monster as the subject.  That's one way to resolve #4903 .
