### PR TITLE
Tidy logic for message about revealed object when rubble cleared

### DIFF
--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -561,7 +561,8 @@ static bool do_cmd_tunnel_aux(struct loc grid)
 							 ORIGIN_RUBBLE, 0);
 
 				/* Observe the new object */
-				if (!ignore_item_ok(player,
+				if (square_object(cave, grid)
+						&& !ignore_item_ok(player,
 						square_object(cave, grid))
 						&& square_isseen(cave, grid)) {
 					msg("You have found something!");

--- a/src/project-feat.c
+++ b/src/project-feat.c
@@ -20,6 +20,7 @@
 #include "cave.h"
 #include "game-world.h"
 #include "generate.h"
+#include "obj-ignore.h"
 #include "obj-pile.h"
 #include "obj-util.h"
 #include "player-calcs.h"
@@ -112,12 +113,15 @@ static void project_feature_handler_KILL_WALL(project_feature_handler_context_t 
 
 		/* Hack -- place an object */
 		if (randint0(100) < 10){
-			if (square_isseen(cave, grid)) {
+			place_object(cave, grid, player->depth, false, false,
+						 ORIGIN_RUBBLE, 0);
+			if (square_object(cave, grid)
+					&& !ignore_item_ok(player,
+					square_object(cave, grid))
+					&& square_isseen(cave, grid)) {
 				msg("There was something buried in the rubble!");
 				context->obvious = true;
 			}
-			place_object(cave, grid, player->depth, false, false,
-						 ORIGIN_RUBBLE, 0);
 		}
 	} else if (square_isdoor(cave, grid)) {
 		/* Hack -- special message */


### PR DESCRIPTION
- Make more robust against failures in place_object().  At least in current Vanilla, though, didn't see how place_object() could fail since the newly cleared spot will satisfy square_isobjectholding() as far as I know.  Resolves #5086 .
- When the rubble is cleared with stone-to-mud, use the same logic as is used when digging.