### PR TITLE
Change how src/Makefile deals with the build ID to avoid requiring GNU Make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ src/autoconf.h.in
 src/config
 src/stats/db.dep
 src/tests/ran-already
+src/version.h

--- a/src/Makefile
+++ b/src/Makefile
@@ -7,10 +7,8 @@ INCLUDE = $(HDRS) $(INCS)
 OBJECTS = $(ANGFILES) $(ZFILES)
 SRCS    = ${OBJECTS:.o=.c} ${MAINFILES:.o=.c}
 PROG    = $(PROGNAME)$(PROG_SUFFIX)
-VERSION := $(shell ../scripts/version.sh)
-ifneq (${VERSION},)
-	CFLAGS += -DBUILD_ID=${VERSION}
-endif
+# Will dynamically generate version.h with the build number.
+CFLAGS += -DHAVE_VERSION_H
 
 CFLAGS += -I. -fPIC -std=c99 -O0
 # Replace above line with the two below and then look at gmon.out
@@ -22,7 +20,7 @@ CFLAGS += -I. -fPIC -std=c99 -O0
 GCOBJS = $(OBJECTS:.o=.gcno) $(OBJECTS:.o=.gcda)
 GCOVS = $(OBJECTS:.o=.c.gcov)
 
-CLEAN = angband.o $(OBJECTS) win/angband.res
+CLEAN = angband.o $(OBJECTS) win/angband.res version.h
 DISTCLEAN = autoconf.h tests/.deps
 
 $(PROG): $(PROGNAME).o $(MAINFILES)
@@ -46,6 +44,31 @@ test-clean:
 
 # Hack to descend into tests and clean since it isn't included in SUBDIRS.
 pre-clean: test-clean
+
+# Track the build number in the dynamically generated file, version.h.
+# Use INSTALL_STATUS/INSTALL_OK from buildsys in lieu of something more
+# appropriate for automatically generated source files.
+version.h: FORCE
+	@xversion=`../scripts/version.sh` ; \
+	i="$@" ; \
+	if test -r "$$i" ; then \
+		xoldversion=`grep -E '^/\*"' "$$i" | sed -e 's%^/\*"%%' -e 's%"\*/$$%%' -e 'q'` ; \
+	else \
+		xoldversion=x$$xversion ; \
+	fi ; \
+	if test "x$$xversion" != "x$$xoldversion" ; then \
+		${INSTALL_STATUS} ; \
+		echo "#ifndef VERSION_H" > "$$i" ; \
+		echo "#define VERSION_H" >> "$$i" ; \
+		echo '/*"'"$$xversion"'"*/' >> "$$i" ; \
+		echo " $$xversion" | sed -e '/^[ \t\r]$$/q' -e 's/^ /#define VERSION_STRING "/' -e 's/$$/"/' -e 'q' >> "$$i" ; \
+		echo "#endif" >> "$$i" ; \
+		${INSTALL_OK} ; \
+	fi
+
+# Since version.h is dynamically generated, explicitly specify everything that
+# depends on it.
+buildid.o: version.h
 
 splint:
 	splint -f .splintrc ${OBJECTS:.o=.c} main.c main-gcu.c
@@ -79,4 +102,5 @@ post-install:
 		fi \
 	fi
 
+FORCE :
 .PHONY : tests coverage clean-coverage tests/ran-already

--- a/src/buildid.c
+++ b/src/buildid.c
@@ -18,6 +18,22 @@
 
 #include "buildid.h"
 
+/*
+ * Allow the build system to generate version.h (and define
+ * the HAVE_VERSION_H preprocessor macro) or get the version via the BUILD_ID
+ * preprocessor macro.  If neither is available, use a sensible default.
+ */
+#ifdef HAVE_VERSION_H
+#include "version.h"
+#elif defined(BUILD_ID)
+#define STR(x) #x
+#define XSTR(x) STR(x)
+#define VERSION_STRING XSTR(BUILD_ID)
+#endif
+#ifndef VERSION_STRING
+#define VERSION_STRING "4.2.3"
+#endif
+
 const char *buildid = VERSION_NAME " " VERSION_STRING;
 const char *buildver = VERSION_STRING;
 

--- a/src/buildid.h
+++ b/src/buildid.h
@@ -21,14 +21,6 @@
 
 #define VERSION_NAME	"Angband"
 
-#ifdef BUILD_ID
-# define STR(x) #x
-# define XSTR(x) STR(x)
-# define VERSION_STRING XSTR(BUILD_ID)
-#else
-# define VERSION_STRING "4.2.3"
-#endif
-
 extern const char *buildid;
 extern const char *buildver;
 extern const char *copyright;

--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -5467,7 +5467,7 @@ static NSString* get_doc_directory(void)
 	NSString *documents = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) lastObject];
 
 #if defined(SAFE_DIRECTORY)
-	NSString *versionedDirectory = [NSString stringWithFormat: @"%@-%s", AngbandDirectoryNameBase, VERSION_STRING];
+	NSString *versionedDirectory = [NSString stringWithFormat: @"%@-%s", AngbandDirectoryNameBase, buildver];
 	return [documents stringByAppendingPathComponent: versionedDirectory];
 #else
 	return [documents stringByAppendingPathComponent: AngbandDirectoryNameBase];

--- a/src/main-sdl.c
+++ b/src/main-sdl.c
@@ -3265,7 +3265,7 @@ static void init_morewindows(void)
 	AboutSelect = sdl_ButtonBankNew(&StatusBar.buttons);
 	button = sdl_ButtonBankGet(&StatusBar.buttons, AboutSelect);
 
-	my_strcpy(buf, format("%s %s", VERSION_NAME, VERSION_STRING), sizeof(buf));
+	my_strcpy(buf, buildid, sizeof(buf));
 
 	/* Initialize the 'about' button */
 	sdl_ButtonSize(button, StatusBar.font.width * strlen(buf) + 5,

--- a/src/main-test.c
+++ b/src/main-test.c
@@ -67,7 +67,7 @@ static void c_verbose(char *rest) {
 }
 
 static void c_version(char *rest) {
-	printf("cmd-version: %s %s\n", VERSION_NAME, VERSION_STRING);
+	printf("cmd-version: %s\n", buildid);
 }
 
 /**
@@ -176,7 +176,7 @@ typedef struct {
 } term_xtra_func;
 
 static void term_init_test(term *t) {
-	if (verbose) printf("term-init %s %s\n", VERSION_NAME, VERSION_STRING);
+	if (verbose) printf("term-init %s\n", buildid);
 }
 
 static void term_nuke_test(term *t) {


### PR DESCRIPTION
That finishes off the current places where GNU Make was assumed.  The change here to generate version.h with the build number doesn't work cleanly on OpenBSD with the default make:  it always rebuilds buildid.o and relinks angband even though the timestamp on version.h didn't change.  On Linux with GNU Make, it does work as expected:  buildid.o is only rebuilt when version.h changes, and that happens when version.h doesn't exist or the output from scripts/version.sh changes.