### PR TITLE
Disable KEYMAPCHANGED event handling

### DIFF
--- a/src/main-sdl2.c
+++ b/src/main-sdl2.c
@@ -5617,6 +5617,8 @@ static void init_systems(void)
 	SDL_EventState(SDL_FINGERMOTION, SDL_DISABLE);
 	SDL_EventState(SDL_FINGERDOWN, SDL_DISABLE);
 	SDL_EventState(SDL_FINGERUP, SDL_DISABLE);
+	/* Ignore Keymap changed events since they are not handled */
+	SDL_EventState(SDL_KEYMAPCHANGED, SDL_DISABLE);
 
 	SDL_StartTextInput();
 	SDL_SetHint(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "0");


### PR DESCRIPTION
I tried to compile angband on Fedora 35 and found a problem with the menu, I can navigate through it, but I can't click on the buttons (similar to the #4762 issue), this happens to me while using X11 and Wayland. 

I tried to debug the problem and noticed that whenever I made a mouse click, the app receives a SDL_KEYMAPCHANGED event before the SDL_MOUSEBUTTONDOWN event, breaking the menu loop before it can handle the mouse click event. I don't know if this is an SDL problem, a Gnome problem, an expected behavior or a problem with my computer configuration, but since the game is not actually doing anything to handle those events, I made a patch to disable them.