### PR TITLE
configure script:  with --enable-win don't try, by default, to build curses/X11/spoiler front ends

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -249,7 +249,7 @@ jobs:
         id: create_windows_archive
         run: |
           ./autogen.sh
-          env CFLAGS="-O2" ./configure --enable-release --enable-win --disable-curses --build=i686-pc-linux-gnu --host=i686-w64-mingw32
+          env CFLAGS="-O2" ./configure --enable-release --enable-win --build=i686-pc-linux-gnu --host=i686-w64-mingw32
           make
           cp src/${{ steps.store_config.outputs.progname }}.exe src/win/dll/libpng12.dll src/win/dll/zlib1.dll .
           archive_prefix=${{ steps.store_config.outputs.name }}-${{ steps.store_config.outputs.version }}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -21,6 +21,6 @@ jobs:
       - name: Build
         run: |
           ./autogen.sh
-          ./configure --enable-win --disable-curses --build=i686-pc-linux-gnu --host=i686-w64-mingw32
+          ./configure --enable-win --build=i686-pc-linux-gnu --host=i686-w64-mingw32
           make
 

--- a/configure.ac
+++ b/configure.ac
@@ -234,11 +234,11 @@ dnl Frontends
 AC_ARG_ENABLE(curses,
 	[AS_HELP_STRING([--enable-curses], [enable Curses frontend (default: enabled)])],
 	[enable_curses=$enableval],
-	[enable_curses=yes])
+	[enable_curses=default])
 AC_ARG_ENABLE(x11,
 	[AS_HELP_STRING([--enable-x11], [enable X11 frontend (default: enabled)])],
 	[enable_x11=$enableval],
-	[enable_x11=yes])
+	[enable_x11=default])
 AC_ARG_ENABLE(sdl2,
 	[AS_HELP_STRING([--enable-sdl2], [enable SDL2 frontend (default: disabled)])],
 	[enable_sdl2=$enableval],
@@ -262,7 +262,7 @@ AC_ARG_ENABLE(stats,
 AC_ARG_ENABLE(spoil,
 	[AS_HELP_STRING([--enable-spoil], [enable command-line spoiler generation (default: enabled)])],
 	[enable_spoil=$enableval],
-	[enable_spoil=yes])
+	[enable_spoil=default])
 
 dnl Sound modules
 AC_ARG_ENABLE(sdl2_mixer,
@@ -275,6 +275,23 @@ AC_ARG_ENABLE(sdl_mixer,
 	[enable_sdl_mixer=$enable_sdl])
 
 MAINFILES="\$(BASEMAINFILES)"
+
+dnl The Windows front end does not allow access to the others so disable them
+dnl unless explicitly told to build them.
+if test x"$enable_win" = xyes; then
+	default_override=no
+else
+	default_override=yes
+fi
+if test x"$enable_curses" = xdefault; then
+	enable_curses="$default_override"
+fi
+if test x"$enable_x11" = xdefault; then
+	enable_x11="$default_override"
+fi
+if test x"$enable_spoil" = xdefault; then
+	enable_spoil="$default_override"
+fi
 
 dnl curses checking
 if test "$enable_curses" = "yes"; then

--- a/docs/hacking/compiling.rst
+++ b/docs/hacking/compiling.rst
@@ -202,7 +202,7 @@ a .tar.gz file, for a release.
 
 Then configure the cross-comilation and perform the compilation itself::
 
-	./configure --enable-win --disable-curses --build=i686-pc-linux-gnu --host=i586-mingw32msvc
+	./configure --enable-win --build=i686-pc-linux-gnu --host=i586-mingw32msvc
 	make
 
 One way to run the generated executable, src/angband.exe, with wine is to first
@@ -221,9 +221,13 @@ see i686, amd64, etc. The value of --build should be the host you're building
 on. (See http://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.68/html_node/Specifying-Target-Triplets.html#Specifying%20Names for
 gory details of how these triplets are arrived at)
 
-TODO: you will probably need to manually disable curses, or the host curses
-installation will be found, and will not be able to link properly. More
-checking of permissible combinations to configure is necessary
+TODO: except for recent versions (after Angband 4.2.3) you likely need to
+manually disable curses (add --disable-curses to the options passed to
+configure), or the host curses installation will be found causing the build
+process to fail when linking angband.exe (the error message will likely be
+"cannot find -lncursesw" and "cannot find -ltinfo"). More checking of
+permissible combinations to configure is necessary. The --enable-release and
+--enable-more-gcc-warnings options are safe to use with --enable-win.
 
 Debug build
 ~~~~~~~~~~~


### PR DESCRIPTION
Adjust the GitHub workflow scripts (dropping --disable-curses for Windows builds) and compiling documentation to match that change.