### PR TITLE
Add a chunk and player argument to become_aware()

### DIFF
--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -290,7 +290,7 @@ void do_cmd_open(struct command *cmd)
 	if (mon) {
 		/* Mimics surprise the player */
 		if (monster_is_mimicking(mon)) {
-			become_aware(mon);
+			become_aware(cave, mon, player);
 
 			/* Mimic wakes up and becomes aware*/
 			monster_wake(mon, false, 100);
@@ -1010,7 +1010,7 @@ void move_player(int dir, bool disarm)
 	if (m_idx > 0) {
 		/* Attack monsters */
 		if (monster_is_mimicking(mon)) {
-			become_aware(mon);
+			become_aware(cave, mon, player);
 
 			/* Mimic wakes up and becomes aware*/
 			monster_wake(mon, false, 100);

--- a/src/mon-attack.c
+++ b/src/mon-attack.c
@@ -452,7 +452,7 @@ bool make_ranged_attack(struct monster *mon)
 
 	/* If we see a hidden monster try to cast a spell, become aware of it */
 	if (monster_is_camouflaged(mon))
-		become_aware(mon);
+		become_aware(cave, mon, player);
 
 	/* Check for spell failure (innate attacks never fail) */
 	failrate = monster_spell_failrate(mon);

--- a/src/mon-move.c
+++ b/src/mon-move.c
@@ -1010,7 +1010,7 @@ bool multiply_monster(struct chunk *c, const struct monster *mon)
 
 			if (child && monster_is_mimicking(child)
 					&& !monster_is_mimicking(mon)) {
-				become_aware(child);
+				become_aware(c, child, player);
 			}
 		}
 
@@ -1356,7 +1356,7 @@ static bool monster_turn_try_push(struct chunk *c, struct monster *mon,
 
 		/* Reveal mimics */
 		if (monster_is_mimicking(mon1))
-			become_aware(mon1);
+			become_aware(c, mon1, player);
 
 		/* Note if visible */
 		if (monster_is_visible(mon) && monster_is_in_view(mon))
@@ -1670,7 +1670,7 @@ static void monster_turn(struct chunk *c, struct monster *mon)
 
 	/* If we see an unaware monster do something, become aware of it */
 	if (did_something && monster_is_camouflaged(mon))
-		become_aware(mon);
+		become_aware(c, mon, player);
 }
 
 

--- a/src/mon-util.h
+++ b/src/mon-util.h
@@ -33,7 +33,7 @@ bool monster_carry(struct chunk *c, struct monster *mon, struct object *obj);
 void monster_swap(struct loc grid1, struct loc grid2);
 void monster_wake(struct monster *mon, bool notify, int aware_chance);
 bool monster_can_see(struct chunk *c, struct monster *mon, struct loc grid);
-void become_aware(struct monster *m);
+void become_aware(struct chunk *c, struct monster *m, struct player *p);
 void update_smart_learn(struct monster *mon, struct player *p, int flag,
 						int pflag, int element);
 bool find_any_nearby_injured_kin(struct chunk *c, const struct monster *mon);

--- a/src/project-mon.c
+++ b/src/project-mon.c
@@ -1375,7 +1375,7 @@ void project_m(struct source origin, int r, struct loc grid, int dam, int typ,
 	/* Reveal a camouflaged monster if in view and it stopped an effect. */
 	if ((flg & PROJECT_STOP) && monster_is_camouflaged(mon)
 			&& monster_is_in_view(mon)) {
-		become_aware(mon);
+		become_aware(cave, mon, player);
 		/* Reevaluate whether it's seen. */
 		if (monster_is_visible(mon)) {
 			seen = true;

--- a/src/project-obj.c
+++ b/src/project-obj.c
@@ -555,7 +555,9 @@ bool project_o(struct source origin, int r, struct loc grid, int dam, int typ,
 			} else if (obj->mimicking_m_idx) {
 				/* Reveal mimics */
 				if (obvious)
-					become_aware(cave_monster(cave, obj->mimicking_m_idx));
+					become_aware(cave, cave_monster(
+						cave, obj->mimicking_m_idx),
+						player);
 			} else {
 				/* Describe if needed */
 				if (obvious && obj->known && note_kill && !ignore_item_ok(obj))


### PR DESCRIPTION
The chunk argument is to avoid cases where the caller took a chunk argument but become_aware used the cave global.  Resolves https://github.com/angband/angband/issues/4944 part of https://github.com/angband/angband/issues/4934 .