### PR TITLE
Make textui_get_check() safer to use with a prompt constructed by format()

### DIFF
--- a/src/ui-input.c
+++ b/src/ui-input.c
@@ -939,11 +939,14 @@ static bool textui_get_check(const char *prompt)
 
 	char buf[80];
 
+	/*
+	 * Hack -- Build a "useful" prompt; do this first so prompts built by
+	 * format() won't run afoul of event_signal()'s side effects.
+	 */
+	strnfmt(buf, 78, "%.70s[y/n] ", prompt);
+
 	/* Paranoia */
 	event_signal(EVENT_MESSAGE_FLUSH);
-
-	/* Hack -- Build a "useful" prompt */
-	strnfmt(buf, 78, "%.70s[y/n] ", prompt);
 
 	/* Prompt for it */
 	prt(buf, 0, 0);


### PR DESCRIPTION
Use the prompt early in case future changes to how EVENT_MESSAGE_FLUSH is handled invoke format() as a side effect.