### PR TITLE
configure:  prefer cc to gcc for better compatibility with OpenBSD and FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,7 +69,9 @@ if test "x$with_no_install" = "x"; then
 "
 fi
 
-AC_PROG_CC
+# Prefer cc to gcc (default behavior is the opposite) for better compatibility
+# with OpenBSD and FreeBSD.
+AC_PROG_CC([cc gcc clang])
 AC_PROG_MAKE_SET
 AC_PROG_LN_S
 AC_PROG_INSTALL


### PR DESCRIPTION
In particular, allows compiling the SDL2 front end on OpenBSD without overriding the default compiler (the old behavior chose gcc which couldn't find a header included by the SDL2 headers).

On Debian Bullseye with the gcc package installed, the change appears to have no effect (/usr/bin/cc points to /etc/alternatives/cc which points to /usr/bin/gcc).  Similarly, there's no effect on macOS 11.6.1 with Xcode:  cc and gcc both end up invoking clang.