### PR TITLE
Clear links when orphaning an object

### DIFF
--- a/src/obj-pile.c
+++ b/src/obj-pile.c
@@ -332,6 +332,8 @@ void object_delete(struct chunk *c, struct chunk *p_c,
 	if (c && p_c && obj->oidx && (obj == c->objects[obj->oidx]) &&
 		p_c->objects[obj->oidx]) {
 		obj->grid = loc(0, 0);
+		obj->prev = NULL;
+		obj->next = NULL;
 		obj->held_m_idx = 0;
 		obj->mimicking_m_idx = 0;
 


### PR DESCRIPTION
Avoids use after free detected by address sanitation in the destruction and earthquake tests.