### PR TITLE
Changed purchase message to show if a book is not usable

### DIFF
--- a/src/ui-store.c
+++ b/src/ui-store.c
@@ -703,9 +703,9 @@ static bool store_purchase(struct store_context *ctx, int item, bool single)
 		prt(format("Price: %d", price), 1, 0);
 
 		/* Confirm purchase */
-		response = store_get_check(format("Buy %s? %s %s",
+		response = store_get_check(format("Buy %s?%s %s",
 					o_name,
-					obj_can_use ? "" : "(Can't use!)",
+					obj_can_use ? "" : " (Can't use!)",
 					"[ESC, any other key to accept]"));
 
 		screen_load();


### PR DESCRIPTION
* The purchase confirmation message now looks like: "Buy a book_name? (Can't use!) [ESC, any other key to accept]", when you try to buy a book that you are unable to browse. Otherwise, the message remains the same. Closes #5096