### PR TITLE
docs:  fix two places referencing Timo Pietilä

### DIFF
--- a/docs/thanks.rst
+++ b/docs/thanks.rst
@@ -229,7 +229,7 @@ bugfixes, and other stuff for Angband prior to 4.0:
 
 Peter Berger, Andrew Hill, Werner Baer, Tom Morton, "Cyric the Mad", 
 Chris Kern, Jurriaan Kalkman, Alexander Wilkins, Mauro Scarpa, "facade", 
-Dennis van Es, Kenneth A. Strom, Wei-Hwa Huang, Nikodemus, Timo Pietila, 
+Dennis van Es, Kenneth A. Strom, Wei-Hwa Huang, Nikodemus, Timo Pietilä,
 Shayne Steele, Dr. Andrew White, Greg Flint, Christopher Jeris, Ian 
 Parkhouse, "Warhammer", Scott Holder, Brent Ross, Kazuo Ito, Willem 
 Siemelink, "Luthien", David J. Grabiner, Ilya Bely, "chungkuo", Kieron 

--- a/docs/version.rst
+++ b/docs/version.rst
@@ -456,6 +456,6 @@ Peter Berger, "Prfnoff", Arcum Dagsson, Ed Cogburn, Matthias Kurzke,
 Ben Harrison, Steven Fuerst, Julian Lighton, Andrew Hill, Werner Baer,
 Tom Morton, "Cyric the Mad", Chris Kern, Tim Baker, Jurriaan Kalkman,
 Alexander Wilkins, Mauro Scarpa, John I'anson-Holton, "facade",
-Dennis van Es, Kenneth A. Strom, Wei-Hwa Huang, Nikodemus, Timo Pietil‰,
+Dennis van Es, Kenneth A. Strom, Wei-Hwa Huang, Nikodemus, Timo Pietil√§,
 Greg Wooledge, Keldon Jones, Shayne Steele, Dr. Andrew White, Musus Umbra,
 Jonathan Ellis


### PR DESCRIPTION
The second one is a workaround for what appears to be a bug somewhere in the restructured text parsing (line in version.rst triggers an "undecidable source character" warning while the same line in thanks.rst does not).