### PR TITLE
Add option to include monster list in screenshot …

### DIFF
--- a/src/ui-command.c
+++ b/src/ui-command.c
@@ -292,16 +292,19 @@ static void screenshot_term_query(int wid, int hgt, int x, int y, int *a, wchar_
 /**
  * Take an html screenshot
  */
-void html_screenshot(const char *path, int mode)
+void html_screenshot(const char *path, int mode, term *other_term)
 {
+	/* Put the contents of the other terminal on the right by default. */
+	bool other_left = false;
 	int y, x;
-	int wid, hgt;
-
+	int main_wid, main_hgt, other_wid, other_hgt, wid, hgt;
+	int main_xst, other_xst;
 	int a = COLOUR_WHITE;
 	int oa = COLOUR_WHITE;
 	int fg_colour = COLOUR_WHITE;
 	int bg_colour = COLOUR_DARK;
 	wchar_t c = L' ';
+	term *main_term = Term;
 
 	const char *new_color_fmt = "<font color=\"#%02X%02X%02X\" style=\"background-color: #%02X%02X%02X\">";
 	const char *change_color_fmt = (mode == 0) ?
@@ -323,7 +326,24 @@ void html_screenshot(const char *path, int mode)
 	}
 
 	/* Retrieve current screen size */
-	Term_get_size(&wid, &hgt);
+	Term_get_size(&main_wid, &main_hgt);
+	if (other_term) {
+		Term_activate(other_term);
+		Term_get_size(&other_wid, &other_hgt);
+		Term_activate(main_term);
+	} else {
+		other_wid = 0;
+		other_hgt = 0;
+	}
+	if (other_left) {
+		other_xst = 0;
+		main_xst = (other_wid > 0) ? other_wid + 1 : 0;
+	} else {
+		other_xst = main_wid + 1;
+		main_xst = 0;
+	}
+	hgt = MAX(main_hgt, other_hgt);
+	wid = (other_wid > 0) ? main_wid + other_wid + 1 : main_wid;
 
 	if (mode == 0) {
 		file_putf(fp, "<!DOCTYPE html><html><head>\n");
@@ -352,7 +372,23 @@ void html_screenshot(const char *path, int mode)
 	for (y = 0; y < hgt; y++) {
 		for (x = 0; x < wid; x++) {
 			/* Get the attr/char */
-			screenshot_term_query(wid, hgt, x, y, &a, &c);
+			if (x >= main_xst && x < main_xst + main_wid
+					&& y < main_hgt) {
+				screenshot_term_query(wid, hgt, x - main_xst, y,
+					&a, &c);
+			} else if (x >= other_xst && x < other_xst + other_wid
+					&& y < other_hgt) {
+				if (x == other_xst) {
+					Term_activate(other_term);
+				}
+				Term_what(x - other_xst, y, &a, &c);
+				if (x == other_xst + other_wid - 1) {
+					Term_activate(main_term);
+				}
+			} else {
+				a = main_term->attr_blank;
+				c = main_term->char_blank;
+			}
 
 			/* Set the foreground and background */
 			fg_colour = a % MAX_COLORS;
@@ -447,7 +483,7 @@ void html_screenshot(const char *path, int mode)
 /**
  * Hack -- save a screen dump to a file in html format
  */
-static void do_cmd_save_screen_html(int mode)
+static void do_cmd_save_screen_html(int mode, term *other_term)
 {
 	size_t i;
 
@@ -465,8 +501,7 @@ static void do_cmd_save_screen_html(int mode)
 
 	/* Save current preferences */
 	path_build(file_name, sizeof(file_name), ANGBAND_DIR_USER, "dump.prf");
-	fff = file_open(file_name, MODE_WRITE,
-					(mode == 0 ? FTYPE_HTML : FTYPE_TEXT));
+	fff = file_open(file_name, MODE_WRITE, FTYPE_TEXT);
 
 	/* Check for failure */
 	if (!fff) {
@@ -484,7 +519,7 @@ static void do_cmd_save_screen_html(int mode)
 	/* Dump the screen with raw character attributes */
 	reset_visuals(false);
 	do_cmd_redraw();
-	html_screenshot(tmp_val, mode);
+	html_screenshot(tmp_val, mode, other_term);
 
 	/* Recover current graphics settings */
 	reset_visuals(true);
@@ -502,12 +537,23 @@ static void do_cmd_save_screen_html(int mode)
  */
 void do_cmd_save_screen(void)
 {
-	char ch;
-	ch = get_char("Dump as (H)TML or (F)orum text? ", "hf", 2, ' ');
+	char ch = get_char("Dump as (H)TML or (F)orum text? ", "hf", 2, ' ');
+	int mode = 0;
+	term *ml_term;
 
-	switch (ch)
-	{
-		case 'h': do_cmd_save_screen_html(0); break;
-		case 'f': do_cmd_save_screen_html(1); break;
+	switch (ch) {
+		case 'h':
+			mode = 0;
+			break;
+		case 'f':
+			mode = 1;
+			break;
+		default:
+			return;
 	}
+	ml_term = find_first_subwindow(PW_MONLIST);
+	if (ml_term) {
+		if (!get_check("Include monster list? ")) ml_term = NULL;
+	}
+	do_cmd_save_screen_html(mode, ml_term);
 }

--- a/src/ui-command.h
+++ b/src/ui-command.h
@@ -19,12 +19,14 @@
 #ifndef UI_COMMAND_H
 #define UI_COMMAND_H
 
+#include "ui-term.h"
+
 void do_cmd_redraw(void);
 void do_cmd_xxx_options(void);
 void do_cmd_unknown(void);
 void do_cmd_version(void);
 void textui_cmd_suicide(void);
-void html_screenshot(const char *path, int mode);
+void html_screenshot(const char *path, int mode, term *other_term);
 void do_cmd_save_screen(void);
 void textui_cmd_rest(void);
 void textui_quit(void);

--- a/src/ui-prefs.c
+++ b/src/ui-prefs.c
@@ -1467,3 +1467,29 @@ void do_cmd_pref(void)
 	/* Process that pref command */
 	(void)process_pref_file_command(tmp);
 }
+
+/**
+ * ------------------------------------------------------------------------
+ * Utility functions
+ * ------------------------------------------------------------------------ */
+
+/**
+ * Return the first active subwindow with the given flag enabled or NULL if
+ * there isn't an active subwindow with that flag enabled.
+ *
+ * \param flag is the flag to test.
+ */
+term *find_first_subwindow(uint32_t flag)
+{
+	int i = 1;
+
+	while (1) {
+		if (i >= ANGBAND_TERM_MAX) {
+			return NULL;
+		}
+		if ((window_flag[i] & flag) && angband_term[i]) {
+			return angband_term[i];
+		}
+		++i;
+	}
+}

--- a/src/ui-prefs.h
+++ b/src/ui-prefs.h
@@ -65,6 +65,7 @@ void dump_features(ang_file *fff);
 void dump_flavors(ang_file *fff);
 void dump_colors(ang_file *fff);
 void dump_ui_entry_renderers(ang_file *fff);
+term *find_first_subwindow(uint32_t flag);
 void option_dump(ang_file *fff);
 bool prefs_save(const char *path, void (*dump)(ang_file *), const char *title);
 errr process_pref_file_command(const char *buf);


### PR DESCRIPTION
… if it's displayed in a subwindow.  Implements a suggestion from Pete Mack here, http://angband.oook.cz/forum/showpost.php?p=151773&postcount=67 .

It's currently hardwired to append the monster list to the right and can be switched to the left by changing one line of code.  Allowing it to be put on top or on bottom would require some changes.