### PR TITLE
Rewrite scatter() so it will always find a location if there is one …

### DIFF
--- a/src/cave-square.c
+++ b/src/cave-square.c
@@ -912,6 +912,15 @@ bool square_suits_stairs_ok(struct chunk *c, struct loc grid)
 		(square_num_walls_diagonal(c, grid) == 4) && square_isempty(c, grid);
 }
 
+/**
+ * Checks if a square is appropriate for placing a summoned creature.
+ */
+bool square_allows_summon(struct chunk *c, struct loc grid)
+{
+	return square_isempty(c, grid) && !square_iswarded(c, grid)
+		&& !square_isdecoyed(c, grid);
+}
+
 
 
 /**

--- a/src/cave.h
+++ b/src/cave.h
@@ -382,6 +382,7 @@ bool square_in_bounds_fully(struct chunk *c, struct loc grid);
 bool square_isbelievedwall(struct chunk *c, struct loc grid);
 bool square_suits_stairs_well(struct chunk *c, struct loc grid);
 bool square_suits_stairs_ok(struct chunk *c, struct loc grid);
+bool square_allows_summon(struct chunk *c, struct loc grid);
 
 
 const struct square *square(struct chunk *c, struct loc grid);
@@ -454,6 +455,8 @@ void delist_object(struct chunk *c, struct object *obj);
 void object_lists_check_integrity(struct chunk *c, struct chunk *c_k);
 void scatter(struct chunk *c, struct loc *place, struct loc grid, int d,
 			 bool need_los);
+int scatter_ext(struct chunk *c, struct loc *places, int n, struct loc grid,
+		int d, bool need_los, bool (*pred)(struct chunk *, struct loc));
 
 struct monster *cave_monster(struct chunk *c, int idx);
 int cave_monster_max(struct chunk *c);

--- a/src/cmd-wizard.c
+++ b/src/cmd-wizard.c
@@ -2649,19 +2649,17 @@ void do_cmd_wiz_summon_named(struct command *cmd)
 
 	/* Try 10 times */
 	while (1) {
-		struct loc grid = player->grid;
+		struct loc grid;
 
-		if (i >= 10) {
+		/* Pick an empty location. */
+		if (i >= 10 || scatter_ext(cave, &grid, 1, player->grid, 1,
+				true, square_isempty) == 0) {
 			msg("Could not place monster.");
 			break;
 		}
 
-		/* Pick a location */
-		scatter(cave, &grid, player->grid, 1, true);
-
-		/* Try to place (allowing groups) if empty */
-		if (square_isempty(cave, grid) &&
-				place_new_monster(cave, grid, r, true, true,
+		/* Try to place. */
+		if (place_new_monster(cave, grid, r, true, true,
 				info, ORIGIN_DROP_WIZARD)) {
 			player->upkeep->redraw |= PR_MAP | PR_MONLIST;
 			break;

--- a/src/gen-util.c
+++ b/src/gen-util.c
@@ -810,13 +810,11 @@ void vault_monsters(struct chunk *c, struct loc grid, int depth, int num)
 	for (k = 0; k < num; k++) {
 		/* Try nine locations */
 		for (i = 0; i < 9; i++) {
-			struct loc near = grid;
+			struct loc near;
 
-			/* Pick a nearby location */
-			scatter(c, &near, grid, 1, true);
-
-			/* Require "empty" floor grids */
-			if (!square_isempty(c, near)) continue;
+			/* Pick a nearby empty location. */
+			if (scatter_ext(c, &near, 1, grid, 1, true,
+					square_isempty) == 0) continue;
 
 			/* Place the monster (allow groups) */
 			pick_and_place_monster(c, near, depth, true, true,

--- a/src/mon-make.c
+++ b/src/mon-make.c
@@ -1311,25 +1311,23 @@ static bool place_friends(struct chunk *c, struct loc grid, struct monster_race 
 			return place_new_monster_group(c, grid, race, sleep, group_info,
 										   total, origin);
 		} else {
-			int j;
-			struct loc new = grid;
+			struct loc new;
 
-			/* Find a nearby place to put the other groups */
-			for (j = 0; j < 50; j++) {
-				scatter(c, &new, grid, z_info->monster_group_dist, false);
-				if (square_isopen(c, new)) {
-					break;
+			/* Find a nearby place to put the other groups. */
+			if (scatter_ext(c, &new, 1, grid,
+					z_info->monster_group_dist, false,
+					square_isopen) > 0) {
+				/* Place the monsters */
+				bool success = place_new_monster_one(c, new,
+					friends_race, sleep, group_info, origin);
+
+				if (total > 1) {
+					success = place_new_monster_group(c,
+						new, friends_race, sleep,
+						group_info, total, origin);
 				}
+				return success;
 			}
-
-			/* Place the monsters */
-			bool success = place_new_monster_one(c, new, friends_race, sleep,
-												 group_info, origin);
-			if (total > 1)
-				success = place_new_monster_group(c, new, friends_race, sleep,
-												  group_info, total, origin);
-
-			return success;
 		}
 	}
 

--- a/src/mon-move.c
+++ b/src/mon-move.c
@@ -981,24 +981,16 @@ static bool get_move(struct monster *mon, int *dir, bool *good)
  */
 bool multiply_monster(const struct monster *mon)
 {
-	struct loc grid = mon->grid;
-	int i;
-	bool result = false;
+	struct loc grid;
+	bool result;
 	struct monster_group_info info = { 0, 0 };
 
-	/* Try up to 18 times */
-	for (i = 0; i < 18; i++) {
-		int d = 1;
-
-		/* Pick a location */
-		scatter(cave, &grid, mon->grid, d, true);
-
-		/* Require an "empty" floor grid */
-		if (!square_isempty(cave, grid)) continue;
-
+	/* Pick an empty location. */
+	if (scatter_ext(cave, &grid, 1, mon->grid, 1, true,
+			square_isempty) > 0) {
 		/* Create a new monster (awake, no groups) */
-		result = place_new_monster(cave, grid, mon->race, false, false, info,
-								   ORIGIN_DROP_BREED);
+		result = place_new_monster(cave, grid, mon->race, false, false,
+			info, ORIGIN_DROP_BREED);
 		/*
 		 * Fix so multiplying a revealed mimic creates another
 		 * revealed mimic.
@@ -1011,9 +1003,8 @@ bool multiply_monster(const struct monster *mon)
 				become_aware(cave, child, player);
 			}
 		}
-
-		/* Done */
-		break;
+	} else {
+		result = false;
 	}
 
 	/* Result */

--- a/src/mon-summon.c
+++ b/src/mon-summon.c
@@ -399,34 +399,21 @@ static int call_monster(struct loc grid)
  */
 int summon_specific(struct loc grid, int lev, int type, bool delay, bool call)
 {
-	int i;
+	int d;
 	struct loc near = grid;
 	struct monster *mon;
 	struct monster_race *race;
 	struct monster_group_info info = { 0, 0 };
 
 	/* Look for a location, allow up to 4 squares away */
-	for (i = 0; i < 60; ++i) {
-		/* Pick a distance */
-		int d = (i / 15) + 1;
-
-		/* Pick a location */
-		scatter(cave, &near, grid, d, true);
-
-		/* Require "empty" floor grid */
-		if (!square_isempty(cave, near)) continue;
-
-		/* No summon on glyphs */
-		if (square_iswarded(cave, near) || square_isdecoyed(cave, near)) {
-			continue;
-		}
-
-		/* Okay */
-		break;
+	for (d = 1; d < 5; ++d) {
+		/* Pick a location. */
+		if (scatter_ext(cave, &near, 1, grid, d, true,
+				square_allows_summon) > 0) break;
 	}
 
 	/* Failure */
-	if (i == 60) return (0);
+	if (d == 5) return 0;
 
 	/* Save the "summon" type */
 	summon_specific_type = type;

--- a/src/tests/cave/scatter.c
+++ b/src/tests/cave/scatter.c
@@ -1,0 +1,752 @@
+/* cave/scatter */
+
+#include "unit-test.h"
+#include "test-utils.h"
+#include "cave.h"
+#include "init.h"
+
+static struct chunk *create_empty_cave(int height, int width) {
+	struct chunk *c = cave_new(height, width);
+	struct loc grid;
+
+	grid.y = 0;
+	for (grid.x = 0; grid.x < width; ++grid.x) {
+		square_set_feat(c, grid, FEAT_PERM);
+	}
+	for (grid.y = 1; grid.y < height - 1; ++grid.y) {
+		grid.x = 0;
+		square_set_feat(c, grid, FEAT_PERM);
+		for (grid.x = 1; grid.x < width - 1; ++grid.x) {
+			square_set_feat(c, grid, FEAT_FLOOR);
+		}
+		grid.x = width - 1;
+		square_set_feat(c, grid, FEAT_PERM);
+	}
+	grid.y = height - 1;
+	for (grid.x = 0; grid.x < width; ++grid.x) {
+		square_set_feat(c, grid, FEAT_PERM);
+	}
+	return c;
+}
+
+int setup_tests(void **state) {
+	struct chunk *c;
+
+	/* Need to initialize the terrain information. */
+	set_file_paths();
+	if (!init_angband()) {
+		*state = NULL;
+		return 1;
+	}
+
+	c  = create_empty_cave(7, 9);
+	*state = c;
+
+	return 0;
+}
+
+int teardown_tests(void *state) {
+	cave_free(state);
+	cleanup_angband();
+	return 0;
+}
+
+static int test_scatter_0(void *state) {
+	struct chunk *c = state;
+	struct loc ctr = loc(c->width / 2, c->height / 2);
+	struct loc grids[3] = { loc(-1, -1), loc(-1, -1), loc(-1, -1) };
+	int n;
+
+	/* For a point fully in bounds, should get the search origin back. */
+	n = scatter_ext(c, grids + 1, 9, ctr, 0, false, NULL);
+	eq(n, 1);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x == ctr.x && grids[1].y == ctr.y);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	n = scatter_ext(c, grids + 1, 9, ctr, 0, true, NULL);
+	eq(n, 1);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x == ctr.x && grids[1].y == ctr.y);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	grids[1] = loc(-1, -1);
+	scatter(c, grids + 1, ctr, 0, false);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x == ctr.x && grids[1].y == ctr.y);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	grids[1] = loc(-1, -1);
+	scatter(c, grids + 1, ctr, 0, true);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x == ctr.x && grids[1].y == ctr.y);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	/* For a point not fully in bounds, should get nothing. */
+	ctr = loc(c->width - 1, -1);
+	grids[1] = loc(-1, -1);
+	n = scatter_ext(c, grids + 1, 9, ctr, 0, false, NULL);
+	eq(n, 0);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x == -1 && grids[1].y == -1);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	ctr = loc(c->width - 1, -1);
+	grids[1] = loc(-1, -1);
+	n = scatter_ext(c, grids + 1, 9, ctr, 0, true, NULL);
+	eq(n, 0);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x == -1 && grids[1].y == -1);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	scatter(c, grids + 1, ctr, 0, false);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x == -1 && grids[1].y == -1);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	scatter(c, grids + 1, ctr, 0, true);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x == -1 && grids[1].y == -1);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	ok;
+}
+
+static int test_scatter_1(void *state) {
+	struct chunk *c = state;
+	struct loc ctr = loc(c->width / 2, c->height / 2);
+	struct loc grids[11];
+	int n, i, j;
+
+	/* Asking for 9 locations should give nine distinct locations. */
+	for (i = 0; i < (int) N_ELEMENTS(grids); ++i) {
+		grids[i] = loc(-1, -1);
+	}
+	n = scatter_ext(c, grids + 1, (int) N_ELEMENTS(grids) - 1, ctr, 1,
+		false, NULL);
+	eq(n, 9);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	for (i = 1; i < n + 1; ++i) {
+		require(grids[i].x >= ctr.x - 1 && grids[i].x <= ctr.x + 1);
+		require(grids[i].y >= ctr.y - 1 && grids[i].y <= ctr.y + 1);
+		for (j = 1; j < i; ++j) {
+			require(grids[i].x != grids[j].x
+				|| grids[i].y != grids[j].y);
+		}
+	}
+	require(grids[n + 1].x == -1 && grids[n + 1].y == -1);
+
+	for (i = 0; i < (int) N_ELEMENTS(grids); ++i) {
+		grids[i] = loc(-1, -1);
+	}
+	n = scatter_ext(c, grids + 1, (int) N_ELEMENTS(grids) - 1, ctr, 1,
+		true, NULL);
+	eq(n, 9);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	for (i = 1; i < n + 1; ++i) {
+		require(grids[i].x >= ctr.x - 1 && grids[i].x <= ctr.x + 1);
+		require(grids[i].y >= ctr.y - 1 && grids[i].y <= ctr.y + 1);
+		for (j = 1; j < i; ++j) {
+			require(grids[i].x != grids[j].x
+				|| grids[i].y != grids[j].y);
+		}
+	}
+	require(grids[n + 1].x == -1 && grids[n + 1].y == -1);
+
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	scatter(c, grids + 1, ctr, 1, false);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x >= ctr.x - 1 && grids[1].x <= ctr.x + 1);
+	require(grids[1].y >= ctr.y - 1 && grids[1].y <= ctr.y + 1);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	scatter(c, grids + 1, ctr, 1, true);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x >= ctr.x - 1 && grids[1].x <= ctr.x + 1);
+	require(grids[1].y >= ctr.y - 1 && grids[1].y <= ctr.y + 1);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	/*
+	 * Put the search origin diagonally in from the corners to test for
+	 * fully in bounds.
+	 */
+	ctr = loc(1, 1);
+	for (i = 0; i < (int) N_ELEMENTS(grids); ++i) {
+		grids[i] = loc(-1, -1);
+	}
+	n = scatter_ext(c, grids + 1, (int) N_ELEMENTS(grids) - 1, ctr, 1,
+		false, NULL);
+	eq(n, 4);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	for (i = 1; i < n + 1; ++i) {
+		require(grids[i].x >= ctr.x && grids[i].x <= ctr.x + 1);
+		require(grids[i].y >= ctr.y && grids[i].y <= ctr.y + 1);
+		for (j = 0; j < i; ++j) {
+			require(grids[i].x != grids[j].x
+				|| grids[i].y != grids[j].y);
+		}
+	}
+	require(grids[n + 1].x == -1 && grids[n + 1].y == -1);
+
+	for (i = 0; i < (int) N_ELEMENTS(grids); ++i) {
+		grids[i] = loc(-1, -1);
+	}
+	n = scatter_ext(c, grids + 1, (int) N_ELEMENTS(grids) - 1, ctr, 1,
+		true, NULL);
+	eq(n, 4);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	for (i = 1; i < n + 1; ++i) {
+		require(grids[i].x >= ctr.x && grids[i].x <= ctr.x + 1);
+		require(grids[i].y >= ctr.y && grids[i].y <= ctr.y + 1);
+		for (j = 0; j < i; ++j) {
+			require(grids[i].x != grids[j].x
+				|| grids[i].y != grids[j].y);
+		}
+	}
+	require(grids[n + 1].x == -1 && grids[n + 1].y == -1);
+
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	scatter(c, grids + 1, ctr, 1, false);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x >= ctr.x && grids[1].x <= ctr.x + 1);
+	require(grids[1].y >= ctr.y && grids[1].y <= ctr.y + 1);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	scatter(c, grids + 1, ctr, 1, true);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x >= ctr.x && grids[1].x <= ctr.x + 1);
+	require(grids[1].y >= ctr.y && grids[1].y <= ctr.y + 1);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	ctr = loc(c->width - 2, 1);
+	for (i = 0; i < (int) N_ELEMENTS(grids); ++i) {
+		grids[i] = loc(-1, -1);
+	}
+	n = scatter_ext(c, grids + 1, (int) N_ELEMENTS(grids) - 1, ctr, 1,
+		false, NULL);
+	eq(n, 4);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	for (i = 1; i < n + 1; ++i) {
+		require(grids[i].x >= ctr.x - 1 && grids[i].x <= ctr.x);
+		require(grids[i].y >= ctr.y && grids[i].y <= ctr.y + 1);
+		for (j = 0; j < i; ++j) {
+			require(grids[i].x != grids[j].x
+				|| grids[i].y != grids[j].y);
+		}
+	}
+	require(grids[n + 1].x == -1 && grids[n + 1].y == -1);
+
+	for (i = 0; i < (int) N_ELEMENTS(grids); ++i) {
+		grids[i] = loc(-1, -1);
+	}
+	n = scatter_ext(c, grids + 1, (int) N_ELEMENTS(grids) - 1, ctr, 1,
+		true, NULL);
+	eq(n, 4);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	for (i = 1; i < n + 1; ++i) {
+		require(grids[i].x >= ctr.x - 1 && grids[i].x <= ctr.x);
+		require(grids[i].y >= ctr.y && grids[i].y <= ctr.y + 1);
+		for (j = 0; j < i; ++j) {
+			require(grids[i].x != grids[j].x
+				|| grids[i].y != grids[j].y);
+		}
+	}
+	require(grids[n + 1].x == -1 && grids[n + 1].y == -1);
+
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	scatter(c, grids + 1, ctr, 1, false);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x >= ctr.x - 1 && grids[1].x <= ctr.x);
+	require(grids[1].y >= ctr.y && grids[1].y <= ctr.y + 1);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	scatter(c, grids + 1, ctr, 1, true);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x >= ctr.x - 1 && grids[1].x <= ctr.x);
+	require(grids[1].y >= ctr.y && grids[1].y <= ctr.y + 1);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	ctr = loc(1, c->height - 2);
+	for (i = 0; i < (int) N_ELEMENTS(grids); ++i) {
+		grids[i] = loc(-1, -1);
+	}
+	n = scatter_ext(c, grids + 1, (int) N_ELEMENTS(grids) - 1, ctr, 1,
+		false, NULL);
+	eq(n, 4);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	for (i = 1; i < n + 1; ++i) {
+		require(grids[i].x >= ctr.x && grids[i].x <= ctr.x + 1);
+		require(grids[i].y >= ctr.y - 1 && grids[i].y <= ctr.y);
+		for (j = 0; j < i; ++j) {
+			require(grids[i].x != grids[j].x
+				|| grids[i].y != grids[j].y);
+		}
+	}
+	require(grids[n + 1].x == -1 && grids[n + 1].y == -1);
+
+	for (i = 0; i < (int) N_ELEMENTS(grids); ++i) {
+		grids[i] = loc(-1, -1);
+	}
+	n = scatter_ext(c, grids + 1, (int) N_ELEMENTS(grids) - 1, ctr, 1,
+		true, NULL);
+	eq(n, 4);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	for (i = 1; i < n + 1; ++i) {
+		require(grids[i].x >= ctr.x && grids[i].x <= ctr.x + 1);
+		require(grids[i].y >= ctr.y - 1 && grids[i].y <= ctr.y);
+		for (j = 0; j < i; ++j) {
+			require(grids[i].x != grids[j].x
+				|| grids[i].y != grids[j].y);
+		}
+	}
+	require(grids[n + 1].x == -1 && grids[n + 1].y == -1);
+
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	scatter(c, grids + 1, ctr, 1, false);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x >= ctr.x && grids[1].x <= ctr.x + 1);
+	require(grids[1].y >= ctr.y - 1 && grids[1].y <= ctr.y);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	scatter(c, grids + 1, ctr, 1, true);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x >= ctr.x && grids[1].x <= ctr.x + 1);
+	require(grids[1].y >= ctr.y - 1 && grids[1].y <= ctr.y);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	ctr = loc(c->width - 2, c->height - 2);
+	for (i = 0; i < (int) N_ELEMENTS(grids); ++i) {
+		grids[i] = loc(-1, -1);
+	}
+	n = scatter_ext(c, grids + 1, (int) N_ELEMENTS(grids) - 1, ctr, 1,
+		false, NULL);
+	eq(n, 4);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	for (i = 1; i < n + 1; ++i) {
+		require(grids[i].x >= ctr.x - 1 && grids[i].x <= ctr.x);
+		require(grids[i].y >= ctr.y - 1 && grids[i].y <= ctr.y);
+		for (j = 0; j < i; ++j) {
+			require(grids[i].x != grids[j].x
+				|| grids[i].y != grids[j].y);
+		}
+	}
+	require(grids[n + 1].x == -1 && grids[n + 1].y == -1);
+
+	for (i = 0; i < (int) N_ELEMENTS(grids); ++i) {
+		grids[i] = loc(-1, -1);
+	}
+	n = scatter_ext(c, grids + 1, (int) N_ELEMENTS(grids) - 1, ctr, 1,
+		true, NULL);
+	eq(n, 4);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	for (i = 1; i < n + 1; ++i) {
+		require(grids[i].x >= ctr.x - 1 && grids[i].x <= ctr.x);
+		require(grids[i].y >= ctr.y - 1 && grids[i].y <= ctr.y);
+		for (j = 0; j < i; ++j) {
+			require(grids[i].x != grids[j].x
+				|| grids[i].y != grids[j].y);
+		}
+	}
+	require(grids[n + 1].x == -1 && grids[n + 1].y == -1);
+
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	scatter(c, grids + 1, ctr, 1, false);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x >= ctr.x - 1 && grids[1].x <= ctr.x);
+	require(grids[1].y >= ctr.y - 1 && grids[1].y <= ctr.y);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	scatter(c, grids + 1, ctr, 1, true);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x >= ctr.x - 1 && grids[1].x <= ctr.x);
+	require(grids[1].y >= ctr.y - 1 && grids[1].y <= ctr.y);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	/* Check the four corners. */
+	ctr = loc(0, 0);
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	n = scatter_ext(c, grids + 1, 2, ctr, 1, false, NULL);
+	eq(n, 1);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x == 1 && grids[1].y == 1);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	n = scatter_ext(c, grids + 1, 2, ctr, 1, true, NULL);
+	eq(n, 1);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x == 1 && grids[1].y == 1);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	scatter(c, grids + 1, ctr, 1, false);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x == 1 && grids[1].y == 1);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	scatter(c, grids + 1, ctr, 1, true);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x == 1 && grids[1].y == 1);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	ctr = loc(c->width - 1, 0);
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	n = scatter_ext(c, grids + 1, 2, ctr, 1, false, NULL);
+	eq(n, 1);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x == c->width - 2 && grids[1].y == 1);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	n = scatter_ext(c, grids + 1, 2, ctr, 1, true, NULL);
+	eq(n, 1);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x == c->width - 2 && grids[1].y == 1);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	scatter(c, grids + 1, ctr, 1, false);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x == c->width - 2 && grids[1].y == 1);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	scatter(c, grids + 1, ctr, 1, true);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x == c->width - 2 && grids[1].y == 1);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	ctr = loc(0, c->height - 1);
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	n = scatter_ext(c, grids + 1, 2, ctr, 1, false, NULL);
+	eq(n, 1);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x == 1 && grids[1].y == c->height - 2);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	n = scatter_ext(c, grids + 1, 2, ctr, 1, true, NULL);
+	eq(n, 1);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x == 1 && grids[1].y == c->height - 2);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	scatter(c, grids + 1, ctr, 1, false);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x == 1 && grids[1].y == c->height - 2);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	scatter(c, grids + 1, ctr, 1, true);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x == 1 && grids[1].y == c->height - 2);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	ctr = loc(c->width - 1, c->height - 1);
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	n = scatter_ext(c, grids + 1, 2, ctr, 1, false, NULL);
+	eq(n, 1);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x == c->width - 2 && grids[1].y == c->height - 2);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	n = scatter_ext(c, grids + 1, 2, ctr, 1, true, NULL);
+	eq(n, 1);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x == c->width - 2 && grids[1].y == c->height - 2);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	scatter(c, grids + 1, ctr, 1, false);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x == c->width - 2 && grids[1].y == c->height - 2);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	scatter(c, grids + 1, ctr, 1, true);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x == c->width - 2 && grids[1].y == c->height - 2);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	/* If it's far enough outside, there should be no matches. */
+	ctr = loc(-1, c->height);
+	for (i = 0; i < (int) N_ELEMENTS(grids); ++i) {
+		grids[i] = loc(-1, -1);
+	}
+	n = scatter_ext(c, grids + 1, 9, ctr, 1, false, NULL);
+	eq(n, 0);
+	for (i = 0; i < (int) N_ELEMENTS(grids); ++i) {
+		require(grids[i].x == -1 && grids[i].y == -1);
+	}
+
+	n = scatter_ext(c, grids + 1, 9, ctr, 1, true, NULL);
+	eq(n, 0);
+	for (i = 0; i < (int) N_ELEMENTS(grids); ++i) {
+		require(grids[i].x == -1 && grids[i].y == -1);
+	}
+
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	scatter(c, grids + 1, ctr, 1, false);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x == -1 && grids[1].y == -1);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	scatter(c, grids + 1, ctr, 1, true);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(grids[1].x == -1 && grids[1].y == -1);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	ok;
+}
+
+static int test_scatter_2(void *state) {
+	struct chunk *c = state;
+	struct loc ctr = loc(c->width / 2, c->height / 2);
+	struct loc grids[27];
+	int n, i, j;
+
+	/*
+	 * Should get 21 locations with the way distance is currently
+	 * approximated.
+	 */
+	for (i = 0; i < (int) N_ELEMENTS(grids); ++i) {
+		grids[i] = loc(-1, -1);
+	}
+	n = scatter_ext(c, grids + 1, (int) N_ELEMENTS(grids) - 1, ctr, 2,
+		false, NULL);
+	eq(n, 21);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	for (i = 1; i < n + 1; ++i) {
+		require(distance(ctr, grids[i]) <= 2);
+		for (j = 1; j < i; ++j) {
+			require(grids[i].x != grids[j].x
+				|| grids[i].y != grids[j].y);
+		}
+	}
+	for (i = n + 1; i < (int) N_ELEMENTS(grids); ++i) {
+		require(grids[i].x == -1 && grids[i].y == -1);
+	}
+
+	for (i = 0; i < (int) N_ELEMENTS(grids); ++i) {
+		grids[i] = loc(-1, -1);
+	}
+	n = scatter_ext(c, grids + 1, (int) N_ELEMENTS(grids) - 1, ctr, 2,
+		true, NULL);
+	eq(n, 21);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	for (i = 1; i < n + 1; ++i) {
+		require(distance(ctr, grids[i]) <= 2);
+		for (j = 1; j < i; ++j) {
+			require(grids[i].x != grids[j].x
+				|| grids[i].y != grids[j].y);
+		}
+	}
+	for (i = n + 1; i < (int) N_ELEMENTS(grids); ++i) {
+		require(grids[i].x == -1 && grids[i].y == -1);
+	}
+
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	scatter(c, grids + 1, ctr, 2, false);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(distance(ctr, grids[1]) <= 2);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	scatter(c, grids + 1, ctr, 2, true);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(distance(ctr, grids[1]) <= 2);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	ok;
+}
+
+static int test_scatter_los(void *state) {
+	struct chunk *c = state;
+	struct loc ctr = loc(c->width / 2, c->height / 2);
+	struct loc grids[27];
+	int n, i, j;
+
+	for (i = 1; i < c->height - 1; ++i) {
+		square_set_feat(c, loc(ctr.x - 1, i), FEAT_GRANITE);
+	}
+
+	/*
+	 * Should get 18 locations (the wall is in the line of sight) with
+	 * the way distance is currently approximated.
+	 */
+	for (i = 0; i < (int) N_ELEMENTS(grids); ++i) {
+		grids[i] = loc(-1, -1);
+	}
+	n = scatter_ext(c, grids + 1, (int) N_ELEMENTS(grids) - 1, ctr, 2,
+		true, NULL);
+	eq(n, 18);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	for (i = 1; i < n + 1; ++i) {
+		require(distance(ctr, grids[i]) <= 2 &&
+			grids[i].x >= ctr.x - 1);
+		for (j = 1; j < i; ++j) {
+			require(grids[i].x != grids[j].x
+				|| grids[i].y != grids[j].y);
+		}
+	}
+	for (i = n + 1; i < (int) N_ELEMENTS(grids); ++i) {
+		require(grids[i].x == -1 && grids[i].y == -1);
+	}
+
+	grids[1] = loc(-1, -1);
+	grids[2] = loc(-1, -1);
+	scatter(c, grids + 1, ctr, 2, true);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(distance(ctr, grids[1]) <= 2 && grids[1].x >= ctr.x - 1);
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	ok;
+}
+
+static int test_scatter_pred(void *state) {
+	struct chunk *c = state;
+	struct loc ctr = loc(c->width / 2, c->height / 2);
+	struct loc grids[27], g;
+	int n, i, j;
+
+	for (g.y = ctr.y - 2; g.y <= ctr.y + 2; ++g.y) {
+		for (g.x = ctr.x - 2; g.x <= ctr.x + 2; ++g.x) {
+			square_set_feat(c, g, FEAT_FLOOR);
+		}
+	}
+	g.x = rand_range(ctr.x - 2, ctr.x + 2);
+	switch (ABS(g.x - ctr.x)) {
+		case 0: g.y = rand_range(ctr.y - 2, ctr.y + 2); break;
+		case 1: g.y = rand_range(ctr.y - 1, ctr.y + 1); break;
+		default: g.y = ctr.y; break;
+	}
+	square_set_feat(c, g, FEAT_LESS);
+
+	for (i = 0; i < (int) N_ELEMENTS(grids); ++i) {
+		grids[i] = loc(-1, -1);
+	}
+	n = scatter_ext(c, grids + 1, (int) N_ELEMENTS(grids) - 1, ctr, 2,
+		true, square_isstairs);
+	eq(n, 1);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	require(loc_eq(g, grids[1]));
+	require(grids[2].x == -1 && grids[2].y == -1);
+
+	/*
+	 * Should get 20 locations with the current approximation for distance.
+	 */
+	for (i = 0; i < (int) N_ELEMENTS(grids); ++i) {
+		grids[i] = loc(-1, -1);
+	}
+	n = scatter_ext(c, grids + 1, (int) N_ELEMENTS(grids) - 1, ctr, 2,
+		true, square_isfloor);
+	eq(n, 20);
+	require(grids[0].x == -1 && grids[0].y == -1);
+	for (i = 1; i < n + 1; ++i) {
+		require(distance(ctr, grids[i]) <= 2 && !loc_eq(g, grids[i]));
+		for (j = 1; j < i; ++j) {
+			require(grids[i].x != grids[j].x
+				|| grids[i].y != grids[j].y);
+		}
+	}
+	for (i = n + 1; i < (int) N_ELEMENTS(grids); ++i) {
+		require(grids[i].x == -1 && grids[i].y == -1);
+	}
+
+	ok;
+}
+
+/*
+ * There's a non-deterministic aspect to this test.  It could fail (about .01%
+ * of the time) even if random selection is working correctly).
+ */
+static int test_scatter_distribution(void *state) {
+	struct chunk *c = state;
+	struct loc ctr = loc(c->width / 2, c->height / 2);
+	int counts[9] = { 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+	int n = 9000, i;
+	int nexp, dmax;
+
+	for (i = 0; i < n; ++i) {
+		struct loc grid = loc(-1, -1);
+		int dx, dy;
+
+		scatter(c, &grid, ctr, 1, false);
+		dx = grid.x - ctr.x;
+		dy = grid.y - ctr.y;
+		require(ABS(dx) <= 1 && ABS(dy) <= 1);
+		++counts[dx + 1 + 3 * (dy + 1)];
+	}
+
+	/* Locate the one that's furthest from the expected value. */
+	nexp = n / 9;
+	dmax = ABS(counts[0] - nexp);
+	for (i = 1; i < 9; ++i) {
+		int d = ABS(counts[i] - nexp);
+
+		if (dmax < d) {
+			dmax = d;
+		}
+	}
+
+	/*
+	 * By my calculation of the Chernoff upper bound for the cumulative
+	 * distribution function of the binomial distribution,
+	 * https://en.wikipedia.org/wiki/Binomial_distribution#Tail_bounds
+	 * , with n = 9000 and p = 1/9, 874 is the closest point to where the
+	 * upper bound crosses a probability of .0001.
+	 */
+	require(nexp - dmax >= 874);
+
+	ok;
+}
+
+const char *suite_name = "cave/scatter";
+struct test tests[] = {
+	{ "scatter dist=0", test_scatter_0 },
+	{ "scatter dist=1", test_scatter_1 },
+	{ "scatter dist=2", test_scatter_2 },
+	{ "scatter los", test_scatter_los },
+	{ "scatter pred", test_scatter_pred },
+	{ "scatter distribution", test_scatter_distribution },
+	{ NULL, NULL }
+};

--- a/src/tests/cave/suite.mk
+++ b/src/tests/cave/suite.mk
@@ -1,0 +1,1 @@
+TESTPROGS += cave/scatter


### PR DESCRIPTION
…that meets the criteria: previous versions had a stochastic element.  Add an extended version of scatter than can return more than one (all distinct) locations satisfying the criteria and allow for the criteria to include an arbitrary square predicate test on each grid in addition to the existing criteria (fully in bounds, distance, and, optionally, line of sight from the source).  Change some of the existing scatter() calls to use the extended version.  Add unit test cases for scatter().

This boosts multiply_monster() somewhat:  if only one in 9 squares was available the previous version would have a (8/9)^18 = 12% chance of not placing a monster; with this change it would always place a monster in that situation.  There'll also be boosts to the chances to place monsters in place_friends(), vault_monsters(), and summon_specific().