### PR TITLE
Add a player argument to is_quest() and dungeon_get_next_level()

### DIFF
--- a/src/cave-square.c
+++ b/src/cave-square.c
@@ -25,6 +25,7 @@
 #include "obj-pile.h"
 #include "obj-util.h"
 #include "object.h"
+#include "player-quest.h"
 #include "player-timed.h"
 #include "trap.h"
 
@@ -1237,7 +1238,7 @@ void square_add_stairs(struct chunk *c, struct loc grid, int depth) {
 	int down = randint0(100) < 50;
 	if (depth == 0)
 		down = 1;
-	else if (is_quest(depth) || depth >= z_info->max_depth - 1)
+	else if (is_quest(player, depth) || depth >= z_info->max_depth - 1)
 		down = 0;
 
 	square_set_feat(c, grid, down ? FEAT_MORE : FEAT_LESS);

--- a/src/cave.h
+++ b/src/cave.h
@@ -467,7 +467,6 @@ int count_feats(struct loc *grid,
 int count_neighbors(struct loc *match, struct chunk *c, struct loc grid,
 	bool (*test)(struct chunk *c, struct loc grid), bool under);
 struct loc cave_find_decoy(struct chunk *c);
-bool is_quest(int level);
 
 void cave_known(struct player *p);
 

--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -43,6 +43,7 @@
 #include "player-attack.h"
 #include "player-calcs.h"
 #include "player-path.h"
+#include "player-quest.h"
 #include "player-timed.h"
 #include "player-util.h"
 #include "project.h"
@@ -68,7 +69,7 @@ void do_cmd_go_up(struct command *cmd)
 		return;
 	}
 	
-	ascend_to = dungeon_get_next_level(player->depth, -1);
+	ascend_to = dungeon_get_next_level(player, player->depth, -1);
 	
 	if (ascend_to == player->depth) {
 		msg("You can't go up from here!");
@@ -95,7 +96,7 @@ void do_cmd_go_up(struct command *cmd)
  */
 void do_cmd_go_down(struct command *cmd)
 {
-	int descend_to = dungeon_get_next_level(player->depth, 1);
+	int descend_to = dungeon_get_next_level(player, player->depth, 1);
 
 	/* Verify stairs */
 	if (!square_isdownstairs(cave, player->grid)) {
@@ -111,8 +112,9 @@ void do_cmd_go_down(struct command *cmd)
 
 	/* Warn a force_descend player if they're going to a quest level */
 	if (OPT(player, birth_force_descend)) {
-		descend_to = dungeon_get_next_level(player->max_depth, 1);
-		if (is_quest(descend_to) &&
+		descend_to = dungeon_get_next_level(player,
+			player->max_depth, 1);
+		if (is_quest(player, descend_to) &&
 			!get_check("Are you sure you want to descend? "))
 			return;
 	}

--- a/src/game-world.c
+++ b/src/game-world.c
@@ -784,8 +784,8 @@ void process_world(struct chunk *c)
 		if (player->deep_descent == 0) {
 			/* Calculate target depth */
 			int target_increment = (4 / z_info->stair_skip) + 1;
-			int target_depth = dungeon_get_next_level(player->max_depth,
-													  target_increment);
+			int target_depth = dungeon_get_next_level(player,
+				player->max_depth, target_increment);
 			disturb(player);
 
 			/* Determine the level */

--- a/src/gen-room.c
+++ b/src/gen-room.c
@@ -1197,7 +1197,7 @@ static bool build_room_template(struct chunk *c, struct loc centre, int ymax,
 					place_object(c, grid, c->depth, false, false,
 								 ORIGIN_SPECIAL, 0);
 				} else {
-					place_random_stairs(c, grid);
+					place_random_stairs(c, grid, dun->quest);
 				}
 				/* Place nearby guards in second pass. */
 				break;
@@ -1472,10 +1472,12 @@ bool build_vault(struct chunk *c, struct loc centre, struct vault *v)
 			case '>': {
 				if (dun->persist) break;
 				/* No down stairs at bottom or on quests */
-				if (is_quest(c->depth) || c->depth >= z_info->max_depth - 1)
+				if (dun->quest || c->depth
+						>= z_info->max_depth - 1) {
 					square_set_feat(c, grid, FEAT_LESS);
-				else
+				} else {
 					square_set_feat(c, grid, FEAT_MORE);
+				}
 				break;
 			}
 				/* Lava */
@@ -2452,7 +2454,7 @@ bool build_large(struct chunk *c, struct loc centre, int rating)
 		if (randint0(100) < 80 || dun->persist) {
 			place_object(c, centre, c->depth, false, false, ORIGIN_SPECIAL, 0);
 		} else {
-			place_random_stairs(c, centre);
+			place_random_stairs(c, centre, dun->quest);
 		}
 
 		/* Traps to protect the treasure */

--- a/src/gen-util.c
+++ b/src/gen-util.c
@@ -382,33 +382,38 @@ static void place_rubble(struct chunk *c, struct loc grid)
 
 /**
  * Place stairs (of the requested type 'feat' if allowed) at a given location.
+ *
  * \param c current chunk
  * \param grid location
+ * \param quest is whether or not this is a quest level.
  * \param feat stair terrain type
  *
  * All stairs from town go down. All stairs on an unfinished quest level go up.
  */
-static void place_stairs(struct chunk *c, struct loc grid, int feat)
+static void place_stairs(struct chunk *c, struct loc grid, bool quest, int feat)
 {
-	if (!c->depth)
+	if (!c->depth) {
 		square_set_feat(c, grid, FEAT_MORE);
-	else if (is_quest(c->depth) || c->depth >= z_info->max_depth - 1)
+	} else if (quest || c->depth >= z_info->max_depth - 1) {
 		square_set_feat(c, grid, FEAT_LESS);
-	else
+	} else {
 		square_set_feat(c, grid, feat);
+	}
 }
 
 
 /**
  * Place random stairs at a given location.
+ *
  * \param c current chunk
  * \param grid location
+ * \param quest is whether or not this is a quest level.
  */
-void place_random_stairs(struct chunk *c, struct loc grid)
+void place_random_stairs(struct chunk *c, struct loc grid, bool quest)
 {
 	int feat = randint0(100) < 50 ? FEAT_LESS : FEAT_MORE;
 	if (square_canputitem(c, grid))
-		place_stairs(c, grid, feat);
+		place_stairs(c, grid, quest, feat);
 }
 
 
@@ -542,9 +547,10 @@ void place_random_door(struct chunk *c, struct loc grid)
  * to staircases of the same type.
  * \param avoid_list If not NULL and minsep is greater than zero, also avoid
  * the locations in avoid_list which have staircases of the opposite type.
+ * \param quest is whether or not this is a quest level.
  */
 void alloc_stairs(struct chunk *c, int feat, int num, int minsep, bool sepany,
-		const struct connector *avoid_list)
+		const struct connector *avoid_list, bool quest)
 {
 	int i, navalloc, nav;
 	struct loc *av;
@@ -638,7 +644,7 @@ void alloc_stairs(struct chunk *c, int feat, int num, int minsep, bool sepany,
 					av[nav++] = grid;
 				}
 
-				place_stairs(c, grid, feat);
+				place_stairs(c, grid, quest, feat);
 				assert(square_isstairs(c, grid));
 				done = true;
 			}

--- a/src/generate.h
+++ b/src/generate.h
@@ -181,7 +181,10 @@ struct dun_data {
     /*!< The number of staircase rooms */
     int nstair_room;
 
-    /*!< Whether or not  persistent levels are being used */
+    /*!< Whether or not this is a quest level */
+    bool quest;
+
+    /*!< Whether or not persistent levels are being used */
     bool persist;
 };
 
@@ -414,9 +417,9 @@ void place_gold(struct chunk *c, struct loc grid, int level, byte origin);
 void place_secret_door(struct chunk *c, struct loc grid);
 void place_closed_door(struct chunk *c, struct loc grid);
 void place_random_door(struct chunk *c, struct loc grid);
-void place_random_stairs(struct chunk *c, struct loc grid);
+void place_random_stairs(struct chunk *c, struct loc grid, bool quest);
 void alloc_stairs(struct chunk *c, int feat, int num, int minsep, bool sepany,
-	const struct connector *avoid_list);
+	const struct connector *avoid_list, bool quest);
 void vault_objects(struct chunk *c, struct loc grid, int depth, int num);
 void vault_traps(struct chunk *c, struct loc grid, int yd, int xd, int num);
 void vault_monsters(struct chunk *c, struct loc grid, int depth, int num);

--- a/src/player-quest.c
+++ b/src/player-quest.c
@@ -137,7 +137,7 @@ struct file_parser quests_parser = {
 /**
  * Check if the given level is a quest level.
  */
-bool is_quest(int level)
+bool is_quest(struct player *p, int level)
 {
 	size_t i;
 
@@ -145,7 +145,7 @@ bool is_quest(int level)
 	if (!level) return false;
 
 	for (i = 0; i < z_info->quest_max; i++)
-		if (player->quests[i].level == level)
+		if (p->quests[i].level == level)
 			return true;
 
 	return false;

--- a/src/player-quest.h
+++ b/src/player-quest.h
@@ -23,7 +23,7 @@
 extern struct quest *quests;
 
 /* Functions */
-bool is_quest(int level);
+bool is_quest(struct player *p, int level);
 void player_quests_reset(struct player *p);
 void player_quests_free(struct player *p);
 bool quest_check(struct player *p, const struct monster *m);

--- a/src/player-util.c
+++ b/src/player-util.c
@@ -32,6 +32,7 @@
 #include "obj-util.h"
 #include "player-calcs.h"
 #include "player-history.h"
+#include "player-quest.h"
 #include "player-spell.h"
 #include "player-timed.h"
 #include "player-util.h"
@@ -48,7 +49,7 @@
    Keep in mind to check all intermediate level for unskippable
    quests
 */
-int dungeon_get_next_level(int dlev, int added)
+int dungeon_get_next_level(struct player *p, int dlev, int added)
 {
 	int target_level, i;
 
@@ -64,7 +65,7 @@ int dungeon_get_next_level(int dlev, int added)
 
 	/* Check intermediate levels for quests */
 	for (i = dlev; i <= target_level; i++) {
-		if (is_quest(i)) return i;
+		if (is_quest(p, i)) return i;
 	}
 
 	return target_level;
@@ -78,8 +79,10 @@ void player_set_recall_depth(struct player *p)
 	/* Account for forced descent */
 	if (OPT(p, birth_force_descend)) {
 		/* Force descent to a lower level if allowed */
-		if ((p->max_depth < z_info->max_depth - 1) && !is_quest(p->max_depth)) {
-			p->recall_depth = dungeon_get_next_level(p->max_depth, 1);
+		if (p->max_depth < z_info->max_depth - 1
+				&& !is_quest(p, p->max_depth)) {
+			p->recall_depth = dungeon_get_next_level(p,
+				p->max_depth, 1);
 		}
 	}
 

--- a/src/player-util.h
+++ b/src/player-util.h
@@ -60,7 +60,7 @@ enum
  */
 #define REST_REQUIRED_FOR_REGEN 5
 
-int dungeon_get_next_level(int dlev, int added);
+int dungeon_get_next_level(struct player *p, int dlev, int added);
 void player_set_recall_depth(struct player *p);
 bool player_get_recall_depth(struct player *p);
 void dungeon_change_level(struct player *p, int dlev);

--- a/src/trap.c
+++ b/src/trap.c
@@ -24,6 +24,7 @@
 #include "mon-util.h"
 #include "obj-knowledge.h"
 #include "player-attack.h"
+#include "player-quest.h"
 #include "player-timed.h"
 #include "player-util.h"
 #include "trap.h"
@@ -299,7 +300,7 @@ static int pick_trap(struct chunk *c, int feat, int trap_level)
 		/* Check legality of trapdoors. */
 		if (trf_has(kind->flags, TRF_DOWN)) {
 			/* No trap doors on quest levels */
-			if (is_quest(player->depth)) continue;
+			if (is_quest(player, player->depth)) continue;
 
 			/* No trap doors on the deepest level */
 			if (player->depth >= z_info->max_depth - 1)
@@ -556,7 +557,8 @@ extern void hit_trap(struct loc grid, int delayed)
 		/* Some traps drop you a dungeon level */
 		if (trf_has(trap->kind->flags, TRF_DOWN))
 			dungeon_change_level(player,
-								 dungeon_get_next_level(player->depth, 1));
+				dungeon_get_next_level(player,
+				player->depth, 1));
 
 		/* Some traps drop you onto them */
 		if (trf_has(trap->kind->flags, TRF_PIT))


### PR DESCRIPTION
Remove duplicated declaration of is_quest() from cave.h leaving the declaration in player-quest.h.  Add a Boolean argument to place_random_stairs() and alloc_stairs() to indicate whether this is a quest level or not.  Cache the result of is_quest() in the dun_data structure for cave generation.

In the cave profile selection for quest levels, simply use classic levels since those are now allowed when persistent levels are used.  That also simplifies the logic in labyrinth_check() a bit.

Resolves https://github.com/angband/angband/issues/5027 .  Resolves https://github.com/angband/angband/issues/5028.  Both are part of https://github.com/angband/angband/issues/4934 :  places where callers take a struct chunk or struct player but end up calling functions that use the cave or player globals.