### PR TITLE
Add Term_redraw_all() to redraw all terminals.  Use it to replace …

### DIFF
--- a/src/main-sdl2.c
+++ b/src/main-sdl2.c
@@ -3661,13 +3661,7 @@ static void refresh_angband_terms(void)
 		handle_stuff(player);
 		move_cursor_relative(player->grid.x, player->grid.y);
 
-		for (size_t i = 0; i < ANGBAND_TERM_MAX; i++) {
-			if (angband_term[i] == NULL) {
-				continue;
-			}
-			Term_activate(angband_term[i]);
-			Term_redraw();
-		}
+		Term_redraw_all();
 	}
 
 	Term_activate(old);

--- a/src/ui-command.c
+++ b/src/ui-command.c
@@ -63,10 +63,6 @@
  */
 void do_cmd_redraw(void)
 {
-	int j;
-
-	term *old = Term;
-
 	/* Low level flush */
 	Term_flush();
 
@@ -117,14 +113,7 @@ void do_cmd_redraw(void)
 	}
 
 	/* Redraw every window */
-	for (j = 0; j < ANGBAND_TERM_MAX; j++) {
-		if (!angband_term[j]) continue;
-
-		Term_activate(angband_term[j]);
-		Term_redraw();
-		Term_fresh();
-		Term_activate(old);
-	}
+	(void) Term_redraw_all();
 }
 
 

--- a/src/ui-display.c
+++ b/src/ui-display.c
@@ -2680,6 +2680,7 @@ static void ui_leave_init(game_event_type type, game_event_data *data,
 	reset_visuals(true);
 	process_character_pref_files();
 	Term_xtra(TERM_XTRA_REACT, 0);
+	(void) Term_redraw_all();
 
 	/* Remove our splashscreen handlers */
 	event_remove_handler(EVENT_INITSTATUS, splashscreen_note, NULL);

--- a/src/ui-init.c
+++ b/src/ui-init.c
@@ -81,6 +81,7 @@ void textui_init(void)
 
 		/* Update terminals for preference changes. */
 		(void) Term_xtra(TERM_XTRA_REACT, 0);
+		(void) Term_redraw_all();
 	}
 
 	/* initialize window options that will be overridden by the savefile */

--- a/src/ui-options.c
+++ b/src/ui-options.c
@@ -826,7 +826,7 @@ static void colors_pref_load(const char *title, int row)
 	 * colour changes - how about doing this in the pref file
 	 * loading code too? */
 	Term_xtra(TERM_XTRA_REACT, 0);
-	Term_redraw();
+	Term_redraw_all();
 }
 
 static void colors_pref_dump(const char *title, int row)

--- a/src/ui-term.c
+++ b/src/ui-term.c
@@ -430,6 +430,37 @@ static errr term_win_copy(term_win *s, term_win *f, int w, int h)
 
 /**
  * ------------------------------------------------------------------------
+ * Public functions operating on all terminals
+ * ------------------------------------------------------------------------
+ */
+
+
+/**
+ * Redraw all the terminals.
+ */
+extern errr Term_redraw_all(void)
+{
+	term *old = Term;
+	errr combined = 0;
+	int j;
+
+	for (j = 0; j < ANGBAND_TERM_MAX; j++) {
+		errr one_result;
+
+		if (!angband_term[j]) continue;
+		(void) Term_activate(angband_term[j]);
+		one_result = Term_redraw();
+		if (!one_result) {
+			combined = one_result;
+		}
+	}
+	(void) Term_activate(old);
+
+	return combined;
+}
+
+/**
+ * ------------------------------------------------------------------------
  * External hooks
  * ------------------------------------------------------------------------ */
 

--- a/src/ui-term.h
+++ b/src/ui-term.h
@@ -370,6 +370,7 @@ extern u32b window_flag[ANGBAND_TERM_MAX];
  *  Available Functions
  * ------------------------------------------------------------------------ */
 
+extern errr Term_redraw_all(void);
 extern errr Term_xtra(int n, int v);
 
 extern void Term_queue_char(term *t, int x, int y, int a, wchar_t c, int ta, wchar_t tc);


### PR DESCRIPTION
…analogous code in do_cmd_redraw() and the SDL2 front end.  Call it after reloading preferences in ui-init.c and ui-display.c to resolve https://github.com/angband/angband/issues/5131 .

Need that redrawing after the preference change since the window contents may not have changed but the color table has.  The logic in ui-term.c for pushing out changes to the front ends isn't set up to detect that.