### PR TITLE
Remove redundant item testers

### DIFF
--- a/src/effects.c
+++ b/src/effects.c
@@ -356,23 +356,6 @@ static const int enchant_table[16] =
 };
 
 /**
- * Hook to specify "weapon"
- */
-static bool item_tester_hook_weapon(const struct object *obj)
-{
-	return tval_is_weapon(obj);
-}
-
-
-/**
- * Hook to specify "armour"
- */
-static bool item_tester_hook_armour(const struct object *obj)
-{
-	return tval_is_armor(obj);
-}
-
-/**
  * Tries to increase an items bonus score, if possible.
  *
  * \returns true if the bonus was increased
@@ -492,8 +475,7 @@ static bool enchant_spell(int num_hit, int num_dam, int num_ac, struct command *
 
 	const char *q, *s;
 	int itemmode = (USE_EQUIP | USE_INVEN | USE_QUIVER | USE_FLOOR);
-	item_tester filter = num_ac ?
-		item_tester_hook_armour : item_tester_hook_weapon;
+	item_tester filter = num_ac ? tval_is_armor : tval_is_weapon;
 
 	/* Get an item */
 	q = "Enchant which item? ";
@@ -592,41 +574,6 @@ static void brand_object(struct object *obj, const char *name)
 		event_signal(EVENT_INPUT_FLUSH);
 		msg("The branding failed.");
 	}
-}
-
-/**
- * Hook for "get_item()".  Determine if something is rechargable.
- */
-static bool item_tester_hook_recharge(const struct object *obj)
-{
-	/* Recharge staves and wands */
-	if (tval_can_have_charges(obj)) return true;
-
-	return false;
-}
-
-/**
- * Hook to specify a staff
- */
-static bool item_tester_hook_staff(const struct object *obj)
-{
-	return obj->tval == TV_STAFF;
-}
-
-/**
- * Hook to specify "ammo"
- */
-static bool item_tester_hook_ammo(const struct object *obj)
-{
-	return tval_is_ammo(obj);
-}
-
-/**
- * Hook to specify bolts
- */
-static bool item_tester_hook_bolt(const struct object *obj)
-{
-	return obj->tval == TV_BOLT;
 }
 
 /**
@@ -2463,11 +2410,10 @@ static bool effect_handler_RECHARGE(effect_handler_context_t *context)
 	s = "You have nothing to recharge.";
 	if (context->cmd) {
 		if (cmd_get_item(context->cmd, "tgtitem", &obj, q, s,
-				item_tester_hook_recharge, itemmode)) {
+				tval_can_have_charges, itemmode)) {
 			return used;
 		}
-	} else if (!get_item(&obj, q, s, 0, item_tester_hook_recharge,
-				  itemmode)) {
+	} else if (!get_item(&obj, q, s, 0, tval_can_have_charges, itemmode)) {
 		return (used);
 	}
 
@@ -4690,10 +4636,10 @@ static bool effect_handler_BRAND_AMMO(effect_handler_context_t *context)
 	s = "You have nothing to brand.";
 	if (context->cmd) {
 		if (cmd_get_item(context->cmd, "tgtitem", &obj, q, s,
-				item_tester_hook_ammo, itemmode)) {
+				tval_is_ammo, itemmode)) {
 			return used;
 		}
-	} else if (!get_item(&obj, q, s, 0, item_tester_hook_ammo, itemmode))
+	} else if (!get_item(&obj, q, s, 0, tval_is_ammo, itemmode))
 		return used;
 
 	/* Brand the ammo */
@@ -4720,10 +4666,10 @@ static bool effect_handler_BRAND_BOLTS(effect_handler_context_t *context)
 	s = "You have no bolts to brand.";
 	if (context->cmd) {
 		if (cmd_get_item(context->cmd, "tgtitem", &obj, q, s,
-				item_tester_hook_bolt, itemmode)) {
+				tval_is_bolt, itemmode)) {
 			return used;
 		}
-	} else if (!get_item(&obj, q, s, 0, item_tester_hook_bolt, itemmode))
+	} else if (!get_item(&obj, q, s, 0, tval_is_bolt, itemmode))
 		return used;
 
 	/* Brand the bolts */
@@ -4751,11 +4697,10 @@ static bool effect_handler_CREATE_ARROWS(effect_handler_context_t *context)
 	s = "You have no staff to use.";
 	if (context->cmd) {
 		if (cmd_get_item(context->cmd, "tgtitem", &obj, q, s,
-				item_tester_hook_staff, itemmode)) {
+				tval_is_staff, itemmode)) {
 			return false;
 		}
-	} else if (!get_item(&obj, q, s, 0, item_tester_hook_staff,
-				  itemmode)) {
+	} else if (!get_item(&obj, q, s, 0, tval_is_staff, itemmode)) {
 		return false;
 	}
 
@@ -4808,11 +4753,10 @@ static bool effect_handler_TAP_DEVICE(effect_handler_context_t *context)
 	s = "You have nothing to drain charges from.";
 	if (context->cmd) {
 		if (cmd_get_item(context->cmd, "tgtitem", &obj, q, s,
-				item_tester_hook_recharge, itemmode)) {
+				tval_can_have_charges, itemmode)) {
 			return used;
 		}
-	} else if (!get_item(&obj, q, s, 0, item_tester_hook_recharge,
-				  itemmode)) {
+	} else if (!get_item(&obj, q, s, 0, tval_can_have_charges, itemmode)) {
 		return (used);
 	}
 

--- a/src/obj-tval.c
+++ b/src/obj-tval.c
@@ -162,6 +162,11 @@ bool tval_is_sharp_missile(const struct object *obj)
 	}
 }
 
+bool tval_is_bolt(const struct object *obj)
+{
+	return obj->tval == TV_BOLT;
+}
+
 bool tval_is_launcher(const struct object *obj)
 {
 	return obj->tval == TV_BOW;

--- a/src/obj-tval.h
+++ b/src/obj-tval.h
@@ -35,6 +35,7 @@ int tval_find_idx(const char *name);
 const char *tval_find_name(int tval);
 bool tval_is_ammo(const struct object *obj);
 bool tval_is_sharp_missile(const struct object *obj);
+bool tval_is_bolt(const struct object *obj);
 bool tval_is_armor(const struct object *obj);
 bool tval_is_body_armor(const struct object *obj);
 bool tval_is_book_k(const struct object_kind *kind);


### PR DESCRIPTION
Remove the following static (local) redundant item testers from **effects.c**:
* `item_tester_hook_weapon`
* `item_tester_hook_armour`
* `item_tester_hook_recharge`
* `item_tester_hook_staff`
* `item_tester_hook_ammo`
* `item_tester_hook_bolt` (technically not redundant since I had to add `tval_is_bolt`)

I would like to reduce the almost 6000 line effects.c file size to a reasonable level (< 5000 at least). I ran some stats on the file:
* There are 136 functions
* The function sizes range between 6-285 lines. Only 8 functions are above 100 lines. Average function size is ~42 lines
* The majority of functions (80%) are effect_handlers, and the rest are helpers

I think the solution would be to break the file up into multiple parts. Based on the distribution of effect handlers, I think something like this would be a good place to start:
* effects-attack.c (damage dealing effects)
* effects-obj.c (effects that manipulate objects)
* effects-util.c (the rest)

Are you interested in seeing what that would look like?