### PR TITLE
GCU: preprocess out body, rather than entire declaration, of …

### DIFF
--- a/src/main-gcu.c
+++ b/src/main-gcu.c
@@ -727,11 +727,11 @@ static int create_color(int i, int scale) {
 }
 
 
-#ifdef A_COLOR
 /**
  * Adjust the color tables if there's more than 16 available.
  */
 static void handle_extended_color_tables(void) {
+#ifdef A_COLOR
 	if (COLORS == 256 || COLORS == 88) {
 		/* If we have more than 16 colors, find the best matches. These numbers
 		 * correspond to xterm/rxvt's builtin color numbers--they do not
@@ -776,8 +776,8 @@ static void handle_extended_color_tables(void) {
 			}
 		}
 	}
-}
 #endif
+}
 
 
 /**


### PR DESCRIPTION
…handle_extended_color_tables() if A_COLOR not set.  Fixes regression introduced by https://github.com/angband/angband/pull/5137 : will get a compiler error if A_COLOR not set.