### PR TITLE
Reorder checks/confirmations so they happen before additional prompts to the player

### DIFF
--- a/src/cmd-obj.c
+++ b/src/cmd-obj.c
@@ -369,14 +369,14 @@ void do_cmd_drop(struct command *cmd)
 			/* Choice */ USE_EQUIP | USE_INVEN | USE_QUIVER) != CMD_OK)
 		return;
 
-	if (cmd_get_quantity(cmd, "quantity", &amt, obj->number) != CMD_OK)
-		return;
-
 	/* Cannot remove stickied items */
 	if (object_is_equipped(player->body, obj) && !obj_can_takeoff(obj)) {
 		msg("Hmmm, it seems to be stuck.");
 		return;
 	}
+
+	if (cmd_get_quantity(cmd, "quantity", &amt, obj->number) != CMD_OK)
+		return;
 
 	inven_drop(obj, amt);
 	player->upkeep->energy_use = z_info->move_energy / 2;
@@ -918,6 +918,16 @@ void do_cmd_refill(struct command *cmd)
 		return;
 	}
 
+	/* Check what we're wielding. */
+	if (!light || !tval_is_light(light)) {
+		msg("You are not wielding a light.");
+		return;
+	} else if (of_has(light->flags, OF_NO_FUEL)
+			|| !of_has(light->flags, OF_TAKES_FUEL)) {
+		msg("Your light cannot be refilled.");
+		return;
+	}
+
 	/* Get an item */
 	if (cmd_get_item(cmd, "item", &obj,
 			"Refuel with with fuel source? ",
@@ -925,19 +935,7 @@ void do_cmd_refill(struct command *cmd)
 			obj_can_refill,
 			USE_INVEN | USE_FLOOR | USE_QUIVER) != CMD_OK) return;
 
-	/* Check what we're wielding. */
-	if (!light || !tval_is_light(light)) {
-		msg("You are not wielding a light.");
-		return;
-	} else if (of_has(light->flags, OF_NO_FUEL)) {
-		msg("Your light cannot be refilled.");
-		return;
-	} else if (of_has(light->flags, OF_TAKES_FUEL)) {
-		refill_lamp(light, obj);
-	} else {
-		msg("Your light cannot be refilled.");
-		return;
-	}
+	refill_lamp(light, obj);
 
 	player->upkeep->energy_use = z_info->move_energy / 2;
 }
@@ -1045,6 +1043,10 @@ void do_cmd_study_book(struct command *cmd)
 	struct class_spell *spell;
 	int i, k = 0;
 
+	/* Check the player can study at all atm */
+	if (!player_can_study(player, true))
+		return;
+
 	if (cmd_get_item(cmd, "item", &book_obj,
 			/* Prompt */ "Study which book? ",
 			/* Error  */ "You cannot learn any new spells from the books you have.",
@@ -1055,10 +1057,6 @@ void do_cmd_study_book(struct command *cmd)
 	book = player_object_to_book(player, book_obj);
 	track_object(player->upkeep, book_obj);
 	handle_stuff(player);
-
-	/* Check the player can study at all atm */
-	if (!player_can_study(player, true))
-		return;
 
 	for (i = 0; i < book->num_spells; i++) {
 		spell = &book->spells[i];

--- a/src/cmd-obj.c
+++ b/src/cmd-obj.c
@@ -974,13 +974,6 @@ void do_cmd_cast(struct command *cmd)
 			/* Filter */ spell_okay_to_cast) != CMD_OK)
 		return;
 
-	if (spell_needs_aim(spell_index)) {
-		if (cmd_get_target(cmd, "target", &dir) == CMD_OK)
-			player_confuse_dir(player, &dir, false);
-		else
-			return;
-	}
-
 	/* Get the spell */
 	spell = spell_by_index(player, spell_index);
 
@@ -997,6 +990,13 @@ void do_cmd_cast(struct command *cmd)
 
 		/* Verify */
 		if (!get_check("Attempt it anyway? ")) return;
+	}
+
+	if (spell_needs_aim(spell_index)) {
+		if (cmd_get_target(cmd, "target", &dir) == CMD_OK)
+			player_confuse_dir(player, &dir, false);
+		else
+			return;
 	}
 
 	/* Cast a spell */

--- a/src/player-attack.c
+++ b/src/player-attack.c
@@ -1308,11 +1308,6 @@ void do_cmd_fire(struct command *cmd) {
 		!= CMD_OK)
 		return;
 
-	if (cmd_get_target(cmd, "target", &dir) == CMD_OK)
-		player_confuse_dir(player, &dir, false);
-	else
-		return;
-
 	/* Require a usable launcher */
 	if (!bow || !player->state.ammo_tval) {
 		msg("You have nothing to fire with.");
@@ -1330,6 +1325,11 @@ void do_cmd_fire(struct command *cmd) {
 		msg("That ammo cannot be fired by your current weapon.");
 		return;
 	}
+
+	if (cmd_get_target(cmd, "target", &dir) == CMD_OK)
+		player_confuse_dir(player, &dir, false);
+	else
+		return;
 
 	ranged_helper(player, obj, dir, range, shots, attack, ranged_hit_types,
 				  (int) N_ELEMENTS(ranged_hit_types));


### PR DESCRIPTION
One is per PowerWyrm's suggestion, http://angband.oook.cz/forum/showthread.php?t=10997 :  confirm unsafe casting before asking for a spell's target.

The others are similar situations with other commands.  Because of the enforcement of prerequisites by the textui interface, most of these won't affect what the player sees.

- In do_cmd_fire(), check the objects involved before targeting.
- When dropping, check for dropping a sticky equipped item before prompting for the quantity to drop (though, since equipped items are currently only in stacks of one item, there is no quantity prompt anyways in that case).
- Check light source before prompting for the stack to use when refueling.
- Check for whether studying is at all possible before prompting for the book to use in do_cmd_study_book().