### PR TITLE
Apply fixes for failure to load a mp3 on Windows

### DIFF
--- a/src/main-win.c
+++ b/src/main-win.c
@@ -1158,7 +1158,6 @@ static bool load_sound_win(const char *filename, int file_type, struct sound_dat
 			data->loaded = (0 != sample->op.wDeviceID);
 
 			if (!data->loaded) {
-				plog_fmt("Sound: Failed to load sound '%s')", data->name);
 				mem_free(sample);
 				sample = NULL;
 			}


### PR DESCRIPTION
1. Avoid a crash.
2. After resolving (1), was displaying two nearly identical warning dialogs for the failure.  Remove one of those.