### PR TITLE
Mac:  provide feedback about full path selected with get_file()

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -5760,6 +5760,9 @@ static bool cocoa_get_file(const char *suggested_name, char *path, size_t len)
 	    const char *p = [[[panel URL] path] UTF8String];
 	    my_strcpy(path, p, len);
 	    result = true;
+	    prt(format("Saving as %s.", path), 0, 0);
+	    anykey();
+	    prt("", 0, 0);
 	}
     }
 


### PR DESCRIPTION
Resolves https://github.com/angband/angband/issues/3174 (other front ends use the default get_file() which already provides feedback to the user about the full path).