### PR TITLE
Add an option to play_game() for an in-game savefile selector.

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -6044,7 +6044,7 @@ static void cocoa_reinit(void)
      * even handler as appropriate
      */
     Term_fresh();
-    play_game(new_game);
+    play_game((new_game) ? GAME_NEW : GAME_LOAD);
 
     /* Free resources */
     textui_cleanup();

--- a/src/main-nds.c
+++ b/src/main-nds.c
@@ -736,7 +736,7 @@ int main(int argc, char *argv[])
 	pause_line(Term);
 
 	/* Play the game */
-	play_game(false);
+	play_game(GAME_LOAD);
 
 	/* Free resources */
 	textui_cleanup();

--- a/src/main-win.c
+++ b/src/main-win.c
@@ -3164,7 +3164,7 @@ static void check_for_save_file(LPSTR cmd_line)
 	/* Start game */
 	game_in_progress = true;
 	Term_fresh();
-	play_game(false);
+	play_game(GAME_LOAD);
 	quit(NULL);
 }
 
@@ -3240,7 +3240,7 @@ static void process_menus(WORD wCmd)
 				/* Start game */
 				game_in_progress = true;
 				Term_fresh();
-				play_game(true);
+				play_game(GAME_NEW);
 				quit(NULL);
 			}
 			break;
@@ -3272,7 +3272,7 @@ static void process_menus(WORD wCmd)
 						/* Start game */
 						game_in_progress = true;
 						Term_fresh();
-						play_game(false);
+						play_game(GAME_LOAD);
 						quit(NULL);
 					}
 				}

--- a/src/main-xxx.c
+++ b/src/main-xxx.c
@@ -655,8 +655,8 @@ errr init_xxx(int argc, char **argv)
  *
  * These systems usually have some form of "event loop", run forever
  * as the last step of "main()", which handles things like menus and
- * window movement, and calls "play_game(false)" to load a game after
- * initializing "savefile" to a filename, or "play_game(true)" to make
+ * window movement, and calls "play_game(GAME_LOAD)" to load a game after
+ * initializing "savefile" to a filename, or "play_game(GAME_NEW)" to make
  * a new game.  The event loop would also be triggered by "Term_xtra()"
  * (the TERM_XTRA_EVENT action), in which case the event loop would not
  * actually "loop", but would run once and return.

--- a/src/ui-game.h
+++ b/src/ui-game.h
@@ -23,6 +23,37 @@
 #include "cmd-core.h"
 #include "game-event.h"
 
+/* These are the allowed modes of operation for play_game(). */
+enum game_mode_type {
+	GAME_LOAD,	/* try to load the game from savefile; if it does not
+				exist or the character is dead, start a new
+				game that'll be stored in that savefile */
+	GAME_NEW,	/* always start a new game regardless of the state
+				of the character in savefile; new game will
+				be stored with the name in savefile unless it
+				is empty */
+	GAME_SELECT	/* have the player select with a menu what to do; if
+				savefile is set and exists that will be the
+				default option in the menu for loading; if
+				savefile is not empty and does not exist,
+				it'll be the file used if the player selects
+				the menu option for a new game */
+};
+
+/*
+ * This is an opaque pointer for enumerating the savefiles available to the
+ * current player from the savefile directory.
+ */
+typedef struct savefile_getter_impl *savefile_getter;
+
+/* Holds the information that can be gotten back from a savefile_getter. */
+struct savefile_details {
+	char *fnam;	/* holds the file name component of its path */
+	char *desc;	/* holds the result from savefile_get_description() */
+	size_t foff;	/* holds the offset in fnam to get past the
+				player-specific prefix */
+};
+
 extern bool arg_wizard;
 extern char savefile[1024];
 extern char panicfile[1024];
@@ -37,10 +68,17 @@ void textui_process_command(void);
 errr textui_get_cmd(cmd_context context);
 void check_for_player_interrupt(game_event_type type, game_event_data *data,
 								void *user);
-void play_game(bool new_game);
+void play_game(enum game_mode_type mode);
 void savefile_set_name(const char *fname, bool make_safe, bool strip_suffix);
+bool savefile_name_already_used(const char *fname, bool make_safe,
+	bool strip_suffix);
 void save_game(void);
 bool save_game_checked(void);
 void close_game(bool prompt_failed_save);
+
+bool got_savefile(savefile_getter *pg);
+bool got_savefile_dir(const savefile_getter g);
+const struct savefile_details *get_savefile_details(const savefile_getter g);
+void cleanup_savefile_getter(savefile_getter g);
 
 #endif /* INCLUDED_UI_GAME_H */


### PR DESCRIPTION
Resolves https://github.com/angband/angband/issues/2244 .  Since the selector includes a new game option, also check name generation during birth for whether the name would coincide with an existing savefile.

For the front-ends using main.c, the selector will be shown if the -c option is used on the command line.  That option will override the -n option if it is present.  There's some interaction between the -c and -f (force name) option as well.  If -f is used and the default savefile set by the front end is already present, the -c option won't include an option for a brand new game with a new savefile.

The other front ends don't use the selector and their interaction with play_game() is basically the same as before.  The difference is the argument to play_game() is now an enum rather than a boolean.