### PR TITLE
Drop phrase in monster name when forming a possesive

### DIFF
--- a/src/mon-blows.c
+++ b/src/mon-blows.c
@@ -134,9 +134,8 @@ char *monster_blow_method_action(struct blow_method *method, int midx)
 					if (midx > 0) {
 						monster_desc(m_name,
 							sizeof(m_name), t_mon,
-							MDESC_TARG | MDESC_COMMA);
+							MDESC_TARG | MDESC_POSS);
 						strnfcat(buf, sizeof(buf), &end, m_name);
-						strnfcat(buf, sizeof(buf), &end, "'s");
 					} else {
 						strnfcat(buf, sizeof(buf), &end, "your");
 					}

--- a/src/mon-desc.c
+++ b/src/mon-desc.c
@@ -187,7 +187,7 @@ void monster_desc(char *desc, size_t max, const struct monster *mon, int mode)
 			 */
 			if ((mode & MDESC_POSS)
 					&& rf_has(mon->race->flags, RF_NAME_COMMA)
-					&& (comma_pos = strrchr(mon->race->name, ','))
+					&& (comma_pos = strchr(mon->race->name, ','))
 					&& comma_pos - mon->race->name < 1024) {
 				strnfmt(desc, max, "%.*s",
 					(int) (comma_pos - mon->race->name),
@@ -211,7 +211,7 @@ void monster_desc(char *desc, size_t max, const struct monster *mon, int mode)
 			 */
 			if ((mode & MDESC_POSS)
 					&& rf_has(mon->race->flags, RF_NAME_COMMA)
-					&& (comma_pos = strrchr(mon->race->name, ','))
+					&& (comma_pos = strchr(mon->race->name, ','))
 					&& comma_pos - mon->race->name < 1024) {
 				my_strcat(desc, format("%.*s",
 					(int) (comma_pos - mon->race->name),

--- a/src/mon-desc.c
+++ b/src/mon-desc.c
@@ -79,10 +79,6 @@ void get_mon_name(char *buf, size_t buflen,
  *
  * Reflexives are acquired by requesting Objective plus Possessive.
  *
- * Note that the "possessive" for certain unique monsters will look
- * really silly, as in "Morgoth, King of Darkness's".  We should
- * perhaps add a flag to "remove" any "descriptives" in the name.
- *
  * Note that "offscreen" monsters will get a special "(offscreen)"
  * notation in their name if they are visible but offscreen.  This
  * may look silly with possessives, as in "the rat's (offscreen)".
@@ -180,10 +176,25 @@ void monster_desc(char *desc, size_t max, const struct monster *mon, int mode)
 		else
 			my_strcpy(desc, "itself", max);
 	} else {
+		const char *comma_pos;
+
 		/* Unique, indefinite or definite */
 		if (rf_has(mon->race->flags, RF_UNIQUE)) {
 			/* Start with the name (thus nominative and objective) */
-			my_strcpy(desc, mon->race->name, max);
+			/*
+			 * Strip off descriptive phrase if a possessive will be
+			 * added.
+			 */
+			if ((mode & MDESC_POSS)
+					&& rf_has(mon->race->flags, RF_NAME_COMMA)
+					&& (comma_pos = strrchr(mon->race->name, ','))
+					&& comma_pos - mon->race->name < 1024) {
+				strnfmt(desc, max, "%.*s",
+					(int) (comma_pos - mon->race->name),
+					mon->race->name);
+			} else {
+				my_strcpy(desc, mon->race->name, max);
+			}
 		} else {
 			if (mode & MDESC_IND_VIS) {
 				/* XXX Check plurality for "some" */
@@ -194,7 +205,20 @@ void monster_desc(char *desc, size_t max, const struct monster *mon, int mode)
 				my_strcpy(desc, "the ", max);
 			}
 
-			my_strcat(desc, mon->race->name, max);
+			/*
+			 * As with uniques, strip off phrase if a possessive
+			 * will be added.
+			 */
+			if ((mode & MDESC_POSS)
+					&& rf_has(mon->race->flags, RF_NAME_COMMA)
+					&& (comma_pos = strrchr(mon->race->name, ','))
+					&& comma_pos - mon->race->name < 1024) {
+				my_strcat(desc, format("%.*s",
+					(int) (comma_pos - mon->race->name),
+					mon->race->name), max);
+			} else {
+				my_strcat(desc, mon->race->name, max);
+			}
 		}
 
 		if ((mode & MDESC_COMMA)

--- a/src/tests/monster/desc.c
+++ b/src/tests/monster/desc.c
@@ -65,7 +65,7 @@ static void fill_fluff(char *buf, const char *lead, size_t sz) {
 			buf[i] = '\0';
 			++i;
 		}
-	}	
+	}
 
 	for (ind = i % sizeof(fluff); i < sz; ++i) {
 		buf[i] = fluff[ind];
@@ -461,8 +461,7 @@ static int test_monster_desc_seen_def_0(void *state) {
 			"the satyr", "the nymph", "the alligator" } },
 		{ MDESC_OBJE, 3, { "Gi", "In", "Wa", "Wo", "th", "th", "th" } },
 		{ MDESC_POSS, MY_SZ, { "Gilgamesh's", "Inanna's",
-			"Watcher in the Water's",
-			"Wormtongue, Agent of Saruman's", "the satyr's",
+			"Watcher in the Water's", "Wormtongue's", "the satyr's",
 			"the nymph's", "the alligator's" } },
 		{ MDESC_POSS, 4, { "Gil", "Ina", "Wat", "Wor", "the", "the",
 			"the" } },
@@ -586,9 +585,8 @@ static int test_monster_desc_seen_indef_0(void *state) {
 		{ MDESC_IND_VIS | MDESC_OBJE, 4, { "Gil", "Ina", "Wat", "Wor",
 			"a s", "a n", "an " } },
 		{ MDESC_IND_VIS | MDESC_POSS, MY_SZ, { "Gilgamesh's",
-			"Inanna's", "Watcher in the Water's",
-			"Wormtongue, Agent of Saruman's", "a satyr's",
-			"a nymph's", "an alligator's" } },
+			"Inanna's", "Watcher in the Water's", "Wormtongue's",
+			"a satyr's", "a nymph's", "an alligator's" } },
 		{ MDESC_IND_VIS | MDESC_POSS, 7, { "Gilgam", "Inanna",
 			"Watche", "Wormto", "a saty", "a nymp", "an all" } },
 		{ MDESC_IND_VIS | MDESC_OBJE | MDESC_POSS, MY_SZ, { "himself",


### PR DESCRIPTION
So, use "Morgoth's" rather than "Morgoth, Lord of Darkness's".