### PR TITLE
Allow test cases to link properly if SDL2 sound was enabled

### DIFF
--- a/src/tests/test-utils.c
+++ b/src/tests/test-utils.c
@@ -12,7 +12,7 @@
 #include "test-utils.h"
 #include "z-util.h"
 
-#ifdef SOUND_SDL
+#if defined(SOUND_SDL) || defined(SOUND_SDL2)
 #include "sound.h"
 #include "snd-sdl.h"
 


### PR DESCRIPTION
Without the change, this

```
./autogen.sh
./configure --enable-sdl2 --with-no-install
make tests
```

was failing when it tried to link the first test case (no symbol found to satisfy the reference to init_sound_sdl() in angband.o).