### PR TITLE
Remember cursor size so, with a soft cursor, the redrawing of the …

### DIFF
--- a/src/ui-term.h
+++ b/src/ui-term.h
@@ -40,6 +40,7 @@ struct term_win
 {
 	bool cu, cv;
 	int cx, cy;
+	int cnx, cny;
 
 	int **a;
 	wchar_t **c;


### PR DESCRIPTION
…previous location can be properly done when there's a big cursor.

At least on the Mac, prevents clearing artifacts when the interface is configured for big tiles and the cursor is moved in the visuals editor for a flavored item (say a ring of protection or potion of berserk strength).