### PR TITLE
Actually use the sdl-config binary that we found when configuring

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -385,6 +385,7 @@ if test "$enable_sdl2_mixer" = "yes"; then
 	hold_CPPFLAGS="${CPPFLAGS}"
 	hold_LIBS="${LIBS}"
 	if test "$with_sdl2" != "yes"; then
+		AM_PATH_SDL2(2.0.0,,)
 		SDL2_CFLAGS=`${SDL2_CONFIG} --cflags`
 		SDL2_LIBS=`${SDL2_CONFIG} --libs`
 		CPPFLAGS="${CPPFLAGS} ${SDL2_CFLAGS}"
@@ -408,6 +409,7 @@ if test "$enable_sdl_mixer" = "yes"; then
 	hold_CPPFLAGS="${CPPFLAGS}"
 	hold_LIBS="${LIBS}"
 	if test "$with_sdl" != "yes"; then
+		AM_PATH_SDL(1.2.10,,)
 		SDL_CFLAGS=`${SDL_CONFIG} --cflags`
 		CPPFLAGS="${CPPFLAGS} ${SDL_CFLAGS}"
 		SDL_LIBS=`${SDL_CONFIG} --libs`

--- a/configure.ac
+++ b/configure.ac
@@ -318,9 +318,9 @@ if test "$enable_sdl2" = "yes"; then
 	else
 		hold_CPPFLAGS="${CPPFLAGS}"
 		hold_LIBS="${LIBS}"
-		SDL2_CFLAGS=`sdl2-config --cflags`
+		SDL2_CFLAGS=`${SDL2_CONFIG} --cflags`
 		CPPFLAGS="${CPPFLAGS} ${SDL2_CFLAGS}"
-		SDL2_LIBS=`sdl2-config --libs`
+		SDL2_LIBS=`${SDL2_CONFIG} --libs`
 		LIBS="${LIBS} ${SDL2_LIBS}"
 		AC_CHECK_LIB(SDL2_image, IMG_LoadPNG_RW, with_sdl2=yes, with_sdl2=no)
 		AC_CHECK_LIB(SDL2_ttf, TTF_Init, with_sdl2x=yes, with_sdl2=no)
@@ -346,9 +346,9 @@ else
 	   else
 			hold_CPPFLAGS="${CPPFLAGS}"
 			hold_LIBS="${LIBS}"
-			SDL_CFLAGS=`sdl-config --cflags`
+			SDL_CFLAGS=`${SDL_CONFIG} --cflags`
 			CPPFLAGS="${CPPFLAGS} ${SDL_CFLAGS}"
-			SDL_LIBS=`sdl-config --libs`
+			SDL_LIBS=`${SDL_CONFIG} --libs`
 			LIBS="${LIBS} ${SDL_LIBS}"
 			AC_CHECK_LIB(SDL_image, IMG_LoadPNG_RW, with_sdl=yes, with_sdl=no)
 			AC_CHECK_LIB(SDL_ttf, TTF_Init, with_sdlx=yes, with_sdl=no)
@@ -385,8 +385,8 @@ if test "$enable_sdl2_mixer" = "yes"; then
 	hold_CPPFLAGS="${CPPFLAGS}"
 	hold_LIBS="${LIBS}"
 	if test "$with_sdl2" != "yes"; then
-		SDL2_CFLAGS=`sdl2-config --cflags`
-		SDL2_LIBS=`sdl2-config --libs`
+		SDL2_CFLAGS=`${SDL2_CONFIG} --cflags`
+		SDL2_LIBS=`${SDL2_CONFIG} --libs`
 		CPPFLAGS="${CPPFLAGS} ${SDL2_CFLAGS}"
 		LIBS="${LIBS} ${SDL2_LIBS}"
 	fi
@@ -408,9 +408,9 @@ if test "$enable_sdl_mixer" = "yes"; then
 	hold_CPPFLAGS="${CPPFLAGS}"
 	hold_LIBS="${LIBS}"
 	if test "$with_sdl" != "yes"; then
-		SDL_CFLAGS=`sdl-config --cflags`
+		SDL_CFLAGS=`${SDL_CONFIG} --cflags`
 		CPPFLAGS="${CPPFLAGS} ${SDL_CFLAGS}"
-		SDL_LIBS=`sdl-config --libs`
+		SDL_LIBS=`${SDL_CONFIG} --libs`
 		LIBS="${LIBS} ${SDL_LIBS}"
 	fi
 	AC_CHECK_LIB(SDL_mixer, Mix_OpenAudio, found_sdl_mixer=yes, found_sdl_mixer=no)


### PR DESCRIPTION
This is helpful when cross-compiling or when choosing an SDL prefix that is not in the default path.