### PR TITLE
Add a player argument to mon_take_hit()

### DIFF
--- a/src/effects.c
+++ b/src/effects.c
@@ -4851,7 +4851,7 @@ static bool effect_handler_TAP_UNLIFE(effect_handler_context_t *context)
 	monster_desc(m_name, sizeof(m_name), mon, MDESC_TARG);
 	msg("You draw power from the %s.", m_name);
 	drain = MIN(mon->hp, amount) / 4;
-	dead = mon_take_hit(mon, amount, &fear, " is destroyed!");
+	dead = mon_take_hit(mon, player, amount, &fear, " is destroyed!");
 
 	/* Gain mana */
 	effect_simple(EF_RESTORE_MANA, context->origin, format("%d", drain), 0, 0,
@@ -4917,7 +4917,7 @@ static bool effect_handler_CURSE(effect_handler_context_t *context)
 	}
 
 	/* Hit it */
-	dead = mon_take_hit(mon, dam, &fear, " dies!");
+	dead = mon_take_hit(mon, player, dam, &fear, " dies!");
 
 	/* Handle fear for surviving monsters */
 	if (!dead && monster_is_visible(mon)) {
@@ -5018,7 +5018,7 @@ static bool effect_handler_JUMP_AND_BITE(effect_handler_context_t *context)
 	} else {
 		msg("You bite %s.", m_name);
 	}
-	dead = mon_take_hit(mon, amount, &fear, " is drained dry!");
+	dead = mon_take_hit(mon, player, amount, &fear, " is drained dry!");
 
 	/* Heal and nourish */
 	effect_simple(EF_HEAL_HP, context->origin, format("%d", drain), 0, 0, 0,

--- a/src/main-stats.c
+++ b/src/main-stats.c
@@ -273,7 +273,7 @@ static void kill_all_monsters(int level)
 
 		level_data[level].monsters[mon->race->ridx]++;
 
-		monster_death(mon, true);
+		monster_death(mon, player, true);
 
 		if (rf_has(mon->race->flags, RF_UNIQUE))
 			mon->race->max_num = 0;

--- a/src/mon-util.c
+++ b/src/mon-util.c
@@ -949,7 +949,7 @@ struct monster *choose_nearby_injured_kin(struct chunk *c,
  * If `stats` is true, then we skip updating the monster memory. This is
  * used by stats-generation code, for efficiency.
  */
-void monster_death(struct monster *mon, bool stats)
+void monster_death(struct monster *mon, struct player *p, bool stats)
 {
 	int dump_item = 0;
 	int dump_gold = 0;
@@ -1002,16 +1002,17 @@ void monster_death(struct monster *mon, bool stats)
 		lore_treasure(mon, dump_item, dump_gold);
 
 	/* Update monster list window */
-	player->upkeep->redraw |= PR_MONLIST;
+	p->upkeep->redraw |= PR_MONLIST;
 
 	/* Check if we finished a quest */
-	quest_check(mon);
+	quest_check(p, mon);
 }
 
 /**
  * Handle the consequences of the killing of a monster by the player
  */
-static void player_kill_monster(struct monster *mon, const char *note)
+static void player_kill_monster(struct monster *mon, struct player *p,
+		const char *note)
 {
 	s32b div, new_exp, new_exp_frac;
 	struct monster_lore *lore = get_lore(mon->race);
@@ -1048,14 +1049,14 @@ static void player_kill_monster(struct monster *mon, const char *note)
 			my_strcap(str);
 
 			/* Make sure to flush any monster messages first */
-			notice_stuff(player);
+			notice_stuff(p);
 
 			/* Death by Missile attack */
 			msgt(soundfx, "%s", str);
 		}
 	} else {
 		/* Make sure to flush any monster messages first */
-		notice_stuff(player);
+		notice_stuff(p);
 
 		if (!monster_is_visible(mon))
 			/* Death by physical attack -- invisible monster */
@@ -1069,21 +1070,21 @@ static void player_kill_monster(struct monster *mon, const char *note)
 	}
 
 	/* Player level */
-	div = player->lev;
+	div = p->lev;
 
 	/* Give some experience for the kill */
 	new_exp = ((long)mon->race->mexp * mon->race->level) / div;
 
 	/* Handle fractional experience */
 	new_exp_frac = ((((long)mon->race->mexp * mon->race->level) % div)
-					* 0x10000L / div) + player->exp_frac;
+					* 0x10000L / div) + p->exp_frac;
 
 	/* Keep track of experience */
 	if (new_exp_frac >= 0x10000L) {
 		new_exp++;
-		player->exp_frac = (u16b)(new_exp_frac - 0x10000L);
+		p->exp_frac = (u16b)(new_exp_frac - 0x10000L);
 	} else {
-		player->exp_frac = (u16b)new_exp_frac;
+		p->exp_frac = (u16b)new_exp_frac;
 	}
 
 	/* When the player kills a Unique, it stays dead */
@@ -1101,20 +1102,20 @@ static void player_kill_monster(struct monster *mon, const char *note)
 
 		/* Log the slaying of a unique */
 		strnfmt(buf, sizeof(buf), "Killed %s", unique_name);
-		history_add(player, buf, HIST_SLAY_UNIQUE);
+		history_add(p, buf, HIST_SLAY_UNIQUE);
 	}
 
 	/* Gain experience */
-	player_exp_gain(player, new_exp);
+	player_exp_gain(p, new_exp);
 
 	/* Generate treasure */
-	monster_death(mon, false);
+	monster_death(mon, p, false);
 
 	/* Bloodlust bonus */
-	if (player->timed[TMD_BLOODLUST]) {
-		player_inc_timed(player, TMD_BLOODLUST, 10, false, false);
-		player_over_exert(player, PY_EXERT_CONF, 5, 3);
-		player_over_exert(player, PY_EXERT_HALLU, 5, 10);
+	if (p->timed[TMD_BLOODLUST]) {
+		player_inc_timed(p, TMD_BLOODLUST, 10, false, false);
+		player_over_exert(p, PY_EXERT_CONF, 5, 3);
+		player_over_exert(p, PY_EXERT_HALLU, 5, 10);
 	}
 
 	/* Recall even invisible uniques or winners */
@@ -1127,7 +1128,7 @@ static void player_kill_monster(struct monster *mon, const char *note)
 
 		/* Update lore and tracking */
 		lore_update(mon->race, lore);
-		monster_race_track(player->upkeep, mon->race);
+		monster_race_track(p->upkeep, mon->race);
 	}
 
 	/* Delete the monster */
@@ -1220,7 +1221,7 @@ bool mon_take_nonplayer_hit(int dam, struct monster *t_mon,
 		add_monster_message(t_mon, die_msg, false);
 
 		/* Generate treasure, etc */
-		monster_death(t_mon, false);
+		monster_death(t_mon, player, false);
 
 		/* Delete the monster */
 		delete_monster_idx(t_mon->midx);
@@ -1258,11 +1259,12 @@ bool mon_take_nonplayer_hit(int dam, struct monster *t_mon,
  * worth more than subsequent monsters.  This would also need to
  * induce changes in the monster recall code.  XXX XXX XXX
  **/
-bool mon_take_hit(struct monster *mon, int dam, bool *fear, const char *note)
+bool mon_take_hit(struct monster *mon, struct player *p, int dam, bool *fear,
+		const char *note)
 {
 	/* Redraw (later) if needed */
-	if (player->upkeep->health_who == mon)
-		player->upkeep->redraw |= (PR_HEALTH);
+	if (p->upkeep->health_who == mon)
+		p->upkeep->redraw |= (PR_HEALTH);
 
 	/* If the hit doesn't kill, wake it up, make it aware of the player */
 	if (dam <= mon->hp) {
@@ -1272,27 +1274,27 @@ bool mon_take_hit(struct monster *mon, int dam, bool *fear, const char *note)
 
 	/* Become aware of its presence */
 	if (monster_is_camouflaged(mon))
-		become_aware(cave, mon, player);
+		become_aware(cave, mon, p);
 
 	/* No damage, we're done */
 	if (dam == 0) return false;
 
 	/* Covering tracks is no longer possible */
-	player->timed[TMD_COVERTRACKS] = 0;
+	p->timed[TMD_COVERTRACKS] = 0;
 
 	/* Hurt it */
 	mon->hp -= dam;
 	if (mon->hp < 0) {
 		/* Deal with arena monsters */
-		if (player->upkeep->arena_level) {
-			player->upkeep->generate_level = true;
-			player->upkeep->health_who = mon;
+		if (p->upkeep->arena_level) {
+			p->upkeep->generate_level = true;
+			p->upkeep->health_who = mon;
 			(*fear) = false;
 			return true;
 		}
 
 		/* It is dead now */
-		player_kill_monster(mon, note);
+		player_kill_monster(mon, p, note);
 
 		/* Not afraid */
 		(*fear) = false;
@@ -1314,7 +1316,7 @@ void kill_arena_monster(struct monster *mon)
 	assert(old_mon);
 	update_mon(old_mon, cave, true);
 	old_mon->hp = -1;
-	player_kill_monster(old_mon, " is defeated!");
+	player_kill_monster(old_mon, player, " is defeated!");
 }
 
 /**

--- a/src/mon-util.h
+++ b/src/mon-util.h
@@ -38,11 +38,12 @@ void update_smart_learn(struct monster *mon, struct player *p, int flag,
 						int pflag, int element);
 bool find_any_nearby_injured_kin(struct chunk *c, const struct monster *mon);
 struct monster *choose_nearby_injured_kin(struct chunk *c, const struct monster *mon);
-void monster_death(struct monster *mon, bool stats);
+void monster_death(struct monster *mon, struct player *p, bool stats);
 bool mon_take_nonplayer_hit(int dam, struct monster *t_mon,
 							enum mon_messages hurt_msg,
 							enum mon_messages die_msg);
-bool mon_take_hit(struct monster *mon, int dam, bool *fear, const char *note);
+bool mon_take_hit(struct monster *mon, struct player *p, int dam, bool *fear,
+	const char *note);
 void kill_arena_monster(struct monster *mon);
 void monster_take_terrain_damage(struct monster *mon);
 bool monster_taking_terrain_damage(struct chunk *c, struct monster *mon);

--- a/src/player-attack.c
+++ b/src/player-attack.c
@@ -828,7 +828,7 @@ bool py_attack_real(struct player *p, struct loc grid, bool *fear)
 
 	/* Damage, check for hp drain, fear and death */
 	drain = MIN(mon->hp, dmg);
-	stop = mon_take_hit(mon, dmg, fear, NULL);
+	stop = mon_take_hit(mon, p, dmg, fear, NULL);
 
 	/* Small chance of bloodlust side-effects */
 	if (p->timed[TMD_BLOODLUST] && one_in_(50)) {
@@ -916,7 +916,7 @@ static bool attempt_shield_bash(struct player *p, struct monster *mon, bool *fea
 	}
 
 	/* Damage, check for fear and death. */
-	if (mon_take_hit(mon, bash_dam, fear, NULL)) return true;
+	if (mon_take_hit(mon, p, bash_dam, fear, NULL)) return true;
 
 	/* Stunning. */
 	if (bash_quality + p->lev > randint1(200 + mon->race->level * 8)) {
@@ -1146,7 +1146,7 @@ static void ranged_helper(struct player *p,	struct object *obj, int dir,
 				}
 
 				/* Hit the monster, check for death */
-				if (!mon_take_hit(mon, dmg, &fear, note_dies)) {
+				if (!mon_take_hit(mon, p, dmg, &fear, note_dies)) {
 					message_pain(mon, dmg);
 					if (fear && monster_is_obvious(mon)) {
 						add_monster_message(mon, MON_MSG_FLEE_IN_TERROR, true);

--- a/src/player-quest.c
+++ b/src/player-quest.c
@@ -185,9 +185,9 @@ void player_quests_free(struct player *p)
 /**
  * Creates magical stairs after finishing a quest monster.
  */
-static void build_quest_stairs(struct loc grid)
+static void build_quest_stairs(struct player *p, struct loc grid)
 {
-	struct loc new_grid = player->grid;
+	struct loc new_grid = p->grid;
 
 	/* Stagger around */
 	while (!square_changeable(cave, grid) &&
@@ -210,13 +210,14 @@ static void build_quest_stairs(struct loc grid)
 	square_set_feat(cave, grid, FEAT_MORE);
 
 	/* Update the visuals */
-	player->upkeep->update |= (PU_UPDATE_VIEW | PU_MONSTERS);
+	p->upkeep->update |= (PU_UPDATE_VIEW | PU_MONSTERS);
 }
 
 /**
  * Check if this (now dead) monster is a quest monster, and act appropriately
  */
-bool quest_check(const struct monster *m) {
+bool quest_check(struct player *p, const struct monster *m)
+{
 	int i, total = 0;
 
 	/* Don't bother with non-questors */
@@ -225,22 +226,22 @@ bool quest_check(const struct monster *m) {
 	/* Mark quests as complete */
 	for (i = 0; i < z_info->quest_max; i++) {
 		/* Note completed quests */
-		if (player->quests[i].level == m->race->level) {
-			player->quests[i].level = 0;
-			player->quests[i].cur_num++;
+		if (p->quests[i].level == m->race->level) {
+			p->quests[i].level = 0;
+			p->quests[i].cur_num++;
 		}
 
 		/* Count incomplete quests */
-		if (player->quests[i].level) total++;
+		if (p->quests[i].level) total++;
 	}
 
 	/* Build magical stairs */
-	build_quest_stairs(m->grid);
+	build_quest_stairs(p, m->grid);
 
 	/* Nothing left, game over... */
 	if (total == 0) {
-		player->total_winner = true;
-		player->upkeep->redraw |= (PR_TITLE);
+		p->total_winner = true;
+		p->upkeep->redraw |= (PR_TITLE);
 		msg("*** CONGRATULATIONS ***");
 		msg("You have won the game!");
 		msg("You may retire (commit suicide) when you are ready.");

--- a/src/player-quest.h
+++ b/src/player-quest.h
@@ -26,7 +26,7 @@ extern struct quest *quests;
 bool is_quest(int level);
 void player_quests_reset(struct player *p);
 void player_quests_free(struct player *p);
-bool quest_check(const struct monster *m);
+bool quest_check(struct player *p, const struct monster *m);
 extern struct file_parser quests_parser;
 
 

--- a/src/project-mon.c
+++ b/src/project-mon.c
@@ -1058,7 +1058,7 @@ static bool project_m_monster_attack(project_monster_handler_context_t *context,
 		add_monster_message(mon, die_msg, false);
 
 		/* Generate treasure, etc */
-		monster_death(mon, false);
+		monster_death(mon, player, false);
 
 		/* Delete the monster */
 		delete_monster_idx(m_idx);
@@ -1111,7 +1111,7 @@ static bool project_m_player_attack(project_monster_handler_context_t *context)
 	/* No damage is now going to mean the monster is not hit - and hence
 	 * is not woken or released from holding */
 	if (dam) {
-		mon_died = mon_take_hit(mon, dam, &fear, "");
+		mon_died = mon_take_hit(mon, player, dam, &fear, "");
 	}
 
 	/* If the monster didn't die, provide additional messages about how it was


### PR DESCRIPTION
Some of its callers already expect a player argument.  Resolves https://github.com/angband/angband/issues/4966 (part of https://github.com/angband/angband/issues/4934 ).  Since mon_take_hit() calls monster_death() and, in turn, quest_check(), add a player argument to those as well.