### PR TITLE
Make calc_inventory() more efficient

### DIFF
--- a/src/player-calcs.c
+++ b/src/player-calcs.c
@@ -1022,211 +1022,223 @@ int equipped_item_slot(struct player_body body, struct object *item)
  */
 void calc_inventory(struct player *p)
 {
-	int i;
 	int old_inven_cnt = p->upkeep->inven_cnt;
 	int n_stack_split = 0;
 	int n_pack_remaining = z_info->pack_size - pack_slots_used(p);
-	struct object **old_quiver = mem_zalloc(z_info->quiver_size *
-												sizeof(struct object *));
-	struct object **old_pack = mem_zalloc(z_info->pack_size *
-											  sizeof(struct object *));
+	int n_max = 1 + z_info->pack_size + z_info->quiver_size
+		+ p->body.count;
+	struct object **old_quiver = mem_zalloc(z_info->quiver_size
+		* sizeof(*old_quiver));
+	struct object **old_pack = mem_zalloc(z_info->pack_size
+		* sizeof(*old_pack));
+	bool *assigned = mem_alloc(n_max * sizeof(*assigned));
+	struct object *current;
+	int i, j;
+
+	/*
+	 * Equipped items are already taken care of.  Only the others need
+	 * to be tested for assignment to the quiver or pack.
+	 */
+	for (current = p->gear, j = 0; current; current = current->next, ++j) {
+		assert(j < n_max);
+		assigned[j] = object_is_equipped(p->body, current);
+	}
 
 	/* Prepare to fill the quiver */
 	p->upkeep->quiver_cnt = 0;
 
-	/* Copy the current quiver */
-	for (i = 0; i < z_info->quiver_size; i++)
-		if (p->upkeep->quiver[i])
-			old_quiver[i] = p->upkeep->quiver[i];
-		else
-			old_quiver[i] = NULL;
-
-	/* First, allocate inscribed items */
+	/* Copy the current quiver and then leave it empty. */
 	for (i = 0; i < z_info->quiver_size; i++) {
-		struct object *current;
+		if (p->upkeep->quiver[i]) {
+			old_quiver[i] = p->upkeep->quiver[i];
+			p->upkeep->quiver[i] = NULL;
+		} else {
+			old_quiver[i] = NULL;
+		}
+	}
 
-		/* Start with an empty slot */
-		p->upkeep->quiver[i] = NULL;
+	/* Fill quiver.  First, allocate inscribed items. */
+	for (current = p->gear, j = 0; current; current = current->next, ++j) {
+		int prefslot;
 
-		/* Find the first quiver object with the correct label */
-		for (current = p->gear; current; current = current->next) {
-			/* Skip equipped items. */
-			if (object_is_equipped(p->body, current)) continue;
+		/* Skip already assigned (i.e. equipped) items. */
+		if (assigned[j]) continue;
 
-			/* Allocate inscribed objects if it's the right slot */
-			if (preferred_quiver_slot(current) == i) {
-				int mult = tval_is_ammo(current) ?
-					1 : z_info->thrown_quiver_mult;
-				struct object *to_quiver;
+		prefslot  = preferred_quiver_slot(current);
+		if (prefslot >= 0 && prefslot < z_info->quiver_size
+				&& !p->upkeep->quiver[prefslot]) {
+			/*
+			 * The preferred slot is empty.  Split the stack if
+			 * necessary.  Don't allow splitting if it could
+			 * result in overfilling the pack by more than one slot.
+			 */
+			int mult = tval_is_ammo(current) ?
+				1 : z_info->thrown_quiver_mult;
+			struct object *to_quiver;
 
-				/*
-				 * Split the stack if necessary.  Don't allow
-				 * splitting if it could result in overfilling
-				 * the pack by more than one slot.
-				 */
-				if (current->number * mult <=
-						z_info->quiver_slot_size) {
+			if (current->number * mult
+					<= z_info->quiver_slot_size) {
+				to_quiver = current;
+			} else {
+				int nsplit = z_info->quiver_slot_size / mult;
+
+				assert(nsplit < current->number);
+				if (nsplit > 0 && n_stack_split
+						<= n_pack_remaining) {
+					/*
+					 * Split off the portion that goes to
+					 * the pack.  Since the stack in the
+					 * quiver is earlier in the gear list it
+					 * will prefer to remain in the quiver
+					 * in future calls to calc_inventory()
+					 * and will be the preferred target for
+					 * in combine_pack().
+					 */
 					to_quiver = current;
+					gear_insert_end(p, object_split(current,
+						current->number - nsplit));
+					++n_stack_split;
 				} else {
-					int nsplit = z_info->quiver_slot_size /
-						mult;
-
-					assert(nsplit < current->number);
-					if (nsplit > 0 && n_stack_split <=
-							n_pack_remaining) {
-						/*
-						 * Split off the portion that
-						 * go to the pack.  Since the
-						 * stack in the quiver is
-						 * earlier in the gear list
-						 * it will prefer to remain
-						 * in the quiver in future
-						 * calls to calc_inventory()
-						 * and will be the preferential
-						 * destination for merges in
-						 * combine_pack().
-						 */
-						to_quiver = current;
-						gear_insert_end(p, object_split(
-							current, current->number
-							- nsplit));
-						++n_stack_split;
-					} else {
-						to_quiver = NULL;
-					}
+					to_quiver = NULL;
 				}
+			}
 
-				if (to_quiver) {
-					p->upkeep->quiver[i] = to_quiver;
-					p->upkeep->quiver_cnt +=
-						to_quiver->number * mult;
+			if (to_quiver) {
+				p->upkeep->quiver[prefslot] = to_quiver;
+				p->upkeep->quiver_cnt +=
+					to_quiver->number * mult;
 
-					/* In the quiver counts as worn */
-					object_learn_on_wield(p, to_quiver);
+				/* In the quiver counts as worn. */
+				object_learn_on_wield(p, to_quiver);
 
-					/* Done with this slot */
-					break;
-				}
+				/* That part of the gear has been dealt with. */
+				assigned[j] = true;
 			}
 		}
 	}
 
-	/* Now fill the rest of the slots in order */
-	for (i = 0; i < z_info->quiver_size; i++) {
-		struct object *current, *to_quiver, *first = NULL;
-		int j;
+	/* Now fill the rest of the slots in order. */
+	for (i = 0; i < z_info->quiver_size; ++i) {
+		struct object *first = NULL;
+		int jfirst = -1;
 
-		/* If the slot is full, move on */
+		/* If the slot is full, move on. */
 		if (p->upkeep->quiver[i]) continue;
 
-		/* Find the first quiver object not yet allocated */
-		for (current = p->gear; current; current = current->next) {
-			bool already = false;
+		/* Find the quiver object that should go there. */
+		j = 0;
+		current = p->gear;
+		while (1) {
+			if (!current) break;
+			assert(j < n_max);
 
-			/* Ignore non-ammo */
-			if (!tval_is_ammo(current)) continue;
-
-			/* Ignore stuff already quivered */
-			for (j = 0; j < z_info->quiver_size; j++)
-				if (p->upkeep->quiver[j] == current)
-					already = true;
-			if (already) continue;
-
-			/* Choose the first in order */
-			if (earlier_object(first, current, false)) {
-				first = current;
+			/*
+			 * Only try to assign if not assigned, ammo, and,
+			 * if necessary to split, have room for the split
+			 * stacks.
+			 */
+			if (!assigned[j] && tval_is_ammo(current)
+					&& (current->number
+					<= z_info->quiver_slot_size
+					|| (z_info->quiver_size > 0
+					&& n_stack_split
+					<= n_pack_remaining))) {
+				/* Choose the first in order. */
+				if (earlier_object(first, current, false)) {
+					first = current;
+					jfirst = j;
+				}
 			}
+
+			current = current->next;
+			++j;
 		}
 
-		/* Stop looking if there's nothing left */
+		/* Stop looking if there's nothing left in the gear. */
 		if (!first) break;
 
-		/* If we have an item, slot it, splitting if needed, to fit. */
-		if (first->number <= z_info->quiver_slot_size) {
-			to_quiver = first;
-		} else if (z_info->quiver_slot_size > 0 &&
-				n_stack_split <= n_pack_remaining) {
-			/*
-			 * As above, split off the portion that goes to the
-			 * pack.
-			 */
-			to_quiver = first;
+		/* Put the item in the slot, splitting (if needed) to fit. */
+		if (first->number > z_info->quiver_slot_size) {
+			assert(z_info->quiver_size > 0
+				&& n_stack_split <= n_pack_remaining);
+			/* As above, split off the portion going to the pack. */
 			gear_insert_end(p, object_split(first,
 				first->number - z_info->quiver_slot_size));
-			++n_stack_split;
-		} else {
-			to_quiver = NULL;
 		}
+		p->upkeep->quiver[i] = first;
+		p->upkeep->quiver_cnt += first->number;
 
-		if (to_quiver) {
-			p->upkeep->quiver[i] = to_quiver;
-			p->upkeep->quiver_cnt += to_quiver->number;
+		/* In the quiver counts as worn. */
+		object_learn_on_wield(p, first);
 
-			/* In the quiver counts as worn */
-			object_learn_on_wield(p, to_quiver);
-		}
+		/* That part of the gear has been dealt with. */
+		assigned[jfirst] = true;
 	}
 
 	/* Note reordering */
-	if (character_dungeon)
-		for (i = 0; i < z_info->quiver_size; i++)
+	if (character_dungeon) {
+		for (i = 0; i < z_info->quiver_size; i++) {
 			if (old_quiver[i] && p->upkeep->quiver[i] != old_quiver[i]) {
 				msg("You re-arrange your quiver.");
 				break;
 			}
+		}
+	}
 
 	/* Copy the current pack */
-	for (i = 0; i < z_info->pack_size; i++)
+	for (i = 0; i < z_info->pack_size; i++) {
 		old_pack[i] = p->upkeep->inven[i];
+	}
 
 	/* Prepare to fill the inventory */
 	p->upkeep->inven_cnt = 0;
 
 	for (i = 0; i <= z_info->pack_size; i++) {
-		struct object *current, *first = NULL;
-		for (current = p->gear; current; current = current->next) {
-			bool possible = true;
-			int j;
+		struct object *first = NULL;
+		int jfirst = -1;
 
-			/* Skip equipment */
-			if (object_is_equipped(p->body, current))
-				possible = false;
+		/* Find the object that should go there. */
+		j = 0;
+		current = p->gear;
+		while (1) {
+			if (!current) break;
+			assert(j < n_max);
 
-			/* Skip quivered objects */
-			for (j = 0; j < z_info->quiver_size; j++)
-				if (p->upkeep->quiver[j] == current)
-					possible = false;
-
-			/* Skip objects already allocated to the inventory */
-			for (j = 0; j < p->upkeep->inven_cnt; j++)
-				if (p->upkeep->inven[j] == current)
-					possible = false;
-
-			/* If still possible, choose the first in order */
-			if (!possible)
-				continue;
-			else if (earlier_object(first, current, false)) {
-				first = current;
+			/* Consider it if it hasn't already been handled. */
+			if (!assigned[j]) {
+				/* Choose the first in order. */
+				if (earlier_object(first, current, false)) {
+					first = current;
+					jfirst = j;
+				}
 			}
+
+			current = current->next;
+			++j;
 		}
 
 		/* Allocate */
 		p->upkeep->inven[i] = first;
-		if (first)
-			p->upkeep->inven_cnt++;
+		if (first) {
+			++p->upkeep->inven_cnt;
+			assigned[jfirst] = true;
+		}
 	}
 
 	/* Note reordering */
-	if (character_dungeon && p->upkeep->inven_cnt == old_inven_cnt)
-		for (i = 0; i < z_info->pack_size; i++)
+	if (character_dungeon && p->upkeep->inven_cnt == old_inven_cnt) {
+		for (i = 0; i < z_info->pack_size; i++) {
 			if (old_pack[i] && p->upkeep->inven[i] != old_pack[i]
 					 && !object_is_equipped(p->body, old_pack[i])) {
 				msg("You re-arrange your pack.");
 				break;
 			}
+		}
+	}
 
-	mem_free(old_quiver);
+	mem_free(assigned);
 	mem_free(old_pack);
+	mem_free(old_quiver);
 }
 
 /**

--- a/src/player-calcs.c
+++ b/src/player-calcs.c
@@ -1043,6 +1043,9 @@ void calc_inventory(struct player *p)
 		assert(j < n_max);
 		assigned[j] = object_is_equipped(p->body, current);
 	}
+	for (; j < n_max; ++j) {
+		assigned[j] = false;
+	}
 
 	/* Prepare to fill the quiver */
 	p->upkeep->quiver_cnt = 0;


### PR DESCRIPTION
Use an O(number in gear) algorithm rather than an O(number in gear * number of quiver slots) one for the placement of inscribed items in the quiver.

Use a temporary array to track what items in the gear have been dealt with to reduce calls to object_is_equipped() and avoid iteration over the newly assigned quiver and pack.

On an early 2015 MacBook Pro (2.7 GHz dual core I5) running macOS 11.5.1 and Angband compiled with "-g -O2 -DNDEBUG", reduces the time (tracked by a compute time profile using the Time Profiler from Instruments) for one million calls to calc_inventory() in a tight loop with a gear list of 24 items (9 equipped; 3 for the quiver) from 17.59 seconds to 5.4 seconds.