### PR TITLE
Move the bits of the artifact structure that are recorded in the save file…

### DIFF
--- a/src/cmd-wizard.c
+++ b/src/cmd-wizard.c
@@ -137,7 +137,7 @@ static void prt_binary(const bitflag *flags, int offset, int row, int col,
  * \param art The artifact to instantiate.
  * \return An object that represents the artifact.
  */
-static struct object *wiz_create_object_from_artifact(struct artifact *art)
+static struct object *wiz_create_object_from_artifact(const struct artifact *art)
 {
 	struct object_kind *kind;
 	struct object *obj;
@@ -155,8 +155,7 @@ static struct object *wiz_create_object_from_artifact(struct artifact *art)
 	obj->artifact = art;
 	copy_artifact_data(obj, art);
 
-	/* Mark that the artifact has been created. */
-	art->created = true;
+	mark_artifact_created(art, true);
 
 	return obj;
 }
@@ -2550,7 +2549,7 @@ void do_cmd_wiz_stat_item(struct command *cmd)
 		 * here.
 		 */
 		if (obj->artifact) {
-			obj->artifact->created = false;
+			mark_artifact_created(obj->artifact, false);
 		}
 
 		/* Check for failures to generate an object. */
@@ -2605,7 +2604,7 @@ void do_cmd_wiz_stat_item(struct command *cmd)
 
 	/* Hack -- normally only make a single artifact */
 	if (obj->artifact) {
-		obj->artifact->created = true;
+		mark_artifact_created(obj->artifact, true);
 	}
 }
 
@@ -2853,7 +2852,7 @@ void do_cmd_wiz_tweak_item(struct command *cmd)
 		obj->artifact = lookup_artifact_name(tmp_val);
 	}
 	if (obj->artifact) {
-		struct artifact *a = obj->artifact;
+		const struct artifact *a = obj->artifact;
 		struct object *prev = obj->prev;
 		struct object *next = obj->next;
 		struct object *known = obj->known;

--- a/src/effect-handler-attack.c
+++ b/src/effect-handler-attack.c
@@ -1208,9 +1208,13 @@ bool effect_handler_DESTRUCTION(effect_handler_context_t *context)
 						if (OPT(player, birth_lose_arts) ||
 							obj_is_known_artifact(obj)) {
 							history_lose_artifact(player, obj->artifact);
-							obj->artifact->created = true;
+							mark_artifact_created(
+								obj->artifact,
+								true);
 						} else {
-							obj->artifact->created = false;
+							mark_artifact_created(
+								obj->artifact,
+								false);
 						}
 					}
 					obj = obj->next;

--- a/src/gen-util.c
+++ b/src/gen-util.c
@@ -441,7 +441,7 @@ void place_object(struct chunk *c, struct loc grid, int level, bool good,
 	/* Give it to the floor */
 	if (!floor_carry(c, grid, new_obj, &dummy)) {
 		if (new_obj->artifact) {
-			new_obj->artifact->created = false;
+			mark_artifact_created(new_obj->artifact, false);
 		}
 		object_delete(&new_obj);
 		return;

--- a/src/generate.c
+++ b/src/generate.c
@@ -1363,9 +1363,9 @@ void prepare_next_level(struct player *p)
 								bool found = obj_is_known_artifact(obj);
 								if (OPT(p, birth_lose_arts) || found) {
 									history_lose_artifact(p, obj->artifact);
-									obj->artifact->created = true;
+									mark_artifact_created(obj->artifact, true);
 								} else {
-									obj->artifact->created = false;
+									mark_artifact_created(obj->artifact, false);
 								}
 							}
 

--- a/src/load.c
+++ b/src/load.c
@@ -1046,11 +1046,11 @@ int rd_artifacts(void)
 		byte tmp8u;
 
 		rd_byte(&tmp8u);
-		a_info[i].created = tmp8u ? true : false;
+		aup_info[i].created = tmp8u ? true : false;
 		rd_byte(&tmp8u);
-		a_info[i].seen = tmp8u ? true : false;
+		aup_info[i].seen = tmp8u ? true : false;
 		rd_byte(&tmp8u);
-		a_info[i].everseen = tmp8u ? true : false;
+		aup_info[i].everseen = tmp8u ? true : false;
 		rd_byte(&tmp8u);
 	}
 
@@ -1707,7 +1707,7 @@ int rd_history(void)
 		s32b turnno;
 		s16b dlev, clev;
 		bitflag type[HIST_SIZE];
-		struct artifact *art = NULL;
+		const struct artifact *art = NULL;
 		int aidx = 0;
 		char name[80];
 		char text[80];

--- a/src/mon-make.c
+++ b/src/mon-make.c
@@ -358,7 +358,7 @@ void delete_monster_idx(int m_idx)
 		 * monster's drop) - this will cause unintended behaviour in preserve
 		 * off mode if monsters can pick up artifacts */
 		if (obj->artifact && !obj_is_known_artifact(obj)) {
-			obj->artifact->created = false;
+			mark_artifact_created(obj->artifact, false);
 		}
 
 		/* Delete the object.  Since it's in the cave's list do
@@ -574,8 +574,10 @@ void wipe_mon_list(struct chunk *c, struct player *p)
 			/* Go through all held objects and check for artifacts */
 			struct object *obj = held_obj;
 			while (obj) {
-				if (obj->artifact && !(obj->known && obj->known->artifact))
-					obj->artifact->created = false;
+				if (obj->artifact && !obj_is_known_artifact(obj)) {
+					mark_artifact_created(obj->artifact,
+						false);
+				}
 				/*
 				 * Also, remove from the cave's object list.
 				 * That way, the scan for orphaned objects
@@ -787,7 +789,7 @@ static bool mon_create_drop(struct chunk *c, struct monster *mon, byte origin)
 	if (rf_has(mon->race->flags, RF_QUESTOR) && (mon->race->level == 100)) {
 		/* Search all the artifacts */
 		for (j = 1; j < z_info->a_max; j++) {
-			struct artifact *art = &a_info[j];
+			const struct artifact *art = &a_info[j];
 			struct object_kind *kind = lookup_kind(art->tval, art->sval);
 			if (!kf_has(kind->kind_flags, KF_QUEST_ART)) {
 				continue;
@@ -798,7 +800,7 @@ static bool mon_create_drop(struct chunk *c, struct monster *mon, byte origin)
 			object_prep(obj, kind, 100, RANDOMISE);
 			obj->artifact = art;
 			copy_artifact_data(obj, obj->artifact);
-			obj->artifact->created = true;
+			mark_artifact_created(art, true);
 
 			/* Set origin details */
 			obj->origin = origin;
@@ -810,7 +812,7 @@ static bool mon_create_drop(struct chunk *c, struct monster *mon, byte origin)
 			if (monster_carry(c, mon, obj)) {
 				any = true;
 			} else {
-				obj->artifact->created = false;
+				mark_artifact_created(obj->artifact, false);
 				object_wipe(obj);
 				mem_free(obj);
 			}
@@ -873,7 +875,7 @@ static bool mon_create_drop(struct chunk *c, struct monster *mon, byte origin)
 			any = true;
 		} else {
 			if (obj->artifact) {
-				obj->artifact->created = false;
+				mark_artifact_created(obj->artifact, false);
 			}
 			object_wipe(obj);
 			mem_free(obj);

--- a/src/obj-init.c
+++ b/src/obj-init.c
@@ -2834,6 +2834,7 @@ static errr finish_parse_artifact(struct parser *p) {
 
 	/* Allocate the direct access list and copy the data to it */
 	a_info = mem_zalloc((z_info->a_max + 1) * sizeof(*a));
+	aup_info = mem_zalloc((z_info->a_max + 1) * sizeof(*aup_info));
 	aidx = z_info->a_max;
 	for (a = parser_priv(p); a; a = n, aidx--) {
 		assert(aidx > 0);
@@ -2841,12 +2842,11 @@ static errr finish_parse_artifact(struct parser *p) {
 		memcpy(&a_info[aidx], a, sizeof(*a));
 		a_info[aidx].aidx = aidx;
 		n = a->next;
-		if (aidx < z_info->a_max)
-			a_info[aidx].next = &a_info[aidx + 1];
-		else
-			a_info[aidx].next = NULL;
-
+		a_info[aidx].next = (aidx < z_info->a_max) ?
+			&a_info[aidx + 1] : NULL;
 		mem_free(a);
+
+		aup_info[aidx].aidx = aidx;
 	}
 	z_info->a_max += 1;
 
@@ -2875,6 +2875,7 @@ static void cleanup_artifact(void)
 		mem_free(art->curses);
 	}
 	mem_free(a_info);
+	mem_free(aup_info);
 }
 
 struct file_parser artifact_parser = {
@@ -2908,6 +2909,7 @@ static errr finish_parse_randart(struct parser *p) {
 
 	/* Allocate the direct access list and copy the data to it */
 	a_info = mem_zalloc((z_info->a_max + 1) * sizeof(*a));
+	aup_info = mem_zalloc((z_info->a_max + 1) * sizeof(*aup_info));
 	aidx = z_info->a_max;
 	for (a = parser_priv(p); a; a = n, aidx--) {
 		assert(aidx > 0);
@@ -2915,12 +2917,11 @@ static errr finish_parse_randart(struct parser *p) {
 		memcpy(&a_info[aidx], a, sizeof(*a));
 		a_info[aidx].aidx = aidx;
 		n = a->next;
-		if (aidx < z_info->a_max)
-			a_info[aidx].next = &a_info[aidx + 1];
-		else
-			a_info[aidx].next = NULL;
-
+		a_info[aidx].next = (aidx < z_info->a_max) ?
+			&a_info[aidx + 1] : NULL;
 		mem_free(a);
+
+		aup_info[aidx].aidx = aidx;
 	}
 	z_info->a_max += 1;
 

--- a/src/obj-make.c
+++ b/src/obj-make.c
@@ -587,7 +587,7 @@ static struct object *make_artifact_special(int level, int tval)
 
 	/* Check the special artifacts */
 	for (i = 0; i < z_info->a_max; ++i) {
-		struct artifact *art = &a_info[i];
+		const struct artifact *art = &a_info[i];
 		struct object_kind *kind = lookup_kind(art->tval, art->sval);
 
 		/* Skip "empty" artifacts */
@@ -603,7 +603,7 @@ static struct object *make_artifact_special(int level, int tval)
 		if (!kf_has(kind->kind_flags, KF_INSTA_ART)) continue;
 
 		/* Cannot make an artifact twice */
-		if (art->created) continue;
+		if (is_artifact_created(art)) continue;
 
 		/* Enforce minimum "depth" (loosely) */
 		if (art->alloc_min > player->depth) {
@@ -640,7 +640,7 @@ static struct object *make_artifact_special(int level, int tval)
 		copy_artifact_data(new_obj, art);
 
 		/* Mark the artifact as "created" */
-		art->created = true;
+		mark_artifact_created(art, true);
 
 		/* Success */
 		return new_obj;
@@ -675,7 +675,7 @@ static bool make_artifact(struct object *obj)
 
 	/* Check the artifact list (skip the "specials") */
 	for (i = 0; !obj->artifact && i < z_info->a_max; i++) {
-		struct artifact *art = &a_info[i];
+		const struct artifact *art = &a_info[i];
 		struct object_kind *kind = lookup_kind(art->tval, art->sval);
 
 		/* Skip "empty" items */
@@ -688,7 +688,7 @@ static bool make_artifact(struct object *obj)
 		if (kf_has(kind->kind_flags, KF_INSTA_ART)) continue;
 
 		/* Cannot make an artifact twice */
-		if (art->created) continue;
+		if (is_artifact_created(art)) continue;
 
 		/* Must have the correct fields */
 		if (art->tval != obj->tval) continue;
@@ -716,7 +716,7 @@ static bool make_artifact(struct object *obj)
 
 	if (obj->artifact) {
 		copy_artifact_data(obj, obj->artifact);
-		obj->artifact->created = true;
+		mark_artifact_created(obj->artifact, true);
 		return true;
 	}
 
@@ -746,7 +746,7 @@ bool make_fake_artifact(struct object *obj, const struct artifact *artifact)
 
 	/* Create the artifact */
 	object_prep(obj, kind, 0, MAXIMISE);
-	obj->artifact = (struct artifact *)artifact;
+	obj->artifact = artifact;
 	copy_artifact_data(obj, artifact);
 
 	return (true);

--- a/src/obj-randart.c
+++ b/src/obj-randart.c
@@ -219,7 +219,7 @@ static int artifact_power(int a_idx, const char *reason, bool verbose)
 static void store_base_power(struct artifact_set_data *data)
 {
 	int i, num;
-	struct artifact *art;
+	const struct artifact *art;
 	struct object_kind *kind;
 	int *fake_total_power;
 	int **fake_tv_power;

--- a/src/obj-util.c
+++ b/src/obj-util.c
@@ -46,6 +46,7 @@
 struct object_base *kb_info;
 struct object_kind *k_info;
 struct artifact *a_info;
+struct artifact_upkeep *aup_info;
 struct ego_item *e_info;
 struct flavor *flavors;
 
@@ -427,14 +428,14 @@ struct object_kind *objkind_byid(int kidx) {
 /**
  * Return the a_idx of the artifact with the given name
  */
-struct artifact *lookup_artifact_name(const char *name)
+const struct artifact *lookup_artifact_name(const char *name)
 {
 	int i;
 	int a_idx = -1;
 
 	/* Look for it */
 	for (i = 0; i < z_info->a_max; i++) {
-		struct artifact *art = &a_info[i];
+		const struct artifact *art = &a_info[i];
 
 		/* Test for equality */
 		if (art->name && streq(name, art->name))
@@ -1040,4 +1041,58 @@ void print_custom_message(struct object *obj, const char *string, int msg_type)
 	strnfcat(buf, 1024, &end, string);
 
 	msgt(msg_type, "%s", buf);
+}
+
+/**
+ * Return if the given artifact has been created.
+ */
+bool is_artifact_created(const struct artifact *art)
+{
+	assert(art->aidx == aup_info[art->aidx].aidx);
+	return aup_info[art->aidx].created;
+}
+
+/**
+ * Return if the given artifact has been seen.
+ */
+bool is_artifact_seen(const struct artifact *art)
+{
+	assert(art->aidx == aup_info[art->aidx].aidx);
+	return aup_info[art->aidx].seen;
+}
+
+/**
+ * Return if the given artifact has ever been seen.
+ */
+bool is_artifact_everseen(const struct artifact *art)
+{
+	assert(art->aidx == aup_info[art->aidx].aidx);
+	return aup_info[art->aidx].everseen;
+}
+
+/**
+ * Set whether the given artifact has been created or not.
+ */
+void mark_artifact_created(const struct artifact *art, bool created)
+{
+	assert(art->aidx == aup_info[art->aidx].aidx);
+	aup_info[art->aidx].created = created;
+}
+
+/**
+ * Set whether the given artifact has been created or not.
+ */
+void mark_artifact_seen(const struct artifact *art, bool seen)
+{
+	assert(art->aidx == aup_info[art->aidx].aidx);
+	aup_info[art->aidx].seen = seen;
+}
+
+/**
+ * Set whether the given artifact has been seen or not.
+ */
+void mark_artifact_everseen(const struct artifact *art, bool seen)
+{
+	assert(art->aidx == aup_info[art->aidx].aidx);
+	aup_info[art->aidx].everseen = seen;
 }

--- a/src/obj-util.h
+++ b/src/obj-util.h
@@ -36,7 +36,7 @@ unsigned check_for_inscrip(const struct object *obj, const char *inscrip);
 unsigned check_for_inscrip_with_int(const struct object *obj, const char *insrip, int *ival);
 struct object_kind *lookup_kind(int tval, int sval);
 struct object_kind *objkind_byid(int kidx);
-struct artifact *lookup_artifact_name(const char *name);
+const struct artifact *lookup_artifact_name(const char *name);
 struct ego_item *lookup_ego_item(const char *name, int tval, int sval);
 int lookup_sval(int tval, const char *name);
 void object_short_name(char *buf, size_t max, const char *name);
@@ -69,5 +69,11 @@ bool recharge_timeout(struct object *obj);
 bool verify_object(const char *prompt, const struct object *obj);
 void print_custom_message(struct object *obj, const char *string, int msg_type);
 
+bool is_artifact_created(const struct artifact *art);
+bool is_artifact_seen(const struct artifact *art);
+bool is_artifact_everseen(const struct artifact *art);
+void mark_artifact_created(const struct artifact *art, bool created);
+void mark_artifact_seen(const struct artifact *art, bool seen);
+void mark_artifact_everseen(const struct artifact *art, bool seen);
 
 #endif /* OBJECT_UTIL_H */

--- a/src/object.h
+++ b/src/object.h
@@ -254,12 +254,7 @@ extern struct object_kind *pile_kind;
 extern struct object_kind *curse_object_kind;
 
 /**
- * Information about artifacts.
- *
- * Note that ::cur_num is written to the savefile.
- *
- * TODO: Fix this max_num/cur_num crap and just have a big boolean array of
- * which artifacts have been created and haven't, so this can become read-only.
+ * Unchanging information about artifacts.
  */
 struct artifact {
 	char *name;
@@ -299,10 +294,6 @@ struct artifact {
 	int alloc_min;		/** Minimum depth (can appear earlier) */
 	int alloc_max;		/** Maximum depth (will NEVER appear deeper) */
 
-	bool created;		/**< Whether this artifact has been created */
-	bool seen;			/**< Whether this artifact has been seen this game */
-	bool everseen;		/**< Whether this artifact has ever been seen  */
-
 	struct activation *activation;	/**< Artifact activation */
 	char *alt_msg;
 
@@ -310,9 +301,21 @@ struct artifact {
 };
 
 /**
+ * Information about artifacts that changes during the course of play;
+ * except for aidx, saved to the save file
+ */
+struct artifact_upkeep {
+	u32b aidx;	/**< For cross-indexing with struct artifact */
+	bool created;	/**< Whether this artifact has been created */
+	bool seen;	/**< Whether this artifact has been seen this game */
+	bool everseen;	/**< Whether this artifact has ever been seen  */
+};
+
+/**
  * The artifact arrays
  */
 extern struct artifact *a_info;
+extern struct artifact_upkeep *aup_info;
 
 
 /**
@@ -419,7 +422,7 @@ struct curse_data {
 struct object {
 	struct object_kind *kind;	/**< Kind of the object */
 	struct ego_item *ego;		/**< Ego item info of the object, if any */
-	struct artifact *artifact;	/**< Artifact info of the object, if any */
+	const struct artifact *artifact;	/**< Artifact info of the object, if any */
 
 	struct object *prev;	/**< Previous object in a pile */
 	struct object *next;	/**< Next object in a pile */

--- a/src/player-birth.c
+++ b/src/player-birth.c
@@ -403,9 +403,8 @@ void player_init(struct player *p)
 
 	/* Start with no artifacts made yet */
 	for (i = 0; z_info && i < z_info->a_max; i++) {
-		struct artifact *art = &a_info[i];
-		art->created = false;
-		art->seen = false;
+		mark_artifact_created(&a_info[i], false);
+		mark_artifact_seen(&a_info[i], false);
 	}
 
 	/* Start with no quests */

--- a/src/save.c
+++ b/src/save.c
@@ -674,10 +674,10 @@ void wr_artifacts(void)
 	tmp16u = z_info->a_max;
 	wr_u16b(tmp16u);
 	for (i = 0; i < tmp16u; i++) {
-		struct artifact *art = &a_info[i];
-		wr_byte(art->created ? 1 : 0);
-		wr_byte(art->seen ? 1 : 0);
-		wr_byte(art->everseen ? 1 : 0);
+		const struct artifact_upkeep *au = &aup_info[i];
+		wr_byte(au->created ? 1 : 0);
+		wr_byte(au->seen ? 1 : 0);
+		wr_byte(au->everseen ? 1 : 0);
 		wr_byte(0);
 	}
 }

--- a/src/ui-knowledge.c
+++ b/src/ui-knowledge.c
@@ -1601,7 +1601,7 @@ static bool artifact_is_known(int a_idx)
 	if (player->wizard)
 		return true;
 
-	if (!a_info[a_idx].created)
+	if (!is_artifact_created(&a_info[a_idx]))
 		return false;
 
 	/* Check all objects to see if it exists but hasn't been IDed */

--- a/src/ui-wizard.c
+++ b/src/ui-wizard.c
@@ -106,7 +106,7 @@ static void get_art_name(char *buf, int max, int a_idx)
 {
 	struct object *obj, *known_obj;
 	struct object_kind *kind;
-	struct artifact *art = &a_info[a_idx];
+	const struct artifact *art = &a_info[a_idx];
 
 	/* Get object */
 	obj = object_new();
@@ -260,7 +260,7 @@ static bool wiz_create_item_action(struct menu *m, const ui_event *e, int oid)
 	if (choose_artifact) {
 		/* ...We have to search the whole artifact list. */
 		for (num = 0, i = 1; (num < 60) && (i < z_info->a_max); i++) {
-			struct artifact *art = &a_info[i];
+			const struct artifact *art = &a_info[i];
 
 			if (art->tval != oid) continue;
 
@@ -349,7 +349,7 @@ void wiz_create_item(bool art)
 		if (art) {
 			int j;
 			for (j = 1; j < z_info->a_max; j++) {
-				struct artifact *art_local = &a_info[j];
+				const struct artifact *art_local = &a_info[j];
 				if (art_local->tval == i) break;
 			}
 			if (j == z_info->a_max) continue;

--- a/src/wiz-spoil.c
+++ b/src/wiz-spoil.c
@@ -405,9 +405,9 @@ void spoil_artifact(const char *fname)
 
 		/* Now search through all of the artifacts */
 		for (j = 1; j < z_info->a_max; ++j) {
-			struct artifact *art = &a_info[j];
+			const struct artifact *art = &a_info[j];
+			struct artifact artc;
 			char buf2[80];
-			char *temp;
 			struct object *obj, *known_obj;
 
 			/* We only want objects in the current group */
@@ -417,8 +417,16 @@ void spoil_artifact(const char *fname)
 			obj = object_new();
 			known_obj = object_new();
 
+			/*
+			 * Make a copy of the artifact state; hide the
+			 * flavour text:  spoilers spoil the mechanics, not
+			 * the atmosphere.
+			 */
+			memcpy(&artc, art, sizeof(artc));
+			artc.text = NULL;
+
 			/* Attempt to "forge" the artifact */
-			if (!make_fake_artifact(obj, art)) {
+			if (!make_fake_artifact(obj, &artc)) {
 				object_delete(&known_obj);
 				object_delete(&obj);
 				continue;
@@ -433,16 +441,8 @@ void spoil_artifact(const char *fname)
 			/* Print name and underline */
 			spoiler_underline(buf2, '-');
 
-			/* Temporarily blank the artifact flavour text - spoilers
-			   spoil the mechanics, not the atmosphere. */
-			temp = obj->artifact->text;
-			obj->artifact->text = NULL;
-
 			/* Write out the artifact description to the spoiler file */
 			object_info_spoil(fh, obj, 80);
-
-			/* Put back the flavour */
-			obj->artifact->text = temp;
 
 			/*
 			 * Determine the minimum and maximum depths an

--- a/src/wiz-stats.c
+++ b/src/wiz-stats.c
@@ -464,7 +464,7 @@ static void get_obj_data(const struct object *obj, int y, int x, bool mon,
 	bool vault = square_isvault(cave, loc(x, y));
 	int number = obj->number;
 	static int lvl;
-	struct artifact *art;
+	const struct artifact *art;
 
 	double gold_temp = 0;
 
@@ -1056,7 +1056,7 @@ static void get_obj_data(const struct object *obj, int y, int x, bool mon,
 			}
 		}
 		/* preserve the artifact */
-		if (!(clearing)) art->created = false;
+		if (!(clearing)) mark_artifact_created(art, false);
 	}
 
 	/* Get info on gold. */
@@ -1461,10 +1461,7 @@ static void uncreate_artifacts(void)
 
 	/* Loop through artifacts */
 	for (i = 0; z_info && i < z_info->a_max; i++) {
-		struct artifact *art = &a_info[i];
-
-		/* Uncreate */
-		art->created = false;
+		mark_artifact_created(&a_info[i], false);
 	}
 }
 


### PR DESCRIPTION
… to their own structure, artifact_upkeep.  Set up a global array of those structures, aup_info.  Define some functions, in obj-util.{c,h}, for querying and modifying the fields in that structure assuming the caller has a struct artifact pointer.  Make the struct artifact pointer in struct object const.  Resolves https://github.com/angband/angband/issues/3273 .