### PR TITLE
Don't overwrite a normal save with a panic save

### DIFF
--- a/lib/user/Makefile
+++ b/lib/user/Makefile
@@ -1,6 +1,6 @@
 MKPATH=../../mk/
 include $(MKPATH)buildsys.mk
 
-SUBDIRS = archive save scores info
+SUBDIRS = archive panic save scores info
 PACKAGE = user
 

--- a/lib/user/panic/Makefile
+++ b/lib/user/panic/Makefile
@@ -1,0 +1,13 @@
+MKPATH=../../../mk/
+include $(MKPATH)buildsys.mk
+
+PACKAGE = panic
+
+install-extra:
+	if [ "x$(SETEGID)" != "x" ]; then \
+		if [ "x$(DRY)" = "x" ]; then \
+			${MKDIR_P} ${DESTDIR}${varshareddatadir}${PACKAGE}; \
+			chown root:${SETEGID} ${DESTDIR}${varshareddatadir}${PACKAGE}; \
+			chmod 171 ${DESTDIR}${varshareddatadir}${PACKAGE}; \
+		fi; \
+	fi

--- a/src/init.c
+++ b/src/init.c
@@ -95,6 +95,7 @@ char *ANGBAND_DIR_SOUNDS;
 char *ANGBAND_DIR_ICONS;
 char *ANGBAND_DIR_USER;
 char *ANGBAND_DIR_SAVE;
+char *ANGBAND_DIR_PANIC;
 char *ANGBAND_DIR_SCORES;
 char *ANGBAND_DIR_INFO;
 char *ANGBAND_DIR_ARCHIVE;
@@ -324,6 +325,7 @@ void init_file_paths(const char *configpath, const char *libpath, const char *da
 	string_free(ANGBAND_DIR_ICONS);
 	string_free(ANGBAND_DIR_USER);
 	string_free(ANGBAND_DIR_SAVE);
+	string_free(ANGBAND_DIR_PANIC);
 	string_free(ANGBAND_DIR_SCORES);
 	string_free(ANGBAND_DIR_INFO);
 	string_free(ANGBAND_DIR_ARCHIVE);
@@ -388,6 +390,7 @@ void init_file_paths(const char *configpath, const char *libpath, const char *da
 	/* Build the path to the score, save and archive directories */
 	BUILD_DIRECTORY_PATH(ANGBAND_DIR_SCORES, userpath, "scores");
 	BUILD_DIRECTORY_PATH(ANGBAND_DIR_SAVE, userpath, "save");
+	BUILD_DIRECTORY_PATH(ANGBAND_DIR_PANIC, userpath, "panic");
 	BUILD_DIRECTORY_PATH(ANGBAND_DIR_ARCHIVE, userpath, "archive");
 
 #undef BUILD_DIRECTORY_PATH
@@ -410,6 +413,9 @@ void create_needed_dirs(void)
 	if (!dir_create(dirpath)) quit_fmt("Cannot create '%s'", dirpath);
 
 	path_build(dirpath, sizeof(dirpath), ANGBAND_DIR_SAVE, "");
+	if (!dir_create(dirpath)) quit_fmt("Cannot create '%s'", dirpath);
+
+	path_build(dirpath, sizeof(dirpath), ANGBAND_DIR_PANIC, "");
 	if (!dir_create(dirpath)) quit_fmt("Cannot create '%s'", dirpath);
 
 	path_build(dirpath, sizeof(dirpath), ANGBAND_DIR_SCORES, "");
@@ -3993,6 +3999,7 @@ void cleanup_angband(void)
 	string_free(ANGBAND_DIR_ICONS);
 	string_free(ANGBAND_DIR_USER);
 	string_free(ANGBAND_DIR_SAVE);
+	string_free(ANGBAND_DIR_PANIC);
 	string_free(ANGBAND_DIR_SCORES);
 	string_free(ANGBAND_DIR_INFO);
 	string_free(ANGBAND_DIR_ARCHIVE);

--- a/src/init.h
+++ b/src/init.h
@@ -148,6 +148,7 @@ extern char *ANGBAND_DIR_SOUNDS;
 extern char *ANGBAND_DIR_ICONS;
 extern char *ANGBAND_DIR_USER;
 extern char *ANGBAND_DIR_SAVE;
+extern char *ANGBAND_DIR_PANIC;
 extern char *ANGBAND_DIR_SCORES;
 extern char *ANGBAND_DIR_INFO;
 extern char *ANGBAND_DIR_ARCHIVE;

--- a/src/main-win.c
+++ b/src/main-win.c
@@ -4997,6 +4997,7 @@ static void init_stuff(void)
 	validate_dir(ANGBAND_DIR_ICONS);
 	validate_dir(ANGBAND_DIR_USER);
 	validate_dir(ANGBAND_DIR_SAVE);
+	validate_dir(ANGBAND_DIR_PANIC);
 	validate_dir(ANGBAND_DIR_SCORES);
 	validate_dir(ANGBAND_DIR_INFO);
 

--- a/src/main.c
+++ b/src/main.c
@@ -191,6 +191,7 @@ static const struct {
 	{ "icons", &ANGBAND_DIR_ICONS, true },
 	{ "user", &ANGBAND_DIR_USER, true },
 	{ "save", &ANGBAND_DIR_SAVE, false },
+	{ "panic", &ANGBAND_DIR_PANIC, false },
 	{ "archive", &ANGBAND_DIR_ARCHIVE, true },
 };
 

--- a/src/savefile.c
+++ b/src/savefile.c
@@ -660,3 +660,25 @@ bool savefile_load(const char *path, bool cheat_death)
 
 	return ok;
 }
+
+
+/**
+ * Fill the given buffer with the panic save equivalent for a savefile.
+ *
+ * \param buf Is the buffer to fill.  The result wil be an empty string if
+ * the result can't fit in the given buffer or the savefile name or panic
+ * save directory are invalid.
+ * \param len Is the maximum number of characters that the buffer can hold.
+ * \param path Is the name of the savefile to use.  The storage for that must
+ * not overlap buffer.
+ */
+void savefile_get_panic_name(char *buf, size_t len, const char *path)
+{
+	size_t name_offset = path_filename_index(path);
+	size_t used = path_build(buf, len, ANGBAND_DIR_PANIC,
+		path + name_offset);
+
+	if (len > 0 && (used == 0 || !suffix(buf, path + name_offset))) {
+		buf[0] = '\0';
+	}
+}

--- a/src/savefile.h
+++ b/src/savefile.h
@@ -47,6 +47,11 @@ bool savefile_load(const char *path, bool cheat_death);
  */
 const char *savefile_get_description(const char *path);
 
+/**
+ * Fill the given buffer with the panic save equivalent for a savefile.
+ */
+void savefile_get_panic_name(char *buffer, size_t len, const char *path);
+
 
 /**
  * ------------------------------------------------------------------------

--- a/src/ui-game.h
+++ b/src/ui-game.h
@@ -25,6 +25,7 @@
 
 extern bool arg_wizard;
 extern char savefile[1024];
+extern char panicfile[1024];
 extern void (*reinit_hook)(void);
 
 void cmd_init(void);

--- a/src/ui-signals.c
+++ b/src/ui-signals.c
@@ -195,12 +195,13 @@ static void handle_signal_abort(int sig)
 
 	/* Panic save */
 	my_strcpy(player->died_from, "(panic save)", sizeof(player->died_from));
+	savefile_get_panic_name(panicfile, sizeof(panicfile), savefile);
 
 	/* Forbid suspend */
 	signals_ignore_tstp();
 
 	/* Attempt to save */
-	if (savefile_save(savefile))
+	if (panicfile[0] && savefile_save(panicfile))
 		Term_putstr(45, 23, -1, COLOUR_RED, "Panic save succeeded!");
 	else
 		Term_putstr(45, 23, -1, COLOUR_RED, "Panic save failed!");


### PR DESCRIPTION
Resolves https://github.com/angband/angband/issues/2162 .

To avoid name clashes or limits on the length of the file name portion, uses a separate, parallel, directory for the panic saves.  Because of that, there's an extra ANGBAND_DIR_PANIC global and related stuff to initialize it and create it.

When loading a save file, looks to see if there is a panic save with the same name which is newer.  If there is, prompts the player for whether the panic save should be used.  If the player opts not to use the panic save, the ordinary save will be used.

Could use some testing on Windows.  I only tried the Windows front end using Linux with Wine.  With that, Wine caught the abort signal I sent to Angband to induce the panic save, and Angband's signal handler wasn't invoked.