### PR TITLE
SDL 2.0.18 fix: Disable POLL_SENTINEL Event

### DIFF
--- a/src/main-sdl2.c
+++ b/src/main-sdl2.c
@@ -5620,6 +5620,9 @@ static void init_systems(void)
 
 	SDL_StartTextInput();
 	SDL_SetHint(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "0");
+#ifdef SDL_HINT_POLL_SENTINEL
+	SDL_SetHint(SDL_HINT_POLL_SENTINEL, "0");
+#endif
 }
 
 errr init_sdl2(int argc, char **argv)


### PR DESCRIPTION
SDL 2.0.18 adds a new feature that helps handling games rendering slowly when using high frequency mice that generate events too fast https://github.com/libsdl-org/SDL/pull/4794

I think that this feature is not relevant to angband, and leaving it enabled breaks the menu.
