### PR TITLE
Constrain search in drop_find_grid() to avoid out-of-bounds access.

### DIFF
--- a/src/obj-pile.c
+++ b/src/obj-pile.c
@@ -1084,6 +1084,9 @@ static void drop_find_grid(const struct player *p, struct chunk *c,
 		/* Start bouncing from grid to grid, stopping if we find an empty one */
 		if (i < 1000) {
 			best = rand_loc(best, 1, 1);
+			/* Keep in bounds. */
+			best.x = MAX(0, MIN(best.x, c->width - 1));
+			best.y = MAX(0, MIN(best.y, c->height - 1));
 		} else {
 			/* Now go to purely random locations */
 			best = loc(randint0(c->width), randint0(c->height));


### PR DESCRIPTION
Only affects artifact drops.  Encountered the out-of-bounds access once during a long statistics run (5000 trials); search started at (160,4) and ended with a crash at (165,-1)