### PR TITLE
Refactor hit chance calculation, and swap armor/life rating in recall

### DIFF
--- a/lib/gamedata/blow_effects.txt
+++ b/lib/gamedata/blow_effects.txt
@@ -3,7 +3,7 @@
 #
 # Fields:
 # name - blow effect name as in monster.txt
-# power - used for attack quality in check_hit()
+# power - used in monster to-hit chance calculation
 # eval - used for power evaluation in eval_blow_effect()
 # desc - description for monster recall
 # lore-color-base - base color for lore

--- a/src/mon-attack.c
+++ b/src/mon-attack.c
@@ -327,6 +327,38 @@ static int monster_spell_failrate(struct monster *mon)
 }
 
 /**
+ * Calculate the base to-hit value for a monster attack based on race only.
+ * See also: chance_of_spell_hit_base
+ *
+ * \param race The monster race
+ * \param effect The attack
+ */
+int chance_of_monster_hit_base(const struct monster_race *race,
+	const struct blow_effect *effect)
+{
+	return MAX(race->level, 1) * 3 + effect->power;
+}
+
+/**
+ * Calculate the to-hit value of a monster attack for a specific monster
+ *
+ * \param mon The monster
+ * \param effect The attack
+ */
+int chance_of_monster_hit(const struct monster *mon,
+	const struct blow_effect *effect)
+{
+	int to_hit = chance_of_monster_hit_base(mon->race, effect);
+
+	/* Apply stun hit reduction if applicable */
+	if (mon->m_timed[MON_TMD_STUN]) {
+		to_hit = to_hit * (100 - STUN_HIT_REDUCTION) / 100;
+	}
+
+	return to_hit;
+}
+
+/**
  * Creatures can cast spells, shoot missiles, and breathe.
  *
  * Returns "true" if a spell (or whatever) was (successfully) cast.
@@ -490,48 +522,15 @@ static int monster_critical(random_value dice, int rlev, int dam)
 }
 
 /**
- * Determine if a monster attack against the player succeeds.
+ * Determine if an attack against the player succeeds.
  */
-bool check_hit(struct player *p, int power, int level, int accuracy)
+bool check_hit(struct player *p, int to_hit)
 {
-	int chance, ac;
-
-	/* Calculate the "attack quality" */
-	chance = (power + (level * 3));
-
-	/* Total armor */
-	ac = p->state.ac + p->state.to_a;
-
-	/* If the monster checks vs ac, the player learns ac bonuses */
+	/* If anything checks vs ac, the player learns ac bonuses */
 	equip_learn_on_defend(p);
 
-	/* Apply accuracy */
-	chance *= accuracy;
-	chance /= 100;
-
 	/* Check if the player was hit */
-	return test_hit(chance, ac, true);
-}
-
-/**
- * Determine if a monster attack against a monster succeeds.
- */
-bool check_hit_monster(struct monster *mon, int power, int level, int accuracy)
-{
-	int chance, ac;
-
-	/* Calculate the "attack quality" */
-	chance = (power + (level * 3));
-
-	/* Total armor */
-	ac = mon->race->ac;
-
-	/* Apply accuracy */
-	chance *= accuracy;
-	chance /= 100;
-
-	/* Check if the monster was hit */
-	return test_hit(chance, ac, true);
+	return test_hit(to_hit, p->state.ac + p->state.to_a);
 }
 
 /**
@@ -554,7 +553,6 @@ bool make_attack_normal(struct monster *mon, struct player *p)
 	char m_name[80];
 	char ddesc[80];
 	bool blinked = false;
-	int accuracy = 100 - (mon->m_timed[MON_TMD_STUN] ? STUN_HIT_REDUCTION : 0);
 
 	/* Not allowed to attack */
 	if (rf_has(mon->race->flags, RF_NEVER_BLOW)) return (false);
@@ -592,7 +590,7 @@ bool make_attack_normal(struct monster *mon, struct player *p)
 		/* Monster hits player */
 		assert(effect);
 		if (streq(effect->name, "NONE") ||
-			check_hit(p, effect->power, rlev, accuracy)) {
+			check_hit(p, chance_of_monster_hit(mon, effect))) {
 			melee_effect_handler_f effect_handler;
 
 			/* Always disturbing */
@@ -786,7 +784,6 @@ bool monster_attack_monster(struct monster *mon, struct monster *t_mon)
 	char m_name[80];
 	char t_name[80];
 	bool blinked = false;
-	int accuracy = 100 - (mon->m_timed[MON_TMD_STUN] ? STUN_HIT_REDUCTION : 0);
 
 	/* Not allowed to attack */
 	if (rf_has(mon->race->flags, RF_NEVER_BLOW)) return (false);
@@ -818,7 +815,7 @@ bool monster_attack_monster(struct monster *mon, struct monster *t_mon)
 		/* Monster hits monster */
 		assert(effect);
 		if (streq(effect->name, "NONE") ||
-			check_hit_monster(t_mon, effect->power, rlev, accuracy)) {
+			test_hit(chance_of_monster_hit(mon, effect), t_mon->race->ac)) {
 			melee_effect_handler_f effect_handler;
 
 			/* Describe the attack method */

--- a/src/mon-attack.h
+++ b/src/mon-attack.h
@@ -19,10 +19,14 @@
 #ifndef MONSTER_ATTACK_H
 #define MONSTER_ATTACK_H
 
+#include "monster.h"
+#include "mon-blows.h"
+
 int choose_attack_spell(bitflag *f, bool innate, bool non_innate);
+int chance_of_monster_hit_base(const struct monster_race *race,
+	const struct blow_effect *effect);
 bool make_ranged_attack(struct monster *mon);
-bool check_hit(struct player *p, int power, int level, int accuracy);
-bool check_hit_monster(struct monster *mon, int power, int level, int accuracy);
+bool check_hit(struct player *p, int to_hit);
 int adjust_dam_armor(int damage, int ac);
 bool make_attack_normal(struct monster *mon, struct player *p);
 bool monster_attack_monster(struct monster *mon, struct monster *t_mon);

--- a/src/mon-lore.c
+++ b/src/mon-lore.c
@@ -1085,7 +1085,7 @@ void lore_append_toughness(textblock *tb, const struct monster_race *race,
 		/* Player's base chance to hit */
 		random_chance c;
 		hit_chance(&c, chance_of_melee_hit_base(player, weapon), race->ac);
-		int percent = random_chance_percent(c, 100);
+		int percent = random_chance_scaled(c, 100);
 
 		textblock_append(tb, "You have a");
 		if (percent == 8 || percent / 10 == 8)
@@ -1703,7 +1703,7 @@ void lore_append_attack(textblock *tb, const struct monster_race *race,
 			random_chance c;
 			hit_chance(&c, chance_of_monster_hit_base(race, race->blow[i].effect),
 				player->state.ac + player->state.to_a);
-			int percent = random_chance_percent(c, 100);
+			int percent = random_chance_scaled(c, 100);
 			textblock_append_c(tb, COLOUR_L_BLUE, "%d", percent);
 			textblock_append(tb, "%%)");
 

--- a/src/mon-lore.c
+++ b/src/mon-lore.c
@@ -1085,12 +1085,12 @@ void lore_append_toughness(textblock *tb, const struct monster_race *race,
 		/* Player's base chance to hit */
 		random_chance c;
 		hit_chance(&c, chance_of_melee_hit_base(player, weapon), race->ac);
-		int chance = calc_random_chance(c, 100);
+		int percent = random_chance_percent(c, 100);
 
 		textblock_append(tb, "You have a");
-		if (chance == 8 || chance / 10 == 8)
+		if (percent == 8 || percent / 10 == 8)
 			textblock_append(tb, "n");
-		textblock_append_c(tb, COLOUR_L_BLUE, " %d", chance);
+		textblock_append_c(tb, COLOUR_L_BLUE, " %d", percent);
 		textblock_append(tb, "%% chance to hit such a creature in melee (if you can see it).  ");
 	}
 }
@@ -1703,11 +1703,11 @@ void lore_append_attack(textblock *tb, const struct monster_race *race,
 			random_chance c;
 			hit_chance(&c, chance_of_monster_hit_base(race, race->blow[i].effect),
 				player->state.ac + player->state.to_a);
-			int chance = calc_random_chance(c, 100);
-			textblock_append_c(tb, COLOUR_L_BLUE, "%d", chance);
+			int percent = random_chance_percent(c, 100);
+			textblock_append_c(tb, COLOUR_L_BLUE, "%d", percent);
 			textblock_append(tb, "%%)");
 
-			total_centidamage += (chance * randcalc(dice, 0, AVERAGE));
+			total_centidamage += (percent * randcalc(dice, 0, AVERAGE));
 		}
 
 		described_count++;

--- a/src/mon-lore.c
+++ b/src/mon-lore.c
@@ -20,6 +20,7 @@
 #include "effects.h"
 #include "game-world.h"
 #include "init.h"
+#include "mon-attack.h"
 #include "mon-blows.h"
 #include "mon-init.h"
 #include "mon-lore.h"
@@ -1058,7 +1059,6 @@ void lore_append_toughness(textblock *tb, const struct monster_race *race,
 						   bitflag known_flags[RF_SIZE])
 {
 	monster_sex_t msex = MON_SEX_NEUTER;
-	long chance = 0, chance2 = 0;
 	struct object *weapon = equipped_item_by_slot_name(player, "weapon");
 
 	assert(tb && race && lore);
@@ -1068,39 +1068,30 @@ void lore_append_toughness(textblock *tb, const struct monster_race *race,
 
 	/* Describe monster "toughness" */
 	if (lore->armour_known) {
-		/* Armor */
-		textblock_append(tb, "%s has an armor rating of ",
-						 lore_pronoun_nominative(msex, true));
-		textblock_append_c(tb, COLOUR_L_BLUE, "%d", race->ac);
-
 		/* Hitpoints */
-		textblock_append(tb, ", and a");
+		textblock_append(tb, "%s has a", lore_pronoun_nominative(msex, true));
 
 		if (!rf_has(known_flags, RF_UNIQUE))
 			textblock_append(tb, "n average");
 
 		textblock_append(tb, " life rating of ");
 		textblock_append_c(tb, COLOUR_L_BLUE, "%d", race->avg_hp);
+
+		/* Armor */
+		textblock_append(tb, ", and an armor rating of ");
+		textblock_append_c(tb, COLOUR_L_BLUE, "%d", race->ac);
 		textblock_append(tb, ".  ");
 
 		/* Player's base chance to hit */
-		chance = chance_of_melee_hit(player, weapon);
-
-		/* The following calculations are based on test_hit();
-		 * make sure to keep it in sync */
-		if (chance < 9) {
-			chance = 9;
-		}
-		chance2 = 12 + (100 - 12 - 5) * (chance - (race->ac * 2 / 3)) / chance;
-		if (chance2 < 12) {
-			chance2 = 12;
-		}
+		random_chance c;
+		hit_chance(&c, chance_of_melee_hit_base(player, weapon), race->ac);
+		int chance = calc_random_chance(c, 100);
 
 		textblock_append(tb, "You have a");
-		if ((chance2 == 8) || ((chance2 / 10) == 8))
+		if (chance == 8 || chance / 10 == 8)
 			textblock_append(tb, "n");
-		textblock_append_c(tb, COLOUR_L_BLUE, " %d", chance2);
-		textblock_append(tb, " percent chance to hit such a creature in melee (if you can see it).  ");
+		textblock_append_c(tb, COLOUR_L_BLUE, " %d", chance);
+		textblock_append(tb, "%% chance to hit such a creature in melee (if you can see it).  ");
 	}
 }
 
@@ -1709,21 +1700,14 @@ void lore_append_attack(textblock *tb, const struct monster_race *race,
 			}
 
 			/* Describe hit chances */
-			long chance = 0, chance2 = 0;
-			// These calculations are based on check_hit() and test_hit();
-			// make sure to keep it in sync
-			chance = (race->blow[i].effect->power + (race->level * 3));
-			if (chance < 9) {
-				chance = 9;
-			}
-			chance2 = 12 + (100 - 12 - 5) * (chance - ((player->state.ac + player->state.to_a) * 2 / 3)) / chance;
-			if (chance2 < 12) {
-				chance2 = 12;
-			}
-			textblock_append_c(tb, COLOUR_L_BLUE, "%d", chance2);
+			random_chance c;
+			hit_chance(&c, chance_of_monster_hit_base(race, race->blow[i].effect),
+				player->state.ac + player->state.to_a);
+			int chance = calc_random_chance(c, 100);
+			textblock_append_c(tb, COLOUR_L_BLUE, "%d", chance);
 			textblock_append(tb, "%%)");
 
-			total_centidamage += (chance2 * randcalc(dice, 0, AVERAGE));
+			total_centidamage += (chance * randcalc(dice, 0, AVERAGE));
 		}
 
 		described_count++;

--- a/src/mon-timed.c
+++ b/src/mon-timed.c
@@ -316,7 +316,7 @@ bool mon_clear_timed(struct monster *mon, int effect_type, int flag)
  * The level at which an effect is affecting a monster.
  * Levels range from 0 (unaffected) to 5 (maximum effect).
  */
-int monster_effect_level(struct monster *mon, int effect_type)
+int monster_effect_level(const struct monster *mon, int effect_type)
 {
 	struct mon_timed_effect *effect = &effects[effect_type];
 	int divisor = MAX(effect->max_timer / 5, 1);

--- a/src/mon-timed.h
+++ b/src/mon-timed.h
@@ -54,6 +54,6 @@ int mon_timed_name_to_idx(const char *name);
 bool mon_inc_timed(struct monster *mon, int effect_type, int timer, int flag);
 bool mon_dec_timed(struct monster *mon, int effect_type, int timer, int flag);
 bool mon_clear_timed(struct monster *mon, int effect_type, int flag);
-int monster_effect_level(struct monster *mon, int effect_type);
+int monster_effect_level(const struct monster *mon, int effect_type);
 
 #endif /* MONSTER_TIMED_H */

--- a/src/player-attack.c
+++ b/src/player-attack.c
@@ -78,26 +78,48 @@ int breakage_chance(const struct object *obj, bool hit_target) {
 }
 
 /**
- * Return the player's chance to hit with a particular weapon.
+ * Calculate the player's base melee to-hit value without regard to a specific
+ * monster.
+ * See also: chance_of_missile_hit_base
+ *
+ * \param p The player
+ * \param weapon The player's weapon
  */
-int chance_of_melee_hit(const struct player *p, const struct object *weapon)
+int chance_of_melee_hit_base(const struct player *p,
+		const struct object *weapon)
 {
-	int chance, bonus = p->state.to_h;
-
-	if (weapon)
-		bonus += weapon->to_h;
-	chance = p->state.skills[SKILL_TO_HIT_MELEE] + bonus * BTH_PLUS_ADJ;
-	return chance;
+	int bonus = p->state.to_h + (weapon ? weapon->to_h : 0);
+	return p->state.skills[SKILL_TO_HIT_MELEE] + bonus * BTH_PLUS_ADJ;
 }
 
 /**
- * Return the player's chance to hit with a particular missile and
- * (optionally) launcher.
+ * Calculate the player's melee to-hit value against a specific monster.
+ * See also: chance_of_missile_hit
+ *
+ * \param p The player
+ * \param weapon The player's weapon
+ * \param mon The monster
  */
-static int chance_of_missile_hit(const struct player *p,
+static int chance_of_melee_hit(const struct player *p,
+		const struct object *weapon, const struct monster *mon)
+{
+	int chance = chance_of_melee_hit_base(p, weapon);
+	/* Non-visible targets have a to-hit penalty of 50% */
+	return monster_is_visible(mon) ? chance : chance / 2;
+}
+
+/**
+ * Calculate the player's base missile to-hit value without regard to a specific
+ * monster.
+ * See also: chance_of_melee_hit_base
+ *
+ * \param p The player
+ * \param missile The missile to launch
+ * \param launcher The launcher to use (optional)
+ */
+static int chance_of_missile_hit_base(const struct player *p,
 								 const struct object *missile,
-								 const struct object *launcher,
-								 struct loc grid)
+								 const struct object *launcher)
 {
 	int bonus = missile->to_h;
 	int chance;
@@ -118,30 +140,83 @@ static int chance_of_missile_hit(const struct player *p,
 		chance = p->state.skills[SKILL_TO_HIT_BOW] + bonus * BTH_PLUS_ADJ;
 	}
 
-	return chance - distance(p->grid, grid);
+	return chance;
 }
 
 /**
- * Determine if the player "hits" a monster.
+ * Calculate the player's missile to-hit value against a specific monster.
+ * See also: chance_of_melee_hit
+ *
+ * \param p The player
+ * \param missile The missile to launch
+ * \param launcher Optional launcher to use (thrown weapons use no launcher)
+ * \param mon The monster
  */
-bool test_hit(int chance, int ac, int vis) {
-	int k = randint0(100);
-
-	/* There is an automatic 12% chance to hit,
-	 * and 5% chance to miss.
-	 */
-	if (k < 17) return k < 12;
-
-	/* Penalize invisible targets */
-	if (!vis) chance /= 2;
-
-	/* Starting a bit higher up on the scale */
-	if (chance < 9) chance = 9;
-
-	/* Power competes against armor */
-	return randint0(chance) >= (ac * 2 / 3);
+static int chance_of_missile_hit(const struct player *p,
+	const struct object *missile, const struct object *launcher,
+	const struct monster *mon)
+{
+	int chance = chance_of_missile_hit_base(p, missile, launcher);
+	/* Penalize for distance */
+	chance -= distance(p->grid, mon->grid);
+	/* Non-visible targets have a to-hit penalty of 50% */
+	return monster_is_obvious(mon) ? chance : chance / 2;
 }
 
+/**
+ * Determine if a hit roll is successful against the target AC.
+ * See also: hit_chance
+ *
+ * \param to_hit To total to-hit value to use
+ * \param ac The AC to roll against
+ */
+bool test_hit(int to_hit, int ac)
+{
+	random_chance c;
+	hit_chance(&c, to_hit, ac);
+	return check_random_chance(c);
+}
+
+/**
+ * Return a random_chance by reference, which represents the likelihood of a
+ * hit roll succeeding for the given to_hit and ac values. The hit calculation
+ * will:
+ *
+ * Always hit 12% of the time
+ * Always miss 5% of the time
+ * Put a floor of 9 on the to-hit value
+ * Roll between 0 and the to-hit value
+ * The outcome must be >= AC*2/3 to be considered a hit
+ *
+ * \param chance The random_chance to return-by-reference
+ * \param to_hit The to-hit value to use
+ * \param ac The AC to roll against
+ */
+void hit_chance(random_chance *chance, int to_hit, int ac)
+{
+	/* Percentages scaled to 10,000 to avoid rounding error */
+	const int HUNDRED_PCT = 10000;
+	const int ALWAYS_HIT = 1200;
+	const int ALWAYS_MISS = 500;
+
+	/* Put a floor on the to_hit */
+	to_hit = MAX(9, to_hit);
+
+	/* Calculate the hit percentage */
+	chance->numerator = MAX(0, to_hit - ac * 2 / 3);
+	chance->denominator = to_hit;
+
+	/* Convert the ratio to a scaled percentage */
+	chance->numerator = HUNDRED_PCT * chance->numerator / chance->denominator;
+	chance->denominator = HUNDRED_PCT;
+
+	/* The calculated rate only applies when the guaranteed hit/miss don't */
+	chance->numerator = chance->numerator *
+			(HUNDRED_PCT - ALWAYS_MISS - ALWAYS_HIT) / HUNDRED_PCT;
+
+	/* Add in the guaranteed hit */
+	chance->numerator += ALWAYS_HIT;
+}
 
 /**
  * ------------------------------------------------------------------------
@@ -265,7 +340,7 @@ static int o_critical_shot(const struct player *p,
 						   u32b *msg_type)
 {
 	int debuff_to_hit = is_debuffed(monster) ? DEBUFF_CRITICAL_HIT : 0;
-	int power = chance_of_missile_hit(p, missile, launcher, monster->grid)
+	int power = chance_of_missile_hit_base(p, missile, launcher)
 		+ debuff_to_hit;
 	int add_dice = 0;
 
@@ -342,7 +417,7 @@ static int o_critical_melee(const struct player *p,
 							const struct object *obj, u32b *msg_type)
 {
 	int debuff_to_hit = is_debuffed(monster) ? DEBUFF_CRITICAL_HIT : 0;
-	int power = (chance_of_melee_hit(p, obj) + debuff_to_hit) / 3;
+	int power = (chance_of_melee_hit_base(p, obj) + debuff_to_hit) / 3;
 	int add_dice = 0;
 
 	/* Test for critical hit - chance power / (power + 240) */
@@ -623,7 +698,6 @@ bool py_attack_real(struct player *p, struct loc grid, bool *fear)
 	struct object *obj = equipped_item_by_slot_name(p, "weapon");
 
 	/* Information about the attack */
-	int chance = chance_of_melee_hit(p, obj);
 	int drain = 0;
 	int splash = 0;
 	bool do_quake = false;
@@ -658,7 +732,7 @@ bool py_attack_real(struct player *p, struct loc grid, bool *fear)
 	mon_clear_timed(mon, MON_TMD_HOLD, MON_TMD_FLG_NOTIFY);
 
 	/* See if the player hit */
-	success = test_hit(chance, mon->race->ac, monster_is_visible(mon));
+	success = test_hit(chance_of_melee_hit(p, obj, mon), mon->race->ac);
 
 	/* If a miss, skip this hit */
 	if (!success) {
@@ -1116,13 +1190,12 @@ static struct attack_result make_ranged_shot(struct player *p,
 	struct attack_result result = {false, 0, 0, hit_verb};
 	struct object *bow = equipped_item_by_slot_name(p, "shooting");
 	struct monster *mon = square_monster(cave, grid);
-	int chance = chance_of_missile_hit(p, ammo, bow, grid);
 	int b = 0, s = 0;
 
 	my_strcpy(hit_verb, "hits", 20);
 
-	/* Did we hit it (penalize distance travelled) */
-	if (!test_hit(chance, mon->race->ac, monster_is_obvious(mon)))
+	/* Did we hit it */
+	if (!test_hit(chance_of_missile_hit(p, ammo, bow, mon), mon->race->ac))
 		return result;
 
 	result.success = true;
@@ -1153,13 +1226,12 @@ static struct attack_result make_ranged_throw(struct player *p,
 	char *hit_verb = mem_alloc(20 * sizeof(char));
 	struct attack_result result = {false, 0, 0, hit_verb};
 	struct monster *mon = square_monster(cave, grid);
-	int chance = chance_of_missile_hit(p, obj, NULL, grid);
 	int b = 0, s = 0;
 
 	my_strcpy(hit_verb, "hits", 20);
 
 	/* If we missed then we're done */
-	if (!test_hit(chance, mon->race->ac, monster_is_obvious(mon)))
+	if (!test_hit(chance_of_missile_hit(p, obj, NULL, mon), mon->race->ac))
 		return result;
 
 	result.success = true;

--- a/src/player-attack.c
+++ b/src/player-attack.c
@@ -174,7 +174,7 @@ bool test_hit(int to_hit, int ac)
 {
 	random_chance c;
 	hit_chance(&c, to_hit, ac);
-	return check_random_chance(c);
+	return random_chance_check(c);
 }
 
 /**

--- a/src/player-attack.h
+++ b/src/player-attack.h
@@ -55,8 +55,10 @@ extern void do_cmd_throw(struct command *cmd);
 
 
 extern int breakage_chance(const struct object *obj, bool hit_target);
-int chance_of_melee_hit(const struct player *p, const struct object *weapon);
-extern bool test_hit(int chance, int ac, int vis);
+int chance_of_melee_hit_base(const struct player *p,
+	const struct object *weapon);
+extern bool test_hit(int to_hit, int ac);
+void hit_chance(random_chance *, int, int);
 void apply_deadliness(int *die_average, int deadliness);
 extern void py_attack(struct player *p, struct loc grid);
 extern bool py_attack_real(struct player *p, struct loc grid, bool *fear);

--- a/src/tests/monster/attack.c
+++ b/src/tests/monster/attack.c
@@ -21,7 +21,7 @@ int setup_tests(void **state) {
 	r_info = r;
 	*state = m;
 
-	rand_fix(100);
+	rand_fix(10);
 	return 0;
 }
 

--- a/src/tests/monster/attack.c
+++ b/src/tests/monster/attack.c
@@ -21,7 +21,7 @@ int setup_tests(void **state) {
 	r_info = r;
 	*state = m;
 
-	rand_fix(10);
+	rand_fix(100);
 	return 0;
 }
 

--- a/src/trap.c
+++ b/src/trap.c
@@ -20,6 +20,7 @@
 #include "cave.h"
 #include "effects.h"
 #include "init.h"
+#include "mon-attack.h"
 #include "mon-util.h"
 #include "obj-knowledge.h"
 #include "player-attack.h"
@@ -470,17 +471,6 @@ void square_memorize_traps(struct chunk *c, struct loc grid)
 }
 
 /**
- * Determine if a trap affects the player.
- * Always miss 5% of the time, Always hit 5% of the time.
- * Otherwise, match trap power against player armor.
- */
-bool trap_check_hit(int power)
-{
-	return test_hit(power, player->state.ac + player->state.to_a, true);
-}
-
-
-/**
  * Hit a trap. 
  */
 extern void hit_trap(struct loc grid, int delayed)
@@ -528,7 +518,8 @@ extern void hit_trap(struct loc grid, int delayed)
 			}
 
 		/* Test for save due to armor */
-		if (trf_has(trap->kind->flags, TRF_SAVE_ARMOR) && !trap_check_hit(125))
+		if (trf_has(trap->kind->flags, TRF_SAVE_ARMOR)
+			&& !check_hit(player, 125))
 			saved = true;
 
 		/* Test for save due to saving throw */

--- a/src/trap.h
+++ b/src/trap.h
@@ -99,7 +99,6 @@ bool square_trap_flag(struct chunk *c, struct loc grid, int flag);
 bool square_reveal_trap(struct chunk *c, struct loc grid, bool always,
 						bool domsg);
 void square_memorize_traps(struct chunk *c, struct loc grid);
-bool trap_check_hit(int power);
 void hit_trap(struct loc grid, int delayed);
 bool square_player_trap_allowed(struct chunk *c, struct loc grid);
 void place_trap(struct chunk *c, struct loc grid, int t_idx, int trap_level);

--- a/src/z-rand.c
+++ b/src/z-rand.c
@@ -531,6 +531,28 @@ bool randcalc_varies(random_value v)
 	return randcalc(v, 0, MINIMISE) != randcalc(v, 0, MAXIMISE);
 }
 
+/**
+ * Roll on a random chance and check for success.
+ *
+ * \param c The random_chance to roll on
+ */
+bool check_random_chance(random_chance c)
+{
+	return randint0(c.denominator) < c.numerator;
+}
+
+/**
+ * Return a percentage based on the random chance, with the given scale. For
+ * example, a chance of 7 / 13 (53.8%) with scale 100 would be 53
+ *
+ * \param c The random_chance converted to a percentage
+ * \param scale The scale by which the ratio is multiplied
+ */
+int calc_random_chance(random_chance c, int scale)
+{
+	return scale * c.numerator / c.denominator;
+}
+
 void rand_fix(u32b val)
 {
 	rand_fixed = true;

--- a/src/z-rand.c
+++ b/src/z-rand.c
@@ -543,13 +543,15 @@ bool random_chance_check(random_chance c)
 }
 
 /**
- * Return a percentage based on the random chance, with the given scale. For
- * example, a chance of 7 / 13 (53.8%) with scale 100 would be 53
+ * Scales a random chance to use the denominator provided in the scale argument
+ * and returns the appropriate numerator. For example, a chance of 7 / 13 (53.8%)
+ * with scale 100 would be 53. For extra integer precision, a scale of 1000 would
+ * yield 538.
  *
- * \param c The random_chance converted to a percentage
+ * \param c The random_chance to scale
  * \param scale The scale by which the ratio is multiplied
  */
-int random_chance_percent(random_chance c, int scale)
+int random_chance_scaled(random_chance c, int scale)
 {
 	return scale * c.numerator / c.denominator;
 }

--- a/src/z-rand.c
+++ b/src/z-rand.c
@@ -536,9 +536,10 @@ bool randcalc_varies(random_value v)
  *
  * \param c The random_chance to roll on
  */
-bool check_random_chance(random_chance c)
+bool random_chance_check(random_chance c)
 {
-	return randint0(c.denominator) < c.numerator;
+	/* Calculated so that high rolls pass the check */
+	return randint0(c.denominator) >= c.denominator - c.numerator;
 }
 
 /**
@@ -548,7 +549,7 @@ bool check_random_chance(random_chance c)
  * \param c The random_chance converted to a percentage
  * \param scale The scale by which the ratio is multiplied
  */
-int calc_random_chance(random_chance c, int scale)
+int random_chance_percent(random_chance c, int scale)
 {
 	return scale * c.numerator / c.denominator;
 }

--- a/src/z-rand.h
+++ b/src/z-rand.h
@@ -201,7 +201,7 @@ bool randcalc_varies(random_value v);
 
 bool random_chance_check(random_chance c);
 
-int random_chance_percent(random_chance c, int scale);
+int random_chance_scaled(random_chance c, int scale);
 
 extern void rand_fix(u32b val);
 

--- a/src/z-rand.h
+++ b/src/z-rand.h
@@ -199,9 +199,9 @@ bool randcalc_valid(random_value v, int test);
  */
 bool randcalc_varies(random_value v);
 
-bool check_random_chance(random_chance c);
+bool random_chance_check(random_chance c);
 
-int calc_random_chance(random_chance c, int scale);
+int random_chance_percent(random_chance c, int scale);
 
 extern void rand_fix(u32b val);
 

--- a/src/z-rand.h
+++ b/src/z-rand.h
@@ -45,6 +45,14 @@ typedef struct random {
 } random_value;
 
 /**
+ * A struct representing a random chance of success, such as 8 in 125 (6.4%).
+ */
+typedef struct random_chance_s {
+	s32b numerator;
+	s32b denominator;
+} random_chance;
+
+/**
  * The number of 32-bit integers worth of seed state.
  */
 #define RAND_DEG 32
@@ -190,6 +198,10 @@ bool randcalc_valid(random_value v, int test);
  * Test to see if a random_value actually varies.
  */
 bool randcalc_varies(random_value v);
+
+bool check_random_chance(random_chance c);
+
+int calc_random_chance(random_chance c, int scale);
 
 extern void rand_fix(u32b val);
 


### PR DESCRIPTION
### Feature
I want to suggest displaying life rating before armor rating in monster recall:
* Life rating is more important because it's always applicable, while armor rating is only applicable to non-magic attacks.
* Armor rating and the player's hit chance are closely related, so I'd like them to be next to each other.
* Using a % sign is consistent with the style later on, and makes it easier to pick out the hit rate when scanning.

![life_rating_first](https://user-images.githubusercontent.com/24471463/125831816-9bdee3aa-3983-4b8b-9158-899bd4e8e45b.png)

### Refactor
Unfortunately, I noticed the duplication of to-hit logic used in mon-lore.c, so the majority of this work is to refactor that. My goal was to eliminate duplication and improve clarity without changing mechanics. To that end:
* I added a `random_chance` struct to represent chances and can be used to roll or just report out.
* I added a set of `chance_of_*_hit` functions (like the player's chance_of_melee_hit) to encapsulate to-hit calculations (they are melee, missile, monster, spell).
* I split `chance_of_*_hit` calculations into two levels, chance_of_hit for the value against a specific target (such as when attacking) and a `chance_of_*_hit_base` level that doesn't use info for specific targets (such as during monster recall).
* I added a `hit_chance` method to implement the global to-hit rules and create a `random_chance` for the given to-hit and AC values.
*  All to-hit calculation logic was pushed into one of these three places (the `chance_of_*_base`, the `chance_of_*`, or `hit_chance`).

A summary of the to-hit calculation as I understand it (which should remain unchanged):
* Calculate to-hit based on source
   * Monster melee uses `blow power + 3 * level`. May be reduced by stun.
   * Monster spells use `spell power + 3 * level`. May be reduced by confusion.
   * Player melee uses `weapon skill + 3 * to-hit bonus`. May be reduced when attacking a non-visible target.
   * Player missiles use `missile skill | throwing skill + 3 * bonus` where bonus may include the base, the missile, the launcher and throwing skill may be modified for non-throwing weapons. May be reduced by distance, and when attacking non-visible targets.
* Make a roll using the to-hit value against and AC.
   * There is always a 12% chance of hit and 5% chance of miss. This takes precedence, so the actual roll only applies when these don't (which changes the overall odds slightly).
   * Never use a to-hit value less than 9.
   * Otherwise to get a hit, check if `random [0, to-hit) >= AC * 2/ 3`

I arrived at the formula used independently, and it looks like the same formula that were previously used for monster recall calculations. I have tested a few scenarios and numbers seem alright, but if you want a more detailed comparison or tests, I can provide them.

### Side-effects
I removed the mostly extraneous function `trap_check_hit` and replaced it with the player's `check_hit`. This means traps will give the player on-defense knowledge, like monster attacks. Since traps do check against AC, I think this is appropriate and it's easier to get hit by a monster than find a trap anyway.

Original critical hits also use to-hit values to determine frequency. Since I moved where different parts of the to-hit are calculated, critical rates will change slightly. Previously:
* Criticals did NOT consider monster visibility. While it was harder to hit non-visible creatures, your crit rate was unaffected.
* Criticals DID use a small reduction in frequency for missile attacks at range.

I decided to use the "base" hit rates (unmodified by visibility or distance) since I think it's closer to the original rates, and because I like seeing `You hit it. It was a great hit!` This does means crits from missiles at range will be slightly more common (as common as ranged shots up close). The critical rate for missiles could be adjusted to compensate, but I think the difference is only a couple percent.
