### PR TITLE
Replace "if (cmdq_does_previous_use_floor_item()) cmd_disable_repeat();" …

### DIFF
--- a/src/cmd-core.h
+++ b/src/cmd-core.h
@@ -312,12 +312,6 @@ void cmdq_execute(cmd_context ctx);
 void cmdq_flush(void);
 
 /**
- * Return true if the previous command used an item from the floor.
- * Otherwise, return false.
- */
-bool cmdq_does_previous_use_floor_item(void);
-
-/**
  * ------------------------------------------------------------------------
  * Command repeat manipulation
  * ------------------------------------------------------------------------ */
@@ -337,6 +331,12 @@ void cmd_set_repeat(int nrepeats);
  * "Repeat last command" command.
  */
 void cmd_disable_repeat(void);
+
+/**
+ * Disallow current command from being repeated if it used item from
+ * the floor.
+ */
+void cmd_disable_repeat_floor_item(void);
 
 /**
  * Returns the number of repeats left for the current command.

--- a/src/game-world.c
+++ b/src/game-world.c
@@ -1015,9 +1015,7 @@ static void on_leave_level(void) {
 	player_clear_timed(player, TMD_COMMAND, false);
 
 	/* Don't allow command repeat if moved away from item used. */
-	if (cmdq_does_previous_use_floor_item()) {
-		cmd_disable_repeat();
-	}
+	cmd_disable_repeat_floor_item();
 
 	/* Any pending processing */
 	notice_stuff(player);

--- a/src/mon-util.c
+++ b/src/mon-util.c
@@ -623,9 +623,7 @@ void monster_swap(struct loc grid1, struct loc grid2)
 		player->upkeep->redraw |= (PR_MONLIST);
 
 		/* Don't allow command repeat if moved away from item used. */
-		if (cmdq_does_previous_use_floor_item()) {
-			cmd_disable_repeat();
-		}
+		cmd_disable_repeat_floor_item();
 	}
 
 	/* Monster 2 */
@@ -672,9 +670,7 @@ void monster_swap(struct loc grid1, struct loc grid2)
 		player->upkeep->redraw |= (PR_MONLIST);
 
 		/* Don't allow command repeat if moved away from item used. */
-		if (cmdq_does_previous_use_floor_item()) {
-			cmd_disable_repeat();
-		}
+		cmd_disable_repeat_floor_item();
 	}
 
 	/* Redraw */


### PR DESCRIPTION
… with a single function, cmd_disable_repeat_floor_item().  Avoids a use after free detected by the address sanitizer.

One way to trigger that use after free would be to read a teleport level scroll (in a stack of one) from the pack or the floor.