### PR TITLE
Print total number in pack/quiver when dropping, picking up, or …

### DIFF
--- a/src/obj-gear.h
+++ b/src/obj-gear.h
@@ -41,6 +41,8 @@ int object_slot(struct player_body body, const struct object *obj);
 bool object_is_equipped(struct player_body body, const struct object *obj);
 bool object_is_carried(struct player *p, const struct object *obj);
 bool object_is_in_quiver(struct player *p, const struct object *obj);
+uint16_t object_pack_total(struct player *p, const struct object *obj,
+	bool ignore_inscrip, struct object **first);
 int pack_slots_used(const struct player *p);
 const char *equip_mention(struct player *p, int slot);
 const char *equip_describe(struct player *p, int slot);


### PR DESCRIPTION
…consuming an item that's in the pack/quiver or ends up there.  If there's multiple stacks of the object, preface the printed slot index by "1st ".  Drop recombining messages except when a stack is completely combined with another.  Tries to resolve Bogatyr's complaint here, http://angband.oook.cz/forum/showpost.php?p=156776&postcount=151 , without resurrecting PowerWyrm's issue, https://github.com/angband/angband/issues/4882 .