### PR TITLE
Remove empty score file

### DIFF
--- a/lib/user/scores/Makefile
+++ b/lib/user/scores/Makefile
@@ -7,7 +7,6 @@ install-extra:
 	if [ "x$(SETEGID)" != "x" ]; then \
 		if [ "x$(DRY)" = "x" ]; then \
 			${MKDIR_P} ${DESTDIR}${varshareddatadir}${PACKAGE}; \
-			touch ${DESTDIR}${varshareddatadir}${PACKAGE}/scores.raw; \
 			chown -R root:${SETEGID} ${DESTDIR}${varshareddatadir}${PACKAGE}; \
 			chmod -R g+w ${DESTDIR}${varshareddatadir}${PACKAGE}; \
 		fi; \

--- a/lib/user/scores/Makefile
+++ b/lib/user/scores/Makefile
@@ -7,7 +7,7 @@ install-extra:
 	if [ "x$(SETEGID)" != "x" ]; then \
 		if [ "x$(DRY)" = "x" ]; then \
 			${MKDIR_P} ${DESTDIR}${varshareddatadir}${PACKAGE}; \
-			chown -R root:${SETEGID} ${DESTDIR}${varshareddatadir}${PACKAGE}; \
-			chmod -R g+w ${DESTDIR}${varshareddatadir}${PACKAGE}; \
+			chown root:${SETEGID} ${DESTDIR}${varshareddatadir}${PACKAGE}; \
+			chmod g+w ${DESTDIR}${varshareddatadir}${PACKAGE}; \
 		fi; \
 	fi

--- a/src/score.c
+++ b/src/score.c
@@ -46,7 +46,7 @@ size_t highscore_read(struct high_score scores[], size_t sz)
 	path_build(fname, sizeof(fname), ANGBAND_DIR_SCORES, "scores.raw");
 	scorefile = file_open(fname, MODE_READ, FTYPE_TEXT);
 
-	if (!scorefile) return true;
+	if (!scorefile) return 0;
 
 	for (i = 0; i < sz; i++)
 		if (file_read(scorefile, (char *)&scores[i],


### PR DESCRIPTION
I don't see the convenience of including this empty file on instalation since the code actually checks if it exists and always creates a new one.

Also changed the return value of highscore_read when the file doesn't exist since it's not consistent with the function definition. It's also not used in the codebase.