### PR TITLE
Add a player arg to gear_insert_end() and gear_last_item(); change calc_inventory()'s arguments

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -1179,8 +1179,7 @@ int rd_gear(void)
 		player->upkeep->total_weight += (obj->number * obj->weight);
 	}
 
-	/* Maybe we have to duplicate also upkeep and body */
-	calc_inventory(player->upkeep, player->gear, player->body);
+	calc_inventory(player);
 
 	return 0;
 }

--- a/src/obj-gear.c
+++ b/src/obj-gear.c
@@ -415,7 +415,7 @@ static bool gear_excise_object(struct object *obj)
 	}
 
 	/* Update the gear */
-	calc_inventory(player->upkeep, player->gear, player->body);
+	calc_inventory(player);
 
 	/* Housekeeping */
 	player->upkeep->update |= (PU_BONUS);
@@ -425,15 +425,15 @@ static bool gear_excise_object(struct object *obj)
 	return true;
 }
 
-struct object *gear_last_item(void)
+struct object *gear_last_item(struct player *p)
 {
-	return pile_last_item(player->gear);
+	return pile_last_item(p->gear);
 }
 
-void gear_insert_end(struct object *obj)
+void gear_insert_end(struct player *p, struct object *obj)
 {
-	pile_insert_end(&player->gear, obj);
-	pile_insert_end(&player->gear_k, obj->known);
+	pile_insert_end(&p->gear, obj);
+	pile_insert_end(&p->gear_k, obj->known);
 }
 
 /**
@@ -722,7 +722,7 @@ void inven_carry(struct player *p, struct object *obj, bool absorb,
 		/* Paranoia */
 		assert(pack_slots_used(p) <= z_info->pack_size);
 
-		gear_insert_end(obj);
+		gear_insert_end(p, obj);
 		apply_autoinscription(obj);
 
 		/* Remove cave object details */
@@ -1032,7 +1032,7 @@ void combine_pack(void)
 	bool disable_repeat = false;
 
 	/* Combine the pack (backwards) */
-	obj1 = gear_last_item();
+	obj1 = gear_last_item(player);
 	while (obj1) {
 		assert(obj1->kind);
 		assert(!tval_is_money(obj1));
@@ -1091,7 +1091,7 @@ void combine_pack(void)
 		obj1 = prev;
 	}
 
-	calc_inventory(player->upkeep, player->gear, player->body);
+	calc_inventory(player);
 
 	/* Redraw gear */
 	event_signal(EVENT_INVENTORY);

--- a/src/obj-gear.h
+++ b/src/obj-gear.h
@@ -47,8 +47,8 @@ const char *equip_describe(struct player *p, int slot);
 int wield_slot(const struct object *obj);
 bool minus_ac(struct player *p);
 char gear_to_label(struct player *p, struct object *obj);
-struct object *gear_last_item(void);
-void gear_insert_end(struct object *obj);
+struct object *gear_last_item(struct player *p);
+void gear_insert_end(struct player *p, struct object *obj);
 struct object *gear_object_for_use(struct object *obj, int num, bool message,
 								   bool *none_left);
 int inven_carry_num(const struct object *obj);

--- a/src/obj-ignore.c
+++ b/src/obj-ignore.c
@@ -648,7 +648,7 @@ void ignore_drop(void)
 	struct object *obj;
 
 	/* Scan through the slots backwards */
-	for (obj = gear_last_item(); obj; obj = obj->prev) {
+	for (obj = gear_last_item(player); obj; obj = obj->prev) {
 		/* Skip non-objects and unignoreable objects */
 		assert(obj->kind);
 		if (!ignore_item_ok(obj)) continue;

--- a/src/player-calcs.h
+++ b/src/player-calcs.h
@@ -105,8 +105,7 @@ extern const int adj_str_hold[STAT_RANGE];
 
 bool earlier_object(struct object *orig, struct object *new, bool store);
 int equipped_item_slot(struct player_body body, struct object *obj);
-void calc_inventory(struct player_upkeep *upkeep, struct object *gear,
-					struct player_body body);
+void calc_inventory(struct player *p);
 void calc_bonuses(struct player *p, struct player_state *state, bool known_only,
 				  bool update);
 void calc_digging_chances(struct player_state *state, int chances[DIGGING_MAX]);

--- a/src/tests/player/calc-inventory.c
+++ b/src/tests/player/calc-inventory.c
@@ -110,7 +110,7 @@ static bool populate_gear(const struct in_slot_desc *slots) {
 		if (slots->known && ! object_flavor_is_aware(obj)) {
 			object_learn_on_use(player, obj);
 		}
-		gear_insert_end(obj);
+		gear_insert_end(player, obj);
 		if (!object_is_carried(player, obj)) {
 			return false;
 		}
@@ -241,7 +241,7 @@ static bool verify_stability(struct player *p) {
 	for (i = 0; i < z_info->quiver_size; ++i) {
 		old_quiver[i] = p->upkeep->quiver[i];
 	}
-	calc_inventory(p->upkeep, p->gear, p->body);
+	calc_inventory(p);
 	for (i = 0; i < z_info->pack_size; ++i) {
 		if (old_pack[i] != p->upkeep->inven[i]) {
 			result = false;
@@ -261,7 +261,7 @@ static int test_calc_inventory_empty(void *state) {
 	struct out_slot_desc empty = { -1, -1, -1 };
 
 	require(flush_gear());
-	calc_inventory(player->upkeep, player->gear, player->body);
+	calc_inventory(player);
 	require(verify_pack(player, &empty, 0));
 	require(verify_quiver(player, &empty));
 	require(verify_stability(player));
@@ -284,7 +284,7 @@ static int test_calc_inventory_only_equipped(void *state) {
 
 	require(flush_gear());
 	require(populate_gear(only_equipped_case.gear_in));
-	calc_inventory(player->upkeep, player->gear, player->body);
+	calc_inventory(player);
 	require(verify_pack(player, only_equipped_case.pack_out, 0));
 	require(verify_quiver(player, only_equipped_case.quiv_out));
 	require(verify_stability(player));
@@ -328,7 +328,7 @@ static int test_calc_inventory_only_pack(void *state) {
 
 	require(flush_gear());
 	require(populate_gear(only_pack_case.gear_in));
-	calc_inventory(player->upkeep, player->gear, player->body);
+	calc_inventory(player);
 	require(verify_pack(player, only_pack_case.pack_out, 0));
 	require(verify_quiver(player, only_pack_case.quiv_out));
 	require(verify_stability(player));
@@ -378,7 +378,7 @@ static int test_calc_inventory_only_quiver(void *state) {
 		}
 		obj = obj->next;
 	}
-	calc_inventory(player->upkeep, player->gear, player->body);
+	calc_inventory(player);
 	require(verify_pack(player, only_quiver_case.pack_out,
 		(quiver_size + z_info->quiver_slot_size - 1) /
 		z_info->quiver_slot_size));
@@ -463,7 +463,7 @@ static int test_calc_inventory_equipped_pack_quiver(void *state) {
 		}
 		obj = obj->next;
 	}
-	calc_inventory(player->upkeep, player->gear, player->body);
+	calc_inventory(player);
 	require(verify_pack(player, this_test_case.pack_out,
 		(quiver_size + z_info->quiver_slot_size - 1) /
 		z_info->quiver_slot_size));
@@ -526,7 +526,7 @@ static int test_calc_inventory_oversubscribed_quiver(void *state) {
 	}
 	/* Adjust for the ones that will end up in the pack. */
 	quiver_size -= 57;
-	calc_inventory(player->upkeep, player->gear, player->body);
+	calc_inventory(player);
 	require(verify_pack(player, this_test_case.pack_out,
 		(quiver_size + z_info->quiver_slot_size - 1) /
 		z_info->quiver_slot_size));
@@ -591,7 +591,7 @@ static int test_calc_inventory_oversubscribed_quiver_slot(void *state) {
 		++i;
 		obj = obj->next;
 	}
-	calc_inventory(player->upkeep, player->gear, player->body);
+	calc_inventory(player);
 	require(verify_pack(player, this_test_case.pack_out,
 		(quiver_size + z_info->quiver_slot_size - 1) /
 		z_info->quiver_slot_size));
@@ -621,7 +621,7 @@ static int test_calc_inventory_quiver_split_pile(void *state) {
 	require(populate_gear(this_test_case.gear_in));
 	/* Inscribe the flasks so they want to go to the quiver. */
 	player->gear->note = quark_add("@v1");
-	calc_inventory(player->upkeep, player->gear, player->body);
+	calc_inventory(player);
 	require(verify_pack(player, this_test_case.pack_out, 1));
 	require(verify_quiver(player, this_test_case.quiv_out));
 	require(verify_stability(player));

--- a/src/tests/player/inven-carry-num.c
+++ b/src/tests/player/inven-carry-num.c
@@ -164,7 +164,7 @@ static bool fill_pack_quiver(struct carry_num_state *cns, int n_pack,
 			object_copy(curr->known, cns->torch->known);
 		}
 		inven_carry(cns->p, curr, false, false);
-		calc_inventory(cns->p->upkeep, cns->p->gear, cns->p->body);
+		calc_inventory(cns->p);
 		if (! object_is_carried(cns->p, curr) ||
 				object_is_equipped(cns->p->body, curr)) {
 			return false;
@@ -191,7 +191,7 @@ static bool fill_pack_quiver(struct carry_num_state *cns, int n_pack,
 			curr->known->number = n;
 		}
 		inven_carry(cns->p, curr, false, false);
-		calc_inventory(cns->p->upkeep, cns->p->gear, cns->p->body);
+		calc_inventory(cns->p);
 		if (! object_is_carried(cns->p, curr) ||
 				object_is_equipped(cns->p->body, curr)) {
 			return false;
@@ -220,7 +220,7 @@ static bool fill_pack_quiver(struct carry_num_state *cns, int n_pack,
 			curr->known->number = n;
 		}
 		inven_carry(cns->p, curr, false, false);
-		calc_inventory(cns->p->upkeep, cns->p->gear, cns->p->body);
+		calc_inventory(cns->p);
 		if (! object_is_carried(cns->p, curr) ||
 				object_is_equipped(cns->p->body, curr)) {
 			return false;
@@ -261,7 +261,7 @@ static bool fill_pack_quiver(struct carry_num_state *cns, int n_pack,
 			curr->known->note = curr->note;
 		}
 		inven_carry(cns->p, curr, false, false);
-		calc_inventory(cns->p->upkeep, cns->p->gear, cns->p->body);
+		calc_inventory(cns->p);
 		if (! object_is_carried(cns->p, curr) ||
 				object_is_equipped(cns->p->body, curr)) {
 			return false;

--- a/src/tests/player/inven-wield.c
+++ b/src/tests/player/inven-wield.c
@@ -132,7 +132,7 @@ static bool fill_pack(void) {
 		if (!obj) return false;
 		/* Inscribe it so it doesn't stack. */
 		obj->note = quark_add(format("%d", slots_used));
-		gear_insert_end(obj);
+		gear_insert_end(player, obj);
 		if (!object_is_carried(player, obj)) return false;
 		player->upkeep->total_weight += obj->weight;
 		++slots_used;
@@ -217,7 +217,7 @@ static int test_inven_wield_pack_single_empty(void *state) {
 	require(empty_gear(player));
 	obj = setup_object(TV_CLOAK, 1, 1);
 	require(obj != NULL);
-	gear_insert_end(obj);
+	gear_insert_end(player, obj);
 	require(object_is_carried(player, obj));
 	player->upkeep->total_weight += obj->weight;
 	old_weight = player->upkeep->total_weight;
@@ -244,7 +244,7 @@ static int test_inven_wield_pack_stack_empty(void *state) {
 	require(empty_gear(player));
 	obj = setup_object(TV_LIGHT, 1, 3);
 	require(obj != NULL);
-	gear_insert_end(obj);
+	gear_insert_end(player, obj);
 	require(object_is_carried(player, obj));
 	player->upkeep->total_weight += obj->weight * obj->number;
 	old_weight = player->upkeep->total_weight;
@@ -276,14 +276,14 @@ static int test_inven_wield_pack_single_filled(void *state) {
 	require(empty_gear(player));
 	obj1 = setup_object(TV_SHIELD, 1, 1);
 	require(obj1 != NULL);
-	gear_insert_end(obj1);
+	gear_insert_end(player, obj1);
 	require(object_is_carried(player, obj1));
 	player->upkeep->total_weight += obj1->weight;
 	slot = wield_slot(obj1);
 	inven_wield(obj1, slot);
 	obj2 = setup_object(TV_SHIELD, 2, 1);
 	require(obj2 != NULL);
-	gear_insert_end(obj2);
+	gear_insert_end(player, obj2);
 	require(object_is_carried(player, obj2));
 	player->upkeep->total_weight += obj2->weight;
 	old_weight = player->upkeep->total_weight;
@@ -312,14 +312,14 @@ static int test_inven_wield_pack_stack_filled(void *state) {
 	require(empty_gear(player));
 	obj1 = setup_object(TV_GLOVES, 1, 1);
 	require(obj1 != NULL);
-	gear_insert_end(obj1);
+	gear_insert_end(player, obj1);
 	require(object_is_carried(player, obj1));
 	player->upkeep->total_weight += obj1->weight;
 	slot = wield_slot(obj1);
 	inven_wield(obj1, slot);
 	obj2 = setup_object(TV_GLOVES, 2, 2);
 	require(obj2 != NULL);
-	gear_insert_end(obj2);
+	gear_insert_end(player, obj2);
 	require(object_is_carried(player, obj2));
 	player->upkeep->total_weight += obj2->weight * obj2->number;
 	old_weight = player->upkeep->total_weight;
@@ -413,7 +413,7 @@ static int test_inven_wield_floor_single_filled(void *state) {
 	require(empty_floor(cave, player->grid));
 	obj1 = setup_object(TV_AMULET, 1, 1);
 	require(obj1 != NULL);
-	gear_insert_end(obj1);
+	gear_insert_end(player, obj1);
 	require(object_is_carried(player, obj1));
 	player->upkeep->total_weight += obj1->weight;
 	slot = wield_slot(obj1);
@@ -451,7 +451,7 @@ static int test_inven_wield_floor_stack_filled(void *state) {
 	require(empty_floor(cave, player->grid));
 	obj1 = setup_object(TV_DIGGING, 1, 1);
 	require(obj1 != NULL);
-	gear_insert_end(obj1);
+	gear_insert_end(player, obj1);
 	require(object_is_carried(player, obj1));
 	player->upkeep->total_weight += obj1->weight;
 	slot = wield_slot(obj1);
@@ -493,14 +493,14 @@ static int test_inven_wield_pack_full_no_overflow(void *state) {
 	require(empty_floor(cave, player->grid));
 	obj1 = setup_object(TV_SOFT_ARMOR, 1, 1);
 	require(obj1 != NULL);
-	gear_insert_end(obj1);
+	gear_insert_end(player, obj1);
 	require(object_is_carried(player, obj1));
 	player->upkeep->total_weight += obj1->weight;
 	slot = wield_slot(obj1);
 	inven_wield(obj1, slot);
 	obj2 = setup_object(TV_HARD_ARMOR, 1, 1);
 	require(obj2 != NULL);
-	gear_insert_end(obj2);
+	gear_insert_end(player, obj2);
 	require(object_is_carried(player, obj2));
 	player->upkeep->total_weight += obj2->weight;
 	require(fill_pack());
@@ -533,14 +533,14 @@ static int test_inven_wield_pack_full_overflow(void *state) {
 	require(empty_floor(cave, player->grid));
 	obj1 = setup_object(TV_HELM, 1, 1);
 	require(obj1 != NULL);
-	gear_insert_end(obj1);
+	gear_insert_end(player, obj1);
 	require(object_is_carried(player, obj1));
 	player->upkeep->total_weight += obj1->weight;
 	slot = wield_slot(obj1);
 	inven_wield(obj1, slot);
 	obj2 = setup_object(TV_HELM, 2, 3);
 	require(obj2 != NULL);
-	gear_insert_end(obj2);
+	gear_insert_end(player, obj2);
 	require(object_is_carried(player, obj2));
 	player->upkeep->total_weight += obj2->weight * obj2->number;
 	require(fill_pack());
@@ -578,7 +578,7 @@ static int test_inven_wield_floor_full_overflow(void *state) {
 	require(empty_floor(cave, player->grid));
 	obj1 = setup_object(TV_BOW, 1, 1);
 	require(obj1 != NULL);
-	gear_insert_end(obj1);
+	gear_insert_end(player, obj1);
 	require(object_is_carried(player, obj1));
 	player->upkeep->total_weight += obj1->weight;
 	slot = wield_slot(obj1);
@@ -615,7 +615,7 @@ static int test_inven_wield_ring_none(void *state) {
 	require(empty_gear(player));
 	obj = setup_object(TV_RING, 1, 1);
 	require(obj != NULL);
-	gear_insert_end(obj);
+	gear_insert_end(player, obj);
 	require(object_is_carried(player, obj));
 	player->upkeep->total_weight += obj->weight;
 	old_weight = player->upkeep->total_weight;
@@ -642,7 +642,7 @@ static int test_inven_wield_ring_one(void *state) {
 	require(empty_gear(player));
 	obj1 = setup_object(TV_RING, 1, 1);
 	require(obj1 != NULL);
-	gear_insert_end(obj1);
+	gear_insert_end(player, obj1);
 	require(object_is_carried(player, obj1));
 	player->upkeep->total_weight += obj1->weight;
 	slot1 = wield_slot(obj1);
@@ -650,7 +650,7 @@ static int test_inven_wield_ring_one(void *state) {
 	inven_wield(obj1, slot1);
 	obj2 = setup_object(TV_RING, 2, 1);
 	require(obj2 != NULL);
-	gear_insert_end(obj2);
+	gear_insert_end(player, obj2);
 	require(object_is_carried(player, obj2));
 	player->upkeep->total_weight += obj2->weight;
 	old_weight = player->upkeep->total_weight;
@@ -684,7 +684,7 @@ static int test_inven_wield_ring_two(void *state) {
 	require(empty_gear(player));
 	obj1 = setup_object(TV_RING, 1, 1);
 	require(obj1 != NULL);
-	gear_insert_end(obj1);
+	gear_insert_end(player, obj1);
 	require(object_is_carried(player, obj1));
 	player->upkeep->total_weight += obj1->weight;
 	slot1 = wield_slot(obj1);
@@ -692,7 +692,7 @@ static int test_inven_wield_ring_two(void *state) {
 	inven_wield(obj1, slot1);
 	obj2 = setup_object(TV_RING, 2, 1);
 	require(obj2 != NULL);
-	gear_insert_end(obj2);
+	gear_insert_end(player, obj2);
 	require(object_is_carried(player, obj2));
 	player->upkeep->total_weight += obj2->weight;
 	slot2 = wield_slot(obj2);
@@ -701,7 +701,7 @@ static int test_inven_wield_ring_two(void *state) {
 	inven_wield(obj2, slot2);
 	obj3 = setup_object(TV_RING, 3, 1);
 	require(obj3 != NULL);
-	gear_insert_end(obj3);
+	gear_insert_end(player, obj3);
 	require(object_is_carried(player, obj3));
 	player->upkeep->total_weight += obj3->weight;
 	old_weight = player->upkeep->total_weight;


### PR DESCRIPTION
The change to gear_insert_end() resolves https://github.com/angband/angband/issues/4982 (part of https://github.com/angband/angband/issues/4934 ).  The change to gear_last_item() is so its prototype is analogous to gear_insert_end()'s.

Since calc_inventory() takes pieces of the player structure as arguments while still accessing the player global (including for what it would have to do to accommodate the change to gear_insert_end()'s prototype), have it take the entire player structure instead.  That makes the update_inventory() helper for update_stuff() superfluous so remove it, resolving https://github.com/angband/angband/issues/4981 (also part of #4934 ).  There was a comment in load.c about the possibility of working with copies of the upkeep and body; that would be harder with the revised calc_inventory():  load.c would need to swap out the parts of the player structure.  That said, nothing was using calc_inventory()'s three separate arguments to work with a copy of a portion of the player structure.