### PR TITLE
More single combat paranoia

### DIFF
--- a/src/effect-handler-general.c
+++ b/src/effect-handler-general.c
@@ -1129,6 +1129,8 @@ bool effect_handler_DEEP_DESCENT(effect_handler_context_t *context)
 
 bool effect_handler_ALTER_REALITY(effect_handler_context_t *context)
 {
+	/* Don't allow in single combat arenas. */
+	if (player->upkeep->arena_level) return true;
 	msg("The world changes!");
 	dungeon_change_level(player, player->depth);
 	context->ident = true;

--- a/src/effect-handler-general.c
+++ b/src/effect-handler-general.c
@@ -1870,8 +1870,8 @@ bool effect_handler_CREATE_STAIRS(effect_handler_context_t *context)
 		return false;
 	}
 
-	/* Fails for persistent levels (for now) */
-	if (OPT(player, birth_levels_persist)) {
+	/* Fails for persistent levels (for now) and arenas */
+	if (OPT(player, birth_levels_persist) || player->upkeep->arena_level) {
 		msg("Nothing happens!");
 		return false;
 	}

--- a/src/trap.c
+++ b/src/trap.c
@@ -349,16 +349,21 @@ void place_trap(struct chunk *c, struct loc grid, int t_idx, int trap_level)
 {
 	struct trap *new_trap;
 
-    /* We've been called with an illegal index; choose a random trap */
-    if ((t_idx <= 0) || (t_idx >= z_info->trap_max)) {
+	/* We've been called with an illegal index; choose a random trap */
+	if ((t_idx <= 0) || (t_idx >= z_info->trap_max)) {
 		/* Require the correct terrain */
 		if (!square_player_trap_allowed(c, grid)) return;
 
 		t_idx = pick_trap(c, square(c, grid)->feat, trap_level);
-    }
+	}
 
-    /* Failure */
-    if (t_idx < 0) return;
+	/* Failure */
+	if (t_idx < 0) return;
+	/* Don't allow trap doors in single combat arenas. */
+	if (player && player->upkeep && player->upkeep->arena_level
+			&& trf_has(trap_info[t_idx].flags, TRF_DOWN)) {
+		return;
+	}
 
 	/* Allocate a new trap for this grid (at the front of the list) */
 	new_trap = mem_zalloc(sizeof(*new_trap));


### PR DESCRIPTION
- Don't allow trap doors (i.e. from a trap creation projection) in a single combat arena
- Don't allow the alter reality effect in a single combat arena.

The first plugs a possible one route out of a single combat arena that doesn't involve killing the monster:  read a trap creation scroll (or have a monster trigger that projection), get a trap door, and fall through it.
Since there's no current way to trigger an alter reality effect in a single combat arena (no device, activation, paladin spell, or monster spell uses it), the second is only protecting against possible future changes.