### PR TITLE
Protect against empty name when checking for panic save

### DIFF
--- a/src/ui-game.c
+++ b/src/ui-game.c
@@ -641,7 +641,7 @@ static void start_game(bool new_game)
 
 	/* Try loading */
 	savefile_get_panic_name(panicfile, sizeof(panicfile), loadpath);
-	if (file_exists(panicfile)) {
+	if (loadpath[0] && file_exists(panicfile)) {
 		if (file_newer(panicfile, loadpath)) {
 			if (get_check("A panic save exists.  Use it? ")) {
 				loadpath = panicfile;


### PR DESCRIPTION
Fixes regression introduced by #5156 : the Mac front end prompts for using a panic save if the player selects File->New from the menu.