### PR TITLE
Add a player argument to object_flavor_aware

### DIFF
--- a/src/obj-gear.c
+++ b/src/obj-gear.c
@@ -737,10 +737,10 @@ void inven_carry(struct player *p, struct object *obj, bool absorb,
 		/* Hobbits ID mushrooms on pickup, gnomes ID wands and staffs on pickup */
 		if (!object_flavor_is_aware(obj)) {
 			if (player_has(p, PF_KNOW_MUSHROOM) && tval_is_mushroom(obj)) {
-				object_flavor_aware(obj);
+				object_flavor_aware(p, obj);
 				msg("Mushrooms for breakfast!");
 			} else if (player_has(p, PF_KNOW_ZAPPER) && tval_is_zapper(obj))
-				object_flavor_aware(obj);
+				object_flavor_aware(p, obj);
 		}
 	}
 

--- a/src/obj-knowledge.c
+++ b/src/obj-knowledge.c
@@ -1124,7 +1124,7 @@ void player_know_object(struct player *p, struct object *obj)
 
 	if (object_non_curse_runes_known(obj) && tval_is_jewelry(obj)) {
 		seen = obj->kind->everseen;
-		object_flavor_aware(obj);
+		object_flavor_aware(p, obj);
 	}
 
 	/* Ensure effect is known as if object_set_base_known() had been called. */
@@ -1827,7 +1827,7 @@ void object_learn_on_use(struct player *p, struct object *obj)
 	/* Object level */
 	int lev = obj->kind->level;
 
-	object_flavor_aware(obj);
+	object_flavor_aware(p, obj);
 	obj->known->effect = obj->effect;
 	update_player_object_knowledge(p);
 	player_exp_gain(p, (lev + (p->lev / 2)) / p->lev);
@@ -2212,9 +2212,10 @@ bool object_flavor_was_tried(const struct object *obj)
 /**
  * Mark an object's flavour as as one the player is aware of.
  *
+ * \param p is the player becoming aware of the flavor
  * \param obj is the object whose flavour should be marked as aware
  */
-void object_flavor_aware(struct object *obj)
+void object_flavor_aware(struct player *p, struct object *obj)
 {
 	int y, x, i;
 	struct object *obj1;
@@ -2227,17 +2228,17 @@ void object_flavor_aware(struct object *obj)
 	/* Fix ignore/autoinscribe */
 	if (kind_is_ignored_unaware(obj->kind))
 		kind_ignore_when_aware(obj->kind);
-	player->upkeep->notice |= PN_IGNORE;
+	p->upkeep->notice |= PN_IGNORE;
 
 	/* Update player objects */
-	for (obj1 = player->gear; obj1; obj1 = obj1->next)
-		object_set_base_known(player, obj1);
+	for (obj1 = p->gear; obj1; obj1 = obj1->next)
+		object_set_base_known(p, obj1);
 
 	/* Store objects */
 	for (i = 0; i < MAX_STORES; i++) {
 		struct store *s = &stores[i];
 		for (obj1 = s->stock; obj1; obj1 = obj1->next)
-			object_set_base_known(player, obj1);
+			object_set_base_known(p, obj1);
 	}
 
 	/* Quit if no dungeon yet */

--- a/src/obj-knowledge.h
+++ b/src/obj-knowledge.h
@@ -101,5 +101,5 @@ void missile_learn_on_ranged_attack(struct player *p, struct object *obj);
 bool easy_know(const struct object *obj);
 bool object_flavor_is_aware(const struct object *obj);
 bool object_flavor_was_tried(const struct object *obj);
-void object_flavor_aware(struct object *obj);
+void object_flavor_aware(struct player *p, struct object *obj);
 void object_flavor_tried(struct object *obj);

--- a/src/player-birth.c
+++ b/src/player-birth.c
@@ -645,7 +645,7 @@ static void player_outfit(struct player *p)
 		known_obj = object_new();
 		obj->known = known_obj;
 		object_set_base_known(p, obj);
-		object_flavor_aware(obj);
+		object_flavor_aware(p, obj);
 		obj->known->pval = obj->pval;
 		obj->known->effect = obj->effect;
 		obj->known->notice |= OBJ_NOTICE_ASSESSED;

--- a/src/player-util.c
+++ b/src/player-util.c
@@ -254,13 +254,13 @@ void death_knowledge(struct player *p)
 
 	player_learn_all_runes(p);
 	for (obj = p->gear; obj; obj = obj->next) {
-		object_flavor_aware(obj);
+		object_flavor_aware(p, obj);
 		obj->known->effect = obj->effect;
 		obj->known->activation = obj->activation;
 	}
 
 	for (obj = home->stock; obj; obj = obj->next) {
-		object_flavor_aware(obj);
+		object_flavor_aware(p, obj);
 		obj->known->effect = obj->effect;
 		obj->known->activation = obj->activation;
 	}

--- a/src/store.c
+++ b/src/store.c
@@ -1717,7 +1717,7 @@ void do_cmd_buy(struct command *cmd)
 	bought->known = known_obj;
 
 	/* Learn flavor, any effect and all the runes */
-	object_flavor_aware(bought);
+	object_flavor_aware(player, bought);
 	bought->known->effect = bought->effect;
 	while (!object_fully_known(bought)) {
 		object_learn_unknown_rune(player, bought);
@@ -1916,7 +1916,7 @@ void do_cmd_sell(struct command *cmd)
 	object_wipe(&dummy_item);
 
 	/* Know flavor of consumables */
-	object_flavor_aware(obj);
+	object_flavor_aware(player, obj);
 	obj->known->effect = obj->effect;
 	while (!object_fully_known(obj)) {
 		object_learn_unknown_rune(player, obj);


### PR DESCRIPTION
Many of its callers already expect such an argument.  Resolves https://github.com/angband/angband/issues/5010 (part of https://github.com/angband/angband/issues/4934 ).