### PR TITLE
Allow yes/no interface options to carry over between characters like …

### DIFF
--- a/docs/option.rst
+++ b/docs/option.rst
@@ -22,6 +22,14 @@ below).
 User Interface Options
 ======================
 
+When setting the user interface options, there are a handful of commands
+to make it easier to get to a well-known state for all of those options.
+They are:  's' to save the current selections so that they will be used
+as the starting point for future characters, 'r' to reset the current
+selections to the defaults for a new character, and 'x' to reset the
+current selections to the Angband maintainer's defaults for the user
+interface options.
+
 Rogue-like commands ``rogue_like_commands``
   Selects the "roguelike" command set (see "command.txt" for info).
 
@@ -120,8 +128,8 @@ Birth options
 
 The birth options may only be changed when creating a character or using
 the quick restart option for a dead character.  When setting the birth
-options, there are handful of commands to make it easier to get to a
-well-known state for all the birth options.  They are:  's' to save the
+options, there are a handful of commands to make it easier to get to a
+well-known state for all of the birth options.  They are:  's' to save the
 current selections so that they will be used as the starting point for
 future characters, 'r' to reset the current selections to the defaults
 for a new character, and 'x' to reset the current selections to the

--- a/src/option.h
+++ b/src/option.h
@@ -74,6 +74,7 @@ extern int option_page[OPT_PAGE_MAX][OPT_PAGE_PER];
 /**
  * Functions
  */
+const char *option_type_name(int page);
 const char *option_name(int opt);
 const char *option_desc(int opt);
 int option_type(int opt);
@@ -81,8 +82,8 @@ bool option_set(const char *opt, int val);
 void options_init_cheat(void);
 void options_init_defaults(struct player_options *opts);
 void init_options(void);
-bool options_save_custom_birth(struct player_options *opts);
-bool options_restore_custom_birth(struct player_options *opts);
-void options_reset_birth(struct player_options *opts);
+bool options_save_custom(struct player_options *opts, int page);
+bool options_restore_custom(struct player_options *opts, int page);
+void options_restore_maintainer(struct player_options *opts, int page);
 
 #endif /* !INCLUDED_OPTIONS_H */


### PR DESCRIPTION
…the birth options do if one doesn't start from the savefile for a dead character.  Prompted by smbhax's suggestion here, http://angband.oook.cz/forum/showpost.php?p=156157&postcount=4 .  Does change the names and add a page number parameter for the functions that were added to carry over the birth options:  options_save_custom_birth() -> options_save_custom(), options_restore_custom_birth() -> options_restore_custom(), and options_reset_birth() -> options_restore_maintainer().

Seems like it would be desirable to carry over the delay factors, hit point warning threshold, and sidebar mode as well, but that's not been implemented here.