### PR TITLE
Disable save versus trap effects when the trap is deliberately set off ...

### DIFF
--- a/src/cmds.h
+++ b/src/cmds.h
@@ -32,7 +32,7 @@ void do_cmd_tunnel(struct command *cmd);
 void do_cmd_disarm(struct command *cmd);
 void do_cmd_alter(struct command *cmd);
 void do_cmd_steal(struct command *cmd);
-void move_player(int dir, bool disarm);
+void move_player(int dir, bool disarm, bool skip_trap_save);
 void do_cmd_walk(struct command *cmd);
 void do_cmd_jump(struct command *cmd);
 void do_cmd_run(struct command *cmd);

--- a/src/effect-handler-attack.c
+++ b/src/effect-handler-attack.c
@@ -1769,7 +1769,7 @@ bool effect_handler_MOVE_ATTACK(effect_handler_context_t *context)
 			}
 		}
 
-		move_player(clockwise_ddd[d], false);
+		move_player(clockwise_ddd[d], false, false);
 		moves--;
 		if (attack) return false;
 	}

--- a/src/mon-util.c
+++ b/src/mon-util.c
@@ -513,7 +513,7 @@ static void player_leaving(struct loc grid1, struct loc grid2)
 	}
 
 	/* Delayed traps trigger when the player leaves. */
-	hit_trap(grid1, 1);
+	hit_trap(grid1, 1, false);
 }
 
 /**

--- a/src/player-path.c
+++ b/src/player-path.c
@@ -861,7 +861,7 @@ void run_step(int dir)
 	player->upkeep->energy_use = energy_per_move(player);
 
 	/* Move the player; running straight into a trap == trying to disarm */
-	move_player(run_cur_dir, dir && disarm ? true : false);
+	move_player(run_cur_dir, dir && disarm ? true : false, false);
 
 	/* Decrease counter if it hasn't been cancelled */
 	/* occurs after movement so that using p->u->running as flag works */

--- a/src/trap.h
+++ b/src/trap.h
@@ -99,7 +99,7 @@ bool square_trap_flag(struct chunk *c, struct loc grid, int flag);
 bool square_reveal_trap(struct chunk *c, struct loc grid, bool always,
 						bool domsg);
 void square_memorize_traps(struct chunk *c, struct loc grid);
-void hit_trap(struct loc grid, int delayed);
+void hit_trap(struct loc grid, int delayed, bool skip_save);
 bool square_player_trap_allowed(struct chunk *c, struct loc grid);
 void place_trap(struct chunk *c, struct loc grid, int t_idx, int trap_level);
 void square_free_trap(struct chunk *c, struct loc grid);


### PR DESCRIPTION
... (i.e. with 'W' - CMD_JUMP).  For now, only do that for non-delayed traps (doing so for delayed traps would require maintaining some state between entering a grid and leaving the grid to store that the save should be skipped; since the player could exit the game while in the grid, would have to be able to record that state in the savefile).  This is part of resolving https://github.com/angband/angband/issues/3425 .  The only delayed trap in Vanilla is the block fall trap, and that does not allow a saving throw.

Adds an argument to hit_trap() and move_player().