### PR TITLE
In new_level_display_update(), put the request to update the view and monster distances…

### DIFF
--- a/src/ui-display.c
+++ b/src/ui-display.c
@@ -2508,11 +2508,11 @@ static void new_level_display_update(game_event_type type,
 	/* Calculate torch radius */
 	player->upkeep->update |= (PU_TORCH);
 
-	/* Update stuff */
-	update_stuff(player);
-
 	/* Fully update the visuals (and monster distances) */
 	player->upkeep->update |= (PU_UPDATE_VIEW | PU_DISTANCE);
+
+	/* Update stuff */
+	update_stuff(player);
 
 	/* Redraw dungeon */
 	player->upkeep->redraw |= (PR_BASIC | PR_EXTRA | PR_MAP);


### PR DESCRIPTION
… before the call to update_player().  May resolve the reports of the monster list flashing; see http://angband.oook.cz/forum/showpost.php?p=155338&postcount=75 and follow-up posts.  Before that change and with some logging added, see this on entering a new level:

1. Entering prepare_next_level()...
2. Entering new_level_display_update()...
3. Entering update_view()...
4. Entering update_monster(); character_dungeon = true; full = false...
5. Entering update_view()...
6. Entering update_monster(); character_dungeon = true; full = true
7. Entering update_monlist_subwindow()...

This change would alter (4) so full would be true.  If the monster list was updated between 4 and 6 (not seen in the above; though I only added a logging statement to update_monlist_subwindow()), then, with the unchanged code, it would have the wrong distances to the monsters.