### PR TITLE
Prevent use of an unitialized variable when firing off a chest trap

### DIFF
--- a/src/obj-chest.c
+++ b/src/obj-chest.c
@@ -546,7 +546,7 @@ static void chest_trap(struct object *obj)
 {
 	int traps = obj->pval;
 	struct chest_trap *trap;
-	bool ident;
+	bool ident = false;
 
 	/* Ignore disarmed chests */
 	if (traps <= 0) return;


### PR DESCRIPTION
Detected by the address sanitizer.