### PR TITLE
Don't create ANGBAND_DIR_HELP in create_needed_dirs()

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -429,9 +429,6 @@ void create_needed_dirs(void)
 	path_build(dirpath, sizeof(dirpath), ANGBAND_DIR_INFO, "");
 	if (!dir_create(dirpath)) quit_fmt("Cannot create '%s'", dirpath);
 
-	path_build(dirpath, sizeof(dirpath), ANGBAND_DIR_HELP, "");
-	if (!dir_create(dirpath)) quit_fmt("Cannot create '%s'", dirpath);
-
 	path_build(dirpath, sizeof(dirpath), ANGBAND_DIR_ARCHIVE, "");
 	if (!dir_create(dirpath)) quit_fmt("Cannot create '%s'", dirpath);
 


### PR DESCRIPTION
It's handled at installation and is not one created in the private user directories.