### PR TITLE
CMake:  for self-contained installs, copy lib at build time rather …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -659,9 +659,21 @@ IF(SC_INSTALL)
         INSTALL(DIRECTORY docs/ DESTINATION docs)
     ENDIF()
 
-    MESSAGE(STATUS "Copying needed files")
-
-    FILE(COPY ${CMAKE_CURRENT_SOURCE_DIR}/lib DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/ PATTERN Makefile EXCLUDE PATTERN .deps EXCLUDE)
+    # Set up a target to transfer the files in lib/ at build time.
+    ADD_CUSTOM_TARGET(TransferLib ALL)
+    ADD_CUSTOM_COMMAND(
+        TARGET TransferLib
+        PRE_BUILD
+        COMMAND "${CMAKE_COMMAND}" "-P"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/cmake/scripts/copy_with_exclude.cmake"
+        "--"
+        "${CMAKE_CURRENT_BINARY_DIR}"
+        "${CMAKE_CURRENT_SOURCE_DIR}/lib"
+        "Makefile"
+        ".deps"
+        COMMENT "Copying needed files"
+        VERBATIM
+    )
 
     IF(SUPPORT_WINDOWS_FRONTEND)
         # Transfer the packaged DLLs so there in the same directory as the
@@ -704,8 +716,14 @@ ADD_CUSTOM_TARGET(allunittests
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 IF(SUPPORT_TEST_FRONTEND)
     ADD_DEPENDENCIES(alltests OurExecutable)
+    IF(SC_INSTALL)
+        ADD_DEPENDENCIES(alltests TransferLib)
+    ENDIF()
 ENDIF()
 ADD_DEPENDENCIES(alltests allunittests)
+IF(SC_INSTALL)
+    ADD_DEPENDENCIES(allunittests TransferLib)
+ENDIF()
 
 # Set up an object library with the shared code for unit tests.
 ADD_LIBRARY(OurUnitTestLib OBJECT EXCLUDE_FROM_ALL

--- a/src/cmake/scripts/copy_with_exclude.cmake
+++ b/src/cmake/scripts/copy_with_exclude.cmake
@@ -1,0 +1,29 @@
+# Usage: cmake -P copy_with_exclude.cmake -- <out> <in> [<exclude1> ...]
+# Copy directory, <in>, to the directory <out> excluding any files that match
+# one of the optionally specified patterns, <exclude1> and so on.
+
+CMAKE_POLICY(VERSION 3.5)
+SET(_USAGE "usage: cmake [[-D <var>=<value>] ...] -P copy_with_exclude.cmake -- out in [exclude1 ...]")
+SET(_X 0)
+WHILE(_X LESS CMAKE_ARGC)
+    IF(CMAKE_ARGV${_X} STREQUAL "--")
+        BREAK()
+    ENDIF()
+    MATH(EXPR _X "${_X} + 1")
+ENDWHILE()
+MATH(EXPR _X "${_X} + 2")
+IF(_X GREATER_EQUAL ${CMAKE_ARGC})
+    MESSAGE(FATAL_ERROR "${_USAGE}")
+ENDIF()
+
+MATH(EXPR _Y "${_X} - 1")
+SET(_OUT "${CMAKE_ARGV${_Y}}")
+SET(_IN "${CMAKE_ARGV${_X}}")
+UNSET(_PATTERNS)
+MATH(EXPR _X "${_X} + 1")
+WHILE(_X LESS CMAKE_ARGC)
+    LIST(APPEND _PATTERNS "PATTERN" "${CMAKE_ARGV${_X}}" "EXCLUDE")
+    MATH(EXPR _X "${_X} + 1")
+ENDWHILE()
+
+FILE(COPY "${_IN}" DESTINATION "${_OUT}" ${_PATTERNS})


### PR DESCRIPTION
…than when CMake is run so that any changes in lib are captured.