### PR TITLE
Add a player argument to inven_carry_num()

### DIFF
--- a/src/cmd-pickup.c
+++ b/src/cmd-pickup.c
@@ -167,7 +167,7 @@ static int auto_pickup_okay(const struct object *obj)
 	 * inscriptions.  The player option to pickup if in the inventory
 	 * honors those inscriptions.
 	 */
-	int num = inven_carry_num(obj);
+	int num = inven_carry_num(player, obj);
 	unsigned obj_has_auto, obj_has_maxauto;
 	int obj_maxauto;
 
@@ -236,7 +236,7 @@ static int auto_pickup_okay(const struct object *obj)
 static void player_pickup_aux(struct player *p, struct object *obj,
 							  int auto_max, bool domsg)
 {
-	int max = inven_carry_num(obj);
+	int max = inven_carry_num(p, obj);
 
 	/* Confirm at least some of the object can be picked up */
 	if (max == 0)
@@ -340,7 +340,7 @@ static byte player_pickup_item(struct player *p, struct object *obj, bool menu)
 	/* Tally objects that can be at least partially picked up.*/
 	floor_num = scan_floor(floor_list, floor_max, p, OFLOOR_VISIBLE, NULL);
 	for (i = 0; i < floor_num; i++)
-	    if (inven_carry_okay(floor_list[i]))
+	    if (inven_carry_num(p, floor_list[i]) > 0)
 			can_pickup++;
 
 	if (!can_pickup) {

--- a/src/obj-gear.h
+++ b/src/obj-gear.h
@@ -41,7 +41,7 @@ int object_slot(struct player_body body, const struct object *obj);
 bool object_is_equipped(struct player_body body, const struct object *obj);
 bool object_is_carried(struct player *p, const struct object *obj);
 bool object_is_in_quiver(struct player *p, const struct object *obj);
-int pack_slots_used(struct player *p);
+int pack_slots_used(const struct player *p);
 const char *equip_mention(struct player *p, int slot);
 const char *equip_describe(struct player *p, int slot);
 int wield_slot(const struct object *obj);
@@ -51,7 +51,7 @@ struct object *gear_last_item(struct player *p);
 void gear_insert_end(struct player *p, struct object *obj);
 struct object *gear_object_for_use(struct player *p, struct object *obj,
 	int num, bool message, bool *none_left);
-int inven_carry_num(const struct object *obj);
+int inven_carry_num(const struct player *p, const struct object *obj);
 bool inven_carry_okay(const struct object *obj);
 void inven_item_charges(struct object *obj);
 void inven_carry(struct player *p, struct object *obj, bool absorb,

--- a/src/store.c
+++ b/src/store.c
@@ -1666,7 +1666,7 @@ void do_cmd_buy(struct command *cmd)
 	object_copy_amt(bought, obj, amt);
 
 	/* Ensure we have room */
-	if (bought->number > inven_carry_num(bought)) {
+	if (bought->number > inven_carry_num(player, bought)) {
 		msg("You cannot carry that many items.");
 		object_delete(&bought);
 		return;
@@ -1796,7 +1796,7 @@ void do_cmd_retrieve(struct command *cmd)
 	object_copy_amt(picked_item, obj, amt);
 
 	/* Ensure we have room */
-	if (picked_item->number > inven_carry_num(picked_item)) {
+	if (picked_item->number > inven_carry_num(player, picked_item)) {
 		msg("You cannot carry that many items.");
 		object_delete(&picked_item);
 		return;

--- a/src/tests/player/inven-carry-num.c
+++ b/src/tests/player/inven-carry-num.c
@@ -280,7 +280,7 @@ static bool perform_one_test(struct carry_num_state *cns, struct object *obj,
 	bool success = true;
 
 	obj->number = n_try;
-	if (inven_carry_num(obj) != n_expected) {
+	if (inven_carry_num(cns->p, obj) != n_expected) {
 		success = false;
 	}
 	if (inven_carry_okay(obj)) {

--- a/src/ui-store.c
+++ b/src/ui-store.c
@@ -642,7 +642,7 @@ static bool store_purchase(struct store_context *ctx, int item, bool single)
 		}
 
 		/* Limit to the number that can be carried */
-		amt = MIN(amt, inven_carry_num(obj));
+		amt = MIN(amt, inven_carry_num(player, obj));
 
 		/* Fail if there is no room.  Don't leak information about
 		 * unknown flavors for a purchase (getting it from home doesn't


### PR DESCRIPTION
Resolves https://github.com/angband/angband/issues/5042 as much as is possible now:  inven_carry_okay() is used as an item_tester so its prototype is unchanged.  Mark the struct player* argument to pack_slots_used() as const so the player argument to inven_carry_num() can be const as well.