### PR TITLE
Force target and health_who to be consistent in setup for Single Combat

### DIFF
--- a/src/effect-handler-attack.c
+++ b/src/effect-handler-attack.c
@@ -1823,6 +1823,7 @@ bool effect_handler_SINGLE_COMBAT(effect_handler_context_t *context)
 			monster_index_move(old_idx, 1);
 		}
 		target_set_monster(cave_monster(cave, 1));
+		player->upkeep->health_who = cave_monster(cave, 1);
 	} else {
 		msg("No monster selected!");
 		return false;


### PR DESCRIPTION
Should resolve http://angband.oook.cz/forum/showthread.php?t=10944 (targeting hack to pull one monster into the arena but defeat another foe from the dungeon).  Should also resolve one source of crashes upon calling Single Combat (previous target hack but hit monster is killed prior to Single Combat; that could also be what happened in http://angband.oook.cz/forum/showpost.php?p=155804&postcount=122 where health_who was NULL upon entry to arena_gen(); that crash was added to litany of problems in https://github.com/angband/angband/issues/4249 ).