### PR TITLE
Update Linux desktop files

### DIFF
--- a/lib/icons/Makefile
+++ b/lib/icons/Makefile
@@ -2,6 +2,7 @@ MKPATH=../../mk/
 include $(MKPATH)buildsys.mk
 
 DATA = att-16.png att-32.png att-128.png att-256.png att-512.png \
-		angband-x11.desktop angband-sdl.desktop
+		angband-x11.desktop angband-sdl.desktop angband-sdl2.desktop \
+		angband.metainfo.xml
 PACKAGE = icons
 

--- a/lib/icons/angband-sdl.desktop
+++ b/lib/icons/angband-sdl.desktop
@@ -4,5 +4,5 @@ Type=Application
 Comment=A roguelike dungeon exploration game based on the books of J.R.R.Tolkien
 Exec=angband -msdl
 TryExec=angband
-Icon=/usr/share/angband/xtra/icon/att-32.png
+Icon=angband
 Categories=Game;RolePlaying;

--- a/lib/icons/angband-sdl2.desktop
+++ b/lib/icons/angband-sdl2.desktop
@@ -1,8 +1,8 @@
 [Desktop Entry]
-Name=Angband (X11)
+Name=Angband (SDL2)
 Type=Application
 Comment=A roguelike dungeon exploration game based on the books of J.R.R.Tolkien
-Exec=angband -mx11
+Exec=sh -c "if [ \\$XDG_SESSION_TYPE == \"wayland\" ]; then env SDL_VIDEODRIVER=wayland angband -msdl2; else angband -msdl2; fi"
 TryExec=angband
 Icon=angband
 Categories=Game;RolePlaying;

--- a/lib/icons/angband.metainfo.xml
+++ b/lib/icons/angband.metainfo.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>angband</id>
+  <launchable type="desktop-id">angband.desktop</launchable>
+  <name>Angband</name>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0</project_license>
+  <summary>Angband is a free, single-player dungeon exploration game.</summary>
+  <description>
+    <p>
+      A roguelike game where you explore a very deep 
+      dungeon, kill monsters, try to equip yourself with 
+      the best weapons and armor you can find, and finally 
+      face Morgoth - "The Dark Enemy".
+    </p>
+  </description>
+  <url type="homepage">https://angband.github.io/angband/</url>
+  <url type="help">https://angband.readthedocs.io/en/latest/</url>
+  <url type="bugtracker">https://github.com/angband/angband/issues</url>
+  <screenshots>
+    <screenshot type="default">
+      <caption>Title screen</caption>
+      <image>https://github.com/angband/angband/raw/master/screenshots/title.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Gameplay</caption>
+      <image>https://github.com/angband/angband/raw/master/screenshots/game.png</image>
+    </screenshot>
+  </screenshots>
+  <categories>
+    <category>Game</category>
+    <category>RolePlaying</category>
+  </categories>
+</component>


### PR DESCRIPTION
Updated desktop files and added a metainfo file.

Some general instructions when packaging on Linux:

* The .metainfo file should be packaged at {prefix}/share/metainfo/
* Desktop files expect for icons to be packaged at {prefix}/share/icons/hicolor/{res}/apps/angband.png
* The .metainfo.xml file expects that at least one of the desktop files to be packaged at {prefix}/share/applications/angband.desktop

References:
https://freedesktop.org/software/appstream/docs/chap-Metadata.html#spec-component-location
https://specifications.freedesktop.org/icon-theme-spec/latest/ar01s07.html