### PR TITLE
Recompute depth by name lookup when loading chunk list for nonpersistent levels

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -1653,6 +1653,21 @@ int rd_chunks(void)
 				rd_u16b(&tmp16u);
 				c->feat_count[i] = tmp16u;
 			}
+		} else if (c->name) {
+			struct level *lev = level_by_name(c->name);
+
+			if (lev) {
+				c->depth = lev->depth;
+			} else if (suffix(c->name, " known")) {
+				size_t offset = strlen(c->name) -
+					strlen(" known");
+				c->name[offset] = '\0';
+				lev = level_by_name(c->name);
+				if (lev) {
+					c->depth = lev->depth;
+				}
+				c->name[offset] = ' ';
+			}
 		}
 
 		chunk_list_add(c);


### PR DESCRIPTION
Resolves one way to trigger https://github.com/angband/angband/issues/4249 : use Single Combat on a level, save while in single combat, kill the arena monster, use Single Combat again on the level, kill the arena monster, and get stuck in the arena.