### PR TITLE
Improve "puff of smake" messaging

### DIFF
--- a/src/effect-handler-general.c
+++ b/src/effect-handler-general.c
@@ -2502,7 +2502,21 @@ bool effect_handler_TELEPORT(effect_handler_context_t *context)
 
 	/* Report failure (very unlikely) */
 	if (!num_spots) {
-		msg("Failed to find teleport destination!");
+		if (is_player) {
+			msg("Failed to find teleport destination!");
+		} else {
+			/*
+			 * With either teleport self or teleport other, it'll
+			 * be the caster that is puzzled.
+			 */
+			struct monster *mon = cave_monster(cave,
+				context->origin.which.monster);
+
+			if (square_isseen(cave, mon->grid)) {
+				add_monster_message(mon, MON_MSG_BRIEF_PUZZLE,
+					true);
+			}
+		}
 		return true;
 	}
 

--- a/src/list-mon-message.h
+++ b/src/list-mon-message.h
@@ -61,6 +61,7 @@ MON_MSG(BRIEF_PUZZLE,		MSG_GENERIC,	false,	"look[s] briefly puzzled.")
 MON_MSG(MAINTAIN_SHAPE,		MSG_GENERIC,	false,	"maintain[s] the same shape.")
 MON_MSG(UNHARMED,			MSG_GENERIC,	false,	"[is|are] unharmed.")
 MON_MSG(APPEAR,			MSG_GENERIC,	false,	"appear[s]!")
+MON_MSG(HIT_AND_RUN,		MSG_GENERIC,	true,	"There is a puff of smoke!")
 /* Dummy messages for monster pain - we use edit file info instead. */
 MON_MSG(95,					MSG_GENERIC,	false,	"")
 MON_MSG(75,					MSG_GENERIC,	false,	"")

--- a/src/mon-attack.c
+++ b/src/mon-attack.c
@@ -757,7 +757,10 @@ bool make_attack_normal(struct monster *mon, struct player *p)
 	/* Blink away */
 	if (blinked) {
 		char dice[5];
-		msg("There is a puff of smoke!");
+
+		if (!p->is_dead && square_isseen(cave, mon->grid)) {
+			add_monster_message(mon, MON_MSG_HIT_AND_RUN, true);
+		}
 		strnfmt(dice, sizeof(dice), "%d", z_info->max_sight * 2 + 5);
 		effect_simple(EF_TELEPORT, source_monster(mon->midx), dice, 0, 0, 0, 0, 0, NULL);
 	}
@@ -774,7 +777,7 @@ bool make_attack_normal(struct monster *mon, struct player *p)
 }
 
 /**
- * Attack the player via physical attacks.
+ * Attack the another monster via physical attacks.
  */
 bool monster_attack_monster(struct monster *mon, struct monster *t_mon)
 {
@@ -917,7 +920,10 @@ bool monster_attack_monster(struct monster *mon, struct monster *t_mon)
 	/* Blink away */
 	if (blinked) {
 		char dice[5];
-		msg("There is a puff of smoke!");
+
+		if (square_isseen(cave, mon->grid)) {
+			add_monster_message(mon, MON_MSG_HIT_AND_RUN, true);
+		}
 		strnfmt(dice, sizeof(dice), "%d", z_info->max_sight * 2 + 5);
 		effect_simple(EF_TELEPORT, source_monster(mon->midx), dice, 0, 0, 0, 0, 0, NULL);
 	}


### PR DESCRIPTION
1. Avoid ordering problem mentioned in the comments on #2798 .
2. Account for visibility.
3. In the teleport handler, make the "no target squares" message depend on the context.

In regards to (2), this change won't generate a message in the out-of-sight case.  Should it (at least in the monster versus player scenario)?