### PR TITLE
Adopt changes to tests from FAangband so they'll work in the GitHub workflow when randarts are enabled

### DIFF
--- a/src/tests/effects/chain.c
+++ b/src/tests/effects/chain.c
@@ -30,6 +30,10 @@ struct simple_effect {
 int setup_tests(void **state) {
 	set_file_paths();
 	init_angband();
+#ifdef UNIX
+	/* Necessary for creating the randart file. */
+	create_needed_dirs();
+#endif
 	/* Set up the player so there's a target available for the effects. */
 	if (!player_make_simple(NULL, NULL, "Tester")) {
 		cleanup_angband();

--- a/src/tests/game/basic.c
+++ b/src/tests/game/basic.c
@@ -46,6 +46,10 @@ int setup_tests(void **state) {
 	/* Init the game */
 	set_file_paths();
 	init_angband();
+#ifdef UNIX
+	/* Necessary for creating the randart file. */
+	create_needed_dirs();
+#endif
 
 	return 0;
 }

--- a/src/tests/game/mage.c
+++ b/src/tests/game/mage.c
@@ -37,6 +37,10 @@ int setup_tests(void **state) {
 	/* Init the game */
 	set_file_paths();
 	init_angband();
+#ifdef UNIX
+	/* Necessary for creating the randart file. */
+	create_needed_dirs();
+#endif
 
 	return 0;
 }

--- a/src/tests/player/calc-inventory.c
+++ b/src/tests/player/calc-inventory.c
@@ -36,6 +36,10 @@ struct simple_test_case {
 int setup_tests(void **state) {
 	set_file_paths();
 	init_angband();
+#ifdef UNIX
+	/* Necessary for creating the randart file. */
+	create_needed_dirs();
+#endif
 
 	/* Set up the player.  Use a mage so magic books are browseable. */
 	if (!player_make_simple(NULL, "Mage", "Tester")) {

--- a/src/tests/player/inven-carry-num.c
+++ b/src/tests/player/inven-carry-num.c
@@ -33,6 +33,10 @@ int setup_tests(void **state) {
 
 	set_file_paths();
 	init_angband();
+#ifdef UNIX
+	/* Necessary for creating the randart file. */
+	create_needed_dirs();
+#endif
 
 	/*
 	 * Use a smaller than normal pack and quiver so it is less tedious to

--- a/src/tests/player/inven-wield.c
+++ b/src/tests/player/inven-wield.c
@@ -187,6 +187,10 @@ static bool check_similar(const struct object* obj1, const struct object *obj2) 
 int setup_tests(void **state) {
 	set_file_paths();
 	init_angband();
+#ifdef UNIX
+	/* Necessary for creating the randart file. */
+	create_needed_dirs();
+#endif
 
 	/* Set up the player. */
 	if (!player_make_simple(NULL, NULL, "Tester")) {


### PR DESCRIPTION
That's to make it easier for forks (like FAangband, though it already has these changes, and Xygos that have some form of randarts by default).