### PR TITLE
Protect against command repetition accessing a deleted object after …

### DIFF
--- a/src/project-obj.c
+++ b/src/project-obj.c
@@ -18,6 +18,7 @@
 
 #include "angband.h"
 #include "cave.h"
+#include "cmd-core.h"
 #include "mon-util.h"
 #include "obj-chest.h"
 #include "obj-desc.h"
@@ -569,6 +570,11 @@ bool project_o(struct source origin, int r, struct loc grid, int dam, int typ,
 				if (obvious && obj->known && note_kill
 						&& !ignore_item_ok(player, obj)) {
 					msgt(MSG_DESTROY, "The %s %s!", o_name, note_kill);
+				}
+
+				/* Prevent command repetition, if necessary. */
+				if (loc_eq(grid, player->grid)) {
+					cmd_disable_repeat_floor_item();
 				}
 
 				/* Delete the object */


### PR DESCRIPTION
… a projection effect destroys an object on the floor.

Steps to get an access after deletion with the unchanged code:

1. Summon a giant white dragon fly (ctrl-a then n).
2. Step away from it so it's more likely to breathe.
3. Create a potion of boldness on the floor (ctrl-a then c).
4. Turn that potion into a decent-sized stack (ctrl-a then o).
5. Wait for the dragon fly to wake up.
6. Drink a potion of boldness from the floor.  Use n to repeat that until the dragon fly breathes and destroys the potions.  Then use n once more.