### PR TITLE
Add a mode to object_desc() that allows overriding obj->number with a…

### DIFF
--- a/src/obj-desc.h
+++ b/src/obj-desc.h
@@ -38,7 +38,11 @@ enum {
 
 	ODESC_CAPITAL = 0x80,	/*!< Capitalise object name */
 	ODESC_TERSE = 0x100,  	/*!< Make terse names */
-	ODESC_NOEGO = 0x200  	/*!< Don't show ego names */
+	ODESC_NOEGO = 0x200,  	/*!< Don't show ego names */
+	ODESC_ALTNUM = 0x400	/*!< Use the high 16 bits of mode rather
+					than obj->number as the number
+					of objects; not fully compatible
+					with ODESC_EXTRA */
 };
 
 
@@ -49,7 +53,7 @@ void object_kind_name(char *buf, size_t max, const struct object_kind *kind,
 					  bool easy_know);
 size_t obj_desc_name_format(char *buf, size_t max, size_t end, const char *fmt,
 							const char *modstr, bool pluralise);
-size_t object_desc(char *buf, size_t max, const struct object *obj, int mode,
-		const struct player *p);
+size_t object_desc(char *buf, size_t max, const struct object *obj,
+	uint32_t mode, const struct player *p);
 
 #endif /* OBJECT_DESC_H */

--- a/src/obj-list.c
+++ b/src/obj-list.c
@@ -370,7 +370,6 @@ void object_list_format_name(const object_list_entry_t *entry,
 	bool has_singular_prefix;
 	bool los = false;
 	int field;
-	uint8_t old_number;
 	struct loc pgrid = player->grid;
 	struct object *base_obj;
 	struct loc grid;
@@ -414,16 +413,11 @@ void object_list_format_name(const object_list_entry_t *entry,
 	field = los ? OBJECT_LIST_SECTION_LOS : OBJECT_LIST_SECTION_NO_LOS;
 
 	/*
-	 * Because each entry points to a specific object and not something more
-	 * general, the number of similar objects we counted has to be swapped in.
-	 * This isn't an ideal way to do this, but it's the easiest way until
-	 * object_desc is more flexible.
+	 * Pass the accumulated number via object_desc()'s ODESC_ALTNUM
+	 * mechanism:  it's in the high 16 bits of the mode.
 	 */
-	old_number = entry->object->number;
-	entry->object->number = entry->count[field];
-	object_desc(name, sizeof(name), base_obj, ODESC_PREFIX | ODESC_FULL,
-		player);
-	entry->object->number = old_number;
+	object_desc(name, sizeof(name), base_obj, ODESC_PREFIX | ODESC_FULL |
+		ODESC_ALTNUM | (entry->count[field] << 16), player);
 
 	/* The source string for strtok() needs to be set properly, depending on
 	 * when we use it. */

--- a/src/ui-store.c
+++ b/src/ui-store.c
@@ -268,7 +268,7 @@ static void store_display_entry(struct menu *menu, int oid, bool cursor, int row
 {
 	struct object *obj;
 	int32_t x;
-	int desc = ODESC_PREFIX;
+	uint32_t desc = ODESC_PREFIX;
 
 	char o_name[80];
 	char out_val[160];
@@ -742,7 +742,7 @@ static void store_examine(struct store_context *ctx, int item)
 	char header[120];
 	textblock *tb;
 	region area = { 0, 0, 0, 0 };
-	int odesc_flags = ODESC_PREFIX | ODESC_FULL;
+	uint32_t odesc_flags = ODESC_PREFIX | ODESC_FULL;
 
 	if (item < 0) return;
 


### PR DESCRIPTION
… different count for the number of objects.  Doesn't change the number of arguments to object_desc():  the alternate count is packed into the high 16 bits of the mode.  Change the mode from an int to a uint32_t so it's guaranteed  that those high 16 bits won't overlap existing modes.

Change obj-list.c to use the new mode.  That avoids an integer conversion warning from Visual Studio and a value swap that a comment flagged as a non-ideal way to handle an accumulated count.