### PR TITLE
Nintendo workflow and release

### DIFF
--- a/.github/workflows/nintendo.yaml
+++ b/.github/workflows/nintendo.yaml
@@ -1,0 +1,40 @@
+# based on https://angband.readthedocs.io/en/latest/hacking/compiling.html#nintendo-ds-nintendo-3ds
+name: Nintendo DS
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  _3ds:
+    name: Nintendo 3DS
+    runs-on: ubuntu-latest
+    container: devkitpro/devkitarm
+    steps:
+      - name: Clone Project
+        uses: actions/checkout@v2
+
+      - name: Build
+        shell: bash
+        run: |
+          pushd src/
+          make -f Makefile.3ds
+          popd
+          test -e src/angband.3dsx
+
+  nds:
+    name: Nintendo DS
+    runs-on: ubuntu-latest
+    container: devkitpro/devkitarm
+    steps:
+      - name: Clone Project
+        uses: actions/checkout@v2
+
+      - name: Build
+        shell: bash
+        run: |
+          pushd src/
+          make -f Makefile.nds
+          popd
+          test -e src/angband.nds

--- a/.github/workflows/nintendo.yaml
+++ b/.github/workflows/nintendo.yaml
@@ -21,7 +21,6 @@ jobs:
           pushd src/
           make -f Makefile.3ds
           popd
-          test -e src/angband.3dsx
 
   nds:
     name: Nintendo DS
@@ -37,4 +36,3 @@ jobs:
           pushd src/
           make -f Makefile.nds
           popd
-          test -e src/angband.nds

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -390,10 +390,10 @@ jobs:
           archive_prefix=${{ steps.store_config.outputs.name }}-${{ steps.store_config.outputs.version }}
           echo "::set-output name=archive_file::${archive_prefix}-3ds.zip"
           echo "::set-output name=archive_content_type::application/zip"
-          mkdir -v 3ds angband
-          cp -v src/angband.3dsx 3ds/${archive_prefix}.3dsx
+          mkdir -v angband
+          cp -v src/angband.3dsx ${archive_prefix}.3dsx
           cp -rv lib angband/
-          zip -r ${archive_prefix}-3ds.zip 3ds/ angband/
+          zip -r ${archive_prefix}-3ds.zip ${archive_prefix}.3dsx angband/
           
       - name: Upload Nintendo 3DS Archive
         id: upload_nintendo_3ds_archive
@@ -459,10 +459,10 @@ jobs:
           archive_prefix=${{ steps.store_config.outputs.name }}-${{ steps.store_config.outputs.version }}
           echo "::set-output name=archive_file::${archive_prefix}-nds.zip"
           echo "::set-output name=archive_content_type::application/zip"
-          mkdir -p -v roms/nds/ angband
-          cp -v src/angband.nds roms/nds/${archive_prefix}.nds
+          mkdir -v angband
+          cp -v src/angband.nds ${archive_prefix}.nds
           cp -rv lib angband/
-          zip -r ${archive_prefix}-nds.zip roms/ angband/
+          zip -r ${archive_prefix}-nds.zip ${archive_prefix}.nds angband/
 
       - name: Upload Nintendo DS Archive
         id: upload_nintendo_ds_archive

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -387,6 +387,11 @@ jobs:
           popd
           test -e src/angband.3dsx
 
+          prefix=${{ steps.store_config.outputs.name }}-${{ steps.store_config.outputs.version }}
+          echo "::set-output name=file::${prefix}.3dsx"
+          cp -v src/angband.3dsx ${prefix}.3dsx
+          echo "::set-output name=archive_content_type::application/octet-stream"
+
       - name: Upload Nintendo 3dsx
         id: upload_nintendo_3dsx
         uses: actions/upload-release-asset@v1
@@ -394,4 +399,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.store_config.outputs.upload_url }}
-          asset_path: ./src/angband.3dsx
+          asset_path: ./${{ steps.create_nintendo_3dsx.outputs.file }}
+          asset_name: ${{ steps.create_nintendo_3dsx.outputs.file }}
+          asset_content_type: ${{ steps.create_nintendo_3dsx.outputs.archive_content_type }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -385,15 +385,15 @@ jobs:
           pushd src/
           make -f Makefile.3ds
           popd
-          test -e src/angband.3dsx
+          test -e src/${{ steps.store_config.outputs.progname }}.3dsx
 
           archive_prefix=${{ steps.store_config.outputs.name }}-${{ steps.store_config.outputs.version }}
           echo "::set-output name=archive_file::${archive_prefix}-3ds.zip"
           echo "::set-output name=archive_content_type::application/zip"
-          mkdir -v angband
-          cp -v src/angband.3dsx ${archive_prefix}.3dsx
-          cp -rv lib angband/
-          zip -r ${archive_prefix}-3ds.zip ${archive_prefix}.3dsx angband/
+          mkdir -v ${{ steps.store_config.outputs.progname }}/
+          cp -v src/${{ steps.store_config.outputs.progname }}.3dsx ${archive_prefix}.3dsx
+          cp -rv lib ${{ steps.store_config.outputs.progname }}/
+          zip -r ${archive_prefix}-3ds.zip ${archive_prefix}.3dsx ${{ steps.store_config.outputs.progname }}/
           
       - name: Upload Nintendo 3DS Archive
         id: upload_nintendo_3ds_archive
@@ -454,15 +454,15 @@ jobs:
           pushd src/
           make -f Makefile.nds
           popd
-          test -e src/angband.nds
+          test -e src/${{ steps.store_config.outputs.progname }}.nds
 
           archive_prefix=${{ steps.store_config.outputs.name }}-${{ steps.store_config.outputs.version }}
           echo "::set-output name=archive_file::${archive_prefix}-nds.zip"
           echo "::set-output name=archive_content_type::application/zip"
-          mkdir -v angband
-          cp -v src/angband.nds ${archive_prefix}.nds
-          cp -rv lib angband/
-          zip -r ${archive_prefix}-nds.zip ${archive_prefix}.nds angband/
+          mkdir -v ${{ steps.store_config.outputs.progname }}/
+          cp -v src/${{ steps.store_config.outputs.progname }}.nds ${archive_prefix}.nds
+          cp -rv lib ${{ steps.store_config.outputs.progname }}/
+          zip -r ${archive_prefix}-nds.zip ${archive_prefix}.nds ${{ steps.store_config.outputs.progname }}/
 
       - name: Upload Nintendo DS Archive
         id: upload_nintendo_ds_archive

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -391,7 +391,7 @@ jobs:
           echo "::set-output name=archive_file::${archive_prefix}-3ds.zip"
           echo "::set-output name=archive_content_type::application/zip"
           mkdir -v 3ds angband
-          cp -v src/angband.3dsx 3ds/${prefix}.3dsx
+          cp -v src/angband.3dsx 3ds/${archive_prefix}.3dsx
           cp -rv lib angband/
           zip -r ${archive_prefix}-3ds.zip 3ds/ angband/
           
@@ -402,8 +402,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.store_config.outputs.upload_url }}
-          asset_path: ./${{ steps.create_nintendo_3ds_archive.outputs.file }}
-          asset_name: ${{ steps.create_nintendo_3ds_archive.outputs.file }}
+          asset_path: ./${{ steps.create_nintendo_3ds_archive.outputs.archive_file }}
+          asset_name: ${{ steps.create_nintendo_3ds_archive.outputs.archive_file }}
           asset_content_type: ${{ steps.create_nintendo_3ds_archive.outputs.archive_content_type }}
 
   nds:
@@ -459,10 +459,10 @@ jobs:
           archive_prefix=${{ steps.store_config.outputs.name }}-${{ steps.store_config.outputs.version }}
           echo "::set-output name=archive_file::${archive_prefix}-nds.zip"
           echo "::set-output name=archive_content_type::application/zip"
-          mkdir -v _nds angband
-          cp -v src/angband.nds _nds/${prefix}.nds
+          mkdir -p -v roms/nds/ angband
+          cp -v src/angband.nds roms/nds/${archive_prefix}.nds
           cp -rv lib angband/
-          zip -r ${archive_prefix}-nds.zip _nds/ angband/
+          zip -r ${archive_prefix}-nds.zip roms/ angband/
 
       - name: Upload Nintendo DS Archive
         id: upload_nintendo_ds_archive
@@ -471,6 +471,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.store_config.outputs.upload_url }}
-          asset_path: ./${{ steps.upload_nintendo_ds_archive.outputs.file }}
-          asset_name: ${{ steps.upload_nintendo_ds_archive.outputs.file }}
-          asset_content_type: ${{ steps.upload_nintendo_ds_archive.outputs.archive_content_type }}
+          asset_path: ./${{ steps.create_nintendo_ds_archive.outputs.archive_file }}
+          asset_name: ${{ steps.create_nintendo_ds_archive.outputs.archive_file }}
+          asset_content_type: ${{ steps.create_nintendo_ds_archive.outputs.archive_content_type }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -337,3 +337,60 @@ jobs:
           asset_name: ${{ steps.create_mac_archive.outputs.archive_file }}
           asset_content_type: ${{ steps.create_mac_archive.outputs.archive_content_type }}
 
+  _3ds:
+    needs: [setup, docconvert]
+    name: Nintendo 3DS
+    runs-on: ubuntu-18.04
+    container: devkitpro/devkitarm
+    steps:
+      - name: Download Artifact with Configuration Information
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ env.CONFIG_ARTIFACT }}
+
+      - name: Extract Configuration Information and Store in Step Outputs
+        id: store_config
+        run: |
+          name=`sed -E -n -e 's/name= //p' $CONFIG_ARTIFACT_PATH`
+          echo "::set-output name=name::$name"
+          progname=`sed -E -n -e 's/progname= //p' $CONFIG_ARTIFACT_PATH`
+          echo "::set-output name=progname::$progname"
+          version=`sed -E -n -e 's/version= //p' $CONFIG_ARTIFACT_PATH`
+          echo "::set-output name=version::$version"
+          prerelease=`sed -E -n -e 's/prerelease= //p' $CONFIG_ARTIFACT_PATH`
+          echo "::set-output name=prerelease::$prerelease"
+          draft=`sed -E -n -e 's/draft= //p' $CONFIG_ARTIFACT_PATH`
+          echo "::set-output name=draft::$draft"
+          upload_url=`sed -E -n -e 's/upload_url= //p' $CONFIG_ARTIFACT_PATH`
+          echo "::set-output name=upload_url::$upload_url"
+
+      - name: Clone Project
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Download Artifact with Converted Documents
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ env.DOC_ARTIFACT }}
+
+      - name: Extract Converted Documents
+        run: |
+          tar -xf ${{ env.DOC_ARTIFACT_PATH }}
+
+      - name: Create Nintendo 3dsx
+        id: create_nintendo_3dsx
+        run: |
+          pushd src/
+          make -f Makefile.3ds
+          popd
+          test -e src/angband.3dsx
+
+      - name: Upload Nintendo 3dsx
+        id: upload_nintendo_3dsx
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.store_config.outputs.upload_url }}
+          asset_path: ./src/angband.3dsx

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -402,3 +402,69 @@ jobs:
           asset_path: ./${{ steps.create_nintendo_3dsx.outputs.file }}
           asset_name: ${{ steps.create_nintendo_3dsx.outputs.file }}
           asset_content_type: ${{ steps.create_nintendo_3dsx.outputs.archive_content_type }}
+
+  nds:
+    needs: [setup, docconvert]
+    name: Nintendo DS
+    runs-on: ubuntu-18.04
+    container: devkitpro/devkitarm
+    steps:
+      - name: Download Artifact with Configuration Information
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ env.CONFIG_ARTIFACT }}
+
+      - name: Extract Configuration Information and Store in Step Outputs
+        id: store_config
+        run: |
+          name=`sed -E -n -e 's/name= //p' $CONFIG_ARTIFACT_PATH`
+          echo "::set-output name=name::$name"
+          progname=`sed -E -n -e 's/progname= //p' $CONFIG_ARTIFACT_PATH`
+          echo "::set-output name=progname::$progname"
+          version=`sed -E -n -e 's/version= //p' $CONFIG_ARTIFACT_PATH`
+          echo "::set-output name=version::$version"
+          prerelease=`sed -E -n -e 's/prerelease= //p' $CONFIG_ARTIFACT_PATH`
+          echo "::set-output name=prerelease::$prerelease"
+          draft=`sed -E -n -e 's/draft= //p' $CONFIG_ARTIFACT_PATH`
+          echo "::set-output name=draft::$draft"
+          upload_url=`sed -E -n -e 's/upload_url= //p' $CONFIG_ARTIFACT_PATH`
+          echo "::set-output name=upload_url::$upload_url"
+
+      - name: Clone Project
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Download Artifact with Converted Documents
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ env.DOC_ARTIFACT }}
+
+      - name: Extract Converted Documents
+        run: |
+          tar -xf ${{ env.DOC_ARTIFACT_PATH }}
+
+      - name: Create Nintendo ds
+        id: create_nintendo_ds
+        shell: bash
+        run: |
+          pushd src/
+          make -f Makefile.nds
+          popd
+          test -e src/angband.nds
+
+          prefix=${{ steps.store_config.outputs.name }}-${{ steps.store_config.outputs.version }}
+          echo "::set-output name=file::${prefix}.nds"
+          cp -v src/angband.nds ${prefix}.nds
+          echo "::set-output name=archive_content_type::application/octet-stream"
+
+      - name: Upload Nintendo ds
+        id: upload_nintendo_ds
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.store_config.outputs.upload_url }}
+          asset_path: ./${{ steps.create_nintendo_ds.outputs.file }}
+          asset_name: ${{ steps.create_nintendo_ds.outputs.file }}
+          asset_content_type: ${{ steps.create_nintendo_ds.outputs.archive_content_type }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -380,6 +380,7 @@ jobs:
 
       - name: Create Nintendo 3dsx
         id: create_nintendo_3dsx
+        shell: bash
         run: |
           pushd src/
           make -f Makefile.3ds

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -378,8 +378,8 @@ jobs:
         run: |
           tar -xf ${{ env.DOC_ARTIFACT_PATH }}
 
-      - name: Create Nintendo 3dsx
-        id: create_nintendo_3dsx
+      - name: Create Nintendo 3DS Archive
+        id: create_nintendo_3ds_archive
         shell: bash
         run: |
           pushd src/
@@ -387,21 +387,24 @@ jobs:
           popd
           test -e src/angband.3dsx
 
-          prefix=${{ steps.store_config.outputs.name }}-${{ steps.store_config.outputs.version }}
-          echo "::set-output name=file::${prefix}.3dsx"
-          cp -v src/angband.3dsx ${prefix}.3dsx
-          echo "::set-output name=archive_content_type::application/octet-stream"
-
-      - name: Upload Nintendo 3dsx
-        id: upload_nintendo_3dsx
+          archive_prefix=${{ steps.store_config.outputs.name }}-${{ steps.store_config.outputs.version }}
+          echo "::set-output name=archive_file::${archive_prefix}-3ds.zip"
+          echo "::set-output name=archive_content_type::application/zip"
+          mkdir -v 3ds angband
+          cp -v src/angband.3dsx 3ds/${prefix}.3dsx
+          cp -rv lib angband/
+          zip -r ${archive_prefix}-3ds.zip 3ds/ angband/
+          
+      - name: Upload Nintendo 3DS Archive
+        id: upload_nintendo_3ds_archive
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.store_config.outputs.upload_url }}
-          asset_path: ./${{ steps.create_nintendo_3dsx.outputs.file }}
-          asset_name: ${{ steps.create_nintendo_3dsx.outputs.file }}
-          asset_content_type: ${{ steps.create_nintendo_3dsx.outputs.archive_content_type }}
+          asset_path: ./${{ steps.create_nintendo_3ds_archive.outputs.file }}
+          asset_name: ${{ steps.create_nintendo_3ds_archive.outputs.file }}
+          asset_content_type: ${{ steps.create_nintendo_3ds_archive.outputs.archive_content_type }}
 
   nds:
     needs: [setup, docconvert]
@@ -444,8 +447,8 @@ jobs:
         run: |
           tar -xf ${{ env.DOC_ARTIFACT_PATH }}
 
-      - name: Create Nintendo ds
-        id: create_nintendo_ds
+      - name: Create Nintendo DS Archive
+        id: create_nintendo_ds_archive
         shell: bash
         run: |
           pushd src/
@@ -453,18 +456,21 @@ jobs:
           popd
           test -e src/angband.nds
 
-          prefix=${{ steps.store_config.outputs.name }}-${{ steps.store_config.outputs.version }}
-          echo "::set-output name=file::${prefix}.nds"
-          cp -v src/angband.nds ${prefix}.nds
-          echo "::set-output name=archive_content_type::application/octet-stream"
+          archive_prefix=${{ steps.store_config.outputs.name }}-${{ steps.store_config.outputs.version }}
+          echo "::set-output name=archive_file::${archive_prefix}-nds.zip"
+          echo "::set-output name=archive_content_type::application/zip"
+          mkdir -v _nds angband
+          cp -v src/angband.nds _nds/${prefix}.nds
+          cp -rv lib angband/
+          zip -r ${archive_prefix}-nds.zip _nds/ angband/
 
-      - name: Upload Nintendo ds
-        id: upload_nintendo_ds
+      - name: Upload Nintendo DS Archive
+        id: upload_nintendo_ds_archive
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.store_config.outputs.upload_url }}
-          asset_path: ./${{ steps.create_nintendo_ds.outputs.file }}
-          asset_name: ${{ steps.create_nintendo_ds.outputs.file }}
-          asset_content_type: ${{ steps.create_nintendo_ds.outputs.archive_content_type }}
+          asset_path: ./${{ steps.upload_nintendo_ds_archive.outputs.file }}
+          asset_name: ${{ steps.upload_nintendo_ds_archive.outputs.file }}
+          asset_content_type: ${{ steps.upload_nintendo_ds_archive.outputs.archive_content_type }}


### PR DESCRIPTION
Added Nintendo workflow and release. 

Zip structure is prepared to copy and paste into the 3ds and nds sd card root.

**3ds**

Angband-4.2.4-9-g45dd706fa-3ds.zip
```
.
├── Angband-4.2.4-9-g45dd706fa.3dsx
└── angband
    └── lib
```

**nds**

Angband-4.2.4-9-g45dd706fa-nds.zip
```
.
├── angband
│   └── lib
└── Angband-4.2.4-9-g45dd706fa.nds
```

I have tested the build on my New 3DS XL and only got the 3DS release running properly. I'll further check my 3DS setup soon since I get only a black screen when running nds using twilightmenu. 

Prerelease: https://github.com/kleo/angband/releases/tag/4.2.4-9-g45dd706fa

Workflow runs:
nintendo.yaml: https://github.com/kleo/angband/actions/runs/1964095445
release.yaml: https://github.com/kleo/angband/actions/runs/1964095445