### PR TITLE
In main-gcu.c, pass a writeable static buffer to putenv()

### DIFF
--- a/src/main-gcu.c
+++ b/src/main-gcu.c
@@ -1014,8 +1014,14 @@ errr init_gcu(int argc, char **argv) {
 
 	/* We do it like this to prevent a link error with curseses that
 	 * lack ESCDELAY. */
-	if (!getenv("ESCDELAY"))
-		putenv("ESCDELAY=20");
+	if (!getenv("ESCDELAY")) {
+#if _POSIX_C_SOURCE < 200112L
+		static char escdelbuf[80] = "ESCDELAY=20";
+		putenv(escdelbuf);
+#else
+		setenv("ESCDELAY", "20", 1);
+#endif
+	}
 
 	/* Initialize */
 	if (initscr() == NULL) return (-1);


### PR DESCRIPTION
Do that since, in principle, it could be modified.  Avoids a compiler warning when compiled with -Wwrite-strings.  Use setenv() rather than putenv() when possible.