### PR TITLE
Allow releasing of command spell under circumstances where 'r' would …

### DIFF
--- a/src/player-util.c
+++ b/src/player-util.c
@@ -1103,7 +1103,12 @@ bool player_can_study_prereq(void)
  */
 bool player_can_read_prereq(void)
 {
-	return player_can_read(player, true);
+	/*
+	 * Accomodate hacks elsewhere:  'r' is overloaded to mean
+	 * release a commanded monster when TMD_COMMAND is active.
+	 */
+	return (player->timed[TMD_COMMAND]) ?
+		true : player_can_read(player, true);
 }
 
 /**


### PR DESCRIPTION
…run afoul of the checks for whether reading is possible.  Resolves https://github.com/angband/angband/issues/5056 .