### PR TITLE
configure:  make "configure --help" prettier 

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -157,11 +157,11 @@ AC_DEFUN([AM_PATH_SDL2],
 [dnl 
 dnl Get the cflags and libraries from the sdl2-config script
 dnl
-AC_ARG_WITH(sdl2-prefix,[  --with-sdl2-prefix=PFX   Prefix where SDL2 is installed (optional)],
+AC_ARG_WITH(sdl2-prefix,[AS_HELP_STRING([--with-sdl2-prefix=PFX], [set prefix where SDL2 is installed (optional)])],
             sdl2_prefix="$withval", sdl2_prefix="")
-AC_ARG_WITH(sdl2-exec-prefix,[  --with-sdl2-exec-prefix=PFX Exec prefix where SDL2 is installed (optional)],
+AC_ARG_WITH(sdl2-exec-prefix,[AS_HELP_STRING([--with-sdl2-exec-prefix=PFX], [set exec prefix where SDL2 is installed (optional)])],
             sdl2_exec_prefix="$withval", sdl2_exec_prefix="")
-AC_ARG_ENABLE(sdl2test, [  --disable-sdl2test       Do not try to compile and run a test SDL2 program],
+AC_ARG_ENABLE(sdl2test, [AS_HELP_STRING([--disable-sdl2test], [do not try to compile and run a test SDL2 program])],
 		    , enable_sdl2test=yes)
 
   if test x$sdl2_exec_prefix != x ; then
@@ -324,11 +324,11 @@ AC_DEFUN([AM_PATH_SDL],
 [dnl 
 dnl Get the cflags and libraries from the sdl-config script
 dnl
-AC_ARG_WITH(sdl-prefix,[  --with-sdl-prefix=PFX   Prefix where SDL is installed (optional)],
+AC_ARG_WITH(sdl-prefix,[AS_HELP_STRING([--with-sdl-prefix=PFX], [set prefix where SDL is installed (optional)])],
             sdl_prefix="$withval", sdl_prefix="")
-AC_ARG_WITH(sdl-exec-prefix,[  --with-sdl-exec-prefix=PFX Exec prefix where SDL is installed (optional)],
+AC_ARG_WITH(sdl-exec-prefix,[AS_HELP_STRING([--with-sdl-exec-prefix=PFX], [set exec prefix where SDL is installed (optional)])],
             sdl_exec_prefix="$withval", sdl_exec_prefix="")
-AC_ARG_ENABLE(sdltest, [  --disable-sdltest       Do not try to compile and run a test SDL program],
+AC_ARG_ENABLE(sdltest, [AS_HELP_STRING([--disable-sdltest], [do not try to compile and run a test SDL program])],
 		    , enable_sdltest=yes)
 
   if test x$sdl_exec_prefix != x ; then
@@ -491,11 +491,11 @@ AC_DEFUN([AM_PATH_NCURSESW],
 [dnl 
 dnl Get the cflags and libraries from the ncursesw5-config script
 dnl
-AC_ARG_WITH(ncurses-prefix,[  --with-ncurses-prefix=PFX   Prefix where ncurses is installed (optional)],
+AC_ARG_WITH(ncurses-prefix,[AS_HELP_STRING([--with-ncurses-prefix=PFX], [set prefix where ncurses is installed (optional)])],
             ncurses_prefix="$withval", ncurses_prefix="")
-AC_ARG_WITH(ncurses-exec-prefix,[  --with-ncurses-exec-prefix=PFX Exec prefix where ncurses is installed (optional)],
+AC_ARG_WITH(ncurses-exec-prefix,[AS_HELP_STRING([--with-ncurses-exec-prefix=PFX], [set exec prefix where ncurses is installed (optional)])],
             ncurses_exec_prefix="$withval", ncurses_exec_prefix="")
-AC_ARG_ENABLE(ncursestest, [  --disable-ncursestest       Do not try to compile and run a test ncurses program],
+AC_ARG_ENABLE(ncursestest, [AS_HELP_STRING([--disable-ncursestest], [do not try to compile and run a test ncurses program])],
 		    , enable_ncursestest=yes)
 
   if test x$ncurses_exec_prefix != x ; then

--- a/configure.ac
+++ b/configure.ac
@@ -20,12 +20,12 @@ AC_DEFINE_UNQUOTED(PACKAGE, "$PACKAGE", [Name of package])
 AC_DEFINE_UNQUOTED(VERSION, "$VERSION", [Version number of package])
 
 AC_ARG_WITH(setgid,
-	[  --with-setgid=NAME      install angband as group NAME],
+	[AS_HELP_STRING([--with-setgid=NAME], [install angband as group NAME])],
 	[wsetgid=yes])
 AC_ARG_WITH(private_dirs,
-	[  --with-private-dirs     use private scorefiles/savefiles])
+	[AS_HELP_STRING([--with-private-dirs], [use private scorefiles/savefiles])])
 AC_ARG_WITH(no_install,
-	[  --with-no-install       don't install, just run in-place])
+	[AS_HELP_STRING([--with-no-install], [don't install, just run in-place])])
 
 if test "x$with_setgid" = "xyes"; then
 	AC_MSG_ERROR([Please specify a group to install as.])
@@ -109,7 +109,7 @@ if test x"$release" = xyes ; then
 fi
 
 AC_ARG_ENABLE(more-gcc-warnings,
-	[  --enable-more-gcc-warnings       enable more warnings if using GCC],
+	[AS_HELP_STRING([--enable-more-gcc-warnings], [enable more warnings if using GCC])],
 	[ more_gcc_warnings=yes],
 	[ more_gcc_warnings=no])
 

--- a/configure.ac
+++ b/configure.ac
@@ -223,45 +223,45 @@ fi
 
 dnl Frontends
 AC_ARG_ENABLE(curses,
-	[AS_HELP_STRING([--enable-curses],    [Enables Curses frontend (default: enabled)])],
+	[AS_HELP_STRING([--enable-curses], [enable Curses frontend (default: enabled)])],
 	[enable_curses=$enableval],
 	[enable_curses=yes])
 AC_ARG_ENABLE(x11,
-	[AS_HELP_STRING([--enable-x11],       [Enables X11 frontend (default: enabled)])],
+	[AS_HELP_STRING([--enable-x11], [enable X11 frontend (default: enabled)])],
 	[enable_x11=$enableval],
 	[enable_x11=yes])
 AC_ARG_ENABLE(sdl2,
-	[AS_HELP_STRING([--enable-sdl2],       [Enables SDL2 frontend (default: disabled)])],
+	[AS_HELP_STRING([--enable-sdl2], [enable SDL2 frontend (default: disabled)])],
 	[enable_sdl2=$enableval],
 	[enable_sdl2=no])
 AC_ARG_ENABLE(sdl,
-	[AS_HELP_STRING([--enable-sdl],       [Enables SDL frontend (default: disabled)])],
+	[AS_HELP_STRING([--enable-sdl], [enable SDL frontend (default: disabled)])],
 	[enable_sdl=$enableval],
 	[enable_sdl=no])
 AC_ARG_ENABLE(win,
-	[AS_HELP_STRING([--enable-win],       [Enables Windows frontend (default: disabled)])],
+	[AS_HELP_STRING([--enable-win], [enable Windows frontend (default: disabled)])],
 	[enable_win=$enableval],
 	[enable_win=no])
 AC_ARG_ENABLE(test,
-	[AS_HELP_STRING([--enable-test],      [Enables test frontend (default: disabled)])],
+	[AS_HELP_STRING([--enable-test], [enable test frontend (default: disabled)])],
 	[enable_test=$enableval],
 	[enable_test=no])
 AC_ARG_ENABLE(stats,
-	[AS_HELP_STRING([--enable-stats],     [Enables stats frontend (default: disabled)])],
+	[AS_HELP_STRING([--enable-stats], [enable stats frontend (default: disabled)])],
 	[enable_stats=$enableval],
 	[enable_stats=no])
 AC_ARG_ENABLE(spoil,
-	[AS_HELP_STRING([--enable-spoil],     [Enable command-line spoiler generation (default: enabled)])],
+	[AS_HELP_STRING([--enable-spoil], [enable command-line spoiler generation (default: enabled)])],
 	[enable_spoil=$enableval],
 	[enable_spoil=yes])
 
 dnl Sound modules
 AC_ARG_ENABLE(sdl2_mixer,
-	[AS_HELP_STRING([--enable-sdl2-mixer], [Enables SDL2 mixer sound support (default: disabled unless SDL2 enabled)])],
+	[AS_HELP_STRING([--enable-sdl2-mixer], [enable SDL2 mixer sound support (default: disabled unless SDL2 enabled)])],
 	[enable_sdl2_mixer=$enable_sdl2_mixer],
 	[enable_sdl2_mixer=$enable_sdl2])
 AC_ARG_ENABLE(sdl_mixer,
-	[AS_HELP_STRING([--enable-sdl-mixer], [Enables SDL mixer sound support (default: disabled unless SDL enabled)])],
+	[AS_HELP_STRING([--enable-sdl-mixer], [enable SDL mixer sound support (default: disabled unless SDL enabled)])],
 	[enable_sdl_mixer=$enable_sdl_mixer],
 	[enable_sdl_mixer=$enable_sdl])
 


### PR DESCRIPTION
- Use AS_HELP_STRING() in more places.
- Use lower case for the first letter and an imperative form (i.e. "enable" rather than "enables") in the explanation.