### PR TITLE
Add a player argument to apply_autoinscription(), autoinscribe_ground(), …

### DIFF
--- a/src/cmd-obj.c
+++ b/src/cmd-obj.c
@@ -214,8 +214,8 @@ void do_cmd_autoinscribe(struct command *cmd)
 {
 	if (player_is_shapechanged(player)) return;
 
-	autoinscribe_ground();
-	autoinscribe_pack();
+	autoinscribe_ground(player);
+	autoinscribe_pack(player);
 
 	player->upkeep->redraw |= (PR_INVEN | PR_EQUIP);
 }
@@ -607,7 +607,7 @@ static void use_aux(struct command *cmd, struct object *obj, enum use use,
 
 	/* Autoinscribe if we are guaranteed to still have any */
 	if (!none_left && !from_floor)
-		apply_autoinscription(obj);
+		apply_autoinscription(player, obj);
 
 	/* Mark as tried and redisplay */
 	player->upkeep->notice |= (PN_COMBINE);

--- a/src/obj-gear.c
+++ b/src/obj-gear.c
@@ -723,7 +723,7 @@ void inven_carry(struct player *p, struct object *obj, bool absorb,
 		assert(pack_slots_used(p) <= z_info->pack_size);
 
 		gear_insert_end(p, obj);
-		apply_autoinscription(obj);
+		apply_autoinscription(p, obj);
 
 		/* Remove cave object details */
 		obj->held_m_idx = 0;

--- a/src/obj-ignore.c
+++ b/src/obj-ignore.c
@@ -190,23 +190,23 @@ static void rune_add_autoinscription(struct object *obj, int i)
 /**
  * Put a rune autoinscription on all available objects
  */
-void rune_autoinscribe(int i)
+void rune_autoinscribe(struct player *p, int i)
 {
 	struct object *obj;
 
 	/* Check the player knows the rune */
-	if (!player_knows_rune(player, i)) {
+	if (!player_knows_rune(p, i)) {
 		return;
 	}
 
 	/* Autoinscribe each object on the ground */
 	if (cave)
-		for (obj = square_object(cave, player->grid); obj; obj = obj->next)
+		for (obj = square_object(cave, p->grid); obj; obj = obj->next)
 			if (object_has_rune(obj, i))
 				rune_add_autoinscription(obj, i);
 
 	/* Autoinscribe each object in the inventory */
-	for (obj = player->gear; obj; obj = obj->next)
+	for (obj = p->gear; obj; obj = obj->next)
 		if (object_has_rune(obj, i))
 			rune_add_autoinscription(obj, i);
 }
@@ -214,12 +214,12 @@ void rune_autoinscribe(int i)
 /**
  * Put all appropriate rune autoinscriptions on an object
  */
-static void runes_autoinscribe(struct object *obj)
+static void runes_autoinscribe(struct player *p, struct object *obj)
 {
 	int i, rune_max = max_runes();
 
 	for (i = 0; i < rune_max; i++)
-		if (object_has_rune(obj, i) && player_knows_rune(player, i))
+		if (object_has_rune(obj, i) && player_knows_rune(p, i))
 			rune_add_autoinscription(obj, i);
 }
 
@@ -239,7 +239,7 @@ const char *get_autoinscription(struct object_kind *kind, bool aware)
 /**
  * Put an autoinscription on an object
  */
-int apply_autoinscription(struct object *obj)
+int apply_autoinscription(struct player *p, struct object *obj)
 {
 	char o_name[80];
 	bool aware = obj->kind->aware;
@@ -251,7 +251,7 @@ int apply_autoinscription(struct object *obj)
 		obj->note = 0;
 
 	/* Make rune autoinscription go first, for now */
-	runes_autoinscribe(obj);
+	runes_autoinscribe(p, obj);
 
 	/* No note - don't inscribe */
 	if (!note)
@@ -262,7 +262,7 @@ int apply_autoinscription(struct object *obj)
 		return 0;
 
 	/* Don't inscribe unless the player is carrying it */
-	if (!object_is_carried(player, obj))
+	if (!object_is_carried(p, obj))
 		return 0;
 
 	/* Don't inscribe if ignored */
@@ -332,25 +332,25 @@ int add_autoinscription(s16b kind, const char *inscription, bool aware)
 /**
  * Put an autoinscription on all objects on the floor beneath the player
  */
-void autoinscribe_ground(void)
+void autoinscribe_ground(struct player *p)
 {
 	struct object *obj;
 
 	/* Autoinscribe each object in the pile */
-	for (obj = square_object(cave, player->grid); obj; obj = obj->next)
-		apply_autoinscription(obj);
+	for (obj = square_object(cave, p->grid); obj; obj = obj->next)
+		apply_autoinscription(p, obj);
 }
 
 /**
  * Put an autoinscription on all the player's carried objects
  */
-void autoinscribe_pack(void)
+void autoinscribe_pack(struct player *p)
 {
 	struct object *obj;
 
 	/* Autoinscribe each object in the inventory */
-	for (obj = player->gear; obj; obj = obj->next)
-		apply_autoinscription(obj);
+	for (obj = p->gear; obj; obj = obj->next)
+		apply_autoinscription(p, obj);
 }
 
 /**

--- a/src/obj-ignore.h
+++ b/src/obj-ignore.h
@@ -88,13 +88,13 @@ extern bool **ego_ignore_types;
 
 /* obj-ignore.c */
 void ignore_birth_init(void);
-void rune_autoinscribe(int i);
+void rune_autoinscribe(struct player *p, int i);
 const char *get_autoinscription(struct object_kind *kind, bool aware);
-int apply_autoinscription(struct object *obj);
+int apply_autoinscription(struct player *p, struct object *obj);
 int remove_autoinscription(s16b kind);
 int add_autoinscription(s16b kind, const char *inscription, bool aware);
-void autoinscribe_ground(void);
-void autoinscribe_pack(void);
+void autoinscribe_ground(struct player *p);
+void autoinscribe_pack(struct player *p);
 void object_ignore_flavor_of(const struct object *obj);
 ignore_type_t ignore_type_of(const struct object *obj);
 byte ignore_level_of(const struct object *obj);

--- a/src/obj-knowledge.c
+++ b/src/obj-knowledge.c
@@ -1194,8 +1194,8 @@ void update_player_object_knowledge(struct player *p)
 
 	/* Update */
 	if (cave)
-		autoinscribe_ground();
-	autoinscribe_pack();
+		autoinscribe_ground(p);
+	autoinscribe_pack(p);
 	event_signal(EVENT_INVENTORY);
 	event_signal(EVENT_EQUIPMENT);
 }

--- a/src/store.c
+++ b/src/store.c
@@ -1944,7 +1944,7 @@ void do_cmd_sell(struct command *cmd)
 
 	/* Autoinscribe if we still have any */
 	if (!none_left)
-		apply_autoinscription(obj);
+		apply_autoinscription(player, obj);
 
 	/* Set ignore flag */
 	player->upkeep->notice |= PN_IGNORE;

--- a/src/ui-knowledge.c
+++ b/src/ui-knowledge.c
@@ -2167,7 +2167,7 @@ static void rune_xtra_act(struct keypress ch, int oid)
 
 			/* Add the autoinscription */
 			rune_set_note(oid, note_text);
-			rune_autoinscribe(oid);
+			rune_autoinscribe(player, oid);
 
 			/* Redraw gear */
 			player->upkeep->redraw |= (PR_INVEN | PR_EQUIP);


### PR DESCRIPTION
autoinscribe_pack(), and rune_autoinscribe() since some of their callers already expect a player argument.  Resolves https://github.com/angband/angband/issues/5020 (part of https://github.com/angband/angband/issues/4934 ).