### PR TITLE
Move remove_object_curse() to obj-curse.c so it can be used by the …

### DIFF
--- a/src/cmd-wizard.c
+++ b/src/cmd-wizard.c
@@ -988,7 +988,7 @@ void do_cmd_wiz_curse_item(struct command *cmd)
 	struct object *obj;
 	int curse_index, power;
 	char s[80];
-	bool changed;
+	int update;
 
 	if (cmd_get_arg_item(cmd, "item", &obj) != CMD_OK) {
 		if (!get_item(&obj, "Change curse on which item? ",
@@ -1030,39 +1030,15 @@ void do_cmd_wiz_curse_item(struct command *cmd)
 	/* Apply. */
 	if (power) {
 		append_object_curse(obj, curse_index, power);
-		changed = true;
-	} else if (obj->curses) {
-		int i = 0;
-
-		changed = (obj->curses[curse_index].power > 0);
-		obj->curses[curse_index].power = 0;
-
-		/* Duplicates logic from non-public check_object_curses(). */
-		while (1) {
-			if (i >= z_info->curse_max) {
-				changed = true;
-				mem_free(obj->curses);
-				obj->curses = NULL;
-				break;
-			}
-			if (obj->curses[i].power) {
-				break;
-			}
-			++i;
-		}
-	} else {
-		changed = false;
+	} else if (!remove_object_curse(obj, curse_index, false)) {
+		return;
 	}
 
-	if (changed) {
-		int update = 0;
-
-		if (cmd_get_arg_choice(cmd, "update", &update) != CMD_OK ||
-				update) {
-			wiz_play_item_standard_upkeep(player, obj);
-		} else {
-			wiz_play_item_notify_changed();
-		}
+	update = 0;
+	if (cmd_get_arg_choice(cmd, "update", &update) != CMD_OK || update) {
+		wiz_play_item_standard_upkeep(player, obj);
+	} else {
+		wiz_play_item_notify_changed();
 	}
 }
 

--- a/src/effect-handler-general.c
+++ b/src/effect-handler-general.c
@@ -124,32 +124,6 @@ static bool item_tester_uncursable(const struct object *obj)
 }
 
 /**
- * Removes an individual curse from an object.
- */
-static void remove_object_curse(struct object *obj, int index, bool message)
-{
-	struct curse_data *c = &obj->curses[index];
-	char *name = curses[index].name;
-	int i;
-
-	c->power = 0;
-	c->timeout = 0;
-	if (message) {
-		msg("The %s curse is removed!", name);
-	}
-
-	/* Check to see if that was the last one */
-	for (i = 1; i < z_info->curse_max; i++) {
-		if (obj->curses[i].power) {
-			return;
-		}
-	}
-
-	mem_free(obj->curses);
-	obj->curses = NULL;
-}
-
-/**
  * Attempts to remove a curse from an object.
  */
 static bool uncurse_object(struct object *obj, int strength, char *dice_string)

--- a/src/obj-curse.c
+++ b/src/obj-curse.c
@@ -201,6 +201,35 @@ bool append_object_curse(struct object *obj, int pick, int power)
 }
 
 /**
+ * Remove a curse from an object.
+ *
+ * \param obj is the object to manipulate
+ * \param pick is the index of the curse to be removed
+ * \param message if true, causes a message to be displayed if a curse was
+ * removed
+ * \return true if the object had the given curse; otherwise, return false
+ */
+bool remove_object_curse(struct object *obj, int pick, bool message)
+{
+	struct curse_data *c = &obj->curses[pick];
+	bool result;
+
+	if (c->power > 0) {
+		result = true;
+		c->power = 0;
+		c->timeout = 0;
+		/* Remove the curses array if that was the last curse. */
+		check_object_curses(obj);
+		if (message) {
+			msg("The %s curse is removed!", curses[pick].name);
+		}
+	} else {
+		result = false;
+	}
+	return result;
+}
+
+/**
  * Check an artifact template for active curses, remove conflicting curses, and
  * remove the "curses" field if no curses remain
  */

--- a/src/obj-curse.h
+++ b/src/obj-curse.h
@@ -27,6 +27,7 @@ int lookup_curse(const char *name);
 void copy_curses(struct object *obj, int *source);
 bool curses_are_equal(const struct object *obj1, const struct object *obj2);
 bool append_object_curse(struct object *obj, int pick, int power);
+bool remove_object_curse(struct object *obj, int pick, bool message);
 void check_artifact_curses(struct artifact *art);
 bool artifact_curse_conflicts(struct artifact *art, int pick);
 bool append_artifact_curse(struct artifact *art, int pick, int power);


### PR DESCRIPTION
…effect handlers and the debugging commands.