### PR TITLE
Add a return value to new_player_spot(); restart dungeon generation when it fails

### DIFF
--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -1278,7 +1278,11 @@ struct chunk *classic_gen(struct player *p, int min_height, int min_width) {
 	alloc_objects(c, SET_CORR, TYP_TRAP, randint1(k)/5, c->depth, 0);
 
 	/* Determine the character location */
-	new_player_spot(c, p);
+	if (!new_player_spot(c, p)) {
+		wipe_mon_list(c, p);
+		cave_free(c);
+		return NULL;
+	}
 
 	/* Pick a base number of monsters */
 	i = z_info->level_monster_min + randint1(8) + k;
@@ -1519,7 +1523,10 @@ struct chunk *labyrinth_gen(struct player *p, int min_height, int min_width) {
 	if (!c) return NULL;
 
 	/* Determine the character location */
-	new_player_spot(c, p);
+	if (!new_player_spot(c, p)) {
+		cave_free(c);
+		return NULL;
+	}
 
 	/* Generate a single set of stairs up if necessary. */
 	if (!cave_find(c, &grid, square_isupstairs))
@@ -2156,7 +2163,10 @@ struct chunk *cavern_gen(struct player *p, int min_height, int min_width) {
 	alloc_objects(c, SET_CORR, TYP_TRAP, randint1(k), c->depth, 0);
 
 	/* Determine the character location */
-	new_player_spot(c, p);
+	if (!new_player_spot(c, p)) {
+		cave_free(c);
+		return NULL;
+	}
 
 	/* Put some monsters in the dungeon */
 	for (i = randint1(8) + k; i > 0; i--)
@@ -2826,7 +2836,11 @@ struct chunk *modified_gen(struct player *p, int min_height, int min_width) {
 	alloc_objects(c, SET_CORR, TYP_TRAP, randint1(k)/5, c->depth, 0);
 
 	/* Determine the character location */
-	new_player_spot(c, p);
+	if (!new_player_spot(c, p)) {
+		wipe_mon_list(c, p);
+		cave_free(c);
+		return NULL;
+	}
 
 	/* Pick a base number of monsters */
 	i = z_info->level_monster_min + randint1(8) + k;
@@ -3021,7 +3035,11 @@ struct chunk *moria_gen(struct player *p, int min_height, int min_width) {
 	alloc_objects(c, SET_CORR, TYP_TRAP, randint1(k)/5, c->depth, 0);
 
 	/* Determine the character location */
-	new_player_spot(c, p);
+	if (!new_player_spot(c, p)) {
+		wipe_mon_list(c, p);
+		cave_free(c);
+		return NULL;
+	}
 
 	/* Pick a base number of monsters */
 	i = z_info->level_monster_min + randint1(8) + k;
@@ -3306,7 +3324,11 @@ struct chunk *hard_centre_gen(struct player *p, int min_height, int min_width)
 	alloc_objects(c, SET_CORR, TYP_TRAP, randint1(k), c->depth, 0);
 
 	/* Determine the character location */
-	new_player_spot(c, p);
+	if (!new_player_spot(c, p)) {
+		wipe_mon_list(c, p);
+		cave_free(c);
+		return NULL;
+	}
 
 	/* Put some monsters in the dungeon */
 	for (i = randint1(8) + k; i > 0; i--)
@@ -3421,7 +3443,12 @@ struct chunk *lair_gen(struct player *p, int min_height, int min_width) {
 	k = MAX(MIN(p->depth / 3, 10), 2) / 2;
 
 	/* Put the character in the normal half */
-	new_player_spot(normal, p);
+	if (!new_player_spot(normal, p)) {
+		cave_free(lair);
+		wipe_mon_list(normal, p);
+		cave_free(normal);
+		return NULL;
+	}
 
 	/* Pick a smallish number of monsters for the normal half */
 	i = randint1(4) + k;
@@ -3605,7 +3632,12 @@ struct chunk *gauntlet_gen(struct player *p, int min_height, int min_width) {
 	k = MAX(MIN(p->depth / 3, 10), 2) / 2;
 
 	/* Put the character in the arrival cavern */
-	new_player_spot(p->upkeep->create_down_stair ? right : left, p);
+	if (!new_player_spot(p->upkeep->create_down_stair ? right : left, p)) {
+		cave_free(gauntlet);
+		cave_free(left);
+		cave_free(right);
+		return NULL;
+	}
 
 	/* Pick some monsters for the left cavern */
 	i = z_info->level_monster_min + randint1(4) + k;

--- a/src/gen-util.c
+++ b/src/gen-util.c
@@ -339,8 +339,9 @@ static bool find_start(struct chunk *c, struct loc *grid)
  * Place the player at a random starting location.
  * \param c current chunk
  * \param p the player
+ * \return true on success or false on failure
  */
-void new_player_spot(struct chunk *c, struct player *p)
+bool new_player_spot(struct chunk *c, struct player *p)
 {
 	struct loc grid;
 
@@ -350,8 +351,9 @@ void new_player_spot(struct chunk *c, struct player *p)
 			square_isstairs(c, p->grid)) {
 		grid = p->grid;
 	} else if (!find_start(c, &grid)) {
+		msg("Failed to place player; please report.  Restarting generation.");
 		dump_level_simple(NULL, "Player Placement Failure", c);
-		quit("Failed to place player!");
+		return false;
 	}
 
 	/* Create stairs the player came down if allowed and necessary */
@@ -363,6 +365,7 @@ void new_player_spot(struct chunk *c, struct player *p)
 		square_set_feat(c, grid, FEAT_LESS);
 
 	player_place(c, p, grid);
+	return true;
 }
 
 

--- a/src/generate.h
+++ b/src/generate.h
@@ -403,7 +403,7 @@ bool find_nearby_grid(struct chunk *c, struct loc *grid, struct loc centre,
 					  int yd, int xd);
 void correct_dir(struct loc *offset, struct loc grid1, struct loc grid2);
 void rand_dir(struct loc *offset);
-void new_player_spot(struct chunk *c, struct player *p);
+bool new_player_spot(struct chunk *c, struct player *p);
 void place_object(struct chunk *c, struct loc grid, int level, bool good,
 				  bool great, byte origin, int tval);
 void place_gold(struct chunk *c, struct loc grid, int level, byte origin);


### PR DESCRIPTION
With that change and #4730 (which would prevent the two reported instances of failures - both were Moria levels with a single room), it may be best to mark #4549 as resolved.