### PR TITLE
Don't allow banish, mass banish, or polymorph in a single combat arena

### DIFF
--- a/src/effects.c
+++ b/src/effects.c
@@ -2678,6 +2678,12 @@ static bool effect_handler_BANISH(effect_handler_context_t *context)
 
 	context->ident = true;
 
+	/* Don't allow in an arena. */
+	if (player->upkeep->arena_level) {
+		msg("Nothing happens.");
+		return true;
+	}
+
 	if (!get_com("Choose a monster race (by symbol) to banish: ", &typ))
 		return false;
 
@@ -2722,6 +2728,12 @@ static bool effect_handler_MASS_BANISH(effect_handler_context_t *context)
 	unsigned dam = 0;
 
 	context->ident = true;
+
+	/* Don't allow in an arena. */
+	if (player->upkeep->arena_level) {
+		msg("Nothing happens.");
+		return true;
+	}
 
 	/* Delete the (nearby) monsters */
 	for (i = 1; i < cave_monster_max(cave); i++) {

--- a/src/project-mon.c
+++ b/src/project-mon.c
@@ -1156,8 +1156,9 @@ static void project_m_apply_side_effects(project_monster_handler_context_t *cont
 		struct monster_race *old;
 		struct monster_race *new;
 
-		/* Uniques cannot be polymorphed */
-		if (rf_has(mon->race->flags, RF_UNIQUE)) {
+		/* Uniques cannot be polymorphed; nor can an arena monster */
+		if (rf_has(mon->race->flags, RF_UNIQUE)
+				|| player->upkeep->arena_level) {
 			if (context->seen) add_monster_message(mon, hurt_msg, false);
 			return;
 		}


### PR DESCRIPTION
Banish and mass banish would strand the player in the arena.  While those would be one way to trigger #4249 , they don't explain the most recent report of that happening since the monster was the Witch King of Angmar.

Also disable polymorph in the arena.  It wouldn't leave the player stranded after killing the polymorphed monster, but, upon returning to the original cave, the original target of single combat would still be there.  I made one attempt to avoid that (using monster_index_move() so the polymorphed monster would keep the same ID in an arena level), but that didn't help.