### PR TITLE
Add an option to configure for making a release build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -249,7 +249,7 @@ jobs:
         id: create_windows_archive
         run: |
           ./autogen.sh
-          env CFLAGS="-O2" ./configure --enable-win --disable-curses --build=i686-pc-linux-gnu --host=i686-w64-mingw32
+          env CFLAGS="-O2" ./configure --enable-release --enable-win --disable-curses --build=i686-pc-linux-gnu --host=i686-w64-mingw32
           make
           cp src/${{ steps.store_config.outputs.progname }}.exe src/win/dll/libpng12.dll src/win/dll/zlib1.dll .
           archive_prefix=${{ steps.store_config.outputs.name }}-${{ steps.store_config.outputs.version }}
@@ -315,11 +315,13 @@ jobs:
       # Currently, macos-latest defaults to using the 10.15 SDK which does not
       # support creating arm64 objects.  Override the default using SDKROOT
       # set to an SDK that can generate both x86_64 and arm64 objects.
+      # Override the default OPT (-O2) to get the equivalent of what
+      # --enable-release does for builds using configure.
       - name: Create Mac Archive
         id: create_mac_archive
         run: |
           cd src
-          env SDKROOT=macosx11.1 make -f Makefile.osx dist
+          env SDKROOT=macosx11.1 OPT="-O2 -DNDEBUG" make -f Makefile.osx dist
           archive_prefix=${{ steps.store_config.outputs.name }}-${{ steps.store_config.outputs.version }}-osx
           echo "::set-output name=archive_file::${archive_prefix}.dmg"
           echo "::set-output name=archive_content_type::application/octet-stream"

--- a/configure.ac
+++ b/configure.ac
@@ -98,6 +98,16 @@ dnl needed because h-basic.h checks for this define for autoconf support.
 CPPFLAGS="$CPPFLAGS -DHAVE_CONFIG_H"
 CPPFLAGS="$CPPFLAGS -I." 
 
+AC_ARG_ENABLE(release,
+	[AS_HELP_STRING([--enable-release], [enable a release build])],
+	[release=yes],
+	[release=no])
+
+if test x"$release" = xyes ; then
+	dnl Currently only adding -DNDEBUG to CFLAGS.
+	CFLAGS="$CFLAGS -DNDEBUG"
+fi
+
 AC_ARG_ENABLE(more-gcc-warnings,
 	[  --enable-more-gcc-warnings       enable more warnings if using GCC],
 	[ more_gcc_warnings=yes],

--- a/src/cmd-obj.c
+++ b/src/cmd-obj.c
@@ -406,7 +406,7 @@ static void use_aux(struct command *cmd, struct object *obj, enum use use,
 	struct trap_kind *rune = lookup_trap("glyph of warding");
 
 	/* Get arguments */
-	assert(cmd_get_arg_item(cmd, "item", &obj) == CMD_OK);
+	if (cmd_get_arg_item(cmd, "item", &obj) != CMD_OK) assert(0);
 
 	was_aware = object_flavor_is_aware(obj);
 

--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -1191,6 +1191,7 @@ static int hasSameBackground(const struct TerminalCell* c)
 
 - (void)assertInvariants
 {
+#ifndef NDEBUG
     const struct TerminalCell *cellsRow = self->cells;
 
     /*
@@ -1339,6 +1340,7 @@ static int hasSameBackground(const struct TerminalCell* c)
 	}
 	cellsRow += self.columnCount;
     }
+#endif
 }
 
 + (wchar_t)getBlankChar

--- a/src/ui-entry.c
+++ b/src/ui-entry.c
@@ -301,7 +301,7 @@ void get_ui_entry_label(const struct ui_entry *entry, int length,
 	if (first_call) {
 		size_t nw = text_mbstowcs(spc, " ", 2);
 
-		assert(nw != (size_t)-1);
+		if (nw == (size_t)-1) assert(0);
 		first_call = false;
 	}
 


### PR DESCRIPTION
Currently, it only add -DNDEBUG to CFLAGS.

Clean up some warnings when the code is compiled with -DNDEBUG.  Change the one case I saw where what's in the assert() had side effects (in use_aux(); though with all the callers of that as they are, throwing away the side effect when compiled with NDEBUG doesn't matter).

Change release.yaml to use the configure option for a release build when building for Windows.  For MacOS, override OPT when running Makefile.osx to set -DNDEBUG.

This is one way to resolve #4948 .