### PR TITLE
Allow '@' to fast forward the birth process from the race, class, or …

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -26,6 +26,7 @@
 #include "player-quest.h"
 #include "player-spell.h"
 #include "player-timed.h"
+#include "randname.h"
 #include "z-color.h"
 #include "z-util.h"
 
@@ -365,6 +366,25 @@ bool player_restore_mana(struct player *p, int amt) {
 	msg("You feel some of your energies returning.");
 
 	return p->csp != old_csp;
+}
+
+/**
+ * Construct a random player name appropriate for the setting.
+ *
+ * \param buf is the buffer to contain the name.  Must have space for at
+ * least buflen characters.
+ * \param buflen is the maximum number of character that can be written to
+ * buf.
+ * \return the number of characters, excluding the terminating null, written
+ * to the buffer
+ */
+size_t player_random_name(char *buf, size_t buflen)
+{
+	size_t result = randname_make(RANDNAME_TOLKIEN, 4, 8, buf, buflen,
+		name_sections);
+
+	my_strcap(buf);
+	return result;
 }
 
 /**

--- a/src/player.h
+++ b/src/player.h
@@ -623,6 +623,7 @@ void player_flags_timed(struct player *p, bitflag f[OF_SIZE]);
 byte player_hp_attr(struct player *p);
 byte player_sp_attr(struct player *p);
 bool player_restore_mana(struct player *p, int amt);
+size_t player_random_name(char *buf, size_t buflen);
 void player_safe_name(char *safe, size_t safelen, const char *name, bool strip_suffix);
 void player_cleanup_members(struct player *p);
 

--- a/src/ui-input.c
+++ b/src/ui-input.c
@@ -26,7 +26,6 @@
 #include "obj-util.h"
 #include "player-calcs.h"
 #include "player-path.h"
-#include "randname.h"
 #include "savefile.h"
 #include "target.h"
 #include "ui-command.h"
@@ -798,9 +797,7 @@ static bool get_name_keypress(char *buf, size_t buflen, size_t *curs,
 	{
 		case '*':
 		{
-			*len = randname_make(RANDNAME_TOLKIEN, 4, 8, buf, buflen,
-								 name_sections);
-			my_strcap(buf);
+			*len = player_random_name(buf, buflen);
 			*curs = 0;
 			result = false;
 			break;


### PR DESCRIPTION
…roller selection screens using random choices and a default point buy for the statistics.  That's one way to resolve https://github.com/angband/angband/issues/2167 .  Add a function player_random_name() in player.c so the logic for generating a random name isn't repeated in two places, ui-input.c and ui-birth.c.

With that change it's a minimum of three actions in the Mac or Windows front end to get to town with a new character:  new character, '@', and 'enter' to confirm.  There's no filtering of race and class combinations.