### PR TITLE
Tweak how building the documentation is integrated with autoconf/CMake

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -114,7 +114,7 @@ jobs:
       - name: Convert
         run: |
           ./autogen.sh
-          ./configure --with-no-install
+          ./configure --with-no-install --with-sphinx
           make manual
 
       - name: Archive

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,10 @@ SET(INSTALL_GROUP_ID "games" CACHE STRING "Group ID (either name or number) to u
 OPTION(READONLY_INSTALL "Install for shared use with variable persistent data stored in the user's directories.  Conflicts with SC_INSTALL, SHARED_INSTALL, and SUPPORT_WINDOWS_FRONTEND." OFF)
 INCLUDE(GNUInstallDirs)
 
+# Allow building the documentation if sphinx-build is available.
+INCLUDE(CMakeDependentOption)
+find_package(Sphinx)
+CMAKE_DEPENDENT_OPTION(BUILD_DOC "Build the documentation" OFF "Sphinx_FOUND" OFF)
 SET(DOC_HTML_THEME "" CACHE STRING "If set and not an empty string, it is the builtin Sphinx HTML theme to use in place of the default theme in conf.py (currently the better theme).")
 
 IF ((SUPPORT_NCURSES_FRONTEND) AND (NOT SUPPORT_GCU_FRONTEND))
@@ -427,9 +431,8 @@ ENDIF()
 TARGET_COMPILE_DEFINITIONS(OurExecutable PRIVATE "${ANGBAND_BUILD_ID_OPTION}")
 TARGET_COMPILE_DEFINITIONS(OurCoreLib PRIVATE "${ANGBAND_BUILD_ID_OPTION}")
 
-# Set up to generate documentation if sphinx-build is available.
-find_package(Sphinx)
-IF(Sphinx_FOUND)
+# Set up to generate documentation if requested.
+IF(BUILD_DOC)
     INCLUDE(src/cmake/modules/SphinxDocument.cmake)
 
     # Use a custom target to rewrite some of the configuration information
@@ -612,7 +615,7 @@ IF((SHARED_INSTALL) OR (READONLY_INSTALL))
         INSTALL(CODE "EXECUTE_PROCESS(COMMAND chmod g+s ${INSTALLED_EXECUTABLE} RESULT_VARIABLE ANGBAND_RESULT)\nIF(NOT ANGBAND_RESULT EQUAL 0)\nMESSAGE(FATAL ERROR \"Resetting setgid bit on ${INSTALLED_EXECUTABLE} failed\")\nENDIF()")
     ENDIF()
 
-    IF(Sphinx_FOUND)
+    IF(BUILD_DOC)
         # Install the built documentation.
         SPHINX_DOCUMENT_GET_OUTPUT_DIRECTORY(_DOC OurManual)
         SPHINX_DOCUMENT_GET_OUTPUT_FORMATS(_FORMATS OurManual)
@@ -667,7 +670,7 @@ IF(SC_INSTALL)
         INSTALL(libpng12.dll DESTINATION . PERMISSIONS ${DATA_PERMISSIONS})
     ENDIF()
     INSTALL(DIRECTORY lib/ DESTINATION lib)
-    IF(Sphinx_FOUND)
+    IF(BUILD_DOC)
         INSTALL(DIRECTORY docs/ DESTINATION docs)
     ENDIF()
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ tests:
 TAG = angband-`cd scripts && ./version.sh`
 OUT = $(TAG).tar.gz
 
+all: manual-optional
+
 manual: manual-optional
 	@if test x"$(SPHINXBUILD)" = x || test x"$(SPHINXBUILD)" = xNOTFOUND ; then \
 		echo "sphinx-build was not found during configuration.  If it is not installed, you will have to install it.  You can either rerun the configuration or set SPHINXBUILD on the command line when running make to inform make how to run sphinx-build.  You may also want to set DOC_HTML_THEME to a builtin Sphinx theme to use instead of what is configured in docs/conf.py.  For instance, 'DOC_HTML_THEME=classic'." ; \
@@ -36,7 +38,7 @@ dist:
 
 # If this isn't a --with-no-install build, build and install the documentation
 # if sphinx-build is available.
-install-extra: manual-optional
+install-extra:
 	@if test x"$(NOINSTALL)" != xyes && test ! x"$(SPHINXBUILD)" = x && test ! x"$(SPHINXBUILD)" = xNOTFOUND ; then \
 		for x in `find docs/_build/html -mindepth 1 \! -type d \! -name .buildinfo -print`; do \
 			i=`echo $$x | sed -e s%^docs/_build/html/%%`; \

--- a/configure.ac
+++ b/configure.ac
@@ -69,6 +69,22 @@ if test "x$with_no_install" = "x"; then
 "
 fi
 
+AC_ARG_WITH(sphinx,
+	[AS_HELP_STRING([--with-sphinx], [build the documentation with sphinx-build])])
+AC_PATH_PROGS([SPHINXBUILD],
+	[sphinx-build sphinx-build3 sphinx-build2],
+	[NOTFOUND],
+	[$PATH$PATH_SEPARATOR/usr/share/sphinx/scripts/python3$PATH_SEPARATOR/usr/share/sphinx/scripts/python2])
+AC_ARG_VAR([SPHINXBUILD], [full path to sphinx-build for building documentation; overrides auto-detected path])
+AC_ARG_VAR([DOC_HTML_THEME], [the builtin Sphinx HTML theme to use or, if not set or empty, use the theme configured in docs/conf.py (currently the better theme)])
+if test "x$with_sphinx" = "xyes"; then
+    if test x"$SPHINXBUILD" = x || test x"$SPHINXBUILD" = xNOTFOUND ; then
+        AC_MSG_ERROR([--with-sphinx specified but could not locate sphinx-build.  Set SPHINXBUILD to the full path to sphinx-build.])
+    fi
+else
+    SPHINXBUILD=
+fi
+
 # Prefer cc to gcc (default behavior is the opposite) for better compatibility
 # with OpenBSD and FreeBSD.
 AC_PROG_CC([cc gcc clang])
@@ -77,13 +93,6 @@ AC_PROG_LN_S
 AC_PROG_INSTALL
 AC_PROG_MKDIR_P
 AC_CHECK_TOOL(RC, windres, no)
-AC_ARG_VAR([SPHINXBUILD], [command to invoke the documentation builder, Sphinx])
-AC_PATH_PROGS([SPHINXBUILD],
-	[sphinx-build sphinx-build3 sphinx-build2],
-	[NOTFOUND],
-	[$PATH$PATH_SEPARATOR/usr/share/sphinx/scripts/python3$PATH_SEPARATOR/usr/share/sphinx/scripts/python2])
-AC_ARG_VAR([DOC_HTML_THEME], [the builtin Sphinx HTML theme to use or, if not set or empty, use the theme configured in docs/conf.py (currently the better theme)])
-
 AC_PATH_PROG(RM, rm)
 AC_PATH_PROG(MV, mv)
 AC_PATH_PROG(CP, cp)
@@ -568,11 +577,15 @@ if test "x$with_gamedata_in_lib" == "xyes"; then
 else
 	echo "  gamedata path:                          ${displayedconfigdir}"
 fi
-
 if test "x$wsetgid" = "xyes"; then
 	echo "  (as group ${SETEGID})"
 elif test "x$with_private_dirs" = "xyes" && test ! "x$enable_win" = "xyes"; then
 	echo "  (with private save and score files in ~/.angband/Angband/)"
+fi
+if test "x$with_sphinx" == "xyes"; then
+	echo "  documentation:                          Yes"
+else
+	echo "  documentation:                          No"
 fi
 
 echo


### PR DESCRIPTION
Make it opt-in, even if sphinx-build is available.  For autoconf, build the documentation as part of the all rule rather than deferring it to the install rule.

The former is so someone with sphinx-build installed isn't forced into building the documentation.

The second lets,

```
make
sudo make install
```

be safer - the documentation will be built in the first invocation of make and not when invoked by root (sphinx-build and the better theme, if used, will still have to be available to both the regular user and for root even after this change).