### PR TITLE
Supply rejection message to get_item() in do_cmd_inven(), …

### DIFF
--- a/src/ui-knowledge.c
+++ b/src/ui-knowledge.c
@@ -3571,8 +3571,9 @@ void do_cmd_inven(void)
 		screen_save();
 
 		/* Get an item to use a context command on (Display the inventory) */
-		if (get_item(&obj, "Select Item:", NULL, CMD_NULL, NULL,
-					 GET_ITEM_PARAMS)) {
+		if (get_item(&obj, "Select Item:",
+				"Error in do_cmd_inven(), please report.",
+				CMD_NULL, NULL, GET_ITEM_PARAMS)) {
 			/* Load screen */
 			screen_load();
 
@@ -3616,8 +3617,9 @@ void do_cmd_equip(void)
 		screen_save();
 
 		/* Get an item to use a context command on (Display the equipment) */
-		if (get_item(&obj, "Select Item:", NULL, CMD_NULL, NULL,
-					 GET_ITEM_PARAMS)) {
+		if (get_item(&obj, "Select Item:",
+				"Error in do_cmd_equip(), please report.",
+				CMD_NULL, NULL, GET_ITEM_PARAMS)) {
 			/* Load screen */
 			screen_load();
 
@@ -3664,8 +3666,9 @@ void do_cmd_quiver(void)
 		screen_save();
 
 		/* Get an item to use a context command on (Display the quiver) */
-		if (get_item(&obj, "Select Item:", NULL, CMD_NULL, NULL,
-					 GET_ITEM_PARAMS)) {
+		if (get_item(&obj, "Select Item:",
+				"Error in do_cmd_quiver(), please report.",
+				CMD_NULL, NULL, GET_ITEM_PARAMS)) {
 			/* Load screen */
 			screen_load();
 


### PR DESCRIPTION
…do_cmd_equip(), and do_cmd_quiver() so the option to show the floor is not shown when there are no items on the floor.  Resolves https://github.com/angband/angband/issues/5241 .