### PR TITLE
Tighten updates in become_aware(); hide camouflaged monsters in lighting calculations

### DIFF
--- a/src/cave-view.c
+++ b/src/cave-view.c
@@ -710,6 +710,9 @@ static void calc_lighting(struct chunk *c, struct player *p)
 		/* Skip dead monsters */
 		if (!mon->race) continue;
 
+		/* Skip if the monster is hidden */
+		if (monster_is_camouflaged(mon)) continue;
+
 		/* Get light info for this monster */
 		light = mon->race->light;
 		radius = ABS(light) - 1;

--- a/src/mon-util.c
+++ b/src/mon-util.c
@@ -771,7 +771,9 @@ void become_aware(struct chunk *c, struct monster *mon, struct player *p)
 		}
 
 		/* Update monster and item lists */
-		p->upkeep->update |= (PU_UPDATE_VIEW | PU_MONSTERS);
+		if (mon->race->light != 0) {
+			p->upkeep->update |= (PU_UPDATE_VIEW | PU_MONSTERS);
+		}
 		p->upkeep->redraw |= (PR_MONLIST | PR_ITEMLIST);
 	}
 


### PR DESCRIPTION
Since become_aware() directly calls update_mon(), there's no need to set PU_MONSTERS, unless the revealed monster affects lighting.  Since the revealed/unrevealed status doesn't affect the view calculations, also only set PU_UPDATE_VIEW if the revealed monster affects lighting.

As a bit of future- or variant-proofing, don't include a monster as a light source in the lighting calculations if it is camouflaged:  having it light its surroundings would likely spoil the point of the camouflage.