### PR TITLE
For setgid installs, use 770 as the permissions for the scores, save,…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -528,11 +528,23 @@ IF(SHARED_INSTALL)
     TARGET_COMPILE_DEFINITIONS(OurExecutable PRIVATE -D SETGID)
     TARGET_COMPILE_DEFINITIONS(OurCoreLib PRIVATE -D SETGID)
     SET(EXECUTABLE_PERMISSIONS ${EXECUTABLE_PERMISSIONS} SETGID)
-    # Override so only readily accessible by the group (i.e. the setgid
-    # executable).
-    SET(STRICT_VARDATADIR_PERMISSIONS OWNER_EXECUTE GROUP_READ GROUP_WRITE GROUP_EXECUTE WORLD_EXECUTE)
-    # As above, but allow general read access.
-    SET(LOOSE_VARDATADIR_PERMISSIONS OWNER_EXECUTE OWNER_READ GROUP_READ GROUP_WRITE GROUP_EXECUTE WORLD_EXECUTE WORLD_READ)
+    # Override so the world has no access (read access for directory listing
+    # would be okay but leads to confusing messages, for instance from ls,
+    # when search access is not allowed; so disallow read access as well) and
+    # group can do anything.  Means the world has to use the elevated
+    # privileges of the setgid executatble to do stuff.
+    SET(
+        STRICT_VARDATADIR_PERMISSIONS
+        OWNER_READ OWNER_WRITE OWNER_EXECUTE
+        GROUP_READ GROUP_WRITE GROUP_EXECUTE
+    )
+    # As above, but allow the world read and search privileges.
+    SET(
+        LOOSE_VARDATADIR_PERMISSIONS
+        OWNER_READ OWNER_WRITE OWNER_EXECUTE
+        GROUP_READ GROUP_WRITE GROUP_EXECUTE
+        WORLD_READ WORLD_EXECUTE
+    )
 ENDIF()
 
 IF(READONLY_INSTALL)
@@ -587,7 +599,7 @@ IF((SHARED_INSTALL) OR (READONLY_INSTALL))
     IF(SHARED_INSTALL)
         FOREACH(ANGBAND_DIR archive panic save scores)
             SET(ANGBAND_DEST ${CMAKE_INSTALL_SHAREDSTATEDIR}/${PROJECT_NAME})
-            IF((ANGBAND_DIR STREQUAL panic) OR (ANGBAND_DIR STREQUAL save))
+            IF(NOT (ANGBAND_DIR STREQUAL archive))
                 INSTALL(DIRECTORY lib/user/${ANGBAND_DIR} DESTINATION ${ANGBAND_DEST} FILE_PERMISSIONS ${DATA_PERMISSIONS} DIRECTORY_PERMISSIONS ${STRICT_VARDATADIR_PERMISSIONS} PATTERN Makefile EXCLUDE PATTERN .deps EXCLUDE)
             ELSE()
                 INSTALL(DIRECTORY lib/user/${ANGBAND_DIR} DESTINATION ${ANGBAND_DEST} FILE_PERMISSIONS ${DATA_PERMISSIONS} DIRECTORY_PERMISSIONS ${LOOSE_VARDATADIR_PERMISSIONS} PATTERN Makefile EXCLUDE PATTERN .deps EXCLUDE)

--- a/lib/user/archive/Makefile
+++ b/lib/user/archive/Makefile
@@ -8,6 +8,6 @@ install-extra:
 		if [ "x$(DRY)" = "x" ]; then \
 			${MKDIR_P} ${DESTDIR}${varshareddatadir}${PACKAGE}; \
 			chown root:${SETEGID} ${DESTDIR}${varshareddatadir}${PACKAGE}; \
-			chmod g+w ${DESTDIR}${varshareddatadir}${PACKAGE}; \
+			chmod 775 ${DESTDIR}${varshareddatadir}${PACKAGE}; \
 		fi; \
 	fi

--- a/lib/user/panic/Makefile
+++ b/lib/user/panic/Makefile
@@ -8,6 +8,6 @@ install-extra:
 		if [ "x$(DRY)" = "x" ]; then \
 			${MKDIR_P} ${DESTDIR}${varshareddatadir}${PACKAGE}; \
 			chown root:${SETEGID} ${DESTDIR}${varshareddatadir}${PACKAGE}; \
-			chmod 171 ${DESTDIR}${varshareddatadir}${PACKAGE}; \
+			chmod 770 ${DESTDIR}${varshareddatadir}${PACKAGE}; \
 		fi; \
 	fi

--- a/lib/user/save/Makefile
+++ b/lib/user/save/Makefile
@@ -8,6 +8,6 @@ install-extra:
 		if [ "x$(DRY)" = "x" ]; then \
 			${MKDIR_P} ${DESTDIR}${varshareddatadir}${PACKAGE}; \
 			chown root:${SETEGID} ${DESTDIR}${varshareddatadir}${PACKAGE}; \
-			chmod 171 ${DESTDIR}${varshareddatadir}${PACKAGE}; \
+			chmod 770 ${DESTDIR}${varshareddatadir}${PACKAGE}; \
 		fi; \
 	fi

--- a/lib/user/scores/Makefile
+++ b/lib/user/scores/Makefile
@@ -8,6 +8,6 @@ install-extra:
 		if [ "x$(DRY)" = "x" ]; then \
 			${MKDIR_P} ${DESTDIR}${varshareddatadir}${PACKAGE}; \
 			chown root:${SETEGID} ${DESTDIR}${varshareddatadir}${PACKAGE}; \
-			chmod g+w ${DESTDIR}${varshareddatadir}${PACKAGE}; \
+			chmod 770 ${DESTDIR}${varshareddatadir}${PACKAGE}; \
 		fi; \
 	fi

--- a/src/main-spoil.c
+++ b/src/main-spoil.c
@@ -305,21 +305,37 @@ errr init_spoil(int argc, char *argv[]) {
 				printf("init-spoil: could not initialize player.\n");
 				result = 1;
 			}
-		} else if (file_exists(savefile)) {
-			bool loaded_save = savefile_load(savefile, false);
+		} else {
+			bool exists;
 
-			deactivate_randart_file();
-			if (!loaded_save) {
-				printf("init-spoil: using artifacts associated with a savefile, but the savefile set by main, '%s', failed to load.\n", savefile);
+			safe_setuid_grab();
+			exists = file_exists(savefile);
+			safe_setuid_drop();
+			if (exists) {
+				bool loaded_save =
+					savefile_load(savefile, false);
+
+				deactivate_randart_file();
+				if (!loaded_save) {
+					printf("init-spoil: using artifacts "
+						"associated with a savefile, "
+						"but the savefile set by "
+						"main, '%s', failed to load.\n",
+						savefile);
+					result = 1;
+				}
+			} else if (savefile[0]) {
+				printf("init-spoil: using artifacts associated "
+					"with a savefile, but the savefile set "
+					"by main, '%s', does not exist.\n",
+					savefile);
+				result = 1;
+			} else {
+				printf("init-spoil: using artifacts associated "
+					"with a savefile, but main did not set "
+					"the savefile.\n");
 				result = 1;
 			}
-		} else {
-			if (savefile[0]) {
-				printf("init-spoil: using artifacts associated with a savefile, but the savefile set by main, '%s', does not exist.\n", savefile);
-			} else {
-				printf("init-spoil: using artifacts associated with a savefile, but main did not set the savefile.\n");
-			}
-			result = 1;
 		}
 	} else if (!player_make_simple(NULL, NULL, "Spoiler")) {
 		printf("init-spoil: could not initialize player.\n");

--- a/src/savefile.c
+++ b/src/savefile.c
@@ -391,6 +391,7 @@ bool savefile_save(const char *path)
 	(void) save_charoutput();
 
 	/* New savefile */
+	safe_setuid_grab();
 	strnfmt(old_savefile, sizeof(old_savefile), "%s%u.old", path,
 			Rand_simple(1000000));
 	while (file_exists(old_savefile) && (count++ < 100))
@@ -400,7 +401,6 @@ bool savefile_save(const char *path)
 	count = 0;
 
 	/* Open the savefile */
-	safe_setuid_grab();
 	strnfmt(new_savefile, sizeof(new_savefile), "%s%u.new", path,
 			Rand_simple(1000000));
 	while (file_exists(new_savefile) && (count++ < 100))
@@ -604,8 +604,11 @@ static int get_desc(void) {
  */
 const char *savefile_get_description(const char *path) {
 	struct blockheader b;
+	ang_file *f;
 
-	ang_file *f = file_open(path, MODE_READ, FTYPE_TEXT);
+	safe_setuid_grab();
+	f = file_open(path, MODE_READ, FTYPE_TEXT);
+	safe_setuid_drop();
 	if (!f) return NULL;
 
 	/* Blank the description */
@@ -635,7 +638,11 @@ const char *savefile_get_description(const char *path) {
 bool savefile_load(const char *path, bool cheat_death)
 {
 	bool ok;
-	ang_file *f = file_open(path, MODE_READ, FTYPE_TEXT);
+	ang_file *f;
+
+	safe_setuid_grab();
+	f = file_open(path, MODE_READ, FTYPE_TEXT);
+	safe_setuid_drop();
 	if (!f) {
 		note("Couldn't open savefile.");
 		return false;

--- a/src/score.c
+++ b/src/score.c
@@ -44,7 +44,9 @@ size_t highscore_read(struct high_score scores[], size_t sz)
 	memset(scores, 0, sz * sizeof(struct high_score));
 
 	path_build(fname, sizeof(fname), ANGBAND_DIR_SCORES, "scores.raw");
+	safe_setuid_grab();
 	scorefile = file_open(fname, MODE_READ, FTYPE_TEXT);
+	safe_setuid_drop();
 
 	if (!scorefile) return 0;
 
@@ -132,6 +134,7 @@ static void highscore_write(const struct high_score scores[], size_t sz)
 	char cur_name[1024];
 	char new_name[1024];
 	char lok_name[1024];
+	bool exists;
 
 	path_build(old_name, sizeof(old_name), ANGBAND_DIR_SCORES, "scores.old");
 	path_build(cur_name, sizeof(cur_name), ANGBAND_DIR_SCORES, "scores.raw");
@@ -144,7 +147,10 @@ static void highscore_write(const struct high_score scores[], size_t sz)
 
 
 	/* Lock scores */
-	if (file_exists(lok_name)) {
+	safe_setuid_grab();
+	exists = file_exists(lok_name);
+	safe_setuid_drop();
+	if (exists) {
 		msg("Lock file in place for scorefile; not writing.");
 		return;
 	}


### PR DESCRIPTION
… and panic directories (was 775 for scores and 171 for save and panic).  Enforces the restriction that the game's executable is the only way to access those files for an unprivileged user.  For files in those directories, requires that the executable elevate privileges when opening for reading, listing files, or checking file attributes.

The change to the permissions on the scores directory is the more important one.  With the previous setting (execute/search access for the world), the last player to write the high score file could open it and modify it.  With the change, that user needs games group membership (i.e. the elevated privileges of the executable) to open or modify the scores file.  For the save files, the change is to honor the intent expressed in the old security guide:  that the save files in a setgid installation not be accessible to player except by playing the game.

root (the owner of those directories in a setgid install) now has no restrictions on access.  Restricting root's access seems counterproductive:  root can always change the permissions to do whatever root wants and don't want to force root to do that when troubleshooting or resolving issues.