### PR TITLE
nds: Compile fixes and documentation

### DIFF
--- a/docs/hacking/compiling.rst
+++ b/docs/hacking/compiling.rst
@@ -507,6 +507,54 @@ so, set your compiler options so that the USE_STATS preprocessor macro is set.
 When using mingw (either stand-alone or as part of Cygwin) and configure,
 include CFLAGS=-DUSE_STATS in the options to configure to do that.
 
+Nintendo DS / Nintendo 3DS
+--------------------------
+
+Builds for the Nintendo DS are made using devkitARM and libnds (or libctru for
+the Nintendo 3DS respectively). All required dependencies can be installed by
+selecting the appropriate package group while following the installation
+instructions for devkitPro ( https://devkitpro.org/wiki/Getting_Started ).
+
+The executable can then be built using::
+
+        cd src
+        make -f Makefile.nds
+
+This will generate ``angband.nds`` in the current directory. For the Nintendo
+3DS, replace the ``Makefile.nds`` part of the command with ``Makefile.3ds``,
+and ``angband.3dsx`` will be generated instead.
+
+Debugging
+~~~~~~~~~
+
+Homebrew can be debugged using a gdbstub-enabled emulator, such as a Windows Dev+ build
+of DeSmuMe (if you really dare to, note that it is very slow compared to real hardware)
+for the Nintendo DS or Citra for the Nintendo 3DS. A Nintendo 3DS that has been modified
+with custom firmware (such as Luma3DS) may also have the ability to debug homebrew on-device.
+
+It is recommended to set/export ``NDS_DEBUG=1`` and to do a clean build when debugging,
+as this disables some optimization and enables more debugging information.
+
+Once the GDB server has been set up (and the host and port noted), the GDB client
+can be loaded with the executable information::
+
+        /path/to/devkitARM/bin/arm-none-eabi-gdb angband.elf
+
+The ``angband.elf`` file is a byproduct from the build process, and it has to match
+the executable that is currently running in the emulator or on the device.
+It is always named ``angband.elf`` for the Nintendo 3DS, and it's always either
+``angband.arm7.elf`` or ``angband.arm9.elf`` for the Nintendo DS, depending on
+which processor should be debugged (as the main game runs on the ARM9 core exclusively,
+this will almost always be the core that should be debugged).
+
+Once the GDB command prompt is available, the following command can be used to
+connect to the target device::
+
+        target remote <host>:<port>
+
+Afterwards, the debugging target will pause automatically and it can be debugged as usual
+using GDB.
+
 Documentation
 -------------
 To convert the documentation from restructured text to the desired output

--- a/src/Makefile.3ds
+++ b/src/Makefile.3ds
@@ -69,7 +69,7 @@ endif
 CFLAGS	+=	$(INCLUDE) -DARM11 -D_3DS
 
 # Angband flags
-CFLAGS	+=	-DNDS
+CFLAGS	+=	-DNDS -DHAVE_DIRENT_H
 
 CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
 

--- a/src/Makefile.3ds
+++ b/src/Makefile.3ds
@@ -66,7 +66,7 @@ ifeq (,$(NDS_DEBUG))
 CFLAGS	+=	-O2 -fomit-frame-pointer -DNDEBUG
 endif
 
-CFLAGS	+=	$(INCLUDE) -DARM11 -D_3DS
+CFLAGS	+=	$(INCLUDE) -D__3DS__
 
 # Angband flags
 CFLAGS	+=	-DNDS -DHAVE_DIRENT_H

--- a/src/Makefile.nds.arm9
+++ b/src/Makefile.nds.arm9
@@ -35,7 +35,7 @@ endif
 CFLAGS	+=	$(INCLUDE) -DARM9
 
 # Angband flags
-CFLAGS	+=	-DNDS
+CFLAGS	+=	-DNDS -DHAVE_DIRENT_H
 
 CXXFLAGS	:=	$(CFLAGS) -fno-rtti -fno-exceptions
 

--- a/src/main-nds.c
+++ b/src/main-nds.c
@@ -19,7 +19,7 @@
  *    are included in all such copies.  Other copyrights may also apply.
  */
 
-#ifdef _3DS
+#ifdef __3DS__
 /* We can't include 3ds.h because utf32_to_utf8 conflicts */
 #include <3ds/types.h>
 #include <3ds/services/apt.h>
@@ -51,7 +51,7 @@
 #include "nds/nds-screenkeys.h"
 #include "nds/nds-slot2-virt.h"
 
-#ifndef _3DS
+#ifndef __3DS__
 #define hidScanInput scanKeys
 #endif
 
@@ -164,7 +164,7 @@ void do_vblank()
 
 	nds_video_vblank();
 
-#ifdef _3DS
+#ifdef __3DS__
 	/* Handle home menu, poweroff, etc */
 	if (!aptMainLoop()) {
 		quit(NULL);
@@ -229,7 +229,7 @@ static void init_color_data(void)
 {
 	/* Initialize the "color_data" array */
 	for (int i = 0; i < MAX_COLORS; i++) {
-#ifdef _3DS
+#ifdef __3DS__
 		color_data[i] = angband_color_table[i][1] << 24 |
 		                angband_color_table[i][2] << 16 |
 		                angband_color_table[i][3] << 8;
@@ -394,7 +394,7 @@ static errr Term_xtra_nds(int n, int v)
 		/*
 		 * Delay for some milliseconds
 		 */
-#ifdef _3DS
+#ifdef __3DS__
 		if (v > 0) {
 			svcSleepThread(1e6 * v);
 		}
@@ -635,7 +635,7 @@ void nds_exit(int code)
 
 	/* Lock up so that the user can see potential errors */
 	while(1) {
-#ifdef _3DS
+#ifdef __3DS__
 		if (!aptMainLoop())
 			break;
 #endif
@@ -665,7 +665,7 @@ static void hook_quit(const char *str)
  */
 int main(int argc, char *argv[])
 {
-#ifdef _3DS
+#ifdef __3DS__
 	osSetSpeedupEnable(1);
 #endif
 
@@ -682,7 +682,7 @@ int main(int argc, char *argv[])
 
 	nds_video_vblank();
 
-#ifndef _3DS
+#ifndef __3DS__
 	mem_init_alt();
 
 	if (!fatInitDefault()) {
@@ -749,7 +749,7 @@ int main(int argc, char *argv[])
 	return (0);
 }
 
-#ifndef _3DS
+#ifndef __3DS__
 double sqrt(double x) {
 	return f32tofloat(sqrtf32(floattof32(x)));
 }

--- a/src/nds/nds-buttons.c
+++ b/src/nds/nds-buttons.c
@@ -7,7 +7,7 @@
 #include "../z-util.h"
 #include "../z-virt.h"
 
-#ifdef _3DS
+#ifdef __3DS__
 #include <3ds/types.h>
 #include <3ds/services/hid.h>
 #else
@@ -48,7 +48,7 @@ const nds_btn_cpad_zone nds_btn_cpad_map[] = {
 	{0, 0, 0},
 };
 
-#ifndef _3DS
+#ifndef __3DS__
 #define KEY_DUP KEY_UP
 #define KEY_DDOWN KEY_DOWN
 #define KEY_DLEFT KEY_LEFT
@@ -148,7 +148,7 @@ void nds_btn_add_mappings_from_file(ang_file *f) {
 				entry.keys |= KEY_L;
 			} else if (streq(button, "R")) {
 				entry.keys |= KEY_R;
-#ifdef _3DS
+#ifdef __3DS__
 			} else if (streq(button, "ZL")) {
 				entry.keys |= KEY_ZL;
 			} else if (streq(button, "ZR")) {
@@ -185,7 +185,7 @@ void nds_btn_init()
 
 void nds_btn_check_cpad()
 {
-#ifdef _3DS
+#ifdef __3DS__
 	static uint8_t input_cooldown = 0;
 
 	/* Skip if cooldown isn't expired yet */

--- a/src/nds/nds-draw.c
+++ b/src/nds/nds-draw.c
@@ -1,19 +1,19 @@
 #include "nds-draw.h"
 
-#ifdef _3DS
+#ifdef __3DS__
 # include <3ds.h>
 #else
 # include <nds.h>
 #endif
 
-#ifdef _3DS
+#ifdef __3DS__
 const nds_font_handle *nds_font = &nds_font_5x8;
 #else
 const nds_font_handle *nds_font = &nds_font_3x8;
 #endif
 
 void nds_video_init() {
-#ifdef _3DS
+#ifdef __3DS__
 	gfxInit(GSP_RGBA8_OES, GSP_RGBA8_OES, false);
 	gfxSetDoubleBuffering(GFX_BOTTOM, false);
 	gfxSetDoubleBuffering(GFX_TOP, false);
@@ -48,7 +48,7 @@ void nds_video_init() {
 }
 
 void nds_video_vblank() {
-#ifdef _3DS
+#ifdef __3DS__
 	gfxFlushBuffers();
 	gfxSwapBuffers();
 	gspWaitForVBlank();
@@ -58,7 +58,7 @@ void nds_video_vblank() {
 }
 
 static inline nds_pixel *nds_get_framebuffer(uint16_t *y) {
-#ifdef _3DS
+#ifdef __3DS__
 	nds_pixel *fb = (nds_pixel *) gfxGetFramebuffer(GFX_TOP, GFX_LEFT, NULL, NULL);
 #else
 	nds_pixel *fb = BG_GFX;
@@ -66,7 +66,7 @@ static inline nds_pixel *nds_get_framebuffer(uint16_t *y) {
 
 	/* Bottom screen? */
 	if (*y >= NDS_SCREEN_HEIGHT) {
-#ifdef _3DS
+#ifdef __3DS__
 		fb = (nds_pixel *) gfxGetFramebuffer(GFX_BOTTOM, GFX_LEFT, NULL, NULL);
 #else
 		fb = &BG_GFX_SUB[16 * 1024];
@@ -80,7 +80,7 @@ static inline nds_pixel *nds_get_framebuffer(uint16_t *y) {
 void nds_draw_pixel(uint16_t x, uint16_t y, nds_pixel data) {
 	nds_pixel *fb = nds_get_framebuffer(&y);
 
-#ifdef _3DS
+#ifdef __3DS__
 	fb[x * NDS_SCREEN_HEIGHT + (NDS_SCREEN_HEIGHT - y - 1)] = data;
 #else
 	fb[y * NDS_SCREEN_WIDTH + x] = data;
@@ -91,7 +91,7 @@ void nds_draw_char_px(uint16_t x, uint16_t y, char c, nds_pixel clr_fg, nds_pixe
 {
 	nds_pixel *fb = nds_get_framebuffer(&y);
 
-#ifdef _3DS
+#ifdef __3DS__
 	nds_font->draw_char(c, fb + (x * NDS_SCREEN_HEIGHT) + (NDS_SCREEN_HEIGHT - y - 1), clr_fg, clr_bg);
 #else
 	nds_font->draw_char(c, fb + (y * NDS_SCREEN_WIDTH) + x, clr_fg, clr_bg);

--- a/src/nds/nds-draw.h
+++ b/src/nds/nds-draw.h
@@ -4,7 +4,7 @@
 #include "../h-basic.h"
 
 
-#ifdef _3DS
+#ifdef __3DS__
 
 /* RGBA8 */
 typedef uint32_t nds_pixel;

--- a/src/nds/nds-event.c
+++ b/src/nds/nds-event.c
@@ -1,9 +1,5 @@
 #include "nds-event.h"
 
-#ifndef _3DS
-#include <nds.h>
-#endif
-
 #define MAX_EBUF	64
 
 /* Event queue ring buffer */

--- a/src/nds/nds-keyboard.c
+++ b/src/nds/nds-keyboard.c
@@ -1,6 +1,6 @@
 #include "nds-keyboard.h"
 
-#ifdef _3DS
+#ifdef __3DS__
 #include <3ds.h>
 #else
 #include <nds.h>
@@ -9,7 +9,7 @@
 #include "nds-draw.h"
 #include "nds-event.h"
 
-#ifdef _3DS
+#ifdef __3DS__
 #define KBD_MARGIN	8
 #define KBD_UNIT	10
 #else

--- a/src/nds/nds-screenkeys.c
+++ b/src/nds/nds-screenkeys.c
@@ -7,7 +7,7 @@
 #include "../z-util.h"
 #include "../z-virt.h"
 
-#ifdef _3DS
+#ifdef __3DS__
 #include <3ds/types.h>
 #include <3ds/services/hid.h>
 #else

--- a/src/nds/nds-slot2-ram.c
+++ b/src/nds/nds-slot2-ram.c
@@ -1,4 +1,4 @@
-#ifndef _3DS
+#ifndef __3DS__
 
 /**********************************
   Copyright (C) Rick Wong (Lick)

--- a/src/nds/nds-slot2-ram.h
+++ b/src/nds/nds-slot2-ram.h
@@ -10,7 +10,7 @@ and GPLv2 (http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt) licenses.
 #ifndef _NDS_SLOT2_RAM
 #define _NDS_SLOT2_RAM
 
-#ifndef _3DS
+#ifndef __3DS__
 
 #include <nds/ndstypes.h>
 

--- a/src/nds/nds-slot2-virt.c
+++ b/src/nds/nds-slot2-virt.c
@@ -2,7 +2,7 @@
  * \file nds-slot2-virt.c
  */
 
-#ifndef _3DS
+#ifndef __3DS__
 
 #include <nds.h>
 #include "../z-virt.h"

--- a/src/nds/nds-slot2-virt.h
+++ b/src/nds/nds-slot2-virt.h
@@ -3,7 +3,7 @@
 
 #include "../h-basic.h"
 
-#ifndef _3DS
+#ifndef __3DS__
 void mem_init_alt(void);
 #endif
 

--- a/src/z-virt.h
+++ b/src/z-virt.h
@@ -28,7 +28,7 @@ void *mem_realloc(void *p, size_t len);
  * with additional restrictions (no 8-bit writes). These "alt" methods
  * provide this; on other platforms, they are aliased.
  */
-#if defined(NDS) && !defined(_3DS)
+#if defined(NDS) && !defined(__3DS__)
 void *mem_alloc_alt(size_t len);
 void *mem_zalloc_alt(size_t len);
 void mem_free_alt(void *p);


### PR DESCRIPTION
This just contains two small compile fixes after recent breakage, as well as a bit of documentation that I wrote up on how to build and debug NDS/3DS builds of the game (I hope I got the syntax right).