### PR TITLE
Add configure option to store gamedata on libpath

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -218,10 +218,12 @@ fi
 AC_ARG_WITH(gamedata_in_lib,
 	[AS_HELP_STRING([--gamedata-in-lib], [store the game data in the lib path.])])
 
+GAMEDATA_IN_LIB="false"
 if test "x$with_gamedata_in_lib" == "xyes"; then
-	GAMEDATA_IN_LIB="$with_gamedata_in_lib"; AC_SUBST(GAMEDATA_IN_LIB)
+	GAMEDATA_IN_LIB="true"
 	AC_DEFINE(GAMEDATA_IN_LIB, 1, [Define to store the game data in the lib path.])
 fi
+AC_SUBST(GAMEDATA_IN_LIB)
 
 AC_SUBST([configdir])
 AC_SUBST([libdatadir])

--- a/configure.ac
+++ b/configure.ac
@@ -215,6 +215,13 @@ else
 	varshareddatadir="${vardatadir}"
 fi
 
+AC_ARG_WITH(gamedata_in_lib,
+	[AS_HELP_STRING([--gamedata-in-lib], [store the game data in the lib path.])])
+
+if test "x$with_gamedata_in_lib" == "xyes"; then
+	GAMEDATA_IN_LIB="$with_gamedata_in_lib"; AC_SUBST(GAMEDATA_IN_LIB)
+	AC_DEFINE(GAMEDATA_IN_LIB, 1, [Define to store the game data in the lib path.])
+fi
 
 AC_SUBST([configdir])
 AC_SUBST([libdatadir])
@@ -527,6 +534,11 @@ echo "  config path:                            ${configdir}"
 echo "  lib path:                               ${libdatadir}"
 echo "  doc path:                               ${docdatadir}"
 echo "  var path:                               ${displayedvardatadir}"
+if test "x$with_gamedata_in_lib" == "xyes"; then
+	echo "  gamedata path:                          ${libdatadir}"
+else
+	echo "  gamedata path:                          ${configdir}"
+fi
 
 if test "x$wsetgid" = "xyes"; then
 	echo "  (as group ${SETEGID})"

--- a/lib/gamedata/Makefile
+++ b/lib/gamedata/Makefile
@@ -10,4 +10,10 @@ CONFIG = activation.txt artifact.txt body.txt blow_methods.txt \
  room_template.txt shape.txt slay.txt store.txt summon.txt terrain.txt \
  trap.txt ui_entry.txt ui_entry_base.txt ui_entry_renderer.txt vault.txt \
  visuals.txt world.txt
+
+ifneq ($(GAMEDATA_IN_LIB),)
+DATA := $(CONFIG)
+undefine CONFIG
+endif
+
 PACKAGE = gamedata

--- a/lib/gamedata/Makefile
+++ b/lib/gamedata/Makefile
@@ -1,7 +1,7 @@
 MKPATH=../../mk/
 include $(MKPATH)buildsys.mk
 
-CONFIG = activation.txt artifact.txt body.txt blow_methods.txt \
+FILES = activation.txt artifact.txt body.txt blow_methods.txt \
  blow_effects.txt brand.txt chest_trap.txt class.txt constants.txt curse.txt \
  dungeon_profile.txt ego_item.txt flavor.txt hints.txt history.txt \
  monster.txt monster_base.txt monster_spell.txt names.txt object.txt \
@@ -11,9 +11,9 @@ CONFIG = activation.txt artifact.txt body.txt blow_methods.txt \
  trap.txt ui_entry.txt ui_entry_base.txt ui_entry_renderer.txt vault.txt \
  visuals.txt world.txt
 
-ifneq ($(GAMEDATA_IN_LIB),)
-DATA := $(CONFIG)
-undefine CONFIG
-endif
+R1 = $(GAMEDATA_IN_LIB:true=$(FILES))
+DATA = $(R1:false=)
+R2 = $(GAMEDATA_IN_LIB:false=$(FILES))
+CONFIG = $(R2:true=)
 
 PACKAGE = gamedata

--- a/mk/extra.mk.in
+++ b/mk/extra.mk.in
@@ -1,5 +1,6 @@
 LIB_CPPFLAGS = @LIB_CPPFLAGS@
 SETEGID = @SETEGID@
+GAMEDATA_IN_LIB = @GAMEDATA_IN_LIB@
 LIBDIR = ${libdir}
 libdatadir = @libdatadir@
 vardatadir = @vardatadir@

--- a/src/init.c
+++ b/src/init.c
@@ -338,7 +338,11 @@ void init_file_paths(const char *configpath, const char *libpath, const char *da
 }
 
 	/* Paths generally containing configuration data for Angband. */
+#ifdef GAMEDATA_IN_LIB
+	BUILD_DIRECTORY_PATH(ANGBAND_DIR_GAMEDATA, libpath, "gamedata");
+#else
 	BUILD_DIRECTORY_PATH(ANGBAND_DIR_GAMEDATA, configpath, "gamedata");
+#endif
 	BUILD_DIRECTORY_PATH(ANGBAND_DIR_CUSTOMIZE, configpath, "customize");
 	BUILD_DIRECTORY_PATH(ANGBAND_DIR_HELP, libpath, "help");
 	BUILD_DIRECTORY_PATH(ANGBAND_DIR_SCREENS, libpath, "screens");


### PR DESCRIPTION
Considering [this conversation](http://angband.oook.cz/forum/showthread.php?t=10995), I thought it would convenient to add this option.

When enabled, it installs the gamedata folder in the libpath instead of the configpath.