### PR TITLE
Add a player argument to no_light()

### DIFF
--- a/src/cave-view.c
+++ b/src/cave-view.c
@@ -907,7 +907,7 @@ void update_view(struct chunk *c, struct player *p)
 /**
  * Returns true if the player's grid is dark
  */
-bool no_light(void)
+bool no_light(struct player *p)
 {
-	return (!square_isseen(cave, player->grid));
+	return (!square_isseen(cave, p->grid));
 }

--- a/src/cave.h
+++ b/src/cave.h
@@ -257,7 +257,7 @@ extern u16b chunk_list_max;
 int distance(struct loc grid1, struct loc grid2);
 bool los(struct chunk *c, struct loc grid1, struct loc grid2);
 void update_view(struct chunk *c, struct player *p);
-bool no_light(void);
+bool no_light(struct player *p);
 
 /* cave-map.c */
 void map_info(struct loc grid, struct grid_data *g);

--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -175,7 +175,7 @@ static bool do_cmd_open_aux(struct loc grid)
 		i = player->state.skills[SKILL_DISARM_PHYS];
 
 		/* Penalize some conditions */
-		if (player->timed[TMD_BLIND] || no_light())
+		if (player->timed[TMD_BLIND] || no_light(player))
 			i = i / 10;
 		if (player->timed[TMD_CONFUSED] || player->timed[TMD_IMAGE])
 			i = i / 10;
@@ -692,7 +692,7 @@ static bool do_cmd_lock_door(struct loc grid)
 	i = player->state.skills[SKILL_DISARM_PHYS];
 
 	/* Penalize some conditions */
-	if (player->timed[TMD_BLIND] || no_light())
+	if (player->timed[TMD_BLIND] || no_light(player))
 		i = i / 10;
 	if (player->timed[TMD_CONFUSED] || player->timed[TMD_IMAGE])
 		i = i / 10;
@@ -762,7 +762,7 @@ static bool do_cmd_disarm_aux(struct loc grid)
 
 	/* Penalize some conditions */
 	if (player->timed[TMD_BLIND] ||
-			no_light() ||
+			no_light(player) ||
 			player->timed[TMD_CONFUSED] ||
 			player->timed[TMD_IMAGE])
 		skill = skill / 10;

--- a/src/obj-chest.c
+++ b/src/obj-chest.c
@@ -601,7 +601,7 @@ bool do_cmd_open_chest(struct loc grid, struct object *obj)
 		i = player->state.skills[SKILL_DISARM_PHYS];
 
 		/* Penalize some conditions */
-		if (player->timed[TMD_BLIND] || no_light()) i = i / 10;
+		if (player->timed[TMD_BLIND] || no_light(player)) i = i / 10;
 		if (player->timed[TMD_CONFUSED] || player->timed[TMD_IMAGE]) i = i / 10;
 
 		/* Extract the difficulty */
@@ -692,7 +692,7 @@ bool do_cmd_disarm_chest(struct object *obj)
 	}
 
 	/* Penalize some conditions */
-	if (player->timed[TMD_BLIND] || no_light()) {
+	if (player->timed[TMD_BLIND] || no_light(player)) {
 		skill /= 10;
 	}
 	if (player->timed[TMD_CONFUSED] || player->timed[TMD_IMAGE]) {

--- a/src/player-util.c
+++ b/src/player-util.c
@@ -927,7 +927,7 @@ bool player_can_cast(struct player *p, bool show_msg)
 		return false;
 	}
 
-	if (p->timed[TMD_BLIND] || no_light()) {
+	if (p->timed[TMD_BLIND] || no_light(p)) {
 		if (show_msg) {
 			msg("You cannot see!");
 		}
@@ -1006,7 +1006,7 @@ bool player_can_read(struct player *p, bool show_msg)
 		return false;
 	}
 
-	if (no_light()) {
+	if (no_light(p)) {
 		if (show_msg)
 			msg("You have no light to read by.");
 
@@ -1463,7 +1463,7 @@ void search(struct player *p)
 	struct loc grid;
 
 	/* Various conditions mean no searching */
-	if (p->timed[TMD_BLIND] || no_light() ||
+	if (p->timed[TMD_BLIND] || no_light(p) ||
 		p->timed[TMD_CONFUSED] || p->timed[TMD_IMAGE])
 		return;
 

--- a/src/ui-display.c
+++ b/src/ui-display.c
@@ -2561,7 +2561,7 @@ static void see_floor_items(game_event_type type, game_event_data *data,
 	int floor_max = z_info->floor_size;
 	struct object **floor_list = mem_zalloc(floor_max * sizeof(*floor_list));
 	int floor_num = 0;
-	bool blind = ((player->timed[TMD_BLIND]) || (no_light()));
+	bool blind = ((player->timed[TMD_BLIND]) || (no_light(player)));
 
 	const char *p = "see";
 	bool can_pickup = false;


### PR DESCRIPTION
That way it doesn't need to access the global. Resolves https://github.com/angband/angband/issues/4950 (part of https://github.com/angband/angband/issues/4934 ).