### PR TITLE
Visual Studio: include lib/customize/font-sdl2.prf in the list of files

### DIFF
--- a/src/win/vs2019/Angband.vcxproj
+++ b/src/win/vs2019/Angband.vcxproj
@@ -513,6 +513,7 @@ xcopy $(MSBuildProjectDirectory)\lib\* $(OutDir)lib\ /DESY /exclude:$(MSBuildPro
   <ItemGroup>
     <None Include="lib\customize\font-gcu.prf" />
     <None Include="lib\customize\font-sdl.prf" />
+    <None Include="lib\customize\font-sdl2.prf" />
     <None Include="lib\customize\font-win.prf" />
     <None Include="lib\customize\font-x11.prf" />
     <None Include="lib\customize\font.prf" />

--- a/src/win/vs2019/Angband.vcxproj.filters
+++ b/src/win/vs2019/Angband.vcxproj.filters
@@ -1088,6 +1088,9 @@
     <None Include="lib\customize\font-sdl.prf">
       <Filter>Resource Files\customize</Filter>
     </None>
+    <None Include="lib\customize\font-sdl2.prf">
+      <Filter>Resource Files\customize</Filter>
+    </None>
     <None Include="lib\customize\font-win.prf">
       <Filter>Resource Files\customize</Filter>
     </None>


### PR DESCRIPTION
Missed that in the "centered dot for SDL2" commit.