### PR TITLE
With OpenBSD's make, avoid "make clean" failing in src/tests when ...

### DIFF
--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -51,7 +51,7 @@ $(TESTPROGS) : ../angband.o test-utils.o unit-test.o
 	@echo "  CC $@"
 
 clean :
-	$(RM) $(TESTOBJS) $(TESTPROGS)
+	-$(RM) $(TESTOBJS) $(TESTPROGS)
 
 .PHONY : all clean
 .PRECIOUS : %.o


### PR DESCRIPTION
…there's nothing to clean.