### PR TITLE
configure:  with --enable-release also define a preprocessor directive in autoconf.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -104,8 +104,11 @@ AC_ARG_ENABLE(release,
 	[release=no])
 
 if test x"$release" = xyes ; then
-	dnl Currently only adding -DNDEBUG to CFLAGS.
+	dnl Currently only adding -DNDEBUG to CFLAGS.  Also leave something
+	dnl in autoconf.h so reconfiguring with or without release build will
+	dnl trigger rebuilds without running make clean.
 	CFLAGS="$CFLAGS -DNDEBUG"
+	AC_DEFINE(RELEASE_BUILD, 1, [Define to mark as a release build with extra optimizations.])
 fi
 
 AC_ARG_ENABLE(more-gcc-warnings,


### PR DESCRIPTION
That way, switching back and forth between release or a non-release build will trigger a full rebuild when make is run.  It also avoids the potential for missing flag_has_dbg or flag_on_dbg symbols:  configure with --enable-release, make, configure without --enable-release, change a source file that includes z-bitflag.h but not something that would otherwise trigger rebuilding z-bitflag.c, then run make and get linker errors.