### PR TITLE
Don't allow nonplayer hits to kill an arena monster

### DIFF
--- a/src/mon-util.c
+++ b/src/mon-util.c
@@ -1192,8 +1192,9 @@ bool mon_take_nonplayer_hit(int dam, struct monster *t_mon,
 {
 	assert(t_mon);
 
-	/* "Unique" monsters can only be "killed" by the player */
-	if (rf_has(t_mon->race->flags, RF_UNIQUE)) {
+	/* "Unique" or arena monsters can only be "killed" by the player */
+	if (rf_has(t_mon->race->flags, RF_UNIQUE)
+			|| player->upkeep->arena_level) {
 		/* Reduce monster hp to zero, but don't kill it. */
 		if (dam > t_mon->hp) dam = t_mon->hp;
 	}


### PR DESCRIPTION
Barring bugs, the only way nonplayer hits should happen in an arena is with damaging terrain.  That seems highly  unlikely (player abilities aren't strong enough to convert a floor to lava; monsters that can do so are likely immune to lava), but, just in case, don't allow them to kill an arena monster and strand the player in the arena (i.e. trigger #4249 .