### PR TITLE
Tweak some things for setgid installations

### DIFF
--- a/lib/user/archive/Makefile
+++ b/lib/user/archive/Makefile
@@ -8,6 +8,6 @@ install-extra:
 		if [ "x$(DRY)" = "x" ]; then \
 			${MKDIR_P} ${DESTDIR}${varshareddatadir}${PACKAGE}; \
 			chown root:${SETEGID} ${DESTDIR}${varshareddatadir}${PACKAGE}; \
-			chmod 171 ${DESTDIR}${varshareddatadir}${PACKAGE}; \
+			chmod g+w ${DESTDIR}${varshareddatadir}${PACKAGE}; \
 		fi; \
 	fi

--- a/src/main.c
+++ b/src/main.c
@@ -179,9 +179,9 @@ static const struct {
 	char **path;
 	bool setgid_ok;
 } change_path_values[] = {
-	{ "scores", &ANGBAND_DIR_SCORES, true },
-	{ "gamedata", &ANGBAND_DIR_GAMEDATA, false },
-	{ "screens", &ANGBAND_DIR_SCREENS, false },
+	{ "scores", &ANGBAND_DIR_SCORES, false },
+	{ "gamedata", &ANGBAND_DIR_GAMEDATA, true },
+	{ "screens", &ANGBAND_DIR_SCREENS, true },
 	{ "help", &ANGBAND_DIR_HELP, true },
 	{ "info", &ANGBAND_DIR_INFO, true },
 	{ "pref", &ANGBAND_DIR_CUSTOMIZE, true },
@@ -192,7 +192,7 @@ static const struct {
 	{ "user", &ANGBAND_DIR_USER, true },
 	{ "save", &ANGBAND_DIR_SAVE, false },
 	{ "panic", &ANGBAND_DIR_PANIC, false },
-	{ "archive", &ANGBAND_DIR_ARCHIVE, true },
+	{ "archive", &ANGBAND_DIR_ARCHIVE, false },
 };
 
 /**


### PR DESCRIPTION
- Make the archive directory readable by owner and others.  That's to allow the indexing in file_archive() to work (currently unused; all current callers pass an append string) with setgid installations.
- For main.c's option to change paths, allow all paths in setgid installations to be changed except those that require privilege changes to access (save, scores, archive, and panic).
- Fix main.c's -l option to work better with setgid installations.