### PR TITLE
In prepare_next_level(), copy known level name to separate buffer

### DIFF
--- a/src/generate.c
+++ b/src/generate.c
@@ -1396,7 +1396,7 @@ void prepare_next_level(struct player *p)
 		if (old_level && (old_level != cave)) {
 			int i;
 			bool arena = cave->name && streq(cave->name, "arena");
-			char *known_name = format("%s known", name);
+			char *known_name = string_make(format("%s known", name));
 			struct chunk *old_known = chunk_find_name(known_name);
 			assert(old_known);
 
@@ -1473,6 +1473,7 @@ void prepare_next_level(struct player *p)
 			/* Remove from the list */
 			chunk_list_remove(name);
 			chunk_list_remove(known_name);
+			string_free(known_name);
 		} else if (p->upkeep->arena_level) {
 			/* We're creating a new arena level */
 			cave = cave_generate(p, 6, 6);


### PR DESCRIPTION
May prevent future occurrences like the report here, http://angband.oook.cz/forum/showthread.php?t=10942 , where exiting from Single Combat crashed because there were multiple known versions of the level in the chunk list.  That's also related to https://github.com/angband/angband/issues/4249 .

For Angband, I didn't track down if format() could be called sometime between the initialization of known_name and when it is passed to chunk_list_remove().  If it could happen I suspect it's somewhere in restore_monsters().  sanitize_player_loc() and player_place() could never call format() as far as I can tell.  For FAangband, paths through monster_desc() definitely call format() so restore_monsters() does have the potential to overwrite what's in format()'s internal buffer.