### PR TITLE
Build a smaller Windows executable in the release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -240,11 +240,16 @@ jobs:
         run: |
           tar -xf ${{ env.DOC_ARTIFACT_PATH }}
 
+      # Override the default CFLAGS, -g -O2, to get a smaller executable (~2
+      # MB versus ~7 MB), all due to compiling without debugging symbols.
+      # Adding the option to strip symbols and relocation information, -s,
+      # or the option to optimize for size, -Os, didn't further reduce the
+      # size of the executable when using mingw 6.0.0 on Debian buster.
       - name: Create Windows Archive
         id: create_windows_archive
         run: |
           ./autogen.sh
-          ./configure --enable-win --disable-curses --build=i686-pc-linux-gnu --host=i686-w64-mingw32
+          env CFLAGS="-O2" ./configure --enable-win --disable-curses --build=i686-pc-linux-gnu --host=i686-w64-mingw32
           make
           cp src/${{ steps.store_config.outputs.progname }}.exe src/win/dll/libpng12.dll src/win/dll/zlib1.dll .
           archive_prefix=${{ steps.store_config.outputs.name }}-${{ steps.store_config.outputs.version }}


### PR DESCRIPTION
Does so by not compiling with debugging symbols.  This needs testing on proper Windows systems; I only exercised it by running the executable with Wine on Debian buster.  A zip file for Windows generated by the modified release workflow can be found here, https://github.com/backwardsEric/angband/releases/download/4.2.2-237-g50f26f22/Angband-4.2.2-237-g50f26f22-win.zip .

This is an attempt to resolve #4634 .  In my hands, I couldn't get a further reduction in size by removing the -static flag added for Windows builds by configure.ac or by also including -s (strip symbols and relocation information) or -Os (optimize for size) in the compiler options.  While the executable size does decrease substantially with this change (now around 2 MB), the impact on the size of the zip file is much more modest.