### PR TITLE
To mimic object_delete(), add a player chunk argument to object_pile_free()

### DIFF
--- a/src/cave-square.c
+++ b/src/cave-square.c
@@ -1003,8 +1003,9 @@ void square_excise_object(struct chunk *c, struct loc grid, struct object *obj){
  * Excise an entire floor pile.
  */
 void square_excise_pile(struct chunk *c, struct loc grid) {
+	struct chunk *p_c = (player && c == cave) ? player->cave : NULL;
 	assert(square_in_bounds(c, grid));
-	object_pile_free(c, square_object(c, grid));
+	object_pile_free(c, p_c, square_object(c, grid));
 	square_set_obj(c, grid, NULL);
 }
 

--- a/src/cave.c
+++ b/src/cave.c
@@ -417,7 +417,7 @@ void cave_free(struct chunk *c) {
 			if (c->squares[y][x].trap)
 				square_free_trap(c, loc(x, y));
 			if (c->squares[y][x].obj)
-				object_pile_free(c, c->squares[y][x].obj);
+				object_pile_free(c, p_c, c->squares[y][x].obj);
 		}
 		mem_free(c->squares[y]);
 		mem_free(c->noise.grids[y]);

--- a/src/mon-make.c
+++ b/src/mon-make.c
@@ -590,7 +590,8 @@ void wipe_mon_list(struct chunk *c, struct player *p)
 				}
 				obj = obj->next;
 			}
-			object_pile_free(c, held_obj);
+			object_pile_free(c, (p && c == cave) ? p->cave : NULL,
+				held_obj);
 		}
 
 		/* Reduce the racial counter */

--- a/src/obj-pile.c
+++ b/src/obj-pile.c
@@ -354,14 +354,20 @@ void object_delete(struct chunk *c, struct chunk *p_c,
 
 /**
  * Free an entire object pile
+ * \param c is the chunk holding the pile; should be NULL for piles held by
+ * players or stores.
+ * \param p_c is the player's view of the chunk holding the pile; should be NULL
+ * when excising a pile in the player's view or for piles held by players or
+ * stores.
+ * \param obj is the pointer to the start of the pile to excise.
  */
-void object_pile_free(struct chunk *c, struct object *obj)
+void object_pile_free(struct chunk *c, struct chunk *p_c, struct object *obj)
 {
 	struct object *current = obj, *next;
 
 	while (current) {
 		next = current->next;
-		object_delete(c, NULL, &current);
+		object_delete(c, p_c, &current);
 		current = next;
 	}
 }

--- a/src/obj-pile.h
+++ b/src/obj-pile.h
@@ -52,7 +52,7 @@ struct object *object_new(void);
 void object_free(struct object *obj);
 void object_delete(struct chunk *c, struct chunk *p_c,
 				   struct object **obj_address);
-void object_pile_free(struct chunk *c, struct object *obj);
+void object_pile_free(struct chunk *c, struct chunk *p_c, struct object *obj);
 
 void pile_insert(struct object **pile, struct object *obj);
 void pile_insert_end(struct object **pile, struct object *obj);

--- a/src/player.c
+++ b/src/player.c
@@ -458,8 +458,8 @@ void player_cleanup_members(struct player *p)
 		player_spells_free(p);
 	}
 	if (p->gear) {
-		object_pile_free(NULL, p->gear);
-		object_pile_free(NULL, p->gear_k);
+		object_pile_free(NULL, NULL, p->gear);
+		object_pile_free(NULL, NULL, p->gear_k);
 	}
 	if (p->body.slots) {
 		for (int i = 0; i < p->body.count; i++)

--- a/src/store.c
+++ b/src/store.c
@@ -111,8 +111,8 @@ static void cleanup_stores(void)
 		struct store *store = &stores[i];
 
 		/* Free the store inventory */
-		object_pile_free(NULL, store->stock_k);
-		object_pile_free(NULL, store->stock);
+		object_pile_free(NULL, NULL, store->stock_k);
+		object_pile_free(NULL, NULL, store->stock);
 		mem_free(store->always_table);
 		mem_free(store->normal_table);
 
@@ -372,7 +372,7 @@ void store_reset(void) {
 		s = &stores[i];
 		s->stock_num = 0;
 		store_shuffle(s);
-		object_pile_free(NULL, s->stock);
+		object_pile_free(NULL, NULL, s->stock);
 		s->stock = NULL;
 		if (i == STORE_HOME)
 			continue;

--- a/src/tests/object/pile.c
+++ b/src/tests/object/pile.c
@@ -85,7 +85,7 @@ static int test_obj_piles(void *state) {
 	null(o4->next);
 
 	/* Free up */
-	object_pile_free(NULL, pile);
+	object_pile_free(NULL, NULL, pile);
 	object_free(o3);
 
 	ok;


### PR DESCRIPTION
That's to avoid pile integrity problems or invalid "real versions" of objects after destruction or earthquake effects.  For an example, see Sideways's report here, http://angband.oook.cz/forum/showpost.php?p=155829&postcount=10 , from FAangband.