### PR TITLE
setgid:  don't elevate and drop privileges when writing pref files, …

### DIFF
--- a/src/ui-prefs.c
+++ b/src/ui-prefs.c
@@ -390,14 +390,11 @@ bool prefs_save(const char *path, void (*dump)(ang_file *), const char *title)
 {
 	ang_file *fff;
 
-	safe_setuid_grab();
-
 	/* Remove old keymaps */
 	remove_old_dump(path, title);
 
 	fff = file_open(path, MODE_APPEND, FTYPE_TEXT);
 	if (!fff) {
-		safe_setuid_drop();
 		return false;
 	}
 
@@ -410,8 +407,6 @@ bool prefs_save(const char *path, void (*dump)(ang_file *), const char *title)
 	file_putf(fff, "\n");
 	pref_footer(fff, title);
 	file_close(fff);
-
-	safe_setuid_drop();
 
 	return true;
 }

--- a/src/z-textblock.c
+++ b/src/z-textblock.c
@@ -696,8 +696,6 @@ errr text_lines_to_file(const char *path, text_writer writer)
 
 	ang_file *new_file;
 
-	safe_setuid_grab();
-
 	/* Format filenames */
 	strnfmt(new_fname, sizeof(new_fname), "%s.new", path);
 	strnfmt(old_fname, sizeof(old_fname), "%s.old", path);
@@ -705,7 +703,6 @@ errr text_lines_to_file(const char *path, text_writer writer)
 	/* Write new file */
 	new_file = file_open(new_fname, MODE_WRITE, FTYPE_TEXT);
 	if (!new_file) {
-		safe_setuid_drop();
 		return -1;
 	}
 
@@ -725,8 +722,6 @@ errr text_lines_to_file(const char *path, text_writer writer)
 	} else {
 		file_delete(new_fname);
 	}
-
-	safe_setuid_drop();
 
 	return 0;
 }


### PR DESCRIPTION
…character dumps, or the lore file:  all are saved to the user's private directory and elevated privileges aren't necessary to write them.