### PR TITLE
For town generation, also clear room flag on the walls

### DIFF
--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -2508,8 +2508,7 @@ static void town_gen_layout(struct chunk *c, struct player *p)
 		/* Turn off room illumination flag */
 		for (grid.y = 1; grid.y < c->height - 1; grid.y++) {
 			for (grid.x = 1; grid.x < c->width - 1; grid.x++) {
-				if (square_isfloor(c, grid))
-					sqinfo_off(square(c, grid)->info, SQUARE_ROOM);
+				sqinfo_off(square(c, grid)->info, SQUARE_ROOM);
 			}
 		}
 


### PR DESCRIPTION
A player could see that it was present by digging out one layer of wall around the town, waiting till dark, and then firing off a light area effect while on or adjacent to a former wall to see all the former walls light up.