### PR TITLE
Refine combining origins

### DIFF
--- a/src/obj-pile.c
+++ b/src/obj-pile.c
@@ -537,24 +537,27 @@ bool object_mergeable(const struct object *obj1, const struct object *obj2,
  */
 void object_origin_combine(struct object *obj1, const struct object *obj2)
 {
-	if (obj1->origin_race && obj2->origin_race) {
-		bool uniq1 = rf_has(obj1->origin_race->flags, RF_UNIQUE) ? true : false;
-		bool uniq2 = rf_has(obj2->origin_race->flags, RF_UNIQUE) ? true : false;
+	if (obj1->origin_race != obj2->origin_race) {
+		bool uniq1 = (obj1->origin_race
+			&& rf_has(obj1->origin_race->flags, RF_UNIQUE));
+		bool uniq2 = (obj2->origin_race
+			&& rf_has(obj2->origin_race->flags, RF_UNIQUE));
 
-		if (obj1->origin_race != obj2->origin_race) {
-			if (uniq1 && !uniq2) {
-				/* Favour keeping record for a unique */
-				;
-			} else if (uniq2 && !uniq1) {
-				/* Favour keeping record for a unique */
-				obj1->origin = obj2->origin;
-				obj1->origin_depth = obj2->origin_depth;
-				obj1->origin_race = obj2->origin_race;
-			} else {
-				/* Different monsters, neither or both unique, mixed origin */
-				obj1->origin = ORIGIN_MIXED;
-			}
+		if (uniq1 && !uniq2) {
+			/* Favour keeping record for a unique */
+			;
+		} else if (uniq2 && !uniq1) {
+			/* Favour keeping record for a unique */
+			obj1->origin = obj2->origin;
+			obj1->origin_depth = obj2->origin_depth;
+			obj1->origin_race = obj2->origin_race;
+		} else {
+			/* Different monsters, neither or both unique, mixed origin */
+			obj1->origin = ORIGIN_MIXED;
 		}
+	} else if (obj1->origin != obj2->origin
+			|| obj1->origin_depth != obj2->origin_depth) {
+		obj1->origin = ORIGIN_MIXED;
 	}
 }
 


### PR DESCRIPTION
Preserve records of drops from a unique when origin_race for the other object is NULL.  When origin_race is not set for either object, mark as mixed if origin or origin_depth differ (that restores the behavior of ~7 years ago for that case).  At least when tested with Angband, did not introduce a regression with the case described in https://github.com/NickMcConnell/FAangband/issues/289 .