### PR TITLE
MacOS:  remove handling of open_when_ready

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -2118,7 +2118,6 @@ static NSString* AngbandCorrectedDirectoryPath(NSString *originalPath);
 static void prepare_paths_and_directories(void);
 static void load_prefs(void);
 static void init_windows(void);
-static void handle_open_when_ready(void);
 static void play_sound(game_event_type unused, game_event_data *data, void *user);
 static BOOL check_events(int wait);
 static void cocoa_file_open_hook(const char *path, file_type ftype);
@@ -4076,11 +4075,6 @@ static int compare_nsrect_yorigin_greater(const void *ap, const void *bp)
 
 @end
 
-/**
- * Delay handling of double-clicked savefiles
- */
-Boolean open_when_ready = FALSE;
-
 
 
 /**
@@ -5083,26 +5077,6 @@ static void wakeup_event_loop(void)
 
 
 /**
- * Handle the "open_when_ready" flag
- */
-static void handle_open_when_ready(void)
-{
-    /* Check the flag XXX XXX XXX make a function for this */
-    if (open_when_ready && initialized && !game_in_progress)
-    {
-        /* Forget */
-        open_when_ready = FALSE;
-        
-        /* Game is in progress */
-        game_in_progress = TRUE;
-        
-        /* Wait for a keypress */
-        pause_line(Term);
-    }
-}
-
-
-/**
  * Handle quit_when_ready, by Peter Ammon,
  * slightly modified to check inkey_flag.
  */
@@ -6023,9 +5997,6 @@ static void cocoa_reinit(void)
 
 	/* We are now initialized */
 	initialized = TRUE;
-
-	/* Handle "open_when_ready" */
-	handle_open_when_ready();
 
 	/* Handle pending events (most notably update) and flush input */
 	Term_flush();


### PR DESCRIPTION
It's never set to true and appears to be vestigial.