### PR TITLE
More consistent background handling for X11, SDL, SDL2, and Mac

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -3363,9 +3363,9 @@ static int compare_nsrect_yorigin_greater(const void *ap, const void *bp)
 	    edge =
 		workingRects[irect].origin.y + workingRects[irect].size.height;
 	    if (edge <= self.borderSize.height) {
-		if (alast != -1) {
-		    [[NSColor blackColor] set];
-		    alast = -1;
+		if (alast != COLOUR_DARK) {
+		    alast = COLOUR_DARK;
+		    set_color_for_index(alast);
 		}
 		NSRectFill(workingRects[irect]);
 		continue;
@@ -3373,9 +3373,9 @@ static int compare_nsrect_yorigin_greater(const void *ap, const void *bp)
 	    clearRect = workingRects[irect];
 	    clearRect.size.height =
 		self.borderSize.height - workingRects[irect].origin.y;
-	    if (alast != -1) {
-		[[NSColor blackColor] set];
-		alast = -1;
+	    if (alast != COLOUR_DARK) {
+		alast = COLOUR_DARK;
+		set_color_for_index(alast);
 	    }
 	    NSRectFill(clearRect);
 	    modRect.origin.x = workingRects[irect].origin.x;
@@ -3390,18 +3390,18 @@ static int compare_nsrect_yorigin_greater(const void *ap, const void *bp)
 	if (modRect.origin.x < self.borderSize.width) {
 	    edge = modRect.origin.x + modRect.size.width;
 	    if (edge <= self.borderSize.width) {
-		if (alast != -1) {
-		    alast = -1;
-		    [[NSColor blackColor] set];
+		if (alast != COLOUR_DARK) {
+		    alast = COLOUR_DARK;
+		    set_color_for_index(alast);
 		}
 		NSRectFill(modRect);
 		continue;
 	    }
 	    clearRect = modRect;
 	    clearRect.size.width = self.borderSize.width - clearRect.origin.x;
-	    if (alast != -1) {
-		alast = -1;
-		[[NSColor blackColor] set];
+	    if (alast != COLOUR_DARK) {
+		alast = COLOUR_DARK;
+		set_color_for_index(alast);
 	    }
 	    NSRectFill(clearRect);
 	    modRect.origin.x = self.borderSize.width;
@@ -3660,9 +3660,9 @@ static int compare_nsrect_yorigin_greater(const void *ap, const void *bp)
 	edge = modRect.origin.x + modRect.size.width;
 	if (edge > rightX) {
 	    if (modRect.origin.x >= rightX) {
-		if (alast != -1) {
-		    alast = -1;
-		    [[NSColor blackColor] set];
+		if (alast != COLOUR_DARK) {
+		    alast = COLOUR_DARK;
+		    set_color_for_index(alast);
 		}
 		NSRectFill(modRect);
 		continue;
@@ -3670,9 +3670,9 @@ static int compare_nsrect_yorigin_greater(const void *ap, const void *bp)
 	    clearRect = modRect;
 	    clearRect.origin.x = rightX;
 	    clearRect.size.width = edge - rightX;
-	    if (alast != -1) {
-		alast = -1;
-		[[NSColor blackColor] set];
+	    if (alast != COLOUR_DARK) {
+		alast = COLOUR_DARK;
+		set_color_for_index(alast);
 	    }
 	    NSRectFill(clearRect);
 	    modRect.size.width = edge - modRect.origin.x;
@@ -3685,9 +3685,9 @@ static int compare_nsrect_yorigin_greater(const void *ap, const void *bp)
 		modRect.origin.y = bottomY;
 		modRect.size.height = edge - bottomY;
 	    }
-	    if (alast != -1) {
-		alast = -1;
-		[[NSColor blackColor] set];
+	    if (alast != COLOUR_DARK) {
+		alast = COLOUR_DARK;
+		set_color_for_index(alast);
 	    }
 	    NSRectFill(modRect);
 	}
@@ -3967,7 +3967,7 @@ static int compare_nsrect_yorigin_greater(const void *ap, const void *bp)
 	if (count > 0) {
 	    NSRect viewRect = [self visibleRect];
 
-	    [[NSColor blackColor] set];
+	    set_color_for_index(COLOUR_DARK);
 	    while (count-- > 0) {
 		CGFloat drawTop = rects[count].origin.y - viewRect.origin.y;
 		CGFloat drawBottom = drawTop + rects[count].size.height;
@@ -4094,14 +4094,7 @@ static int compare_nsrect_yorigin_greater(const void *ap, const void *bp)
  */
 static int get_background_color_index(int idx)
 {
-    /*
-     * The Cocoa interface has always been using (0,0,0) as the clear color
-     * and not angband_color_table[0].  As of January 2020,  the Window's
-     * interface uses both ((0,0,0) in Term_xtra_win_clear() and
-     * Term_xtra_wipe_win() and win_clr[0], which is set from
-     * angband_color_table[0], in Term_text_win() for the BG_BLACK case.
-     */
-    int ibkg = -1;
+    int ibkg = COLOUR_DARK;
 
     switch (idx / MAX_COLORS) {
     case BG_BLACK:

--- a/src/main-sdl.c
+++ b/src/main-sdl.c
@@ -2767,6 +2767,11 @@ static errr Term_xtra_sdl(int n, int v)
 		{
 			int i;
 			/* Re-initialize the colours */
+			back_colour.r = angband_color_table[COLOUR_DARK][1];
+			back_colour.g = angband_color_table[COLOUR_DARK][2];
+			back_colour.b = angband_color_table[COLOUR_DARK][3];
+			back_pixel_colour = SDL_MapRGB(AppWin->format,
+				back_colour.r, back_colour.g, back_colour.b);
 			for (i = 0; i < MAX_COLORS; i++)
 			{
 				text_colours[i].r = angband_color_table[i][1];

--- a/src/main-sdl2.c
+++ b/src/main-sdl2.c
@@ -555,11 +555,12 @@ struct font_info {
 	bool loaded;
 };
 
-/* there are also global arrays of subwindows and windows
- * those are at the end of the file */
 const char help_sdl2[] = "SDL2 frontend";
 static SDL_Color g_colors[MAX_COLORS];
 static struct font_info g_font_info[MAX_FONTS];
+/* these arrays contain windows and terms that the ui operates on */
+static struct subwindow g_subwindows[MAX_SUBWINDOWS];
+static struct window g_windows[MAX_WINDOWS];
 /* True if KC_MOD_KEYPAD will be sent for numeric keypad keys at the expense
  * of not handling some keyboard layouts properly. */
 static int g_kp_as_mod = 1;
@@ -5510,12 +5511,19 @@ static void free_window(struct window *window)
 static void init_colors(void)
 {
 	assert(N_ELEMENTS(g_colors) == N_ELEMENTS(angband_color_table));
+	size_t i;
 
-	for (size_t i = 0; i < N_ELEMENTS(g_colors); i++) {
+	for (i = 0; i < N_ELEMENTS(g_colors); i++) {
 		g_colors[i].r = angband_color_table[i][1];
 		g_colors[i].g = angband_color_table[i][2];
 		g_colors[i].b = angband_color_table[i][3];
 		g_colors[i].a = DEFAULT_ALPHA_FULL;
+	}
+	for (i = 0; i < N_ELEMENTS(g_windows); i++) {
+		g_windows[i].color = g_colors[DEFAULT_WINDOW_BG_COLOR];
+	}
+	for (i = 0; i < N_ELEMENTS(g_subwindows); i++) {
+		g_subwindows[i].color = g_colors[DEFAULT_SUBWINDOW_BG_COLOR];
 	}
 }
 
@@ -5636,9 +5644,6 @@ errr init_sdl2(int argc, char **argv)
 	return 0;
 }
 
-/* these arrays contain windows and terms that the ui operates on */
-static struct subwindow g_subwindows[MAX_SUBWINDOWS];
-static struct window g_windows[MAX_WINDOWS];
 /* the string ANGBAND_DIR_USER is freed before calling quit_hook(),
  * so we need to save the path to config file here */
 static char g_config_file[4096];


### PR DESCRIPTION
For the X11, SDL, and SDL2 front ends also reset background/clearing color in response to TERM_XTRA_REACT.

For the Mac front end, use angband_color_table[COLOUR_DARK] rather than RGB(0, 0, 0) when clearing.

Related to resolving #5132 .