### PR TITLE
In test front end, reset savefile set in main.c so it doesn't interfere with the test

### DIFF
--- a/src/main-test.c
+++ b/src/main-test.c
@@ -21,6 +21,7 @@
 #include "main.h"
 #include "player.h"
 #include "player-birth.h"
+#include "ui-game.h"
 
 #ifdef USE_TEST
 
@@ -308,6 +309,12 @@ errr init_test(int argc, char *argv[]) {
 		}
 		printf("init-test: bad argument '%s'\n", argv[i]);
 	}
+
+	/*
+	 * Reset savefile set by main.c:  don't want it to interfere with the
+	 * test.
+	 */
+	savefile[0] = '\0';
 
 	term_data_link(0);
 	return 0;


### PR DESCRIPTION
Without the change, if the user running the test front end has a savefile matching what main.c selects, the birth/new-game-0 or birth/new-game-1 tests will fail if the character's race and class combination from the save file doesn't happen to match what the test checks for (those tests assume the first key press brings the game to the new character selection screen; with a savefile, the first key press either brings the game to the dungeon level the character is on or to the quick restart screen).