### PR TITLE
As GitHub transitions macos-latest from macOS 10.15 to 11 (expected …

### DIFF
--- a/.github/workflows/mac.yaml
+++ b/.github/workflows/mac.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Cocoa
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
       - name: Clone Project
         uses: actions/checkout@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -273,7 +273,7 @@ jobs:
   mac:
     needs: [setup, docconvert]
     name: Mac
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
       - name: Download Artifact with Configuration Information
         uses: actions/download-artifact@v2


### PR DESCRIPTION
…completion date 2021 November 3), explicitly use macos-10.15 as the runner.  After the transition, could go back to using macos-latest, but will need to update or drop the setting for SDKROOT (macos11.1 isn't installed on the macOS-11 runner; looks like macos11.3 is) or add logic to set it based on what's available.  Was setting SDKROOT because the default SDK in the macos-10.15 runner did not support building universal binaries that included support for arm64.