### PR TITLE
Drop stolen items nearby instead of forcing inventory overflow for full players

### DIFF
--- a/src/mon-util.c
+++ b/src/mon-util.c
@@ -1480,8 +1480,9 @@ void steal_monster_item(struct monster *mon, int midx)
 				object_grab(player, obj);
 				delist_object(player->cave, obj->known);
 				delist_object(cave, obj);
-				/* Drop immediately if ignored to prevent pack overflow */
-				if (ignore_item_ok(player, obj)) {
+				/* Drop immediately if ignored,
+				   or if inventory already full to prevent pack overflow */
+				if (ignore_item_ok(player, obj) || !inven_carry_okay(obj)) {
 					char o_name[80];
 					object_desc(o_name, sizeof(o_name), obj,
 						ODESC_PREFIX | ODESC_FULL,


### PR DESCRIPTION
(This might be more a matter of a difference in vision for this mechanic that may or may not be in line with the project; feel free to close this if so.)

I found that it is more intuitive that if I try to steal from a monster with a full inventory, that rather than creating an overflow and automatically dropping something from my inventory, that I instead drop the item I tried to steal and then figure out which item from my inventory I'd like to drop to pick the stolen item back up, if the item is still worth taking.

For example, in my save, I stole a low-value item from a monster on a full inventory, which overflowed and made me drop one of my artifacts to pick up the stolen item. Since stealing can consume a turn, that also could have been a turn where a nearby monster breathes fire or shoots acid and destroys my dropped artifact without getting a chance to reclaim it.

I also think it makes sense from a roleplay perspective that the player wouldn't just accept any item they steal and instantaneously drop a random item in their possession without hesitation to make room for it.

I think my change is minimal enough, but let me know if there are other parts of the code I may be neglecting.