### PR TITLE
Change the prototype of cave-view.c's update_one()

### DIFF
--- a/src/cave-view.c
+++ b/src/cave-view.c
@@ -840,10 +840,10 @@ static void update_view_one(struct chunk *c, struct loc grid, struct player *p)
 /**
  * Update view for a single square
  */
-static void update_one(struct chunk *c, struct loc grid, int blind)
+static void update_one(struct chunk *c, struct loc grid, struct player *p)
 {
 	/* Remove view if blind, check visible squares for traps */
-	if (blind) {
+	if (p->timed[TMD_BLIND]) {
 		sqinfo_off(square(c, grid)->info, SQUARE_SEEN);
 		sqinfo_off(square(c, grid)->info, SQUARE_CLOSE_PLAYER);
 	} else if (square_isseen(c, grid)) {
@@ -857,9 +857,9 @@ static void update_one(struct chunk *c, struct loc grid, int blind)
 			sqinfo_off(square(c, grid)->info, SQUARE_FEEL);
 			/* Don't display feeling if it will display for the new level */
 			if ((c->feeling_squares == z_info->feeling_need) &&
-				!player->upkeep->only_partial) {
+				!p->upkeep->only_partial) {
 				display_feeling(true);
-				player->upkeep->redraw |= PR_FEELING;
+				p->upkeep->redraw |= PR_FEELING;
 			}
 		}
 
@@ -903,7 +903,7 @@ void update_view(struct chunk *c, struct player *p)
 	/* Update each grid */
 	for (y = 0; y < c->height; y++)
 		for (x = 0; x < c->width; x++)
-			update_one(c, loc(x, y), p->timed[TMD_BLIND]);
+			update_one(c, loc(x, y), p);
 }
 
 


### PR DESCRIPTION
That way it can use the argument passed to update_view() rather than the player global.  Related to https://github.com/angband/angband/issues/4934 though the list there missed this use of the player global.