### PR TITLE
Allow dumping a color with all zero components if in the basic colors

### DIFF
--- a/src/ui-prefs.c
+++ b/src/ui-prefs.c
@@ -302,8 +302,8 @@ void dump_colors(ang_file *fff)
 
 		const char *name = "unknown";
 
-		/* Skip non-entries, except color 0 as a special case */
-		if (!kv && !rv && !gv && !bv && i != 0) continue;
+		/* Skip non-entries, except those in the basic colors */
+		if (!kv && !rv && !gv && !bv && i >= BASIC_COLORS) continue;
 
 		/* Extract the color name */
 		if (i < BASIC_COLORS) name = color_table[i].name;


### PR DESCRIPTION
That's more general than the previous fix (dumping color zero even if it has all zero components) and better handles dumping a color table where the user swapped the color zero entry for one of the other basic colors.