### PR TITLE
Also reset the known pile in store_reset().

### DIFF
--- a/src/store.c
+++ b/src/store.c
@@ -372,7 +372,9 @@ void store_reset(void) {
 		s = &stores[i];
 		s->stock_num = 0;
 		store_shuffle(s);
+		object_pile_free(NULL, NULL, s->stock_k);
 		object_pile_free(NULL, NULL, s->stock);
+		s->stock_k = NULL;
 		s->stock = NULL;
 		if (i == STORE_HOME)
 			continue;


### PR DESCRIPTION
When using the statistics front end, avoids the pile integrity checks for the stores taking up an increasing portion of the run time as the run number increases.