### PR TITLE
GCU: fix regression that prevented player's color table from taking effect

### DIFF
--- a/src/main-gcu.c
+++ b/src/main-gcu.c
@@ -793,8 +793,8 @@ static errr Term_xtra_gcu(int n, int v) {
 		/* Delay */
 		case TERM_XTRA_DELAY: if (v > 0) usleep(1000 * v); return 0;
 
-		/* React to events; nothing special is done */
-		case TERM_XTRA_REACT: return 0;
+		/* React to events */
+		case TERM_XTRA_REACT: handle_extended_color_tables(); return 0;
 	}
 
 	/* Unknown event */


### PR DESCRIPTION
Regression was introduced by https://github.com/angband/angband/pull/5094 (post 4.2.3).