### PR TITLE
When using --with-no-install, ./lib path should depend execution instead of compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -160,7 +160,7 @@ if test "x$bindir" = "x\${exec_prefix}/bin"; then
 fi
 
 if test "x$with_no_install" != "x"; then
-	configpath="${PWD}/lib/"
+	configpath="./lib/"
 else
 	configpath="${sysconfdir}/${PACKAGE}/"
 fi
@@ -172,7 +172,7 @@ esac
 
 
 if test "x$with_no_install" != "x"; then
-	libpath="${PWD}/lib/"
+	libpath="./lib/"
 	bindir=".."
 else
 	libpath="${datarootdir}/${PACKAGE}/"
@@ -184,7 +184,7 @@ case "/$libpath" in
 esac
 
 if test "x$with_no_install" != "x"; then
-	docdir="${PWD}/doc/"
+	docdir="./doc/"
 else
 	# Only change docdir if it's the configure-supplied default, which handily doesn't expand prefix
 	if test "x$docdir" = "x\${datarootdir}/doc/\${PACKAGE_TARNAME}"; then
@@ -198,7 +198,7 @@ case "/$docdir" in
 esac
 
 if test "x$with_no_install" != "x"; then
-	varpath="${PWD}/lib/"
+	varpath="./lib/"
 else
 	varpath="${localstatedir}/games/${PACKAGE}/"
 fi

--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -18,7 +18,7 @@ TESTOBJS += test-utils.o unit-test.o
 build : $(TESTPROGS)
 
 run : build
-	@./run-tests
+	@(cd ../.. ; ./src/tests/run-tests)
 
 %.o : %.c
 	@$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $^


### PR DESCRIPTION
Currently when compiling with the --with-no-install flag, the path that is used to compile angband gets hardcoded in the binary, so the resulting files can't get moved from the full path where it was compiled. This commit changes that behavior so that it searches in the path where the app is being executed instead of the path where it was compiled. 

Current behavior lets you execute the resulting binary from any directory, but the binary stops working if you move the project to another folder. If this behavior is expected, I'll remove this PR.