### PR TITLE
SDL2:  don't reset alpha component for subwindow background color in …

### DIFF
--- a/src/main-sdl2.c
+++ b/src/main-sdl2.c
@@ -5530,7 +5530,13 @@ static void init_colors(void)
 		g_windows[i].color = g_colors[DEFAULT_WINDOW_BG_COLOR];
 	}
 	for (i = 0; i < N_ELEMENTS(g_subwindows); i++) {
-		g_subwindows[i].color = g_colors[DEFAULT_SUBWINDOW_BG_COLOR];
+		/* Retain whatever customized alpha the subwindow has. */
+		g_subwindows[i].color.r =
+			g_colors[DEFAULT_SUBWINDOW_BG_COLOR].r;
+		g_subwindows[i].color.g =
+			g_colors[DEFAULT_SUBWINDOW_BG_COLOR].g;
+		g_subwindows[i].color.b =
+			g_colors[DEFAULT_SUBWINDOW_BG_COLOR].b;
 	}
 }
 


### PR DESCRIPTION
…init_colors();  resolves PowerWyrm's bug report here, http://angband.oook.cz/forum/showpost.php?p=157590&postcount=180