### PR TITLE
docs: use .DEFAULT as the catch-all target for compatibility with …

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -11,15 +11,15 @@ BUILDDIR      = _build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
-
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile
+.DEFAULT:
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 # Explicitly handle this one to take care of the empty directory for the
 # built documents.
-clean: Makefile
+clean:
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) clean
 	@if test -f $(BUILDDIR) -o -d $(BUILDDIR); then rm -fr $(BUILDDIR); fi
+
+.PHONY: help clean


### PR DESCRIPTION
…BSD-style makes.  Drop Makefile as a dependency (.DEFAULT can't have a dependency; the others are phony and always rebuild).