### PR TITLE
Add SDL2 desktop file

### DIFF
--- a/lib/icons/Makefile
+++ b/lib/icons/Makefile
@@ -2,6 +2,6 @@ MKPATH=../../mk/
 include $(MKPATH)buildsys.mk
 
 DATA = att-16.png att-32.png att-128.png att-256.png att-512.png \
-		angband-x11.desktop angband-sdl.desktop
+		angband-x11.desktop angband-sdl.desktop angband-sdl2.desktop
 PACKAGE = icons
 

--- a/lib/icons/angband-sdl2.desktop
+++ b/lib/icons/angband-sdl2.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=Angband (SDL2)
+Type=Application
+Comment=A roguelike dungeon exploration game based on the books of J.R.R.Tolkien
+Exec=sh -c "if [ \\$XDG_SESSION_TYPE == \"wayland\" ]; then env SDL_VIDEODRIVER=wayland angband -msdl2; else angband -msdl2; fi"
+TryExec=angband
+Icon=/usr/share/angband/xtra/icon/att-32.png
+Categories=Game;RolePlaying;


### PR DESCRIPTION
Just as a note, when running angband on the SDL2 frontend you need to explicitly state to use the Wayland driver when running on a Wayland composer. 

The top menu stops working when running the X11 SDL driver on the Wayland composer, which is still the default for SDL2 right now.