### PR TITLE
nds: Support custom foreground and background colors

### DIFF
--- a/src/main-nds.c
+++ b/src/main-nds.c
@@ -159,7 +159,7 @@ void do_vblank()
 #ifdef DEBUG_MEMORY_USAGE
 	char mem_usage_str[96];
 	snprintf(mem_usage_str, sizeof(mem_usage_str), "Free mem: %d bytes", nds_free_memory_bytes());
-	nds_draw_str(0, NDS_SCREEN_LINES * 2 - 1, mem_usage_str, NDS_WHITE_PIXEL);
+	nds_draw_str(0, NDS_SCREEN_LINES * 2 - 1, mem_usage_str, NDS_WHITE_PIXEL, NDS_BLACK_PIXEL);
 #endif
 
 	nds_video_vblank();
@@ -287,7 +287,7 @@ static errr Term_xtra_nds(int n, int v)
 
 		for (y = 0; y < NDS_SCREEN_LINES; y++) {
 			for (x = 0; x < NDS_SCREEN_COLS; x++) {
-				nds_draw_char(x, y, 0, NDS_BLACK_PIXEL);
+				nds_draw_char(x, y, 0, color_data[COLOUR_DARK], color_data[COLOUR_DARK]);
 			}
 		}
 
@@ -438,7 +438,7 @@ static errr Term_wipe_nds(int x, int y, int n)
 
 	/* Draw a blank */
 	for (i = 0; i < n; i++)
-		nds_draw_char(x + i, y, 0, NDS_BLACK_PIXEL);
+		nds_draw_char(x + i, y, 0, color_data[COLOUR_DARK], color_data[COLOUR_DARK]);
 
 	/* Success */
 	return (0);
@@ -479,7 +479,7 @@ static errr Term_wipe_nds(int x, int y, int n)
 static errr Term_text_nds(int x, int y, int n, int a, const wchar_t *s)
 {
 	for (int i = 0; i < n; i++) {
-		nds_draw_char(x + i, y, s[i], color_data[a & (MAX_COLORS - 1)]);
+		nds_draw_char(x + i, y, s[i], color_data[a & (MAX_COLORS - 1)], color_data[COLOUR_DARK]);
 	}
 
 	return (0);

--- a/src/nds/nds-draw.c
+++ b/src/nds/nds-draw.c
@@ -87,33 +87,33 @@ void nds_draw_pixel(u16b x, u16b y, nds_pixel data) {
 #endif
 }
 
-void nds_draw_char_px(u16b x, u16b y, char c, nds_pixel clr)
+void nds_draw_char_px(u16b x, u16b y, char c, nds_pixel clr_fg, nds_pixel clr_bg)
 {
 	nds_pixel *fb = nds_get_framebuffer(&y);
 
 #ifdef _3DS
-	nds_font->draw_char(c, fb + (x * NDS_SCREEN_HEIGHT) + (NDS_SCREEN_HEIGHT - y - 1), clr);
+	nds_font->draw_char(c, fb + (x * NDS_SCREEN_HEIGHT) + (NDS_SCREEN_HEIGHT - y - 1), clr_fg, clr_bg);
 #else
-	nds_font->draw_char(c, fb + (y * NDS_SCREEN_WIDTH) + x, clr);
+	nds_font->draw_char(c, fb + (y * NDS_SCREEN_WIDTH) + x, clr_fg, clr_bg);
 #endif
 }
 
-void nds_draw_str_px(u16b x, u16b y, const char *str, nds_pixel clr)
+void nds_draw_str_px(u16b x, u16b y, const char *str, nds_pixel clr_fg, nds_pixel clr_bg)
 {
 	while (*str != '\0') {
-		nds_draw_char_px(x, y, *(str++), clr);
+		nds_draw_char_px(x, y, *(str++), clr_fg, clr_bg);
 		x += nds_font->width;
 	}
 }
 
-void nds_draw_char(byte x, byte y, char c, nds_pixel clr)
+void nds_draw_char(byte x, byte y, char c, nds_pixel clr_fg, nds_pixel clr_bg)
 {
-	nds_draw_char_px(x * nds_font->width, y * nds_font->height, c, clr);
+	nds_draw_char_px(x * nds_font->width, y * nds_font->height, c, clr_fg, clr_bg);
 }
 
-void nds_draw_str(byte x, byte y, const char *str, nds_pixel clr)
+void nds_draw_str(byte x, byte y, const char *str, nds_pixel clr_fg, nds_pixel clr_bg)
 {
-	nds_draw_str_px(x * nds_font->width, y * nds_font->height, str, clr);
+	nds_draw_str_px(x * nds_font->width, y * nds_font->height, str, clr_fg, clr_bg);
 }
 
 void nds_draw_cursor(int x, int y) {
@@ -149,7 +149,7 @@ void nds_log(const char *msg)
 {
 	static byte x = 2, y = 1;
 	for (byte i = 0; msg[i] != '\0'; i++) {
-		nds_draw_char(x, y, msg[i], NDS_WHITE_PIXEL);
+		nds_draw_char(x, y, msg[i], NDS_WHITE_PIXEL, NDS_BLACK_PIXEL);
 		x++;
 		if (msg[i] == '\n' || x > NDS_SCREEN_COLS - 2) {
 			x = 2;
@@ -177,7 +177,7 @@ void nds_raw_print(const char *str)
 {
 	static u16b x = 0, y = 32;
 	while (*str) {
-		nds_draw_char(x, y, *(str++), NDS_WHITE_PIXEL);
+		nds_draw_char(x, y, *(str++), NDS_WHITE_PIXEL, NDS_BLACK_PIXEL);
 		x++;
 		if (x > 78) {
 			x = 0;
@@ -186,6 +186,6 @@ void nds_raw_print(const char *str)
 				y = 32;
 		}
 	}
-	nds_draw_char(x, y, 219, NDS_WHITE_PIXEL);
+	nds_draw_char(x, y, 219, NDS_WHITE_PIXEL, NDS_BLACK_PIXEL);
 	fflush(0);
 }

--- a/src/nds/nds-draw.h
+++ b/src/nds/nds-draw.h
@@ -36,7 +36,7 @@ typedef uint16_t nds_pixel;
 typedef struct {
 	byte width;
 	byte height;
-	void (*draw_char)(char c, nds_pixel *pixels, nds_pixel clr);
+	void (*draw_char)(char c, nds_pixel *pixels, nds_pixel clr_fg, nds_pixel clr_bg);
 } nds_font_handle;
 
 extern const nds_font_handle *nds_font;
@@ -53,11 +53,11 @@ void nds_video_vblank();
 void nds_draw_pixel(u16b x, u16b y, nds_pixel data);
 
 /* Same as nds_draw_char, but x/y is pixels instead of tiles */
-void nds_draw_char_px(u16b x, u16b y, char c, nds_pixel clr);
-void nds_draw_char(byte x, byte y, char c, nds_pixel clr);
+void nds_draw_char_px(u16b x, u16b y, char c, nds_pixel clr_fg, nds_pixel clr_bg);
+void nds_draw_char(byte x, byte y, char c, nds_pixel clr_fg, nds_pixel clr_bg);
 
-void nds_draw_str_px(u16b x, u16b y, const char *str, nds_pixel clr);
-void nds_draw_str(byte x, byte y, const char *str, nds_pixel clr);
+void nds_draw_str_px(u16b x, u16b y, const char *str, nds_pixel clr_fg, nds_pixel clr_bg);
+void nds_draw_str(byte x, byte y, const char *str, nds_pixel clr_fg, nds_pixel clr_bg);
 
 void nds_draw_cursor(int x, int y);
 

--- a/src/nds/nds-font-3x8.c
+++ b/src/nds/nds-font-3x8.c
@@ -387,12 +387,12 @@ static const nds_pixel ds_subfont[] = {
 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 
 };
 
-static void nds_font_draw(char c, nds_pixel *pixels, nds_pixel clr) {
+static void nds_font_draw(char c, nds_pixel *pixels, nds_pixel clr_fg, nds_pixel clr_bg) {
 	const nds_pixel *font = ds_subfont + (c * 3 * 8);
 
 	for (byte yy = 0; yy < 8; yy++, pixels += NDS_Y_PITCH) {
 		for (byte xx = 0; xx < 3; xx++, font++) {
-			pixels[xx * NDS_X_PITCH] = (*font) & clr;
+			pixels[xx * NDS_X_PITCH] = ((*font) & clr_fg) | (~(*font) & clr_bg);
 		}
 	}
 }

--- a/src/nds/nds-font-5x8.c
+++ b/src/nds/nds-font-5x8.c
@@ -1025,12 +1025,12 @@ EMPTY, EMPTY, EMPTY, EMPTY,
 EMPTY, EMPTY, EMPTY, EMPTY,
 };
 
-static void nds_font_draw(char c, nds_pixel *pixels, nds_pixel clr) {
+static void nds_font_draw(char c, nds_pixel *pixels, nds_pixel clr_fg, nds_pixel clr_bg) {
 	const char *font = ds_subfont + (c * 5 * 8);
 
 	for (byte yy = 0; yy < 8; yy++, pixels += NDS_Y_PITCH) {
 		for (byte xx = 0; xx < 5; xx++, font++) {
-			pixels[xx * NDS_X_PITCH] = ((*font) ? NDS_WHITE_PIXEL : NDS_BLACK_PIXEL) & clr;
+			pixels[xx * NDS_X_PITCH] = ((*font) ? clr_fg : clr_bg);
 		}
 	}
 }

--- a/src/nds/nds-keyboard.c
+++ b/src/nds/nds-keyboard.c
@@ -227,14 +227,14 @@ void nds_kbd_redraw_key(int r, int k, bool initial, bool active)
 	/* If no special handling is required, just print the char */
 	if (s == NULL) {
 		nds_draw_char_px(str_x, str_y, c,
-		                 active ? NDS_CURSOR_COLOR : NDS_WHITE_PIXEL);
+		                 active ? NDS_CURSOR_COLOR : NDS_WHITE_PIXEL, NDS_BLACK_PIXEL);
 		return;
 	}
 
 	/* Print the text */
 	for (int i = 0; i < strlen(s); i++) {
 		nds_draw_char_px(str_x + (i * nds_font->width), str_y, s[i],
-		                 active ? NDS_CURSOR_COLOR : NDS_WHITE_PIXEL);
+		                 active ? NDS_CURSOR_COLOR : NDS_WHITE_PIXEL, NDS_BLACK_PIXEL);
 	}
 }
 

--- a/src/nds/nds-screenkeys.c
+++ b/src/nds/nds-screenkeys.c
@@ -110,7 +110,7 @@ void nds_scrkey_redraw_key(nds_scrkey_entry *key, bool initial, bool active)
 
 	for (int i = 0; i < NDS_SCRKEY_LABEL_LEN && key->label[i]; i++) {
 		nds_draw_char_px(str_x + (i * nds_font->width), str_y, key->label[i],
-		                 active ? NDS_CURSOR_COLOR : NDS_WHITE_PIXEL);
+		                 active ? NDS_CURSOR_COLOR : NDS_WHITE_PIXEL, NDS_BLACK_PIXEL);
 	}
 }
 


### PR DESCRIPTION
Keyboard, on-screen keys and logging functions have been left with a white-on-black color combination deliberately.