### PR TITLE
In player_make_simple(), use default point buy rather than rolling for stats

### DIFF
--- a/src/player-birth.c
+++ b/src/player-birth.c
@@ -566,7 +566,6 @@ bool player_make_simple(const char *nrace, const char *nclass,
 	cmd_set_arg_choice(cmdq_peek(), "choice", ir);
 	cmdq_push(CMD_CHOOSE_CLASS);
 	cmd_set_arg_choice(cmdq_peek(), "choice", ic);
-	cmdq_push(CMD_ROLL_STATS);
 	cmdq_push(CMD_NAME_CHOICE);
 	cmd_set_arg_string(cmdq_peek(), "name",
 		(nplayer == NULL) ? "Simple" : nplayer);


### PR DESCRIPTION
Avoids a potential source of variation when generating artifact spoilers with the spoiler front end.