### PR TITLE
Add player argument to ignore_item_ok()

### DIFF
--- a/src/cave-map.c
+++ b/src/cave-map.c
@@ -159,7 +159,7 @@ void map_info(struct loc grid, struct grid_data *g)
 			g->unseen_money = true;
 		} else if (obj->kind == unknown_item_kind) {
 			g->unseen_object = true;
-		} else if (ignore_known_item_ok(obj)) {
+		} else if (ignore_known_item_ok(player, obj)) {
 			/* Item stays hidden */
 		} else if (!g->first_kind) {
 			g->first_kind = obj->kind;

--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -266,7 +266,7 @@ void do_cmd_open(struct command *cmd)
 	grid = loc_sum(player->grid, ddgrid[dir]);
 
 	/* Check for chest */
-	obj = chest_check(grid, CHEST_OPENABLE);
+	obj = chest_check(player, grid, CHEST_OPENABLE);
 
 	/* Check for door */
 	if (!obj && !do_cmd_open_test(grid)) {
@@ -284,7 +284,7 @@ void do_cmd_open(struct command *cmd)
 		grid = loc_sum(player->grid, ddgrid[dir]);
 
 		/* Check for chest */
-		obj = chest_check(grid, CHEST_OPENABLE);
+		obj = chest_check(player, grid, CHEST_OPENABLE);
 	}
 
 	/* Monster */
@@ -561,9 +561,11 @@ static bool do_cmd_tunnel_aux(struct loc grid)
 							 ORIGIN_RUBBLE, 0);
 
 				/* Observe the new object */
-				if (!ignore_item_ok(square_object(cave, grid)) &&
-					square_isseen(cave, grid))
+				if (!ignore_item_ok(player,
+						square_object(cave, grid))
+						&& square_isseen(cave, grid)) {
 					msg("You have found something!");
+				}
 			} 
 		} else if (gold) {
 			/* Found treasure */
@@ -838,7 +840,7 @@ void do_cmd_disarm(struct command *cmd)
 	grid = loc_sum(player->grid, ddgrid[dir]);
 
 	/* Check for chests */
-	obj = chest_check(grid, CHEST_TRAPPED);
+	obj = chest_check(player, grid, CHEST_TRAPPED);
 
 	/* Verify legality */
 	if (!obj && !do_cmd_disarm_test(grid)) {
@@ -856,7 +858,7 @@ void do_cmd_disarm(struct command *cmd)
 		grid = loc_sum(player->grid, ddgrid[dir]);
 
 		/* Check for chests */
-		obj = chest_check(grid, CHEST_TRAPPED);
+		obj = chest_check(player, grid, CHEST_TRAPPED);
 	}
 
 
@@ -910,9 +912,9 @@ static void do_cmd_alter_aux(int dir)
 	}
 
 	/* Check for closed chest */
-	o_chest_closed = chest_check(grid, CHEST_OPENABLE);
+	o_chest_closed = chest_check(player, grid, CHEST_OPENABLE);
 	/* Check for trapped chest */
-	o_chest_trapped = chest_check(grid, CHEST_TRAPPED);
+	o_chest_trapped = chest_check(player, grid, CHEST_TRAPPED);
 
 	/* Action depends on what's there */
 	if (square(cave, grid)->mon > 0) {
@@ -1629,7 +1631,7 @@ void do_cmd_mon_command(struct command *cmd)
 			drop_near(cave, &obj, 0, mon->grid, true, false);
 			object_desc(o_name, sizeof(o_name), obj,
 				ODESC_PREFIX | ODESC_FULL, player);
-			if (!ignore_item_ok(obj)) {
+			if (!ignore_item_ok(player, obj)) {
 				msg("%s drops %s.", m_name, o_name);
 			}
 

--- a/src/cmd-pickup.c
+++ b/src/cmd-pickup.c
@@ -74,7 +74,7 @@ static void player_pickup_gold(struct player *p)
 			my_strcpy(name, kind->name, sizeof(name));
 
 		/* Remember whether feedback message is in order */
-		if (!ignore_item_ok(obj))
+		if (!ignore_item_ok(p, obj))
 			verbal = true;
 
 		/* Increment total value */
@@ -420,7 +420,7 @@ int do_autopickup(struct player *p)
 		next = obj->next;
 
 		/* Ignore all hidden objects and non-objects */
-		if (!ignore_item_ok(obj)) {
+		if (!ignore_item_ok(p, obj)) {
 			int auto_num;
 
 			/* Hack -- disturb */

--- a/src/effect-handler-general.c
+++ b/src/effect-handler-general.c
@@ -1297,7 +1297,10 @@ bool effect_handler_DETECT_TRAPS(effect_handler_context_t *context)
 			/* Scan all objects in the grid to look for traps on chests */
 			for (obj = square_object(cave, grid); obj; obj = obj->next) {
 				/* Skip anything not a trapped chest */
-				if (!is_trapped_chest(obj)) continue;
+				if (!is_trapped_chest(obj)
+						|| ignore_item_ok(player, obj)) {
+					continue;
+				}
 
 				/* Identify once */
 				if (!obj->known || obj->known->pval != obj->pval) {
@@ -1622,7 +1625,7 @@ bool effect_handler_DETECT_OBJECTS(effect_handler_context_t *context)
 			}
 
 			/* Notice an object is detected */
-			if (!ignore_item_ok(obj)) {
+			if (!ignore_item_ok(player, obj)) {
 				objects = true;
 			}
 

--- a/src/mon-move.c
+++ b/src/mon-move.c
@@ -1416,8 +1416,10 @@ static void monster_turn_grab_objects(struct monster *mon, const char *m_name,
 		/* Try to pick up, or crush */
 		if (safe) {
 			/* Only give a message for "take_item" */
-			if (rf_has(mon->race->flags, RF_TAKE_ITEM) && visible &&
-				square_isview(cave, new) && !ignore_item_ok(obj)) {
+			if (rf_has(mon->race->flags, RF_TAKE_ITEM)
+					&& visible
+					&& square_isview(cave, new)
+					&& !ignore_item_ok(player, obj)) {
 				/* Dump a message */
 				msg("%s tries to pick up %s, but fails.", m_name, o_name);
 			}
@@ -1441,8 +1443,10 @@ static void monster_turn_grab_objects(struct monster *mon, const char *m_name,
 			/* Try to carry the copy */
 			if (monster_carry(cave, mon, taken)) {
 				/* Describe observable situations */
-				if (square_isseen(cave, new) && !ignore_item_ok(obj))
+				if (square_isseen(cave, new)
+						&& !ignore_item_ok(player, obj)) {
 					msg("%s picks up %s.", m_name, o_name);
+				}
 
 				/* Delete the object */
 				square_delete_object(cave, new, obj, true, true);
@@ -1454,8 +1458,11 @@ static void monster_turn_grab_objects(struct monster *mon, const char *m_name,
 			}
 		} else {
 			/* Describe observable situations */
-			if (square_isseen(cave, new) && !ignore_item_ok(obj))
-				msgt(MSG_DESTROY, "%s crushes %s.", m_name, o_name);
+			if (square_isseen(cave, new)
+					 && !ignore_item_ok(player, obj)) {
+				msgt(MSG_DESTROY, "%s crushes %s.",
+					m_name, o_name);
+			}
 
 			/* Delete the object */
 			square_delete_object(cave, new, obj, true, true);

--- a/src/mon-util.c
+++ b/src/mon-util.c
@@ -395,7 +395,7 @@ void update_mon(struct monster *mon, struct chunk *c, bool full)
 	/* If a mimic looks like an ignored item, it's not seen */
 	if (monster_is_mimicking(mon)) {
 		struct object *obj = mon->mimicked_obj;
-		if (ignore_item_ok(obj))
+		if (ignore_item_ok(player, obj))
 			easy = flag = false;
 	}
 
@@ -428,7 +428,8 @@ void update_mon(struct monster *mon, struct chunk *c, bool full)
 		}
 	} else if (monster_is_visible(mon)) {
 		/* Not visible but was previously seen - treat mimics differently */
-		if (!mon->mimicked_obj || ignore_item_ok(mon->mimicked_obj)) {
+		if (!mon->mimicked_obj
+				|| ignore_item_ok(player, mon->mimicked_obj)) {
 			/* Mark as not visible */
 			mflag_off(mon->mflag, MFLAG_VISIBLE);
 
@@ -1482,7 +1483,7 @@ void steal_monster_item(struct monster *mon, int midx)
 				delist_object(player->cave, obj->known);
 				delist_object(cave, obj);
 				/* Drop immediately if ignored to prevent pack overflow */
-				if (ignore_item_ok(obj)) {
+				if (ignore_item_ok(player, obj)) {
 					char o_name[80];
 					object_desc(o_name, sizeof(o_name), obj,
 						ODESC_PREFIX | ODESC_FULL,

--- a/src/obj-chest.h
+++ b/src/obj-chest.h
@@ -36,7 +36,8 @@ bool is_trapped_chest(const struct object *obj);
 bool is_locked_chest(const struct object *obj);
 int pick_chest_traps(struct object *obj);
 void unlock_chest(struct object *obj);
-struct object *chest_check(struct loc grid, enum chest_query check_type);
+struct object *chest_check(const struct player *p, struct loc grid,
+	enum chest_query check_type);
 int count_chests(struct loc *grid, enum chest_query check_type);
 bool do_cmd_open_chest(struct loc grid, struct object *obj);
 bool do_cmd_disarm_chest(struct object *obj);

--- a/src/obj-desc.c
+++ b/src/obj-desc.c
@@ -502,7 +502,7 @@ static size_t obj_desc_charges(const struct object *obj, char *buf, size_t max,
  * Add player-defined inscriptions or game-defined descriptions
  */
 static size_t obj_desc_inscrip(const struct object *obj, char *buf,
-							   size_t max, size_t end)
+		size_t max, size_t end, const struct player *p)
 {
 	const char *u[6] = { 0, 0, 0, 0, 0, 0 };
 	int n = 0;
@@ -524,7 +524,7 @@ static size_t obj_desc_inscrip(const struct object *obj, char *buf,
 		u[n++] = "cursed";
 
 	/* Note ignore */
-	if (ignore_item_ok(obj))
+	if (ignore_item_ok(p, obj))
 		u[n++] = "ignore";
 
 	/* Note unknown properties */
@@ -610,7 +610,7 @@ size_t object_desc(char *buf, size_t max, const struct object *obj, int mode,
 	if (tval_is_money(obj))
 		return strnfmt(buf, max, "%d gold pieces worth of %s%s",
 				obj->pval, obj->kind->name,
-				ignore_item_ok(obj) ? " {ignore}" : "");
+				ignore_item_ok(p, obj) ? " {ignore}" : "");
 
 	/* Egos and kinds whose name we know are seen */
 	if (obj->known->ego && !spoil)
@@ -643,7 +643,7 @@ size_t object_desc(char *buf, size_t max, const struct object *obj, int mode,
 		if (mode & ODESC_STORE)
 			end = obj_desc_aware(obj, buf, max, end);
 		else
-			end = obj_desc_inscrip(obj, buf, max, end);
+			end = obj_desc_inscrip(obj, buf, max, end, p);
 	}
 
 	return end;

--- a/src/obj-ignore.c
+++ b/src/obj-ignore.c
@@ -266,7 +266,7 @@ int apply_autoinscription(struct player *p, struct object *obj)
 		return 0;
 
 	/* Don't inscribe if ignored */
-	if (ignore_item_ok(obj))
+	if (ignore_item_ok(p, obj))
 		return 0;
 
 	/* Get an object description */
@@ -614,9 +614,9 @@ bool object_is_ignored(const struct object *obj)
 /**
  * Determines if an object is eligible for ignoring.
  */
-bool ignore_item_ok(const struct object *obj)
+bool ignore_item_ok(const struct player *p, const struct object *obj)
 {
-	if (player->unignoring)
+	if (p->unignoring)
 		return false;
 
 	return object_is_ignored(obj);
@@ -628,11 +628,11 @@ bool ignore_item_ok(const struct object *obj)
  * This function should only be called on known version of items which have a
  * (real or imaginary) listed base item in the current level
  */
-bool ignore_known_item_ok(const struct object *obj)
+bool ignore_known_item_ok(const struct player *p, const struct object *obj)
 {
 	struct object *base_obj = cave->objects[obj->oidx];
 
-	if (player->unignoring)
+	if (p->unignoring)
 		return false;
 
 	/* Get the real object and check its ignore properties */
@@ -651,7 +651,7 @@ void ignore_drop(struct player *p)
 	for (obj = gear_last_item(p); obj; obj = obj->prev) {
 		/* Skip non-objects and unignoreable objects */
 		assert(obj->kind);
-		if (!ignore_item_ok(obj)) continue;
+		if (!ignore_item_ok(p, obj)) continue;
 
 		/* Check for !d (no drop) inscription */
 		if (!check_for_inscrip(obj, "!d") && !check_for_inscrip(obj, "!*")) {

--- a/src/obj-ignore.h
+++ b/src/obj-ignore.h
@@ -109,8 +109,8 @@ bool kind_is_ignored_unaware(const struct object_kind *kind);
 void kind_ignore_when_aware(struct object_kind *kind);
 void kind_ignore_when_unaware(struct object_kind *kind);
 bool object_is_ignored(const struct object *obj);
-bool ignore_item_ok(const struct object *obj);
-bool ignore_known_item_ok(const struct object *obj);
+bool ignore_item_ok(const struct player *p, const struct object *obj);
+bool ignore_known_item_ok(const struct player *p, const struct object *obj);
 void ignore_drop(struct player *p);
 const char *ignore_name_for_type(ignore_type_t type);
 

--- a/src/obj-list.c
+++ b/src/obj-list.c
@@ -133,14 +133,15 @@ void object_list_reset(object_list_t *list)
 /**
  * Return true if the object should be omitted from the object list.
  */
-static bool object_list_should_ignore_object(const struct object *obj)
+static bool object_list_should_ignore_object(const struct player *p,
+		const struct object *obj)
 {
 	struct object *base_obj = cave->objects[obj->oidx];
 
 	assert(obj->kind);
 	assert(base_obj);
 
-	if (!is_unknown(base_obj) && ignore_known_item_ok(obj))
+	if (!is_unknown(base_obj) && ignore_known_item_ok(p, obj))
 		return true;
 
 	if (tval_is_money(base_obj))
@@ -187,7 +188,7 @@ void object_list_collect(object_list_t *list)
 			loc_eq(grid, pgrid);
 		field = (los) ? OBJECT_LIST_SECTION_LOS : OBJECT_LIST_SECTION_NO_LOS;
 
-		if (object_list_should_ignore_object(obj)) continue;
+		if (object_list_should_ignore_object(player, obj)) continue;
 
 		/* Find or add a list entry. */
 		for (entry_index = 0; entry_index < (int)list->entries_size;

--- a/src/obj-pile.c
+++ b/src/obj-pile.c
@@ -875,12 +875,13 @@ struct object *floor_object_for_use(struct object *obj, int num, bool message,
 /**
  * Find and return the oldest object on the given grid marked as "ignore".
  */
-static struct object *floor_get_oldest_ignored(struct chunk *c, struct loc grid)
+static struct object *floor_get_oldest_ignored(const struct player *p,
+		struct chunk *c, struct loc grid)
 {
 	struct object *obj, *ignore = NULL;
 
 	for (obj = square_object(c, grid); obj; obj = obj->next)
-		if (ignore_item_ok(obj))
+		if (ignore_item_ok(p, obj))
 			ignore = obj;
 
 	return ignore;
@@ -897,7 +898,7 @@ bool floor_carry(struct chunk *c, struct loc grid, struct object *drop,
 				 bool *note)
 {
 	int n = 0;
-	struct object *obj, *ignore = floor_get_oldest_ignored(c, grid);
+	struct object *obj, *ignore = floor_get_oldest_ignored(player, c, grid);
 
 	/* Fail if the square can't hold objects */
 	if (!square_isobjectholding(c, grid))
@@ -916,7 +917,7 @@ bool floor_carry(struct chunk *c, struct loc grid, struct object *drop,
 			}
 
 			/* Don't mention if ignored */
-			if (ignore_item_ok(obj)) {
+			if (ignore_item_ok(player, obj)) {
 				*note = false;
 			}
 
@@ -967,7 +968,7 @@ bool floor_carry(struct chunk *c, struct loc grid, struct object *drop,
 	square_light_spot(c, grid);
 
 	/* Don't mention if ignored */
-	if (ignore_item_ok(drop)) {
+	if (ignore_item_ok(player, drop)) {
 		*note = false;
 	}
 
@@ -1012,8 +1013,8 @@ static void floor_carry_fail(struct chunk *c, struct object *drop, bool broke)
  *
  * If no appropriate grid is found, the given grid is unchanged
  */
-static void drop_find_grid(struct chunk *c, struct object *drop,
-		bool prefer_pile, struct loc *grid)
+static void drop_find_grid(const struct player *p, struct chunk *c,
+		struct object *drop, bool prefer_pile, struct loc *grid)
 {
 	int best_score = -1;
 	struct loc start = *grid;
@@ -1046,7 +1047,7 @@ static void drop_find_grid(struct chunk *c, struct object *drop,
 					combine = true;
 
 				/* Count objects */
-				if (!ignore_item_ok(obj))
+				if (!ignore_item_ok(p, obj))
 					num_shown++;
 				else
 					num_ignored++;
@@ -1055,9 +1056,9 @@ static void drop_find_grid(struct chunk *c, struct object *drop,
 				num_shown++;
 
 			/* Disallow if the stack size is too big */
-			if ((!OPT(player, birth_stacking) && (num_shown > 1)) ||
+			if ((!OPT(p, birth_stacking) && (num_shown > 1)) ||
 				((num_shown + num_ignored) > z_info->floor_size &&
-				 !floor_get_oldest_ignored(c, try)))
+				 !floor_get_oldest_ignored(p, c, try)))
 				continue;
 
 			/* Score the location based on how close and how full the grid is */
@@ -1117,7 +1118,7 @@ void drop_near(struct chunk *c, struct object **dropped, int chance,
 {
 	char o_name[80];
 	struct loc best = grid;
-	bool dont_ignore = verbose && !ignore_item_ok(*dropped);
+	bool dont_ignore = verbose && !ignore_item_ok(player, *dropped);
 
 	/* Only called in the current level */
 	assert(c == cave);
@@ -1132,7 +1133,7 @@ void drop_near(struct chunk *c, struct object **dropped, int chance,
 	}
 
 	/* Find the best grid and drop the item, destroying if there's no space */
-	drop_find_grid(c, *dropped, prefer_pile, &best);
+	drop_find_grid(player, c, *dropped, prefer_pile, &best);
 	if (floor_carry(c, best, *dropped, &dont_ignore)) {
 		sound(MSG_DROP);
 		if (dont_ignore && (square(c, best)->mon < 0)) {
@@ -1300,8 +1301,8 @@ int scan_floor(struct object **items, int max_size, object_floor_t mode,
 		if ((mode & OFLOOR_SENSE) && (!obj->known)) continue;
 
 		/* Visible */
-		if ((mode & OFLOOR_VISIBLE) && !is_unknown(obj) && ignore_item_ok(obj))
-			continue;
+		if ((mode & OFLOOR_VISIBLE) && !is_unknown(obj)
+				&& ignore_item_ok(player, obj)) continue;
 
 		/* Accept this item */
 		items[num++] = obj;
@@ -1335,7 +1336,7 @@ int scan_distant_floor(struct object **items, int max_size, struct loc grid)
 		if (obj->kind == unknown_item_kind) continue;
 
 		/* Visible */
-		if (ignore_known_item_ok(obj)) continue;
+		if (ignore_known_item_ok(player, obj)) continue;
 
 		/* Accept this item's base object */
 		items[num++] = cave->objects[obj->oidx];

--- a/src/player-path.c
+++ b/src/player-path.c
@@ -564,7 +564,7 @@ static void run_init(int dir)
  *
  * Return true if the running should be stopped
  */
-static bool run_test(void)
+static bool run_test(const struct player *p)
 {
 	int prev_dir;
 	int new_dir;
@@ -610,7 +610,7 @@ static bool run_test(void)
 		/* Visible objects abort running */
 		for (obj = square_object(cave, grid); obj; obj = obj->next)
 			/* Visible object */
-			if (obj->known && !ignore_item_ok(obj)) return true;
+			if (obj->known && !ignore_item_ok(p, obj)) return true;
 
 		/* Assume unknown */
 		inv = true;
@@ -775,7 +775,7 @@ void run_step(int dir)
 		/* Continue running */
 		if (!player->upkeep->running_withpathfind) {
 			/* Update regular running */
-			if (run_test()) {
+			if (run_test(player)) {
 				/* Disturb */
 				disturb(player);
 				return;
@@ -831,12 +831,14 @@ void run_step(int dir)
 				}
 
 				/* Visible objects abort running */
-				for (obj = square_object(cave, grid); obj; obj = obj->next)
+				for (obj = square_object(cave, grid); obj;
+						obj = obj->next) {
 					/* Visible object */
-					if (obj->known && !ignore_item_ok(obj)) {
-					disturb(player);
-					player->upkeep->running_withpathfind = false;
-					return;
+					if (obj->known && !ignore_item_ok(player, obj)) {
+						disturb(player);
+						player->upkeep->running_withpathfind = false;
+						return;
+					}
 				}
 
 				/* Get step after */

--- a/src/player-util.c
+++ b/src/player-util.c
@@ -26,6 +26,7 @@
 #include "init.h"
 #include "obj-chest.h"
 #include "obj-gear.h"
+#include "obj-ignore.h"
 #include "obj-knowledge.h"
 #include "obj-pile.h"
 #include "obj-tval.h"
@@ -1485,8 +1486,10 @@ void search(struct player *p)
 
 			/* Traps on chests */
 			for (obj = square_object(cave, grid); obj; obj = obj->next) {
-				if (!obj->known || !is_trapped_chest(obj))
+				if (!obj->known || ignore_item_ok(p, obj)
+						|| !is_trapped_chest(obj)) {
 					continue;
+				}
 
 				if (obj->known->pval != obj->pval) {
 					msg("You have discovered a trap on the chest!");

--- a/src/project-obj.c
+++ b/src/project-obj.c
@@ -359,7 +359,8 @@ static void project_object_handler_KILL_TRAP(project_object_handler_context_t *c
 		unlock_chest((struct object * const)context->obj);
 
 		/* Notice */
-		if (context->obj->known && !ignore_item_ok(context->obj)) {
+		if (context->obj->known
+				&& !ignore_item_ok(player, context->obj)) {
 			context->obj->known->pval = context->obj->pval;
 			msg("Click!");
 			context->obvious = true;
@@ -542,7 +543,7 @@ bool project_o(struct source origin, int r, struct loc grid, int dam, int typ,
 			char o_name[80];
 
 			/* Effect observed */
-			if (obj->known && !ignore_item_ok(obj) &&
+			if (obj->known && !ignore_item_ok(player, obj) &&
 				square_isseen(cave, grid)) {
 				obvious = true;
 				object_desc(o_name, sizeof(o_name), obj,
@@ -552,9 +553,11 @@ bool project_o(struct source origin, int r, struct loc grid, int dam, int typ,
 			/* Artifacts, and other objects, get to resist */
 			if (obj->artifact || ignore) {
 				/* Observe the resist */
-				if (obvious && obj->known && !ignore_item_ok(obj))
+				if (obvious && obj->known
+						&& !ignore_item_ok(player, obj)) {
 					msg("The %s %s unaffected!", o_name,
 						VERB_AGREEMENT(obj->number, "is", "are"));
+				}
 			} else if (obj->mimicking_m_idx) {
 				/* Reveal mimics */
 				if (obvious)
@@ -563,8 +566,10 @@ bool project_o(struct source origin, int r, struct loc grid, int dam, int typ,
 						player);
 			} else {
 				/* Describe if needed */
-				if (obvious && obj->known && note_kill && !ignore_item_ok(obj))
+				if (obvious && obj->known && note_kill
+						&& !ignore_item_ok(player, obj)) {
 					msgt(MSG_DESTROY, "The %s %s!", o_name, note_kill);
+				}
 
 				/* Delete the object */
 				square_delete_object(cave, grid, obj, true, true);

--- a/src/target.c
+++ b/src/target.c
@@ -347,7 +347,8 @@ bool target_accept(int y, int x)
 	/* Scan all objects in the grid */
 	for (obj = square_object(player->cave, grid); obj; obj = obj->next) {
 		/* Memorized object */
-		if ((obj->kind == unknown_item_kind) || !ignore_known_item_ok(obj)) {
+		if (obj->kind == unknown_item_kind
+				 || !ignore_known_item_ok(player, obj)) {
 			return true;
 		}
 	}

--- a/src/ui-context.c
+++ b/src/ui-context.c
@@ -291,7 +291,7 @@ int context_menu_player(int mx, int my)
 
 	/* if object under player add pickup option */
 	obj = square_object(cave, player->grid);
-	if (obj && !ignore_item_ok(obj)) {
+	if (obj && !ignore_item_ok(player, obj)) {
 			menu_row_validity_t valid;
 
 			/* 'f' isn't in rogue keymap, so we can use it here. */
@@ -451,11 +451,11 @@ int context_menu_cave(struct chunk *c, int y, int x, int adjacent, int mx,
 		ADD_LABEL("Cast On", CMD_CAST, MN_ROW_VALID);
 
 	if (adjacent) {
-		struct object *obj = chest_check(grid, CHEST_ANY);
+		struct object *obj = chest_check(player, grid, CHEST_ANY);
 		ADD_LABEL((square(c, grid)->mon) ? "Attack" : "Alter", CMD_ALTER,
 				  MN_ROW_VALID);
 
-		if (obj && !ignore_item_ok(obj)) {
+		if (obj && !ignore_item_ok(player, obj)) {
 			if (obj->known->pval) {
 				if (is_locked_chest(obj)) {
 					ADD_LABEL("Disarm Chest", CMD_DISARM, MN_ROW_VALID);
@@ -522,7 +522,7 @@ int context_menu_cave(struct chunk *c, int y, int x, int adjacent, int mx,
 
 		prt(format("(Enter to select command, ESC to cancel) You see %s:",
 				   m_name), 0, 0);
-	} else if (square_obj && !ignore_item_ok(square_obj)) {
+	} else if (square_obj && !ignore_item_ok(player, square_obj)) {
 		char o_name[80];
 
 		/* Obtain an object description */

--- a/src/ui-equip-cmp.c
+++ b/src/ui-equip-cmp.c
@@ -1715,7 +1715,9 @@ static bool select_wearable(const struct object *obj, const void *closure)
  */
 static bool select_seen_wearable(const struct object *obj, const void *closure)
 {
-	return tval_is_wearable(obj) && obj->known && !ignore_item_ok(obj);
+	const struct player *p = closure;
+
+	return tval_is_wearable(obj) && obj->known && !ignore_item_ok(p, obj);
 }
 
 
@@ -2283,7 +2285,7 @@ static int initialize_summary(struct player *p,
 	apply_visitor_to_pile(p->gear, &visitor);
 	if (cave) {
 		visitor.selfunc = select_seen_wearable;
-		visitor.selfunc_closure = NULL;
+		visitor.selfunc_closure = p;
 		apply_visitor_to_pile(square_object(cave, p->grid), &visitor);
 	}
 	visitor.selfunc = select_wearable;
@@ -2322,7 +2324,7 @@ static int initialize_summary(struct player *p,
 	if (cave) {
 		add_obj_data.src = EQUIP_SOURCE_FLOOR;
 		visitor.selfunc = select_seen_wearable;
-		visitor.selfunc_closure = NULL;
+		visitor.selfunc_closure = p;
 		apply_visitor_to_pile(square_object(cave, p->grid), &visitor);
 	}
 	add_obj_data.src = EQUIP_SOURCE_HOME;


### PR DESCRIPTION
Some of its callers already expected such an argument.  Add player argument to ignore_known_item_ok() for consistency with that.  Rather than add an argument or make use of the player global in is_trapped_chest() or is_locked_chest() since those functions make use of ignore_item_ok(), remove those calls and have the callers is_trapped_chest or is_locked_chest() check for ignored objects (some already were making that check).  Add a player argument to chest_check() since it calls ignore_item_ok().

Resolves https://github.com/angband/angband/issues/5037 (part of https://github.com/angband/angband/issues/4934 ).