### PR TITLE
Refactor cave and monster generation to reduce the dependencies on the player global

### DIFF
--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -1526,7 +1526,6 @@ struct chunk *labyrinth_gen(struct player *p, int min_height, int min_width) {
 	/* Generate the actual labyrinth */
 	c = labyrinth_chunk(p->depth, h, w, lit, soft);
 	if (!c) return NULL;
-	c->depth = p->depth;
 
 	/* Determine the character location */
 	new_player_spot(c, p);
@@ -2146,7 +2145,6 @@ struct chunk *cavern_gen(struct player *p, int min_height, int min_width) {
 	/* Try to build the cavern, fail gracefully */
 	c = cavern_chunk(p->depth, h, w, dun->join);
 	if (!c) return NULL;
-	c->depth = p->depth;
 
 	/* Surround the level with perma-rock */
 	draw_rectangle(c, 0, 0, h - 1, w - 1, FEAT_PERM, SQUARE_NONE, true);
@@ -2811,7 +2809,6 @@ struct chunk *modified_gen(struct player *p, int min_height, int min_width) {
 
 	c = modified_chunk(p->depth, MIN(z_info->dungeon_hgt, y_size),
 		MIN(z_info->dungeon_wid, x_size), OPT(p, birth_levels_persist));
-	c->depth = p->depth;
 
 	/* Generate permanent walls around the edge of the generated area */
 	draw_rectangle(c, 0, 0, c->height - 1, c->width - 1,
@@ -3007,7 +3004,6 @@ struct chunk *moria_gen(struct player *p, int min_height, int min_width) {
 
 	c = moria_chunk(p->depth, MIN(z_info->dungeon_hgt, y_size),
 		MIN(z_info->dungeon_wid, x_size), OPT(p, birth_levels_persist));
-	c->depth = p->depth;
 
 	/* Generate permanent walls around the edge of the generated area */
 	draw_rectangle(c, 0, 0, c->height - 1, c->width - 1,
@@ -3413,7 +3409,6 @@ struct chunk *lair_gen(struct player *p, int min_height, int min_width) {
 	if (!normal) {
 		return NULL;
 	}
-	normal->depth = p->depth;
 
 	/*
 	 * The transformation applied here should match that for chunk_copy()
@@ -3430,7 +3425,6 @@ struct chunk *lair_gen(struct player *p, int min_height, int min_width) {
 		cave_free(normal);
 		return NULL;
 	}
-	lair->depth = p->depth;
 
 	/* General amount of rubble, traps and monsters */
 	k = MAX(MIN(p->depth / 3, 10), 2) / 2;
@@ -3545,14 +3539,12 @@ struct chunk *gauntlet_gen(struct player *p, int min_height, int min_width) {
 	gauntlet = labyrinth_chunk(p->depth, gauntlet_hgt, gauntlet_wid, false,
 		false);
 	if (!gauntlet) return NULL;
-	gauntlet->depth = p->depth;
 
 	left = cavern_chunk(p->depth, y_size, x_size, NULL);
 	if (!left) {
 		cave_free(gauntlet);
 		return NULL;
 	}
-	left->depth = p->depth;
 
 	right = cavern_chunk(p->depth, y_size, x_size, NULL);
 	if (!right) {
@@ -3560,7 +3552,6 @@ struct chunk *gauntlet_gen(struct player *p, int min_height, int min_width) {
 		cave_free(left);
 		return NULL;
 	}
-	right->depth = p->depth;
 
 	/* Record lines between chunks */
 	line1 = left->width;

--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -967,11 +967,11 @@ static void handle_level_stairs(struct chunk *c, struct player *p,
 		/* Don't contrain the separation between the staircases. */
 		minsep = 0;
 	}
-	if (!persistent || !chunk_find_adjacent(p, false)) {
+	if (!persistent || !chunk_find_adjacent(c->depth, false)) {
 		alloc_stairs(c, FEAT_MORE, down_count, minsep, false,
 			dun->one_off_below);
 	}
-	if (!persistent || !chunk_find_adjacent(p, true)) {
+	if (!persistent || !chunk_find_adjacent(c->depth, true)) {
 		alloc_stairs(c, FEAT_LESS, up_count, minsep, false,
 			dun->one_off_above);
 	}

--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -2620,7 +2620,7 @@ struct chunk *town_gen(struct player *p, int min_height, int min_width)
 	} else {
 		/* Copy from the chunk list, remove the old one */
 		c_new->depth = c_old->depth;
-		if (!chunk_copy(c_new, c_old, 0, 0, 0, 0))
+		if (!chunk_copy(c_new, p, c_old, 0, 0, 0, 0))
 			quit_fmt("chunk_copy() level bounds failed!");
 		chunk_list_remove("Town");
 		cave_free(c_old);
@@ -3238,30 +3238,30 @@ struct chunk *hard_centre_gen(struct player *p, int min_height, int min_width)
 	c->depth = p->depth;
 
 	/* Left */
-	chunk_copy(c, left_cavern, 0, 0, 0, false);
+	chunk_copy(c, p, left_cavern, 0, 0, 0, false);
 	find_empty_range(c, &grid, loc(0, 0),
 					 loc(left_cavern_wid - 1, z_info->dungeon_hgt - 1));
 	floor[0] = grid;
 
 	/* Upper */
-	chunk_copy(c, upper_cavern, 0, left_cavern_wid, 0, false);
+	chunk_copy(c, p, upper_cavern, 0, left_cavern_wid, 0, false);
 	find_empty_range(c, &grid, loc(left_cavern_wid, 0),
 					 loc(left_cavern_wid + centre_cavern_wid - 1,
 						 upper_cavern_hgt - 1));
 	floor[1] = grid;
 
 	/* Centre */
-	chunk_copy(c, centre, centre_cavern_ypos, left_cavern_wid, rotate, false);
+	chunk_copy(c, p, centre, centre_cavern_ypos, left_cavern_wid, rotate, false);
 
 	/* Lower */
-	chunk_copy(c, lower_cavern, lower_cavern_ypos, left_cavern_wid, 0, false);
+	chunk_copy(c, p, lower_cavern, lower_cavern_ypos, left_cavern_wid, 0, false);
 	find_empty_range(c, &grid, loc(left_cavern_wid, lower_cavern_ypos),
 					 loc(left_cavern_wid + centre_cavern_wid - 1,
 						 z_info->dungeon_hgt - 1));
 	floor[3] = grid;
 
 	/* Right */
-	chunk_copy(c, right_cavern, 0, left_cavern_wid + centre_cavern_wid, 0,
+	chunk_copy(c, p, right_cavern, 0, left_cavern_wid + centre_cavern_wid, 0,
 		false);
 	find_empty_range(c, &grid, loc(left_cavern_wid + centre_cavern_wid, 0),
 		loc(z_info->dungeon_wid - 1, z_info->dungeon_hgt - 1));
@@ -3464,8 +3464,8 @@ struct chunk *lair_gen(struct player *p, int min_height, int min_width) {
 	/* Make the level */
 	c = cave_new(y_size, x_size);
 	c->depth = p->depth;
-	chunk_copy(c, normal, 0, normal_offset, 0, false);
-	chunk_copy(c, lair, 0, lair_offset, 0, false);
+	chunk_copy(c, p, normal, 0, normal_offset, 0, false);
+	chunk_copy(c, p, lair, 0, lair_offset, 0, false);
 
 	/* Free the chunks */
 	cave_free(normal);
@@ -3658,9 +3658,9 @@ struct chunk *gauntlet_gen(struct player *p, int min_height, int min_width) {
 		SQUARE_NONE);
 
 	/* Copy in the pieces */
-	chunk_copy(c, left, 0, 0, 0, false);
-	chunk_copy(c, gauntlet, (y_size - gauntlet->height) / 2, line1, 0, false);
-	chunk_copy(c, right, 0, line2, 0, false);
+	chunk_copy(c, p, left, 0, 0, 0, false);
+	chunk_copy(c, p, gauntlet, (y_size - gauntlet->height) / 2, line1, 0, false);
+	chunk_copy(c, p, right, 0, line2, 0, false);
 
 	/* Free the chunks */
 	cave_free(left);

--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -2841,7 +2841,7 @@ struct chunk *modified_gen(struct player *p, int min_height, int min_width) {
 	i = z_info->level_monster_min + randint1(8) + k;
 
 	/* Remove all monster restrictions. */
-	mon_restrict(NULL, c->depth, true);
+	mon_restrict(NULL, c->depth, c->depth, true);
 
 	/* Put some monsters in the dungeon */
 	for (; i > 0; i--)
@@ -3036,14 +3036,14 @@ struct chunk *moria_gen(struct player *p, int min_height, int min_width) {
 	i = z_info->level_monster_min + randint1(8) + k;
 
 	/* Moria levels have a high proportion of cave dwellers. */
-	mon_restrict("Moria dwellers", c->depth, true);
+	mon_restrict("Moria dwellers", c->depth, c->depth, true);
 
 	/* Put some monsters in the dungeon */
 	for (; i > 0; i--)
 		pick_and_place_distant_monster(c, p, 0, true, c->depth);
 
 	/* Remove our restrictions. */
-	(void) mon_restrict(NULL, c->depth, false);
+	(void) mon_restrict(NULL, c->depth, c->depth, false);
 
 	/* Put some objects in rooms */
 	alloc_objects(c, SET_ROOM, TYP_OBJECT,
@@ -3456,7 +3456,7 @@ struct chunk *lair_gen(struct player *p, int min_height, int min_width) {
 		set_pit_type(lair->depth, 0);
 
 		/* Set monster generation restrictions */
-		if (mon_restrict(dun->pit_type->name, lair->depth, true))
+		if (mon_restrict(dun->pit_type->name, lair->depth, lair->depth, true))
 			break;
 	}
 
@@ -3468,7 +3468,7 @@ struct chunk *lair_gen(struct player *p, int min_height, int min_width) {
 					ORIGIN_CAVERN);
 
 	/* Remove our restrictions. */
-	(void) mon_restrict(NULL, lair->depth, false);
+	(void) mon_restrict(NULL, lair->depth, lair->depth, false);
 
 	/* Make the level */
 	c = cave_new(y_size, x_size);
@@ -3639,7 +3639,7 @@ struct chunk *gauntlet_gen(struct player *p, int min_height, int min_width) {
 		set_pit_type(gauntlet->depth, 0);
 
 		/* Set monster generation restrictions */
-		if (mon_restrict(dun->pit_type->name, gauntlet->depth, true))
+		if (mon_restrict(dun->pit_type->name, gauntlet->depth, gauntlet->depth, true))
 			break;
 	}
 
@@ -3652,7 +3652,7 @@ struct chunk *gauntlet_gen(struct player *p, int min_height, int min_width) {
 					ORIGIN_LABYRINTH);
 
 	/* Remove our restrictions. */
-	(void) mon_restrict(NULL, gauntlet->depth, false);
+	(void) mon_restrict(NULL, gauntlet->depth, gauntlet->depth, false);
 
 	/* Make the level */
 	c = cave_new(y_size, left->width + gauntlet->width + right->width);

--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -2630,6 +2630,7 @@ struct chunk *town_gen(struct player *p, int min_height, int min_width)
 		town_gen_layout(c_new, p);
 	} else {
 		/* Copy from the chunk list, remove the old one */
+		c_new->depth = c_old->depth;
 		if (!chunk_copy(c_new, c_old, 0, 0, 0, 0))
 			quit_fmt("chunk_copy() level bounds failed!");
 		chunk_list_remove("Town");

--- a/src/gen-chunk.c
+++ b/src/gen-chunk.c
@@ -138,12 +138,15 @@ bool chunk_find(struct chunk *c)
 }
 
 /**
- * Find the saved chunk above or below the current player depth
+ * Find the saved chunk adjacent to a given depth.
+ *
+ * \param depth is the depth to use.
+ * \param above if true, finds the chunk immediately above the given depth.
+ * Otherwise, finds the chunk immediately below that depth.
  */
-struct chunk *chunk_find_adjacent(struct player *p, bool above)
+struct chunk *chunk_find_adjacent(int depth, bool above)
 {
-	int depth = above ? p->depth - 1 : p->depth + 1;
-	struct level *lev = level_by_depth(depth);
+	struct level *lev = level_by_depth(depth + ((above) ? -1 : 1));
 
 	if (lev) {
 		return chunk_find_name(lev->name);

--- a/src/gen-chunk.c
+++ b/src/gen-chunk.c
@@ -332,6 +332,9 @@ int calc_default_transpose_weight(int height, int width)
  * are in their original positions.
  *
  * \param dest the chunk where the copy is going
+ * \param p is the player; if the player is in the chunk being copied, the
+ * player's position will be updated to be the player's location in the
+ * destination
  * \param source the chunk being copied
  * \param y0 transformation parameters  - see symmetry_transform()
  * \param x0 transformation parameters  - see symmetry_transform()
@@ -339,8 +342,8 @@ int calc_default_transpose_weight(int height, int width)
  * \param reflect transformation parameters  - see symmetry_transform()
  * \return success - fails if the copy would not fit in the destination chunk
  */
-bool chunk_copy(struct chunk *dest, struct chunk *source, int y0, int x0,
-				int rotate, bool reflect)
+bool chunk_copy(struct chunk *dest, struct player *p, struct chunk *source,
+		int y0, int x0, int rotate, bool reflect)
 {
 	int i, max_group_id = 0;
 	struct loc grid;
@@ -399,7 +402,7 @@ bool chunk_copy(struct chunk *dest, struct chunk *source, int y0, int x0,
 			/* Player */
 			if (square(source, grid)->mon == -1) {
 				dest->squares[dest_grid.y][dest_grid.x].mon = -1;
-				player->grid = dest_grid;
+				p->grid = dest_grid;
 			}
 		}
 	}

--- a/src/gen-monster.c
+++ b/src/gen-monster.c
@@ -286,13 +286,13 @@ void get_vault_monsters(struct chunk *c, char racial_symbol[], char *vault_type,
 
 		/* Determine level of monster */
 		if (strstr(vault_type, "Lesser vault"))
-			depth = player->depth + 2;
+			depth = c->depth + 2;
 		else if (strstr(vault_type, "Medium vault"))
-			depth = player->depth + 4;
+			depth = c->depth + 4;
 		else if (strstr(vault_type, "Greater vault"))
-			depth = player->depth + 6;
+			depth = c->depth + 6;
 		else
-			depth = player->depth;
+			depth = c->depth;
 
 		/* Prepare allocation table */
 		get_mon_num_prep(mon_select);

--- a/src/gen-monster.c
+++ b/src/gen-monster.c
@@ -333,7 +333,7 @@ void get_vault_monsters(struct chunk *c, char racial_symbol[], char *vault_type,
  * \param x1 the limits of the vault
  * \param y2 the limits of the vault
  * \param x2 the limits of the vault
- * \param name the name of the monster type for use in mon_select()
+ * \param name the name of the monster type for use in mon_restrict()
  * \param area the total room area, used for scaling monster quantity
  */
 void get_chamber_monsters(struct chunk *c, int y1, int x1, int y2, int x2, 

--- a/src/gen-monster.c
+++ b/src/gen-monster.c
@@ -33,11 +33,12 @@
 #include "mon-spell.h"
 
 /**
- * Restrictions on monsters, used in pits, vaults, and chambers.
+ * Restrictions on monsters, used in pits, vaults, and chambers.  Used in
+ * mon_select().
  */
 static bool allow_unique;
 static char base_d_char[15];
-
+static int select_current_level;
 
 /**
  * Return the pit profile matching the given name.
@@ -76,8 +77,8 @@ static bool mon_select(struct monster_race *race)
 	}
 
 	/* No invisible undead until deep. */
-	if ((player->depth < 40) && (rf_has(race->flags, RF_UNDEAD))
-			&& (rf_has(race->flags, RF_INVISIBLE)))
+	if (select_current_level < 40 && rf_has(race->flags, RF_UNDEAD)
+			&& rf_has(race->flags, RF_INVISIBLE))
 		return (false);
 
 	/* Usually decline unique monsters. */
@@ -122,6 +123,7 @@ bool mon_restrict(const char *monster_type, int depth, int current_depth,
 	allow_unique = unique_ok;
 	for (i = 0; i < 10; i++)
 		base_d_char[i] = '\0';
+        select_current_level = current_depth;
 
 	/* No monster type specified, no restrictions. */
 	if (monster_type == NULL) {
@@ -287,6 +289,7 @@ void get_vault_monsters(struct chunk *c, char racial_symbol[], char *vault_type,
 		allow_unique = true;
 		my_strcpy(base_d_char, format("%c", racial_symbol[i]),
 			sizeof(base_d_char));
+		select_current_level = c->depth;
 
 		/* Determine level of monster */
 		if (strstr(vault_type, "Lesser vault"))

--- a/src/gen-monster.c
+++ b/src/gen-monster.c
@@ -209,7 +209,7 @@ void spread_monsters(struct chunk *c, const char *type, int depth, int num,
 		return;
 
 	/* Build the monster probability table. */
-	if (!get_mon_num(depth))
+	if (!get_mon_num(depth, c->depth))
 		return;
 
 
@@ -298,7 +298,7 @@ void get_vault_monsters(struct chunk *c, char racial_symbol[], char *vault_type,
 		get_mon_num_prep(mon_select);
 
 		/* Build the monster probability table. */
-		if (!get_mon_num(depth))
+		if (!get_mon_num(depth, c->depth))
 			continue;
 
 
@@ -367,7 +367,7 @@ void get_chamber_monsters(struct chunk *c, int y1, int x1, int y2, int x2,
 	}
 
 	/* Build the monster probability table. */
-	if (!get_mon_num(depth)) {
+	if (!get_mon_num(depth, c->depth)) {
 		(void) mon_restrict(NULL, depth, false);
 		name = NULL;
 		return;

--- a/src/gen-monster.c
+++ b/src/gen-monster.c
@@ -99,6 +99,7 @@ static bool mon_select(struct monster_race *race)
  *
  * \param monster_type the monster type to be selected, as described below
  * \param depth the native depth to choose monsters
+ * \param current_depth is the depth at which the monsters will be placed
  * \param unique_ok whether to allow uniques to be chosen
  * \return success if the monster allocation table has been rebuilt
  *
@@ -112,7 +113,8 @@ static bool mon_select(struct monster_race *race)
  * If called with monster_type "random", it will get a random monster base and 
  * describe the monsters by its name (for use by cheat_room).
  */
-bool mon_restrict(const char *monster_type, int depth, bool unique_ok)
+bool mon_restrict(const char *monster_type, int depth, int current_depth,
+		bool unique_ok)
 {
 	int i, j = 0;
 
@@ -139,8 +141,8 @@ bool mon_restrict(const char *monster_type, int depth, bool unique_ok)
 			if (i < 200) {
 				if ((!rf_has(r_info[j].flags, RF_UNIQUE))
 					&& (r_info[j].level != 0) && (r_info[j].level <= depth)
-					&& (ABS(r_info[j].level - player->depth) <
-						1 + (player->depth / 4)))
+					&& (ABS(r_info[j].level - current_depth) <
+						1 + (current_depth / 4)))
 					break;
 			} else {
 				if ((!rf_has(r_info[j].flags, RF_UNIQUE))
@@ -205,7 +207,7 @@ void spread_monsters(struct chunk *c, const char *type, int depth, int num,
 	int start_mon_num = c->mon_max;
 
 	/* Restrict monsters.  Allow uniques. Leave area empty if none found. */
-	if (!mon_restrict(type, depth, true))
+	if (!mon_restrict(type, depth, c->depth, true))
 		return;
 
 	/* Build the monster probability table. */
@@ -220,7 +222,8 @@ void spread_monsters(struct chunk *c, const char *type, int depth, int num,
 			y = y0;
 			x = x0;
 			if (!square_in_bounds(c, loc(x, y))) {
-				(void) mon_restrict(NULL, depth, true);
+				(void) mon_restrict(NULL, depth,
+					c->depth, true);
 				return;
 			}
 		} else {
@@ -231,7 +234,8 @@ void spread_monsters(struct chunk *c, const char *type, int depth, int num,
 					if (j < 9) {
 						continue;
 					} else {
-						(void) mon_restrict(NULL, depth, true);
+						(void) mon_restrict(NULL, depth,
+							c->depth, true);
 						return;
 					}
 				}
@@ -255,7 +259,7 @@ void spread_monsters(struct chunk *c, const char *type, int depth, int num,
 	}
 
 	/* Remove monster restrictions. */
-	(void) mon_restrict(NULL, depth, true);
+	(void) mon_restrict(NULL, depth, c->depth, true);
 }
 
 
@@ -357,18 +361,18 @@ void get_chamber_monsters(struct chunk *c, int y1, int x1, int y2, int x2,
 
 	/* Set monster generation restrictions. Occasionally random. */
 	if (random) {
-		if (!mon_restrict("random", depth, true))
+		if (!mon_restrict("random", depth, c->depth, true))
 			return;
 		my_strcpy(name, "random", sizeof(name));
 	} else {
-		if (!mon_restrict(dun->pit_type->name, depth, true))
+		if (!mon_restrict(dun->pit_type->name, depth, c->depth, true))
 			return;
 		my_strcpy(name, dun->pit_type->name, sizeof(name));
 	}
 
 	/* Build the monster probability table. */
 	if (!get_mon_num(depth, c->depth)) {
-		(void) mon_restrict(NULL, depth, false);
+		(void) mon_restrict(NULL, depth, c->depth, false);
 		name = NULL;
 		return;
 	}
@@ -402,6 +406,6 @@ void get_chamber_monsters(struct chunk *c, int y1, int x1, int y2, int x2,
 	}
 
 	/* Remove our restrictions. */
-	(void) mon_restrict(NULL, depth, false);
+	(void) mon_restrict(NULL, depth, c->depth, false);
 }
 

--- a/src/gen-room.c
+++ b/src/gen-room.c
@@ -2678,7 +2678,7 @@ bool build_nest(struct chunk *c, struct loc centre, int rating)
 	/* Pick some monster types */
 	for (i = 0; i < 64; i++) {
 		/* Get a (hard) monster type */
-		what[i] = get_mon_num(c->depth + 10);
+		what[i] = get_mon_num(c->depth + 10, c->depth);
 
 		/* Notice failure */
 		if (!what[i]) empty = true;
@@ -2804,7 +2804,7 @@ bool build_pit(struct chunk *c, struct loc centre, int rating)
 	/* Pick some monster types */
 	for (i = 0; i < 16; i++) {
 		/* Get a (hard) monster type */
-		what[i] = get_mon_num(c->depth + 10);
+		what[i] = get_mon_num(c->depth + 10, c->depth);
 
 		/* Notice failure */
 		if (!what[i]) empty = true;

--- a/src/gen-room.c
+++ b/src/gen-room.c
@@ -1193,7 +1193,7 @@ static bool build_room_template(struct chunk *c, struct loc centre, int ymax,
 			case '8': {
 				/* Put something nice in this square
 				 * Object (80%) or Stairs (20%) */
-				if ((randint0(100) < 80) || OPT(player, birth_levels_persist)) {
+				if (randint0(100) < 80 || dun->persist) {
 					place_object(c, grid, c->depth, false, false,
 								 ORIGIN_SPECIAL, 0);
 				} else {
@@ -1466,11 +1466,11 @@ bool build_vault(struct chunk *c, struct loc centre, struct vault *v)
 			}
 				/* Stairs */
 			case '<': {
-				if (OPT(player, birth_levels_persist)) break;
+				if (dun->persist) break;
 				square_set_feat(c, grid, FEAT_LESS); break;
 			}
 			case '>': {
-				if (OPT(player, birth_levels_persist)) break;
+				if (dun->persist) break;
 				/* No down stairs at bottom or on quests */
 				if (is_quest(c->depth) || c->depth >= z_info->max_depth - 1)
 					square_set_feat(c, grid, FEAT_LESS);
@@ -2449,10 +2449,11 @@ bool build_large(struct chunk *c, struct loc centre, int rating)
 		vault_monsters(c, centre, c->depth + 2, randint1(3) + 2);
 
 		/* Object (80%) or Stairs (20%) */
-		if ((randint0(100) < 80) || OPT(player, birth_levels_persist))
+		if (randint0(100) < 80 || dun->persist) {
 			place_object(c, centre, c->depth, false, false, ORIGIN_SPECIAL, 0);
-		else
+		} else {
 			place_random_stairs(c, centre);
+		}
 
 		/* Traps to protect the treasure */
 		vault_traps(c, centre, 4, 10, 2 + randint1(3));

--- a/src/generate.c
+++ b/src/generate.c
@@ -1131,7 +1131,10 @@ static struct chunk *cave_generate(struct player *p, int height, int width)
 
 		/* Get connector info for persistent levels */
 		if (OPT(p, birth_levels_persist)) {
+			dun->persist = true;
 			get_join_info(p, dun);
+		} else {
+			dun->persist = false;
 		}
 
 		/* Choose a profile and build the level */

--- a/src/generate.h
+++ b/src/generate.h
@@ -335,7 +335,7 @@ void chunk_list_add(struct chunk *c);
 bool chunk_list_remove(const char *name);
 struct chunk *chunk_find_name(const char *name);
 bool chunk_find(struct chunk *c);
-struct chunk *chunk_find_adjacent(struct player *p, bool above);
+struct chunk *chunk_find_adjacent(int depth, bool above);
 void symmetry_transform(struct loc *grid, int y0, int x0, int height, int width,
 	int rotate, bool reflect);
 void get_random_symmetry_transform(int height, int width, int flags,

--- a/src/generate.h
+++ b/src/generate.h
@@ -424,7 +424,8 @@ void dump_level_body(ang_file *fo, const char *title, struct chunk *c,
 void dump_level_footer(ang_file *fo);
 
 /* gen-monster.c */
-bool mon_restrict(const char *monster_type, int depth, bool unique_ok);
+bool mon_restrict(const char *monster_type, int depth,
+	int current_depth, bool unique_ok);
 void spread_monsters(struct chunk *c, const char *type, int depth, int num, 
 					 int y0, int x0, int dy, int dx, byte origin);
 void get_vault_monsters(struct chunk *c, char racial_symbol[], char *vault_type,

--- a/src/generate.h
+++ b/src/generate.h
@@ -345,8 +345,8 @@ void get_random_symmetry_transform(int height, int width, int flags,
 	int transpose_weight, int *rotate, bool *reflect,
 	int *theight, int *twidth);
 int calc_default_transpose_weight(int height, int width);
-bool chunk_copy(struct chunk *dest, struct chunk *source, int y0, int x0,
-				int rotate, bool reflect);
+bool chunk_copy(struct chunk *dest, struct player *p, struct chunk *source,
+	 int y0, int x0, int rotate, bool reflect);
 
 void chunk_validate_objects(struct chunk *c);
 

--- a/src/generate.h
+++ b/src/generate.h
@@ -180,6 +180,9 @@ struct dun_data {
 
     /*!< The number of staircase rooms */
     int nstair_room;
+
+    /*!< Whether or not  persistent levels are being used */
+    bool persist;
 };
 
 

--- a/src/mon-make.c
+++ b/src/mon-make.c
@@ -775,7 +775,7 @@ static bool mon_create_drop(struct chunk *c, struct monster *mon, byte origin)
 
 	/* Take the best of (average of monster level and current depth)
 	   and (monster level) - to reward fighting OOD monsters */
-	level = MAX((monlevel + player->depth) / 2, monlevel);
+	level = MAX((monlevel + c->depth) / 2, monlevel);
 	level = MIN(level, 100);
 
 	/* Morgoth currently drops all artifacts with the QUEST_ART flag */
@@ -797,7 +797,7 @@ static bool mon_create_drop(struct chunk *c, struct monster *mon, byte origin)
 
 			/* Set origin details */
 			obj->origin = origin;
-			obj->origin_depth = player->depth;
+			obj->origin_depth = c->depth;
 			obj->origin_race = mon->race;
 			obj->number = 1;
 
@@ -835,7 +835,7 @@ static bool mon_create_drop(struct chunk *c, struct monster *mon, byte origin)
 
 		/* Set origin details */
 		obj->origin = origin;
-		obj->origin_depth = player->depth;
+		obj->origin_depth = c->depth;
 		obj->origin_race = mon->race;
 		obj->number = (obj->artifact) ?
 			1 : randint0(drop->max - drop->min) + drop->min;
@@ -860,7 +860,7 @@ static bool mon_create_drop(struct chunk *c, struct monster *mon, byte origin)
 
 		/* Set origin details */
 		obj->origin = origin;
-		obj->origin_depth = player->depth;
+		obj->origin_depth = c->depth;
 		obj->origin_race = mon->race;
 
 		/* Try to carry */
@@ -900,14 +900,14 @@ void mon_create_mimicked_object(struct chunk *c, struct monster *mon, int index)
 	}
 
 	if (tval_is_money_k(kind)) {
-		obj = make_gold(player->depth, kind->name);
+		obj = make_gold(c->depth, kind->name);
 	} else {
 		obj = object_new();
 		object_prep(obj, kind, mon->race->level, RANDOMISE);
 		apply_magic(obj, mon->race->level, true, false, false, false);
 		obj->number = 1;
 		obj->origin = ORIGIN_DROP_MIMIC;
-		obj->origin_depth = player->depth;
+		obj->origin_depth = c->depth;
 	}
 
 	obj->mimicking_m_idx = index;
@@ -1092,7 +1092,7 @@ static bool place_new_monster_one(struct chunk *c, struct loc grid,
 		return false;
 
 	/* Depth monsters may NOT be created out of depth */
-	if (rf_has(race->flags, RF_FORCE_DEPTH) && player->depth < race->level)
+	if (rf_has(race->flags, RF_FORCE_DEPTH) && c->depth < race->level)
 		return false;
 
 	/* Add to level feeling, note uniques for cheaters */
@@ -1272,7 +1272,7 @@ static bool place_friends(struct chunk *c, struct loc grid, struct monster_race 
 	int extra_chance;
 
 	/* Find the difference between current dungeon depth and monster level */
-	int level_difference = player->depth - friends_race->level + 5;
+	int level_difference = c->depth - friends_race->level + 5;
 
 	/* Handle unique monsters */
 	bool is_unique = rf_has(friends_race->flags, RF_UNIQUE);

--- a/src/mon-make.h
+++ b/src/mon-make.h
@@ -28,7 +28,7 @@ void compact_monsters(struct chunk *c, int num_to_compact);
 void wipe_mon_list(struct chunk *c, struct player *p);
 s16b mon_pop(struct chunk *c);
 void get_mon_num_prep(bool (*get_mon_num_hook)(struct monster_race *race));
-struct monster_race *get_mon_num(int level);
+struct monster_race *get_mon_num(int generated_level, int current_level);
 int mon_create_drop_count(const struct monster_race *race, bool maximize,
 	bool specific, int *specific_count);
 void mon_create_mimicked_object(struct chunk *c, struct monster *mon,

--- a/src/mon-summon.c
+++ b/src/mon-summon.c
@@ -441,7 +441,7 @@ int summon_specific(struct loc grid, int lev, int type, bool delay, bool call)
 	get_mon_num_prep(summon_specific_okay);
 
 	/* Pick a monster, using the level calculation */
-	race = get_mon_num((player->depth + lev) / 2 + 5);
+	race = get_mon_num((player->depth + lev) / 2 + 5, player->depth);
 
 	/* Prepare allocation table */
 	get_mon_num_prep(NULL);
@@ -493,7 +493,7 @@ struct monster_race *select_shape(struct monster *mon, int type)
 	get_mon_num_prep(summon_specific_okay);
 
 	/* Pick a monster */
-	race = get_mon_num(player->depth + 5);
+	race = get_mon_num(player->depth + 5, player->depth);
 
 	/* Prepare allocation table */
 	get_mon_num_prep(NULL);

--- a/src/mon-util.c
+++ b/src/mon-util.c
@@ -1602,7 +1602,7 @@ bool monster_change_shape(struct monster *mon)
 			get_mon_num_prep(monster_base_shape_okay);
 
 			/* Pick a random race */
-			race = get_mon_num(player->depth + 5);
+			race = get_mon_num(player->depth + 5, player->depth);
 
 			/* Reset allocation table */
 			get_mon_num_prep(NULL);


### PR DESCRIPTION
- In the monster creation and placement functions that already take a chunk, use the chunk's depth rather than the player's as the current depth.
- Add an argument for the current depth to get_mon_num() and mon_restrict().  Replace the player argument to chunk_find_adjacent() with the depth.
- Cache whether persistent levels are being used in the dun_data structure so room generation doesn't have to look at the player.
- Add a player argument to chunk_copy() so the cave generation can pass along their player argument if the player position needs to be updated.

Resolves #4956 and some parts of some of the other items in #4934 .  The remaining references to the global player from cave generation are primarily through object creation and destruction (make_artifact_special(), make_artifact(), make_gold(), floor_carry(), list_object(), and object_delete()).  Others are from is_quest() and obj_kind_can_browse().