### PR TITLE
Fix sdl2 warnings

### DIFF
--- a/src/Makefile.msys2.sdl2
+++ b/src/Makefile.msys2.sdl2
@@ -38,6 +38,7 @@ VIDEO_sdl2 := -DUSE_SDL2 \
 	-lbrotlicommon-static \
 	-lgraphite2 \
 	-lpng \
+	-ldeflate \
 	-ljpeg \
 	-lbz2 \
 	-lintl \
@@ -60,11 +61,15 @@ VIDEO_sdl2 := -DUSE_SDL2 \
 # Compiler to use
 CC := gcc
 
+WARNINGS = -W -Wall -Wextra -Wno-unused-parameter \
+	-Wno-missing-field-initializers -Wwrite-strings -Wmissing-prototypes \
+	-Wnested-externs -Wshadow -Wunused-macros
+
 # Flags to use in compilation
 CFLAGS := -std=c99 \
 	-g \
 	-O2 \
-	-W -Wall -Wextra -Wno-unused-parameter -pedantic \
+	$(WARNINGS) -pedantic \
 	-static \
 	-DUSE_PRIVATE_PATHS \
 	-DHAVE_DIRENT_H \

--- a/src/effects-info.c
+++ b/src/effects-info.c
@@ -677,7 +677,7 @@ size_t effect_get_menu_name(char *buf, size_t max, const struct effect *e)
 		{
 			random_value value = { 0, 0, 0, 0 };
 			char dist[32];
-			int avg;
+			int avg = 0;
 
 			if (e->dice) {
 				avg = dice_evaluate(e->dice, 1, AVERAGE,

--- a/src/h-basic.h
+++ b/src/h-basic.h
@@ -35,7 +35,7 @@
  */
 # if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) \
   || (defined(_MSC_VER) && _MSC_VER >= 1600L)
-#  define HAVE_STDINT_H
+#  define HAVE_STDINT_H 1
 # endif
 
 # if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L

--- a/src/main-sdl2.c
+++ b/src/main-sdl2.c
@@ -24,6 +24,7 @@
 #include "SDL_image.h"
 #include "SDL_ttf.h"
 
+#include "main.h"
 #include "init.h"
 #include "ui-term.h"
 #include "buildid.h"
@@ -96,7 +97,6 @@
 	(DEFAULT_BORDER * 2)
 #define DEFAULT_VISIBLE_BORDER 2
 
-#define DEFAULT_FONT_SIZE 0
 /* XXX hack: the widest character present in a font
  * for determining font advance (width) */
 #define GLYPH_FOR_ADVANCE 'W'
@@ -107,8 +107,6 @@
 #define DEFAULT_FONT_H 20
 
 #define DEFAULT_STATUS_BAR_FONT "8x13x.fon"
-#define DEFAULT_STATUS_BAR_FONT_W 8
-#define DEFAULT_STATUS_BAR_FONT_H 13
 
 #define MAX_VECTOR_FONT_SIZE 24
 #define MIN_VECTOR_FONT_SIZE 4
@@ -3870,7 +3868,7 @@ static errr term_text_hook(int col, int row, int n, int a, const wchar_t *s)
 }
 
 static errr term_pict_hook(int col, int row, int n,
-		const int *ap, const wchar_t *cp, const int *tap, const int *tcp)
+		const int *ap, const wchar_t *cp, const int *tap, const wchar_t *tcp)
 {
 	int dhrclip;
 	struct subwindow *subwindow = Term->data;
@@ -4032,9 +4030,9 @@ static void term_view_map_text(struct subwindow *subwindow)
 	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "0");
 }
 
-static void term_view_map_hook(term *term)
+static void term_view_map_hook(term *terminal)
 {
-	struct subwindow *subwindow = term->data;
+	struct subwindow *subwindow = terminal->data;
 	if (subwindow->window->graphics.id == GRAPHICS_NONE) {
 		term_view_map_text(subwindow);
 	} else {
@@ -5620,7 +5618,7 @@ static void init_systems(void)
 	SDL_SetHint(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "0");
 }
 
-int init_sdl2(int argc, char **argv)
+errr init_sdl2(int argc, char **argv)
 {
 	init_systems();
 	init_globals();


### PR DESCRIPTION
So far, Makefile.msys2.sdl2 has been the path of least resistance for me (developing with MSYS2 on Windows). I had to add -ldeflate to get it to work, and it's missing adequate warning coverage. There's also a few warnings in the front-end that can be squashed.

Contains a bonus uninitialized warning fix in effects-info.c.