### PR TITLE
Add a player argument to object_desc()

### DIFF
--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -1625,7 +1625,8 @@ void do_cmd_mon_command(struct command *cmd)
 			obj->held_m_idx = 0;
 			pile_excise(&mon->held_obj, obj);
 			drop_near(cave, &obj, 0, mon->grid, true, false);
-			object_desc(o_name, sizeof(o_name), obj, ODESC_PREFIX | ODESC_FULL);
+			object_desc(o_name, sizeof(o_name), obj,
+				ODESC_PREFIX | ODESC_FULL, player);
 			if (!ignore_item_ok(obj)) {
 				msg("%s drops %s.", m_name, o_name);
 			}

--- a/src/cmd-obj.c
+++ b/src/cmd-obj.c
@@ -118,7 +118,7 @@ static int beam_chance(int tval)
 /**
  * Print an artifact activation message.
  */
-static void activation_message(struct object *obj)
+static void activation_message(struct object *obj, const struct player *p)
 {
 	const char *message;
 
@@ -130,7 +130,7 @@ static void activation_message(struct object *obj)
 	} else {
 		message = obj->activation->message;
 	}
-	print_custom_message(obj, message, MSG_GENERIC);
+	print_custom_message(obj, message, MSG_GENERIC, p);
 }
 
 
@@ -191,7 +191,8 @@ void do_cmd_inscribe(struct command *cmd)
 		return;
 
 	/* Form prompt */
-	object_desc(o_name, sizeof(o_name), obj, ODESC_PREFIX | ODESC_FULL);
+	object_desc(o_name, sizeof(o_name), obj, ODESC_PREFIX | ODESC_FULL,
+		player);
 	strnfmt(prompt, sizeof prompt, "Inscribing %s.", o_name);
 
 	if (cmd_get_string(cmd, "inscription", &str,
@@ -306,7 +307,8 @@ void do_cmd_wield(struct command *cmd)
 
 	/* Prevent wielding into a stickied slot */
 	if (!obj_can_takeoff(equip_obj)) {
-		object_desc(o_name, sizeof(o_name), equip_obj, ODESC_BASE);
+		object_desc(o_name, sizeof(o_name), equip_obj, ODESC_BASE,
+			player);
 		msg("You cannot remove the %s you are %s.", o_name,
 			equip_describe(player, slot));
 		return;
@@ -317,14 +319,15 @@ void do_cmd_wield(struct command *cmd)
 	while (n--) {
 		/* Prompt */
 		object_desc(o_name, sizeof(o_name), equip_obj,
-					ODESC_PREFIX | ODESC_FULL);
+			ODESC_PREFIX | ODESC_FULL, player);
 		
 		/* Forget it */
 		if (!get_check(format("Really take off %s? ", o_name))) return;
 	}
 
 	/* Describe the object */
-	object_desc(o_name, sizeof(o_name), equip_obj, ODESC_PREFIX | ODESC_FULL);
+	object_desc(o_name, sizeof(o_name), equip_obj,
+		ODESC_PREFIX | ODESC_FULL, player);
 
 	/* Took off weapon */
 	if (slot_type_is(player, slot, EQUIP_WEAPON))
@@ -458,7 +461,7 @@ static void use_aux(struct command *cmd, struct object *obj, enum use use,
 		/* Sound and/or message */
 		if (obj->activation) {
 			msgt(snd, "You activate it.");
-			activation_message(obj);
+			activation_message(obj, player);
 		} else if (obj->kind->effect_msg) {
 			msgt(snd, "%s", obj->kind->effect_msg);
 		} else if (obj->kind->vis_msg && !player->timed[TMD_BLIND]) {
@@ -567,7 +570,8 @@ static void use_aux(struct command *cmd, struct object *obj, enum use use,
 			}
 			/* Get a description */
 			work_obj->number = number + ((used) ? 0 : 1);
-			object_desc(name, sizeof(name), work_obj, ODESC_PREFIX | ODESC_FULL);
+			object_desc(name, sizeof(name), work_obj,
+				ODESC_PREFIX | ODESC_FULL, player);
 			work_obj->number = old_num;
 			if (from_floor) {
 				/* Print a message */

--- a/src/cmd-wizard.c
+++ b/src/cmd-wizard.c
@@ -188,7 +188,8 @@ static struct object *wiz_create_object_from_kind(struct object_kind *kind)
 /**
  * Display an item's properties.
  */
-static void wiz_display_item(const struct object *obj, bool all)
+static void wiz_display_item(const struct object *obj, bool all,
+		const struct player *p)
 {
 	static const char *flagLabels[] = {
 		#define OF(a, b) b,
@@ -212,7 +213,7 @@ static void wiz_display_item(const struct object *obj, bool all)
 
 	/* Describe fully */
 	object_desc(buf, sizeof(buf), obj,
-		ODESC_PREFIX | ODESC_FULL | ODESC_SPOIL);
+		ODESC_PREFIX | ODESC_FULL | ODESC_SPOIL, p);
 
 	prt(buf, 2, j);
 
@@ -1723,7 +1724,7 @@ void do_cmd_wiz_play_item(struct command *cmd)
 	}
 
 	/* Display the (possibly modified) item. */
-	wiz_display_item(obj, display_all_prop != 0);
+	wiz_display_item(obj, display_all_prop != 0, player);
 
 	/* Get choice. */
 	if (get_com("[a]ccept [s]tatistics [r]eroll [t]weak [c]urse [q]uantity [k]nown? ", &ch)) {
@@ -2455,7 +2456,7 @@ void do_cmd_wiz_stat_item(struct command *cmd)
 	}
 
 	/* Display item. */
-	wiz_display_item(obj, true);
+	wiz_display_item(obj, true, player);
 
 	/* Get what kind of treasure to generate. */
 	if (cmd_get_arg_choice(cmd, "choice", &treasure_choice) != CMD_OK) {
@@ -2824,7 +2825,7 @@ void do_cmd_wiz_tweak_item(struct command *cmd)
 		obj->notice = notice;
 		ego_apply_magic(obj, player->depth);
 	}
-	wiz_display_item(obj, true);
+	wiz_display_item(obj, true, player);
 
 	/* Get artifact name */
 	if (obj->artifact) {
@@ -2871,7 +2872,7 @@ void do_cmd_wiz_tweak_item(struct command *cmd)
 		obj->notice = notice;
 		copy_artifact_data(obj, obj->artifact);
 	}
-	wiz_display_item(obj, true);
+	wiz_display_item(obj, true, player);
 
 #define WIZ_TWEAK(attribute, name) do {\
 		char prompt[80];\
@@ -2887,7 +2888,7 @@ void do_cmd_wiz_tweak_item(struct command *cmd)
 		}\
 		if (get_int_from_string(tmp_val, &val)) {\
 			obj->attribute = val;\
-			wiz_display_item(obj, true);\
+			wiz_display_item(obj, true, player);\
 		}\
 } while (0)
 	for (i = 0; i < OBJ_MOD_MAX; i++) {

--- a/src/effect-handler-attack.c
+++ b/src/effect-handler-attack.c
@@ -496,7 +496,8 @@ bool effect_handler_DAMAGE(effect_handler_context_t *context)
 		case SRC_OBJECT: {
 			/* Must be a cursed weapon */
 			struct object *obj = context->origin.which.object;
-			object_desc(killer, sizeof(killer), obj, ODESC_PREFIX | ODESC_BASE);
+			object_desc(killer, sizeof(killer), obj,
+				ODESC_PREFIX | ODESC_BASE, player);
 			break;
 		}
 

--- a/src/effect-handler-general.c
+++ b/src/effect-handler-general.c
@@ -169,7 +169,8 @@ static bool uncurse_object(struct object *obj, int strength, char *dice_string)
 			remove_object_curse(obj, index, true);
 		} else if (!of_has(obj->flags, OF_FRAGILE)) {
 			/* Failure to remove, object is now fragile */
-			object_desc(o_name, sizeof(o_name), obj, ODESC_FULL);
+			object_desc(o_name, sizeof(o_name), obj, ODESC_FULL,
+				player);
 			msgt(MSG_CURSED, "The spell fails; your %s is now fragile.", o_name);
 			of_on(obj->flags, OF_FRAGILE);
 			player_learn_flag(player, OF_FRAGILE);
@@ -357,7 +358,7 @@ static bool enchant_spell(int num_hit, int num_dam, int num_ac, struct command *
 		return false;
 
 	/* Description */
-	object_desc(o_name, sizeof(o_name), obj, ODESC_BASE);
+	object_desc(o_name, sizeof(o_name), obj, ODESC_BASE, player);
 
 	/* Describe */
 	msg("%s %s glow%s brightly!",
@@ -398,7 +399,7 @@ static void brand_object(struct object *obj, const char *name)
 		char o_name[80];
 		char brand[20];
 
-		object_desc(o_name, sizeof(o_name), obj, ODESC_BASE);
+		object_desc(o_name, sizeof(o_name), obj, ODESC_BASE, player);
 		strnfmt(brand, sizeof(brand), "of %s", name);
 
 		/* Describe */
@@ -1922,7 +1923,7 @@ bool effect_handler_DISENCHANT(effect_handler_context_t *context)
 		return true;
 
 	/* Describe the object */
-	object_desc(o_name, sizeof(o_name), obj, ODESC_BASE);
+	object_desc(o_name, sizeof(o_name), obj, ODESC_BASE, player);
 
 	/* Artifacts have a 60% chance to resist */
 	if (obj->artifact && (randint0(100) < 60)) {
@@ -2932,7 +2933,7 @@ bool effect_handler_CURSE_ARMOR(effect_handler_context_t *context)
 	if (!obj) return (true);
 
 	/* Describe */
-	object_desc(o_name, sizeof(o_name), obj, ODESC_FULL);
+	object_desc(o_name, sizeof(o_name), obj, ODESC_FULL, player);
 
 	/* Attempt a saving throw for artifacts */
 	if (obj->artifact && (randint0(100) < 50)) {
@@ -2990,7 +2991,7 @@ bool effect_handler_CURSE_WEAPON(effect_handler_context_t *context)
 	if (!obj) return (true);
 
 	/* Describe */
-	object_desc(o_name, sizeof(o_name), obj, ODESC_FULL);
+	object_desc(o_name, sizeof(o_name), obj, ODESC_FULL, player);
 
 	/* Attempt a saving throw */
 	if (obj->artifact && (randint0(100) < 50)) {

--- a/src/game-world.c
+++ b/src/game-world.c
@@ -174,7 +174,7 @@ static void recharged_notice(const struct object *obj, bool all)
 	if (!notify) return;
 
 	/* Describe (briefly) */
-	object_desc(o_name, sizeof(o_name), obj, ODESC_BASE);
+	object_desc(o_name, sizeof(o_name), obj, ODESC_BASE, player);
 
 	/* Disturb the player */
 	disturb(player);

--- a/src/mon-blows.c
+++ b/src/mon-blows.c
@@ -199,7 +199,7 @@ static void steal_player_item(melee_effect_handler_context_t *context)
         if (obj->artifact) continue;
 
         /* Get a description */
-        object_desc(o_name, sizeof(o_name), obj, ODESC_FULL);
+        object_desc(o_name, sizeof(o_name), obj, ODESC_FULL, context->p);
 
 		/* Is it one of a stack being stolen? */
 		if (obj->number > 1)
@@ -794,11 +794,12 @@ static void melee_effect_handler_EAT_FOOD(melee_effect_handler_context_t *contex
 		if (!tval_is_edible(obj)) continue;
 
 		if (obj->number == 1) {
-			object_desc(o_name, sizeof(o_name), obj, ODESC_BASE);
+			object_desc(o_name, sizeof(o_name), obj, ODESC_BASE,
+				context->p);
 			msg("Your %s (%c) was eaten!", o_name, I2A(index));
 		} else {
 			object_desc(o_name, sizeof(o_name), obj,
-						ODESC_PREFIX | ODESC_BASE);
+				ODESC_PREFIX | ODESC_BASE, context->p);
 			msg("One of your %s (%c) was eaten!", o_name,
 				I2A(index));
 		}

--- a/src/mon-move.c
+++ b/src/mon-move.c
@@ -1406,7 +1406,8 @@ static void monster_turn_grab_objects(struct monster *mon, const char *m_name,
 		}
 
 		/* Get the object name */
-		object_desc(o_name, sizeof(o_name), obj, ODESC_PREFIX | ODESC_FULL);
+		object_desc(o_name, sizeof(o_name), obj,
+			ODESC_PREFIX | ODESC_FULL, player);
 
 		/* React to objects that hurt the monster */
 		if (react_to_slay(obj, mon))

--- a/src/mon-util.c
+++ b/src/mon-util.c
@@ -727,7 +727,7 @@ void become_aware(struct chunk *c, struct monster *mon, struct player *p)
 		if (mon->mimicked_obj) {
 			struct object *obj = mon->mimicked_obj;
 			char o_name[80];
-			object_desc(o_name, sizeof(o_name), obj, ODESC_BASE);
+			object_desc(o_name, sizeof(o_name), obj, ODESC_BASE, p);
 
 			/* Print a message */
 			if (square_isseen(c, obj->grid))
@@ -1485,7 +1485,8 @@ void steal_monster_item(struct monster *mon, int midx)
 				if (ignore_item_ok(obj)) {
 					char o_name[80];
 					object_desc(o_name, sizeof(o_name), obj,
-								ODESC_PREFIX | ODESC_FULL);
+						ODESC_PREFIX | ODESC_FULL,
+						player);
 					drop_near(cave, &obj, 0, player->grid, true, true);
 					msg("You drop %s.", o_name);
 				} else {
@@ -1507,7 +1508,7 @@ void steal_monster_item(struct monster *mon, int midx)
 				(void)strnfmt(o_name, sizeof(o_name), "treasure");
 			} else {
 				object_desc(o_name, sizeof(o_name), obj,
-							ODESC_PREFIX | ODESC_FULL);
+					ODESC_PREFIX | ODESC_FULL, player);
 			}
 			msg("You fail to steal %s from %s.", o_name, m_name);
 			/* Monster wakes, may notice */

--- a/src/obj-desc.h
+++ b/src/obj-desc.h
@@ -49,6 +49,7 @@ void object_kind_name(char *buf, size_t max, const struct object_kind *kind,
 					  bool easy_know);
 size_t obj_desc_name_format(char *buf, size_t max, size_t end, const char *fmt,
 							const char *modstr, bool pluralise);
-size_t object_desc(char *buf, size_t max, const struct object *obj, int mode);
+size_t object_desc(char *buf, size_t max, const struct object *obj, int mode,
+		const struct player *p);
 
 #endif /* OBJECT_DESC_H */

--- a/src/obj-gear.c
+++ b/src/obj-gear.c
@@ -337,7 +337,7 @@ bool minus_ac(struct player *p)
 	/* If we can still damage the item */
 	if (obj && (obj->ac + obj->to_a > 0)) {
 		char o_name[80];
-		object_desc(o_name, sizeof(o_name), obj, ODESC_BASE);
+		object_desc(o_name, sizeof(o_name), obj, ODESC_BASE, p);
 
 		/* Object resists */
 		if (obj->el_info[ELEM_ACID].flags & EL_INFO_IGNORE) {
@@ -461,16 +461,19 @@ struct object *gear_object_for_use(struct player *p, struct object *obj,
 		p->upkeep->total_weight -= (num * obj->weight);
 
 		if (message) {
-			object_desc(name, sizeof(name), obj, ODESC_PREFIX | ODESC_FULL);
+			object_desc(name, sizeof(name), obj,
+				ODESC_PREFIX | ODESC_FULL, p);
 		}
 	} else {
 		if (message) {
 			if (artifact) {
-				object_desc(name, sizeof(name), obj, ODESC_FULL | ODESC_SINGULAR);
+				object_desc(name, sizeof(name), obj,
+					ODESC_FULL | ODESC_SINGULAR, p);
 			} else {
 				/* Describe zero amount */
 				obj->number = 0;
-				object_desc(name, sizeof(name), obj, ODESC_PREFIX | ODESC_FULL);
+				object_desc(name, sizeof(name), obj,
+					ODESC_PREFIX | ODESC_FULL, p);
 				obj->number = num;
 			}
 		}
@@ -750,7 +753,8 @@ void inven_carry(struct player *p, struct object *obj, bool absorb,
 
 	if (message) {
 		char o_name[80];
-		object_desc(o_name, sizeof(o_name), obj, ODESC_PREFIX | ODESC_FULL);
+		object_desc(o_name, sizeof(o_name), obj,
+			ODESC_PREFIX | ODESC_FULL, p);
 		msg("You have %s (%c).", o_name, gear_to_label(p, obj));
 	}
 
@@ -826,7 +830,8 @@ void inven_wield(struct object *obj, int slot)
 		fmt = "You are wearing %s (%c).";
 
 	/* Describe the result */
-	object_desc(o_name, sizeof(o_name), wielded, ODESC_PREFIX | ODESC_FULL);
+	object_desc(o_name, sizeof(o_name), wielded,
+		ODESC_PREFIX | ODESC_FULL, player);
 
 	/* Message */
 	msgt(MSG_WIELD, fmt, o_name, I2A(slot));
@@ -872,7 +877,8 @@ void inven_takeoff(struct object *obj)
 	if (slot == player->body.count) return;
 
 	/* Describe the object */
-	object_desc(o_name, sizeof(o_name), obj, ODESC_PREFIX | ODESC_FULL);
+	object_desc(o_name, sizeof(o_name), obj, ODESC_PREFIX | ODESC_FULL,
+		player);
 
 	/* Describe removal by slot */
 	if (slot_type_is(player, slot, EQUIP_WEAPON))
@@ -943,7 +949,8 @@ void inven_drop(struct object *obj, int amt)
 	dropped = gear_object_for_use(player, obj, amt, false, &none_left);
 
 	/* Describe the dropped object */
-	object_desc(name, sizeof(name), dropped, ODESC_PREFIX | ODESC_FULL);
+	object_desc(name, sizeof(name), dropped, ODESC_PREFIX | ODESC_FULL,
+		player);
 
 	/* Message */
 	msg("You drop %s (%c).", name, label);
@@ -951,17 +958,19 @@ void inven_drop(struct object *obj, int amt)
 	/* Describe what's left */
 	if (dropped->artifact) {
 		object_desc(name, sizeof(name), dropped,
-					ODESC_FULL | ODESC_SINGULAR);
+			ODESC_FULL | ODESC_SINGULAR, player);
 		msg("You no longer have the %s (%c).", name, label);
 	} else if (none_left) {
 		/* Play silly games to get the right description */
 		int number = dropped->number;
 		dropped->number = 0;
-		object_desc(name, sizeof(name), dropped, ODESC_PREFIX | ODESC_FULL);
+		object_desc(name, sizeof(name), dropped,
+			ODESC_PREFIX | ODESC_FULL, player);
 		msg("You have %s (%c).", name, label);
 		dropped->number = number;
 	} else {
-		object_desc(name, sizeof(name), obj, ODESC_PREFIX | ODESC_FULL);
+		object_desc(name, sizeof(name), obj,
+			ODESC_PREFIX | ODESC_FULL, player);
 		msg("You have %s (%c).", name, label);
 	}
 
@@ -1158,7 +1167,8 @@ void pack_overflow(struct object *obj)
 	assert(obj != NULL);
 
 	/* Describe */
-	object_desc(o_name, sizeof(o_name), obj, ODESC_PREFIX | ODESC_FULL);
+	object_desc(o_name, sizeof(o_name), obj, ODESC_PREFIX | ODESC_FULL,
+		player);
 	if (obj->artifact) {
 		artifact = true;
 	}

--- a/src/obj-ignore.c
+++ b/src/obj-ignore.c
@@ -270,7 +270,7 @@ int apply_autoinscription(struct player *p, struct object *obj)
 		return 0;
 
 	/* Get an object description */
-	object_desc(o_name, sizeof(o_name), obj, ODESC_PREFIX | ODESC_FULL);
+	object_desc(o_name, sizeof(o_name), obj, ODESC_PREFIX | ODESC_FULL, p);
 
 	if (note[0] != 0)
 		obj->note = quark_add(note);
@@ -657,7 +657,7 @@ void ignore_drop(struct player *p)
 		if (!check_for_inscrip(obj, "!d") && !check_for_inscrip(obj, "!*")) {
 			/* Confirm the drop if the item is equipped. */
 			if (object_is_equipped(p->body, obj)) {
-				if (!verify_object("Really take off and drop", obj)) {
+				if (!verify_object("Really take off and drop", obj, p)) {
 					/* Hack - inscribe the item with !d to prevent repeated
 					 * confirmations. */
 					const char *inscription = quark_str(obj->note);

--- a/src/obj-knowledge.c
+++ b/src/obj-knowledge.c
@@ -1140,10 +1140,12 @@ void player_know_object(struct player *p, struct object *obj)
 
 		/* Describe the object if it's available */
 		if (object_is_carried(p, obj)) {
-			object_desc(o_name, sizeof(o_name), obj, ODESC_PREFIX | ODESC_FULL);
+			object_desc(o_name, sizeof(o_name), obj,
+				ODESC_PREFIX | ODESC_FULL, p);
 			msg("You have %s (%c).", o_name, gear_to_label(p, obj));
 		} else if (cave && square_holds_object(cave, p->grid, obj)) {
-			object_desc(o_name, sizeof(o_name), obj, ODESC_PREFIX | ODESC_FULL);
+			object_desc(o_name, sizeof(o_name), obj,
+				ODESC_PREFIX | ODESC_FULL, p);
 			msg("On the ground: %s.", o_name);
 		}
 	}
@@ -1545,7 +1547,7 @@ static bool object_curses_find_flags(struct player *p, struct object *obj,
 	char o_name[80];
 	bool new = false;
 
-	object_desc(o_name, sizeof(o_name), obj, ODESC_BASE);
+	object_desc(o_name, sizeof(o_name), obj, ODESC_BASE, p);
 	if (obj->curses) {
 		int i;
 		int index;
@@ -1633,7 +1635,7 @@ static bool object_curses_find_element(struct player *p, struct object *obj, int
 	char o_name[80];
 	bool new = false;
 
-	object_desc(o_name, sizeof(o_name), obj, ODESC_BASE);
+	object_desc(o_name, sizeof(o_name), obj, ODESC_BASE, p);
 	if (obj->curses) {
 		int i;
 
@@ -1724,7 +1726,7 @@ void object_learn_on_wield(struct player *p, struct object *obj)
 	char o_name[80];
 
 	assert(obj->known);
-	object_desc(o_name, sizeof(o_name), obj, ODESC_BASE);
+	object_desc(o_name, sizeof(o_name), obj, ODESC_BASE, p);
 
 	/* Check the worn flag */
 	if (obj->known->notice & OBJ_NOTICE_WORN) {
@@ -2058,7 +2060,8 @@ void equip_learn_flag(struct player *p, int flag)
 		if (of_has(obj->flags, flag)) {
 			if (!of_has(p->obj_k->flags, flag)) {
 				char o_name[80];
-				object_desc(o_name, sizeof(o_name), obj, ODESC_BASE);
+				object_desc(o_name, sizeof(o_name), obj,
+					ODESC_BASE, p);
 				flag_message(flag, o_name);
 				player_learn_rune(p, rune_index(RUNE_VAR_FLAG, flag), true);
 			}
@@ -2096,7 +2099,7 @@ void equip_learn_element(struct player *p, int element)
 		/* Does the object affect the player's resistance to the element? */
 		if (obj->el_info[element].res_level != 0) {
 			char o_name[80];
-			object_desc(o_name, sizeof(o_name), obj, ODESC_BASE);
+			object_desc(o_name, sizeof(o_name), obj, ODESC_BASE, p);
 
 			/* Message */
 			msg("Your %s glows.", o_name);
@@ -2141,7 +2144,7 @@ void equip_learn_after_time(struct player *p)
 
 		if (!obj) continue;
 		assert(obj->known);
-		object_desc(o_name, sizeof(o_name), obj, ODESC_BASE);
+		object_desc(o_name, sizeof(o_name), obj, ODESC_BASE, p);
 
 		/* Get the unknown timed flags for this object */
 		object_flags(obj, f);

--- a/src/obj-list.c
+++ b/src/obj-list.c
@@ -420,7 +420,8 @@ void object_list_format_name(const object_list_entry_t *entry,
 	 */
 	old_number = entry->object->number;
 	entry->object->number = entry->count[field];
-	object_desc(name, sizeof(name), base_obj, ODESC_PREFIX | ODESC_FULL);
+	object_desc(name, sizeof(name), base_obj, ODESC_PREFIX | ODESC_FULL,
+		player);
 	entry->object->number = old_number;
 
 	/* The source string for strtok() needs to be set properly, depending on

--- a/src/obj-pile.c
+++ b/src/obj-pile.c
@@ -858,7 +858,8 @@ struct object *floor_object_for_use(struct object *obj, int num, bool message,
 			obj->number = 0;
 
 		/* Get a description */
-		object_desc(name, sizeof(name), obj, ODESC_PREFIX | ODESC_FULL);
+		object_desc(name, sizeof(name), obj, ODESC_PREFIX | ODESC_FULL,
+			player);
 
 		if (usable == obj)
 			obj->number = num;
@@ -988,7 +989,7 @@ static void floor_carry_fail(struct chunk *c, struct object *drop, bool broke)
 		const char *verb = broke ?
 			VERB_AGREEMENT(drop->number, "breaks", "break") :
 			VERB_AGREEMENT(drop->number, "disappears", "disappear");
-		object_desc(o_name, sizeof(o_name), drop, ODESC_BASE);
+		object_desc(o_name, sizeof(o_name), drop, ODESC_BASE, player);
 		msg("The %s %s.", o_name, verb);
 		if (!loc_is_zero(known->grid))
 			square_excise_object(player->cave, known->grid, known);
@@ -1122,7 +1123,7 @@ void drop_near(struct chunk *c, struct object **dropped, int chance,
 	assert(c == cave);
 
 	/* Describe object */
-	object_desc(o_name, sizeof(o_name), *dropped, ODESC_BASE);
+	object_desc(o_name, sizeof(o_name), *dropped, ODESC_BASE, player);
 
 	/* Handle normal breakage */
 	if (!((*dropped)->artifact) && (randint0(100) < chance)) {

--- a/src/obj-randart.c
+++ b/src/obj-randart.c
@@ -202,7 +202,7 @@ static int artifact_power(int a_idx, const char *reason, bool verbose)
 	object_copy(known_obj, obj);
 	obj->known = known_obj;
 	object_desc(buf, 256 * sizeof(char), obj,
-				ODESC_PREFIX | ODESC_FULL | ODESC_SPOIL);
+		ODESC_PREFIX | ODESC_FULL | ODESC_SPOIL, NULL);
 	file_putf(log_file, "%s\n", buf);
 
 	power = object_power(obj, verbose, log_file);

--- a/src/obj-util.c
+++ b/src/obj-util.c
@@ -933,14 +933,15 @@ bool recharge_timeout(struct object *obj)
  *
  * The item can be negative to mean "item on floor".
  */
-bool verify_object(const char *prompt, const struct object *obj)
+bool verify_object(const char *prompt, const struct object *obj,
+		const struct player *p)
 {
 	char o_name[80];
 
 	char out_val[160];
 
 	/* Describe */
-	object_desc(o_name, sizeof(o_name), obj, ODESC_PREFIX | ODESC_FULL);
+	object_desc(o_name, sizeof(o_name), obj, ODESC_PREFIX | ODESC_FULL, p);
 
 	/* Prompt */
 	strnfmt(out_val, sizeof(out_val), "%s %s? ", prompt, o_name);
@@ -976,7 +977,8 @@ static msg_tag_t msg_tag_lookup(const char *tag)
 /**
  * Print a message from a string, customised to include details about an object
  */
-void print_custom_message(struct object *obj, const char *string, int msg_type)
+void print_custom_message(struct object *obj, const char *string, int msg_type,
+		const struct player *p)
 {
 	char buf[1024] = "\0";
 	const char *next;
@@ -1005,7 +1007,7 @@ void print_custom_message(struct object *obj, const char *string, int msg_type)
 			case MSG_TAG_NAME:
 				if (obj) {
 					end += object_desc(buf, 1024, obj,
-									   ODESC_PREFIX | ODESC_BASE);
+						ODESC_PREFIX | ODESC_BASE, p);
 				} else {
 					strnfcat(buf, 1024, &end, "hands");
 				}

--- a/src/obj-util.h
+++ b/src/obj-util.h
@@ -66,8 +66,10 @@ int get_use_device_chance(const struct object *obj);
 void distribute_charges(struct object *source, struct object *dest, int amt);
 int number_charging(const struct object *obj);
 bool recharge_timeout(struct object *obj);
-bool verify_object(const char *prompt, const struct object *obj);
-void print_custom_message(struct object *obj, const char *string, int msg_type);
+bool verify_object(const char *prompt, const struct object *obj,
+		const struct player *p);
+void print_custom_message(struct object *obj, const char *string, int msg_type,
+		const struct player *p);
 
 bool is_artifact_created(const struct artifact *art);
 bool is_artifact_seen(const struct artifact *art);

--- a/src/player-attack.c
+++ b/src/player-attack.c
@@ -1116,7 +1116,7 @@ static void ranged_helper(struct player *p,	struct object *obj, int dir,
 				 * knowledge now).
 				 */
 				object_desc(o_name, sizeof(o_name), obj,
-					ODESC_FULL | ODESC_SINGULAR);
+					ODESC_FULL | ODESC_SINGULAR, p);
 
 				/* No negative damage; change verb if no damage done */
 				if (dmg <= 0) {

--- a/src/player-history.c
+++ b/src/player-history.c
@@ -207,7 +207,8 @@ static void get_artifact_name(char *buf, size_t len, const struct artifact *arti
 
 	fake->known = known_obj;
 	object_copy(known_obj, fake);
-	object_desc(buf, len, fake, ODESC_PREFIX | ODESC_BASE | ODESC_SPOIL);
+	object_desc(buf, len, fake, ODESC_PREFIX | ODESC_BASE | ODESC_SPOIL,
+		NULL);
 
 	object_wipe(known_obj);
 	object_wipe(fake);

--- a/src/player-timed.c
+++ b/src/player-timed.c
@@ -544,22 +544,27 @@ bool player_set_timed(struct player *p, int idx, int v, bool notify)
 
 	/* Always mention going up a grade, otherwise on request */
 	if (new_grade->grade > current_grade->grade) {
-		print_custom_message(weapon, new_grade->up_msg, effect->msgt);
+		print_custom_message(weapon, new_grade->up_msg,
+			effect->msgt, p);
 		notify = true;
 	} else if ((new_grade->grade < current_grade->grade) &&
 			   (new_grade->down_msg)) {
-		print_custom_message(weapon, new_grade->down_msg, effect->msgt);
+		print_custom_message(weapon, new_grade->down_msg,
+			effect->msgt, p);
 		notify = true;
 	} else if (notify) {
 		if (v == 0) {
 			/* Finishing */
-			print_custom_message(weapon, effect->on_end, MSG_RECOVER);
+			print_custom_message(weapon, effect->on_end,
+				MSG_RECOVER, p);
 		} else if (p->timed[idx] > v && effect->on_decrease) {
 			/* Decrementing */
-			print_custom_message(weapon, effect->on_decrease, effect->msgt);
+			print_custom_message(weapon, effect->on_decrease,
+				effect->msgt, p);
 		} else if (v > p->timed[idx] && effect->on_increase) {
 			/* Incrementing */
-			print_custom_message(weapon, effect->on_increase, effect->msgt);
+			print_custom_message(weapon, effect->on_increase,
+				effect->msgt, p);
 		}
 	}
 

--- a/src/project-obj.c
+++ b/src/project-obj.c
@@ -131,7 +131,8 @@ int inven_damage(struct player *p, int type, int cperc)
 				bool none_left = false;
 
 				/* Get a description */
-				object_desc(o_name, sizeof(o_name), obj, ODESC_BASE);
+				object_desc(o_name, sizeof(o_name), obj,
+					ODESC_BASE, p);
 
 				/* Message */
 				msgt(MSG_DESTROY, "%sour %s (%c) %s %s!",
@@ -544,7 +545,8 @@ bool project_o(struct source origin, int r, struct loc grid, int dam, int typ,
 			if (obj->known && !ignore_item_ok(obj) &&
 				square_isseen(cave, grid)) {
 				obvious = true;
-				object_desc(o_name, sizeof(o_name), obj, ODESC_BASE);
+				object_desc(o_name, sizeof(o_name), obj,
+					ODESC_BASE, player);
 			}
 
 			/* Artifacts, and other objects, get to resist */

--- a/src/project-player.c
+++ b/src/project-player.c
@@ -831,7 +831,8 @@ bool project_p(struct source origin, int r, struct loc grid, int dam, int typ,
 
 		case SRC_OBJECT: {
 			struct object *obj = origin.which.object;
-			object_desc(killer, sizeof(killer), obj, ODESC_PREFIX | ODESC_BASE);
+			object_desc(killer, sizeof(killer), obj,
+				ODESC_PREFIX | ODESC_BASE, player);
 			break;
 		}
 

--- a/src/store.c
+++ b/src/store.c
@@ -1673,7 +1673,8 @@ void do_cmd_buy(struct command *cmd)
 	}
 
 	/* Describe the object (fully) */
-	object_desc(o_name, sizeof(o_name), bought, ODESC_PREFIX | ODESC_FULL);
+	object_desc(o_name, sizeof(o_name), bought, ODESC_PREFIX | ODESC_FULL,
+		player);
 
 	/* Extract the price for the entire stack */
 	price = price_item(store, bought, false, bought->number);
@@ -1694,7 +1695,8 @@ void do_cmd_buy(struct command *cmd)
 	player->upkeep->notice |= (PN_COMBINE | PN_IGNORE);
 
 	/* Describe the object (fully) again for the message */
-	object_desc(o_name, sizeof(o_name), bought, ODESC_PREFIX | ODESC_FULL);
+	object_desc(o_name, sizeof(o_name), bought, ODESC_PREFIX | ODESC_FULL,
+		player);
 
 	/* Message */
 	if (one_in_(3)) msgt(MSG_STORE5, "%s", ONE_OF(comment_accept));
@@ -1930,7 +1932,8 @@ void do_cmd_sell(struct command *cmd)
 	value = object_value_real(sold_item, amt);
 
 	/* Get the description all over again */
-	object_desc(o_name, sizeof(o_name), sold_item, ODESC_PREFIX | ODESC_FULL);
+	object_desc(o_name, sizeof(o_name), sold_item,
+		ODESC_PREFIX | ODESC_FULL, player);
 
 	/* Describe the result (in message buffer) */
 	if (OPT(player, birth_no_selling)) {
@@ -2024,7 +2027,8 @@ void do_cmd_stash(struct command *cmd)
 	dropped = gear_object_for_use(player, obj, amt, false, &none_left);
 
 	/* Describe */
-	object_desc(o_name, sizeof(o_name), dropped, ODESC_PREFIX | ODESC_FULL);
+	object_desc(o_name, sizeof(o_name), dropped,
+		ODESC_PREFIX | ODESC_FULL, player);
 
 	/* Message */
 	msg("You drop %s (%c).", o_name, label);

--- a/src/ui-context.c
+++ b/src/ui-context.c
@@ -527,7 +527,7 @@ int context_menu_cave(struct chunk *c, int y, int x, int adjacent, int mx,
 
 		/* Obtain an object description */
 		object_desc(o_name, sizeof (o_name), square_obj,
-					ODESC_PREFIX | ODESC_FULL);
+			ODESC_PREFIX | ODESC_FULL, player);
 
 		prt(format("(Enter to select command, ESC to cancel) You see %s:",
 				   o_name), 0, 0);
@@ -663,7 +663,8 @@ int context_menu_object(struct object *obj)
 	if (!m || !obj)
 		return 0;
 
-	object_desc(header, sizeof(header), obj, ODESC_PREFIX | ODESC_BASE);
+	object_desc(header, sizeof(header), obj, ODESC_PREFIX | ODESC_BASE,
+		player);
 
 	labels = string_make(lower_case);
 	m->selections = labels;
@@ -774,7 +775,8 @@ int context_menu_object(struct object *obj)
 
 	/* Display info */
 	tb = object_info(obj, OINFO_NONE);
-	object_desc(header, sizeof(header), obj, ODESC_PREFIX | ODESC_FULL);
+	object_desc(header, sizeof(header), obj, ODESC_PREFIX | ODESC_FULL,
+		player);
 
 	textui_textblock_place(tb, area, format("%s", header));
 	textblock_free(tb);
@@ -801,7 +803,8 @@ int context_menu_object(struct object *obj)
 			/* copied from textui_obj_examine */
 			/* Display info */
 			tb = object_info(obj, OINFO_NONE);
-			object_desc(header, sizeof(header), obj, ODESC_PREFIX | ODESC_FULL);
+			object_desc(header, sizeof(header), obj,
+				ODESC_PREFIX | ODESC_FULL, player);
 
 			textui_textblock_show(tb, area, format("%s", header));
 			textblock_free(tb);

--- a/src/ui-death.c
+++ b/src/ui-death.c
@@ -247,7 +247,7 @@ static void death_info(const char *title, int row)
 
 				/* Get the object description */
 				object_desc(o_name, sizeof(o_name), obj,
-						ODESC_PREFIX | ODESC_FULL);
+					ODESC_PREFIX | ODESC_FULL, player);
 
 				/* Get the inventory color */
 				attr = obj->kind->base->attr;
@@ -307,7 +307,7 @@ static void death_examine(const char *title, int row)
 
 		tb = object_info(obj, OINFO_NONE);
 		object_desc(header, sizeof(header), obj,
-				ODESC_PREFIX | ODESC_FULL | ODESC_CAPITAL);
+			ODESC_PREFIX | ODESC_FULL | ODESC_CAPITAL, player);
 
 		textui_textblock_show(tb, area, header);
 		textblock_free(tb);

--- a/src/ui-display.c
+++ b/src/ui-display.c
@@ -2592,10 +2592,13 @@ static void see_floor_items(game_event_type type, game_event_data *data,
 			p = "feel";
 
 		/* Describe the object.  Less detail if blind. */
-		if (blind)
-			object_desc(o_name, sizeof(o_name), obj, ODESC_PREFIX | ODESC_BASE);
-		else
-			object_desc(o_name, sizeof(o_name), obj, ODESC_PREFIX | ODESC_FULL);
+		if (blind) {
+			object_desc(o_name, sizeof(o_name), obj,
+				ODESC_PREFIX | ODESC_BASE, player);
+		} else {
+			object_desc(o_name, sizeof(o_name), obj,
+				ODESC_PREFIX | ODESC_FULL, player);
+		}
 
 		/* Message */
 		event_signal(EVENT_MESSAGE_FLUSH);

--- a/src/ui-equip-cmp.c
+++ b/src/ui-equip-cmp.c
@@ -251,7 +251,8 @@ static int handle_key_equip_cmp_general(struct keypress ch, int istate,
 static int handle_key_equip_cmp_select(struct keypress ch, int istate,
 	struct equippable_summary *s, struct player *p);
 static int prompt_for_easy_filter(struct equippable_summary *s, bool apply_not);
-static void display_object_comparison(const struct equippable_summary *s);
+static void display_object_comparison(const struct equippable_summary *s,
+	const struct player *p);
 static bool dump_to_file(const char *path);
 static void append_to_file(ang_file *fff);
 static void filter_items(struct equippable_summary *s);
@@ -924,7 +925,7 @@ static int handle_key_equip_cmp_select(struct keypress ch, int istate,
 	case 'x':
 		/* Skip the selection. For the first, acts like ESC. */
 		if (istate == EQUIP_CMP_MENU_SEL1) {
-			display_object_comparison(s);
+			display_object_comparison(s, p);
 		}
 		s->isel0 = -1;
 		s->isel1 = -1;
@@ -940,7 +941,7 @@ static int handle_key_equip_cmp_select(struct keypress ch, int istate,
 			result = EQUIP_CMP_MENU_SEL1;
 		} else {
 			s->isel1 = s->sorted_indices[s->work_sel];
-			display_object_comparison(s);
+			display_object_comparison(s, p);
 			s->isel0 = -1;
 			s->isel1 = -1;
 			s->work_sel = -1;
@@ -1174,7 +1175,8 @@ static int prompt_for_easy_filter(struct equippable_summary *s, bool apply_not)
 }
 
 
-static void display_object_comparison(const struct equippable_summary *s)
+static void display_object_comparison(const struct equippable_summary *s,
+		const struct player *p)
 {
 	char hbuf[120];
 	textblock *tb0;
@@ -1183,7 +1185,7 @@ static void display_object_comparison(const struct equippable_summary *s)
 	assert(s->isel0 >= 0 && s->isel0 < s->nitems);
 	tb0 = object_info(s->items[s->isel0].obj, OINFO_NONE);
 	object_desc(hbuf, sizeof(hbuf), s->items[s->isel0].obj,
-		ODESC_PREFIX | ODESC_FULL | ODESC_CAPITAL);
+		ODESC_PREFIX | ODESC_FULL | ODESC_CAPITAL, p);
 	if (s->isel1 != -1 && s->isel1 != s->isel0) {
 		textblock *tb1 = textblock_new();
 		textblock *tb2;
@@ -1192,7 +1194,7 @@ static void display_object_comparison(const struct equippable_summary *s)
 		textblock_append(tb1, "%s\n", hbuf);
 		textblock_append_textblock(tb1, tb0);
 		object_desc(hbuf, sizeof(hbuf), s->items[s->isel1].obj,
-			ODESC_PREFIX | ODESC_FULL | ODESC_CAPITAL);
+			ODESC_PREFIX | ODESC_FULL | ODESC_CAPITAL, p);
 		textblock_append(tb1, "\n%s\n", hbuf);
 		tb2 = object_info(s->items[s->isel1].obj, OINFO_NONE);
 		textblock_append_textblock(tb1, tb2);
@@ -1334,7 +1336,8 @@ static void append_to_file(ang_file *fff)
 }
 
 
-static char *set_short_name(const struct object *obj, size_t length)
+static char *set_short_name(const struct object *obj, size_t length,
+		const struct player *p)
 {
 	char buf[80];
 	const char *nmsrc;
@@ -1350,7 +1353,7 @@ static char *set_short_name(const struct object *obj, size_t length)
 		tail = true;
 	} else {
 		object_desc(buf, N_ELEMENTS(buf), obj, ODESC_COMBAT |
-			ODESC_SINGULAR | ODESC_TERSE);
+			ODESC_SINGULAR | ODESC_TERSE, p);
 		nmsrc = buf;
 		tail = false;
 	}
@@ -1771,7 +1774,8 @@ static void add_obj_to_summary(const struct object *obj, void *closure)
 
 	if (c->summary->nshortnm > 0) {
 		string_free(e->short_name);
-		e->short_name = set_short_name(obj, c->summary->nshortnm);
+		e->short_name = set_short_name(obj, c->summary->nshortnm,
+			c->p);
 		e->nmlen = (int)strlen(e->short_name);
 	}
 
@@ -1848,7 +1852,7 @@ static void apply_visitor_to_equipped(struct player *p,
 
 
 static int reconfigure_for_term_if_necessary(bool update_names,
-	struct equippable_summary *s)
+	const struct player *p, struct equippable_summary *s)
 {
 	int result = 0;
 	int min_length = 16;
@@ -1963,7 +1967,7 @@ static int reconfigure_for_term_if_necessary(bool update_names,
 		for (i = 0; i < s->nitems; ++i) {
 			string_free(s->items[i].short_name);
 			s->items[i].short_name =
-				set_short_name(s->items[i].obj, length);
+				set_short_name(s->items[i].obj, length, p);
 			s->items[i].nmlen =
 				(int)strlen(s->items[i].short_name);
 		}
@@ -2258,7 +2262,7 @@ static int initialize_summary(struct player *p,
 	}
 
 	/* These need to be redone on a change to the terminal size. */
-	if (reconfigure_for_term_if_necessary(false, *s)) {
+	if (reconfigure_for_term_if_necessary(false, p, *s)) {
 		return 1;
 	}
 
@@ -2441,7 +2445,7 @@ static int display_page(struct equippable_summary *s, const struct player *p,
 
 	/* Try to handle terminal size changes while displaying the summary. */
 	if (allow_reconfig) {
-		if (reconfigure_for_term_if_necessary(true, s)) {
+		if (reconfigure_for_term_if_necessary(true, p, s)) {
 			return 1;
 		}
 	}

--- a/src/ui-knowledge.c
+++ b/src/ui-knowledge.c
@@ -1419,7 +1419,8 @@ static void get_artifact_display_name(char *o_name, size_t namelen, int a_idx)
 	object_wipe(known_obj);
 	object_copy(known_obj, obj);
 	obj->known = known_obj;
-	object_desc(o_name, namelen, obj, ODESC_PREFIX | ODESC_BASE | ODESC_SPOIL);
+	object_desc(o_name, namelen, obj,
+		ODESC_PREFIX | ODESC_BASE | ODESC_SPOIL, NULL);
 	object_wipe(known_obj);
 	object_wipe(obj);
 }
@@ -1549,7 +1550,7 @@ static void desc_art_fake(int a_idx)
 
 	tb = object_info(obj, OINFO_NONE);
 	object_desc(header, sizeof(header), obj,
-			ODESC_PREFIX | ODESC_FULL | ODESC_CAPITAL);
+		ODESC_PREFIX | ODESC_FULL | ODESC_CAPITAL, player);
 	if (fake) {
 		object_wipe(known_obj);
 		object_wipe(obj);
@@ -1860,7 +1861,7 @@ static void desc_obj_fake(int k_idx)
 
 	tb = object_info(obj, OINFO_FAKE);
 	object_desc(header, sizeof(header), obj,
-			ODESC_PREFIX | ODESC_CAPITAL);
+		ODESC_PREFIX | ODESC_CAPITAL, player);
 
 	textui_textblock_show(tb, area, header);
 	object_delete(&known_obj);

--- a/src/ui-player.c
+++ b/src/ui-player.c
@@ -1067,7 +1067,8 @@ void write_character_dump(ang_file *fff)
 		struct object *obj = slot_object(player, i);
 		if (!obj) continue;
 
-		object_desc(o_name, sizeof(o_name), obj, ODESC_PREFIX | ODESC_FULL);
+		object_desc(o_name, sizeof(o_name), obj,
+			ODESC_PREFIX | ODESC_FULL, player);
 		file_putf(fff, "%c) %s\n", gear_to_label(player, obj), o_name);
 		object_info_chardump(fff, obj, 5, 72);
 	}
@@ -1079,7 +1080,8 @@ void write_character_dump(ang_file *fff)
 		struct object *obj = player->upkeep->inven[i];
 		if (!obj) break;
 
-		object_desc(o_name, sizeof(o_name), obj, ODESC_PREFIX | ODESC_FULL);
+		object_desc(o_name, sizeof(o_name), obj,
+			ODESC_PREFIX | ODESC_FULL, player);
 		file_putf(fff, "%c) %s\n", gear_to_label(player, obj), o_name);
 		object_info_chardump(fff, obj, 5, 72);
 	}
@@ -1091,7 +1093,8 @@ void write_character_dump(ang_file *fff)
 		struct object *obj = player->upkeep->quiver[i];
 		if (!obj) continue;
 
-		object_desc(o_name, sizeof(o_name), obj, ODESC_PREFIX | ODESC_FULL);
+		object_desc(o_name, sizeof(o_name), obj,
+			ODESC_PREFIX | ODESC_FULL, player);
 		file_putf(fff, "%c) %s\n", gear_to_label(player, obj), o_name);
 		object_info_chardump(fff, obj, 5, 72);
 	}
@@ -1107,7 +1110,8 @@ void write_character_dump(ang_file *fff)
 		for (i = 0; i < z_info->store_inven_max; i++) {
 			struct object *obj = home_list[i];
 			if (!obj) break;
-			object_desc(o_name, sizeof(o_name), obj, ODESC_PREFIX | ODESC_FULL);
+			object_desc(o_name, sizeof(o_name), obj,
+				ODESC_PREFIX | ODESC_FULL, player);
 			file_putf(fff, "%c) %s\n", I2A(i), o_name);
 
 			object_info_chardump(fff, obj, 5, 72);

--- a/src/ui-store.c
+++ b/src/ui-store.c
@@ -287,7 +287,7 @@ static void store_display_entry(struct menu *menu, int oid, bool cursor, int row
 	} else {
 		desc |= ODESC_FULL | ODESC_STORE;
 	}
-	object_desc(o_name, sizeof(o_name), obj, desc);
+	object_desc(o_name, sizeof(o_name), obj, desc, player);
 
 	/* Display the object */
 	c_put_str(obj->kind->base->attr, o_name, row, col);
@@ -537,7 +537,8 @@ static bool store_sell(struct store_context *ctx)
 	}
 
 	/* Get a full description */
-	object_desc(o_name, sizeof(o_name), temp_obj, ODESC_PREFIX | ODESC_FULL);
+	object_desc(o_name, sizeof(o_name), temp_obj,
+		ODESC_PREFIX | ODESC_FULL, player);
 
 	/* Real store */
 	if (store->sidx != STORE_HOME) {
@@ -683,8 +684,8 @@ static bool store_purchase(struct store_context *ctx, int item, bool single)
 	}
 
 	/* Describe the object (fully) */
-	object_desc(o_name, sizeof(o_name), dummy, ODESC_PREFIX | ODESC_FULL |
-		ODESC_STORE);
+	object_desc(o_name, sizeof(o_name), dummy,
+		ODESC_PREFIX | ODESC_FULL | ODESC_STORE, player);
 
 	/* Attempt to buy it */
 	if (store->sidx != STORE_HOME) {
@@ -753,7 +754,7 @@ static void store_examine(struct store_context *ctx, int item)
 
 	/* Show full info in most stores, but normal info in player home */
 	tb = object_info(obj, OINFO_NONE);
-	object_desc(header, sizeof(header), obj, odesc_flags);
+	object_desc(header, sizeof(header), obj, odesc_flags, player);
 
 	textui_textblock_show(tb, area, header);
 	textblock_free(tb);
@@ -939,7 +940,7 @@ static void context_menu_store_item(struct store_context *ctx, const int oid, in
 	char header[120];
 
 	object_desc(header, sizeof(header), obj,
-				ODESC_PREFIX | ODESC_FULL | ODESC_STORE);
+		ODESC_PREFIX | ODESC_FULL | ODESC_STORE, player);
 
 	labels = string_make(lower_case);
 	m->selections = labels;

--- a/src/ui-target.c
+++ b/src/ui-target.c
@@ -262,9 +262,12 @@ static bool adjust_panel_help(int y, int x, bool help)
  * \param coords is part of the output string
  */
 static ui_event target_recall_loop_object(struct object *obj, int y, int x,
-										  char out_val[TARGET_OUT_VAL_SIZE],
-										  const char *s1, const char *s2,
-										  const char *s3, char *coords)
+		char out_val[TARGET_OUT_VAL_SIZE],
+		const char *s1,
+		const char *s2,
+		const char *s3,
+		const char *coords,
+		const struct player *p)
 {
 	bool recall = false;
 	ui_event press;
@@ -277,8 +280,9 @@ static ui_event target_recall_loop_object(struct object *obj, int y, int x,
 			char o_name[80];
 
 			/* Obtain an object description */
-			object_desc(o_name, sizeof(o_name), cave->objects[obj->oidx],
-						ODESC_PREFIX | ODESC_FULL);
+			object_desc(o_name, sizeof(o_name),
+				cave->objects[obj->oidx],
+				ODESC_PREFIX | ODESC_FULL, p);
 
 			/* Describe the object */
 			if (player->wizard) {
@@ -514,7 +518,7 @@ static bool aux_monster(struct chunk *c, struct player *p,
 
 			/* Obtain an object description */
 			object_desc(o_name, sizeof(o_name), obj,
-				ODESC_PREFIX | ODESC_FULL);
+				ODESC_PREFIX | ODESC_FULL, p);
 
 			strnfmt(out_val, sizeof(out_val),
 				"%s%s%s, %s (%d:%d, noise=%d, scent=%d).",
@@ -745,7 +749,7 @@ static bool aux_object(struct chunk *c, struct player *p,
 		/* Allow user to recall an object */
 		auxst->press = target_recall_loop_object(obj_local,
 			auxst->grid.y, auxst->grid.x, out_val, auxst->phrase1,
-			auxst->phrase2, "", auxst->coord_desc);
+			auxst->phrase2, "", auxst->coord_desc, p);
 
 		/* Stop on everything but "return"/"space" */
 		if (auxst->press.key.code != KC_ENTER

--- a/src/ui-wizard.c
+++ b/src/ui-wizard.c
@@ -130,7 +130,7 @@ static void get_art_name(char *buf, int max, int a_idx)
 	known_obj->notice |= OBJ_NOTICE_IMAGINED;
 
 	/* Create the artifact description */
-	object_desc(buf, max, obj, ODESC_SINGULAR | ODESC_SPOIL);
+	object_desc(buf, max, obj, ODESC_SINGULAR | ODESC_SPOIL, NULL);
 
 	object_delete(&known_obj);
 	obj->known = NULL;

--- a/src/wiz-spoil.c
+++ b/src/wiz-spoil.c
@@ -166,8 +166,9 @@ static void kind_info(char *buf, size_t buf_len, char *dam, size_t dam_len,
 	(*val) = object_value(obj, 1);
 
 	/* Description (too brief) */
-	if (buf)
-		object_desc(buf, buf_len, obj, ODESC_BASE | ODESC_SPOIL);
+	if (buf) {
+		object_desc(buf, buf_len, obj, ODESC_BASE | ODESC_SPOIL, NULL);
+	}
 
 	/* Weight */
 	if (wgt)
@@ -436,7 +437,7 @@ void spoil_artifact(const char *fname)
 			object_copy(known_obj, obj);
 			obj->known = known_obj;
 			object_desc(buf2, sizeof(buf2), obj, ODESC_PREFIX |
-				ODESC_COMBAT | ODESC_EXTRA | ODESC_SPOIL);
+				ODESC_COMBAT | ODESC_EXTRA | ODESC_SPOIL, NULL);
 
 			/* Print name and underline */
 			spoiler_underline(buf2, '-');


### PR DESCRIPTION
That way it no longer needs the player global.  Also add a player argument to verify_object() and print_custom_message() since they use object_desc().

Resolves https://github.com/angband/angband/issues/5030 .  Resolves https://github.com/angband/angband/issues/5031 .  Resolves https://github.com/angband/angband/issues/5032 .  Resolves https://github.com/angband/angband/issues/5033 .  Resolves https://github.com/angband/angband/issues/5034 .  Resolves https://github.com/angband/angband/issues/5035 .  For 5030 and 5031, earlier changes handled the other functions which used the player global.