### PR TITLE
Adjust brief description for commands

### DIFF
--- a/docs/playing.rst
+++ b/docs/playing.rst
@@ -85,127 +85,127 @@ which is most convenient when using the original keyset.
 Original Keyset Command Summary
 ===============================
 
-======= ============================= ====== ============================
- ``a``  Aim a wand                    ``A``  Activate an object 
- ``b``  Browse a book                 ``B``  (unused)
- ``c``  Close a door                  ``C``  Character description
- ``d``  Drop an item                  ``D``  Disarm a trap or lock a door
- ``e``  Equipment list                ``E``  Eat some food
- ``f``  Fire an item                  ``F``  Fuel your lantern/torch
- ``g``  Get objects on floor          ``G``  Gain new spells/prayers
- ``h``  Fire default ammo at target   ``H``  (unused)
- ``i``  Inventory list                ``I``  Observe an item
- ``j``  (unused)                      ``J``  (unused)
- ``k``  Ignore an item                ``K``  Toggle ignore
- ``l``  Look around                   ``L``  Locate player on map
- ``m``  Cast a spell                  ``M``  Full dungeon map
- ``n``  Repeat previous command       ``N``  (unused)
- ``o``  Open a door or chest          ``O``  (unused)
- ``p``  (unused)                      ``P``  (unused)
- ``q``  Quaff a potion                ``Q``  End character & quit
- ``r``  Read a scroll                 ``R``  Rest for a period
- ``s``  Steal (rogues only)           ``S``  (unused)
- ``t``  Take off equipment            ``T``  Dig a tunnel
- ``u``  Use a staff                   ``U``  Use an item
- ``v``  Throw an item                 ``V``  Version info
- ``w``  Wear/wield equipment          ``W``  Walk into a trap
- ``x``  (unused)                      ``X``  (unused)
- ``y``  (unused)                      ``Y``  (unused)
- ``z``  Zap a rod                     ``Z``  (unused)
- ``!``  (unused)                      ``^A`` Debug mode
- ``@``  (unused)                      ``^B`` (unused)
- ``#``  (unused)                      ``^C`` (special - break)
- ``$``  (unused)                      ``^D`` (unused)
- ``%``  (unused)                      ``^E`` Toggle inven/equip window
- ``^``  (special - control key)       ``^F`` Repeat level feeling
- ``&``  (unused)                      ``^G`` Do autopickup
- ``*``  Target monster or location    ``^H`` (unused)
- ``(``  Load screen dump              ``^I`` (special - tab)
- ``)``  Dump screen dump              ``^J`` (special - linefeed)
- ``{``  Inscribe an object            ``^K`` (unused)
- ``}``  Uninscribe an object          ``^L`` Center map
- ``[``  Display visible monster list  ``^M`` (special - return)
- ``]``  Display visible object list   ``^N`` (unused)
- ``-``  (unused)                      ``^O`` Show previous message
- ``_``  Enter store                   ``^P`` Show previous messages
- ``+``  Alter grid                    ``^Q`` (unused)
- ``=``  Set options                   ``^R`` Redraw the screen
- ``;``  Walk (with pickup)            ``^S`` Save and don't quit
- ``:``  Take notes                    ``^T`` (unused)
- ``'``  Target closest monster        ``^U`` (unused)
- ``"``  Enter a user pref command     ``^V`` (unused)
- ``,``  Stay still (with pickup)      ``^W`` (special - wizard mode)
- ``<``  Go up staircase               ``^X`` Save and quit
- ``.``  Run                           ``^Y`` (unused)
- ``>``  Go down staircase             ``^Z`` (unused)
- ``\``  (special - bypass keymap)     ``~``  Check knowledge
-`` ` `` (special - escape)            ``?``  Help
- ``/``  Identify symbol
- ``|``  Quiver list
-======= ============================= ====== ============================
+====== ============================= ====== ============================
+``a``  Aim a wand                    ``A``  Activate an object
+``b``  Browse a book                 ``B``  (unused)
+``c``  Close a door                  ``C``  Display character sheet
+``d``  Drop an item                  ``D``  Disarm a trap or lock a door
+``e``  List equipped items           ``E``  Eat some food
+``f``  Fire an item                  ``F``  Fuel your lantern/torch
+``g``  Get objects on floor          ``G``  Gain new spells/prayers
+``h``  Fire default ammo at target   ``H``  (unused)
+``i``  List contents of pack         ``I``  Inspect an item
+``j``  (unused)                      ``J``  (unused)
+``k``  Ignore an item                ``K``  Toggle ignore
+``l``  Look around                   ``L``  Locate player on map
+``m``  Cast a spell                  ``M``  Display map of entire level
+``n``  Repeat previous command       ``N``  (unused)
+``o``  Open a door or chest          ``O``  (unused)
+``p``  (unused)                      ``P``  (unused)
+``q``  Quaff a potion                ``Q``  Kill character & quit
+``r``  Read a scroll                 ``R``  Rest for a period
+``s``  Steal (rogues only)           ``S``  (unused)
+``t``  Take off equipment            ``T``  Dig a tunnel
+``u``  Use a staff                   ``U``  Use an item
+``v``  Throw an item                 ``V``  Display version info
+``w``  Wear/wield equipment          ``W``  Walk into a trap
+``x``  (unused)                      ``X``  (unused)
+``y``  (unused)                      ``Y``  (unused)
+``z``  Zap a rod                     ``Z``  (unused)
+``!``  (unused)                      ``^A`` (special - debug command)
+``@``  (unused)                      ``^B`` (unused)
+``#``  (unused)                      ``^C`` (special - break)
+``$``  (unused)                      ``^D`` (unused)
+``%``  (unused)                      ``^E`` Toggle inven/equip window
+``^``  (special - control key)       ``^F`` Repeat level feeling
+``&``  (unused)                      ``^G`` Do autopickup
+``*``  Target monster or location    ``^H`` (unused)
+``(``  (unused)                      ``^I`` (special - tab)
+``)``  Dump screen to a file         ``^J`` (special - linefeed)
+``{``  Inscribe an object            ``^K`` (unused)
+``}``  Uninscribe an object          ``^L`` Center map
+``[``  Display visible monster list  ``^M`` (special - return)
+``]``  Display visible object list   ``^N`` (unused)
+``-``  (unused)                      ``^O`` Show previous message
+``_``  Enter store                   ``^P`` Show previous messages
+``+``  Alter grid                    ``^Q`` (unused)
+``=``  Set options                   ``^R`` Redraw the screen
+``;``  Walk (with pickup)            ``^S`` Save and don't quit
+``:``  Take notes                    ``^T`` (unused)
+``'``  Target closest monster        ``^U`` (unused)
+``"``  Enter a user pref command     ``^V`` (unused)
+``,``  Stay still (with pickup)      ``^W`` (special - wizard mode)
+``<``  Go up staircase               ``^X`` Save and quit
+``.``  Run                           ``^Y`` (unused)
+``>``  Go down staircase             ``^Z`` (unused)
+``\``  (special - bypass keymap)     ``~``  Check knowledge
+ \`    (special - escape)            ``?``  Display help
+``/``  Identify symbol
+``|``  List contents of quiver
+====== ============================= ====== ============================
 
 Roguelike Keyset Command Summary
 ================================
 
-====== ============================= ====== ============================
-  a    Zap a rod (Activate)            A    Activate an object
-  b    (walk - south west)             B    (run - south west)
-  c    Close a door                    C    Character description
-  d    Drop an item                    D    Disarm a trap or lock a door
-  e    Equipment list                  E    Eat some food
-  f    (unused)                        F    Fuel your lantern/torch
-  g    Get objects on floor            G    Gain new spells/prayers
-  h    (walk - west)                   H    (run - west)
-  i    Inventory list                  I    Observe an item
-  j    (walk - south)                  J    (run - south)
-  k    (walk - north)                  K    (run - north)
-  l    (walk - east)                   L    (run - east)
-  m    Cast a spell                    M    Full dungeon map
-  n    (walk - south east)             N    (run - south east)
-  o    Open a door or chest            O    Toggle ignore
-  p    (unused)                        P    Browse a book
-  q    Quaff a potion                  Q    End character & quit
-  r    Read a scroll                   R    Rest for a period
-  s    Steal (rogues only)             S    (unused)
-  t    Fire an item                    T    Take off equipment
-  u    (walk - north east)             U    (run - north east)
-  v    Throw an item                   V    Version info
-  w    Wear/wield equipment            W    Locate player on map (Where)
-  x    Look around                     X    Use an item
-  y    (walk - north west)             Y    (run - north west)
-  z    Aim a wand (Zap)                Z    Use a staff (Zap)
-  !    (unused)                        ^A   (special - debug command)
-  @    Center map                      ^B   (alter - south west)
-  #    (unused)                        ^C   (special - break)
-  $    (unused)                        ^D   Ignore an item
-  %    (unused)                        ^E   Toggle inven/equip window
-  ^    (special - control key)         ^F   Repeat level feeling
-  &    (unused)                        ^G   Do autopickup
-  \*   Target monster or location      ^H   (alter - west)
-  (    Load screen dump                ^I   (special - tab)
-  )    Dump screen dump                ^J   alter - south)
-  {    Inscribe an object              ^K   (alter - north)
-  }    Uninscribe an object            ^L   (alter - east)
-  [    Display visible monster list    ^M   (special - return)
-  ]    Display visible object list     ^N   (alter - south east)
-  \-   Walk into a trap                ^O   Show previous message
-  _    Enter store                     ^P   Show previous messages
-  \+   Alter grid                      ^Q   (unused)
-  =    Set options                     ^R   Redraw the screen
-  ;    Walk (with pickup)              ^S   Save and don't quit
-  :    Take notes                      ^T   Dig a tunnel
-  '    Target closest monster          ^U   (alter - north east)
-  "    Enter a user pref command       ^V   Repeat previous command
-  ,    Run                             ^W   (special - wizard mode)
-  <    Go up staircase                 ^X   Save and quit
-  .    Stay still (with pickup)        ^Y   (alter - north west)
-  >    Go down staircase               ^Z   (unused)
-  \\    (special - bypass keymap)       ~    Check knowledge 
-  \`    (special - escape)              ?    Help
-  /    Identify symbol                 
-  TAB  Fire default ammo at target 
-  \|    Quiver list
-====== ============================= ====== ============================
+======= ============================= ====== ============================
+ ``a``  Zap a rod (Activate)          ``A``  Activate an object
+ ``b``  (walk - south west)           ``B``  (run - south west)
+ ``c``  Close a door                  ``C``  Display character sheet
+ ``d``  Drop an item                  ``D``  Disarm a trap or lock a door
+ ``e``  List equipped items           ``E``  Eat some food
+ ``f``  (unused)                      ``F``  Fuel your lantern/torch
+ ``g``  Get objects on floor          ``G``  Gain new spells/prayers
+ ``h``  (walk - west)                 ``H``  (run - west)
+ ``i``  List contents of pack         ``I``  Inspect an item
+ ``j``  (walk - south)                ``J``  (run - south)
+ ``k``  (walk - north)                ``K``  (run - north)
+ ``l``  (walk - east)                 ``L``  (run - east)
+ ``m``  Cast a spell                  ``M``  Display map of entire level
+ ``n``  (walk - south east)           ``N``  (run - south east)
+ ``o``  Open a door or chest          ``O``  Toggle ignore
+ ``p``  (unused)                      ``P``  Browse a book
+ ``q``  Quaff a potion                ``Q``  Kill character & quit
+ ``r``  Read a scroll                 ``R``  Rest for a period
+ ``s``  Steal (rogues only)           ``S``  (unused)
+ ``t``  Fire an item                  ``T``  Take off equipment
+ ``u``  (walk - north east)           ``U``  (run - north east)
+ ``v``  Throw an item                 ``V``  Display version info
+ ``w``  Wear/wield equipment          ``W``  Locate player on map (Where)
+ ``x``  Look around                   ``X``  Use an item
+ ``y``  (walk - north west)           ``Y``  (run - north west)
+ ``z``  Aim a wand (Zap)              ``Z``  Use a staff (Zap)
+ ``!``  (unused)                      ``^A`` (special - debug command)
+ ``@``  Center map                    ``^B`` (alter - south west)
+ ``#``  (unused)                      ``^C`` (special - break)
+ ``$``  (unused)                      ``^D`` Ignore an item
+ ``%``  (unused)                      ``^E`` Toggle inven/equip window
+ ``^``  (special - control key)       ``^F`` Repeat level feeling
+ ``&``  (unused)                      ``^G`` Do autopickup
+ ``*``  Target monster or location    ``^H`` (alter - west)
+ ``(``  (unused)                      ``^I`` (special - tab)
+ ``)``  Dump screen to a file         ``^J`` (alter - south)
+ ``{``  Inscribe an object            ``^K`` (alter - north)
+ ``}``  Uninscribe an object          ``^L`` (alter - east)
+ ``[``  Display visible monster list  ``^M`` (special - return)
+ ``]``  Display visible object list   ``^N`` (alter - south east)
+ ``-``  Walk into a trap              ``^O`` Show previous message
+ ``_``  Enter store                   ``^P`` Show previous messages
+ ``+``  Alter grid                    ``^Q`` (unused)
+ ``=``  Set options                   ``^R`` Redraw the screen
+ ``;``  Walk (with pickup)            ``^S`` Save and don't quit
+ ``:``  Take notes                    ``^T`` Dig a tunnel
+ ``'``  Target closest monster        ``^U`` (alter - north east)
+ ``"``  Enter a user pref command     ``^V`` Repeat previous command
+ ``,``  Run                           ``^W`` (special - wizard mode)
+ ``<``  Go up staircase               ``^X`` Save and quit
+ ``.``  Stay still (with pickup)      ``^Y`` (alter - north west)
+ ``>``  Go down staircase             ``^Z`` (unused)
+ ``\``  (special - bypass keymap)     ``~``  Check knowledge
+  \`    (special - escape)            ``?``  Display help
+ ``/``  Identify symbol
+``TAB`` Fire default ammo at target
+ ``|``  List contents of quiver
+======= ============================= ====== ============================
 
 Special Keys
 ============

--- a/lib/help/commands.txt
+++ b/lib/help/commands.txt
@@ -6,29 +6,29 @@ Original Keyset Command Summary
   b    Browse a book                   B    -
   c    Close a door                    C    Character description
   d    Drop an item                    D    Disarm a trap or lock a door
-  e    Equipment list                  E    Eat some food
+  e    List equipped items             E    Eat some food
   f    Fire an item                    F    Fuel your lantern/torch
   g    Get objects on floor            G    Gain new spells/prayers
   h    Fire default ammo at target     H    -
-  i    Inventory list                  I    Observe an item
+  i    List contents of pack           I    Inspect an item
   j    -                               J    -
   k    Ignore an item                  K    Toggle ignore
   l    Look around                     L    Locate player on map
-  m    Cast a spell                    M    Full dungeon map
+  m    Cast a spell                    M    Display map of entire level
   n    Repeat previous command         N    -
   o    Open a door or chest            O    -
   p    -                               P    -
-  q    Quaff a potion                  Q    End character & quit
+  q    Quaff a potion                  Q    Kill character & quit
   r    Read a scroll                   R    Rest for a period
   s    Steal from a monster (rogues)   S    See abilities
   t    Take off equipment              T    Dig a tunnel
   u    Use a staff                     U    Use an item
-  v    Throw an item                   V    Version info
+  v    Throw an item                   V    Display version info
   w    Wear/wield equipment            W    Walk into a trap
   x    -                               X    -
   y    -                               Y    -
   z    Zap a rod                       Z    -
-  !    -                               ^A   Debug mode
+  !    -                               ^A   (special - debug command)
   @    -                               ^B   -
   #    -                               ^C   (special - break)
   $    -                               ^D   -
@@ -37,7 +37,7 @@ Original Keyset Command Summary
   &    -                               ^G   Do autopickup
   *    Target monster or location      ^H   -
   (    -                               ^I   (special - tab)
-  )    Dump screen dump                ^J   (special - linefeed)
+  )    Dump screen to a file           ^J   (special - linefeed)
   {    Inscribe an object              ^K   -
   }    Uninscribe an object            ^L   Center map
   [    Display visible monster list    ^M   (special - return)
@@ -55,9 +55,9 @@ Original Keyset Command Summary
   .    Run                             ^Y   -
   >    Go down staircase               ^Z   -
   \    (special - bypass keymap)        ~   Check knowledge
-  `    (special - escape)               ?   Help
+  `    (special - escape)               ?   Display help
   /    Identify symbol
-  |    Quiver list
+  |    List contents of quiver
 
 
 Roguelike Keyset Command Summary
@@ -67,24 +67,24 @@ Roguelike Keyset Command Summary
   b    (walk - south west)             B    (run - south west)
   c    Close a door                    C    Character description
   d    Drop an item                    D    Disarm a trap or lock a door
-  e    Equipment list                  E    Eat some food
+  e    List equipped items             E    Eat some food
   f    -                               F    Fuel your lantern/torch
   g    Get objects on floor            G    Gain new spells/prayers
   h    (walk - west)                   H    (run - west)
-  i    Inventory list                  I    Observe an item
+  i    List contents of pack           I    Inspect an item
   j    (walk - south)                  J    (run - south)
   k    (walk - north)                  K    (run - north)
   l    (walk - east)                   L    (run - east)
-  m    Cast a spell                    M    Full dungeon map
+  m    Cast a spell                    M    Display map of entire level
   n    (walk - south east)             N    (run - south east)
   o    Open a door or chest            O    Toggle ignore
   p    -                               P    Browse a book
-  q    Quaff a potion                  Q    End character & quit
+  q    Quaff a potion                  Q    Kill character & quit
   r    Read a scroll                   R    Rest for a period
   s    Steal from a monster (rogues)   S    See abilities
   t    Fire an item                    T    Take off equipment
   u    (walk - north east)             U    (run - north east)
-  v    Throw an item                   V    Version info
+  v    Throw an item                   V    Display version info
   w    Wear/wield equipment            W    Locate player on map (Where)
   x    Look around                     X    Use an item
   y    (walk - north west)             Y    (run - north west)
@@ -98,7 +98,7 @@ Roguelike Keyset Command Summary
   &    -                               ^G   Do autopickup
   *    Target monster or location      ^H   (alter - west)
   (    -                               ^I   (special - tab)
-  )    Dump screen dump                ^J   alter - south)
+  )    Dump screen to a file           ^J   (alter - south)
   {    Inscribe an object              ^K   (alter - north)
   }    Uninscribe an object            ^L   (alter - east)
   [    Display visible monster list    ^M   (special - return)
@@ -116,7 +116,7 @@ Roguelike Keyset Command Summary
   .    Stay still (with pickup)        ^Y   (alter - north west)
   >    Go down staircase               ^Z   -
   \    (special - bypass keymap)       ~    Check knowledge
-  `    (special - escape)              ?    Help
+  `    (special - escape)              ?    Display help
   /    Identify symbol
   TAB  Fire default ammo at target
-  |    Quiver list
+  |    List contents of quiver


### PR DESCRIPTION
Resolves https://github.com/angband/angband/issues/5155 .

"Inspect" rather than "Observe" as suggested by tangar.  "Kill" rather than "End" for the suicide command.  Prefer descriptions that have the form "verb + something".  Match the command table in playing.rst to commands.txt.  Use the "as literal" markup in playing.rst for the keys in rogue-like command table as is done in the original command table (exception is "`" in both).