### PR TITLE
Make the mouse more useful during the birth process

### DIFF
--- a/src/game-event.c
+++ b/src/game-event.c
@@ -180,12 +180,23 @@ void event_signal_message(game_event_type type, int t, const char *s)
 	game_event_dispatch(type, &data);
 }
 
-void event_signal_birthpoints(int stats[6], int remaining)
+/**
+ * Signal a change or refresh in the point buy for birth stats.
+ *
+ * \param points points[i] is the number of points already spent to increase
+ * the ith stat, i >= 0 and i < STAT_MAX.
+ * \param inc_points inc_points[i] is the number of additional points it would
+ * take to incrase the ith stat by one, i >= 0 and i < STAT_MAX.
+ * \param remaining is the number of poitns that remain to be spent.
+ */
+void event_signal_birthpoints(const int *points, const int *inc_points,
+		int remaining)
 {
 	game_event_data data;
 
-	data.birthstats.stats = stats;
-	data.birthstats.remaining = remaining;
+	data.birthpoints.points = points;
+	data.birthpoints.inc_points = inc_points;
+	data.birthpoints.remaining = remaining;
 
 	game_event_dispatch(EVENT_BIRTHPOINTS, &data);
 }

--- a/src/game-event.h
+++ b/src/game-event.h
@@ -131,9 +131,10 @@ typedef union
 
   	struct
 	{
-		int *stats;
+		const int *points;
+		const int *inc_points;
 		int remaining;
-	} birthstats;
+	} birthpoints;
 
 	struct
 	{
@@ -213,7 +214,8 @@ void event_remove_all_handlers(void);
 void event_add_handler_set(game_event_type *type, size_t n_types, game_event_handler *fn, void *user);
 void event_remove_handler_set(game_event_type *type, size_t n_types, game_event_handler *fn, void *user);
 
-void event_signal_birthpoints(int stats[6], int remaining);
+void event_signal_birthpoints(const int *points, const int *inc_points,
+	int remaining);
 
 void event_signal_point(game_event_type, int x, int y);
 void event_signal_string(game_event_type, const char *s);

--- a/src/ui-input.h
+++ b/src/ui-input.h
@@ -96,7 +96,12 @@ void message_flush(game_event_type unused, game_event_data *data, void *user);
 void clear_from(int row);
 bool askfor_aux_keypress(char *buf, size_t buflen, size_t *curs, size_t *len,
 						 struct keypress keypress, bool firsttime);
+int askfor_aux_mouse(char *buf, size_t buflen, size_t *curs, size_t *len,
+	struct mouseclick mouse, bool firsttime);
 bool askfor_aux(char *buf, size_t len, bool (*keypress_h)(char *, size_t, size_t *, size_t *, struct keypress, bool));
+bool askfor_aux_ext(char *buf, size_t len,
+	bool (*keypress_h)(char *, size_t, size_t *, size_t *, struct keypress, bool),
+	int (*mouse_h)(char *, size_t, size_t *, size_t *, struct mouseclick, bool));
 bool get_character_name(char *buf, size_t buflen);
 char get_char(const char *prompt, const char *options, size_t len,
 			  char fallback);

--- a/src/ui-menu.c
+++ b/src/ui-menu.c
@@ -633,9 +633,12 @@ bool menu_handle_mouse(struct menu *menu, const ui_event *in,
 		out->type = EVT_ESCAPE;
 	} else if (!region_inside(&menu->active, in)) {
 		/* A click to the left of the active region is 'back' */
-		if (!region_inside(&menu->active, in) &&
-				in->mouse.x < menu->active.col)
+		if (!region_inside(&menu->active, in)
+				&& in->mouse.x < menu->active.col) {
 			out->type = EVT_ESCAPE;
+		} else if (menu->context_hook) {
+			return (*menu->context_hook)(menu, in, out);
+		}
 	} else {
 		int count = menu->filter_list ? menu->filter_count : menu->count;
 
@@ -649,6 +652,8 @@ bool menu_handle_mouse(struct menu *menu, const ui_event *in,
 				out->type = EVT_MOVE;
 
 			menu->cursor = new_cursor;
+		} else if (menu->context_hook) {
+			return (*menu->context_hook)(menu, in, out);
 		}
 	}
 

--- a/src/ui-menu.h
+++ b/src/ui-menu.h
@@ -233,6 +233,16 @@ struct menu
 	 * not. oid is the index of the cursor position in the list. */
 	bool (*keys_hook)(struct menu *m, const ui_event *ev, int oid);
 
+	/* This is an auxiliary function to allow presentation of a context
+	 * menu in response to a mouse click.  If used, the function should
+	 * return true if the event, in, was handled or false if it was not.
+	 * *out has the details for the event that will be passed upstream and
+	 * is initialized prior to the call to the auxiliary function.  If the
+	 * input event was handled, the function way want to modify *out.
+	 * This function is called after screening out any mouse events that
+	 * are handled natively by menu_select(). */
+	bool (*context_hook)(struct menu *m, const ui_event *in, ui_event *out);
+
 	/* Flags specifying the behavior of this menu (from struct menu_flags) */
 	int flags;
 


### PR DESCRIPTION
Since the whole process can be completed (using a random or empty name) with just the mouse, that may be sufficient to resolve https://github.com/angband/angband/issues/2519 .

To have enough information to know whether a stat buy is possible, there's a change to the data associated with EVENT_BIRTHPOINTS and the prototype for event_signal_birthpoints().

Most of the interactions with the mouse are handled via context menus, and nothing was added to what's displayed to indicate where to click.  For the class, race, and roller selection screens, clicking on the hint or the line below it brings up the context menu.  For the birth options screen, clicking on the menu label brings up the context menu.  In the other cases (stat allocation or rolling and name selection) clicking on nearly any location with the first mouse button will bring up the context menu.

I didn't add a way to access the "go back to start" action with the mouse on the screen after accepting the history.  The mouse handling on that screen remains as it was.