### PR TITLE
Update comments in artifact.txt, ego_item.txt and object.txt

### DIFF
--- a/lib/gamedata/artifact.txt
+++ b/lib/gamedata/artifact.txt
@@ -5,13 +5,13 @@
 
 # === Understanding artifact.txt ===
 
-# name: serial number : item name
+# name: item name
 # base-object: tval : sval
 # graphics: symbol : color
 # level: level
 # weight: weight
 # cost: cost
-# alloc: allocation probability : min depth : max depth
+# alloc: allocation probability : min " to " max
 # attack: base damage : plus to-hit : plus to-dam
 # armor: base armor class : plus to-ac
 # flags: flag | flag | etc
@@ -19,10 +19,12 @@
 # time : recharge time
 # msg: message when activated
 # values: label[value] | label[value] | etc.
+# brand: code
+# slay: code
+# curse: name : power
 # desc: description
 
-# 'name' indicates the beginning of an entry. The serial number must
-# increase for each new item.
+# 'name' indicates the beginning of an entry.
 
 # 'base-object' is for base object type. The tval is for the type of item, the
 # sval identifies the subtype.  If the sval is not a standard object kind
@@ -59,12 +61,28 @@
 # 'msg' is for activation message text, if different from the regular effect
 # message.
 
-# 'value' is for properties that take a value and a random expression for that
-# value. Valid properties are object modifiers (as found in list-stats.h and
-# list-object-modifiers.h), brands (based on the first 5 entries from
-# list-elements.h), slays (based on racial monster flags in
-# list-mon-race-flags.h or monster bases in monster_base.txt) and resistances
-# (based on list-elements.h).
+# 'values' is for properties that take a value.  Valid properties are the
+# object modifiers (as found in list-stats.h and list-object-modifiers.h) or
+# resistances ('RES_' prepended to the element name from list-elements.h).
+# The value appears in brackets after the property name and must be an integer.
+# For resistances, the useful values are 1 (resist), 3 (immune), and -1
+# (vulnerable).  Use as many 'values' lines as are needed to specify the
+# properties of the object.  If listing more than one property on a line,
+# separate them with '|'.
+
+# 'brand' adds a brand to the artifact.  It should be omitted for artifacts
+# without brands and may appear more than once for artifacts with multiple
+# brands.  Specify the brand to be added by its code in brand.txt.
+
+# 'slay' adds a slay to the artifact.  It should be omitted for artifacts
+# without slays and may appear more than once for artifacts with multiple
+# slays.  Specify the slay to be added by its code in slay.txt.
+
+# 'curse' adds a curse to the artifact.  It should be omitted for artifacts
+# without curses and may appear more than once for artifacts with multiple
+# curses.  A curse has a name (as given in curse.txt) and a power.  The power
+# is a positive integer and indicates how hard it is to remove the curse.  A
+# larger power is more difficult to remove.
 
 # 'desc' is for the artifact description.  These appear when the item is
 # identified.  Special thanks to J.R.R Tolkien, without whom the words would

--- a/lib/gamedata/ego_item.txt
+++ b/lib/gamedata/ego_item.txt
@@ -22,6 +22,10 @@
 # flags-off: flag | flag | etc
 # values: label[value] | label[value] | etc.
 # min-values: label[value] | label[value] | etc.
+# brand: code
+# slay: code
+# curse: name : power
+# desc: description
 
 # Some fields accept randomized numbers of the form "10+2d3M4" where
 # 10 is the non-variable base, 2d3 is a standard die roll, and
@@ -83,14 +87,34 @@
 # lanterns to take fuel, so we add a 'flags-off:TAKES_FUEL' line to subtract
 # that flag.
 
-# 'values' is for object modifiers which take a value - stats, slays, brands,
-# resistances and so on.  An example is SLAY_UNDEAD[3], which denotes that
-# the weapon concerned has a basic 3x slay against undead creatures.  Like
-# flags, values are separated by '|' and as many values: lines as needed
-# can be used.
+# 'values' is for properties that take a value.  Valid properties are the
+# object modifiers (as found in list-stats.h and list-object-modifiers.h)
+# or resistances ('RES_' prepended to the element name from list-elements.h).
+# The value appears in brackets after the property name.  For object modifiers,
+# the value can be any random expression.  For resistances, it must be a plain
+# integer value with the useful ones being 1 (resist), 3 (immune), and -1
+# (vulnerable).  Like flags, values are separated by '|' and as many values:
+# lines as needed can be used.
 
 # 'min-values' is for minimum values of values recorded in a 'values' line.
 # These work like minimum combat values, but for value-defined modifiers.
+# While resistances can be specified on a 'values' line, they can not appear
+# in a 'min-values' line.  Also, unlike the 'values' line, all the values must
+# be plain integers:  full random expressions are not allowed.
+
+# 'brand' adds a brand to the ego.  It should be omitted for egos without
+# brands and may appear more than once for egos with multiple brands.  Specify
+# the brand to be added by its code in brand.txt.
+
+# 'slay' adds a slay to the ego.  It should be omitted for egos without slays
+# and may appear more than once for egos with multiple slays.  Specify the slay
+# to be added by its code in slay.txt.
+
+# 'curse' adds curse to the ego.  It should be omitted for egos without curses
+# and may appear more than once for egos with multiple curses.  A curse has a
+# name (as given in curse.txt) and a power.  The power is a positive integer
+# and indicates how hard it is to remove the curse.  A larger power is more
+# difficult to remove.
 
 # 'desc' is for description. As many desc: lines may be used as are needed
 # to describe the object. Note that lines will need spaces at their

--- a/lib/gamedata/object.txt
+++ b/lib/gamedata/object.txt
@@ -27,6 +27,9 @@
 # expr:substitution code:base value:expression
 # flags: flag | flag | etc.
 # values: label[value] | label[value] | etc.
+# brand: code
+# slay: code
+# curse: name : power
 # pval: pval
 # desc: description
 
@@ -106,11 +109,28 @@
 # flags: lines may be used as are needed to specify all the flags, and
 # flags are separated by the '|' symbol.
 
-# 'values' is for object modifiers which take a value - stats, slays, brands,
-# resistances and so on.  An example is SLAY_UNDEAD[3], which denotes that
-# the weapon concerned has a basic 3x slay against undead creatures.  Like
-# flags, values are separated by '|' and as many values: lines as needed
-# can be used.
+# 'values' is for properties that take a value.  Valid properties are the
+# object modifiers (as found in list-stats.h and list-object-modifiers.h)
+# or resistances ('RES_' prepended to the element name from list-elements.h).
+# The value appears in brackets after the property name.  For object modifiers,
+# the value can be any random expression.  For resistances, it must be a plain
+# integer value with the useful ones being 1 (resist), 3 (immune), and -1
+# (vulnerable).  Like flags, values are separated by '|' and as many values:
+# lines as needed can be used.
+
+# 'brand' adds a brand to the object.  It should be omitted for objects
+# without brands and may appear more than once for objects with multiple brands.
+# Specify the brand to be added by its code in brand.txt.
+
+# 'slay' adds a slay to the object.  It should be omitted for objects without
+# slays and may appear more than once for objects with multiple slays.  Specify
+# the slay to be added by its code in slay.txt.
+
+# 'curse' adds a curse to the object.  It should be omitted for objects without
+# curses and may appear more than once for objects with multiple curses.  A
+# curse has a name (as given in curse.txt) and a power.  The power is a
+# is a positive integer and indicates how hard it is to remove the curse.  A
+# larger power is more difficult to remove.
 
 # 'power' is used in calculating the power of the object for pricing and 
 # generating random artifacts.  It reflects the power of the effect of the


### PR DESCRIPTION
That's mostly for how serial numbers are no longer used in artifact.txt, the splitting off of brands and slays from the values line, and addition of the curse line.

Related to https://github.com/angband/angband/issues/3522 .