### PR TITLE
Set character_saved to false if savefile could not be opened.

### DIFF
--- a/src/savefile.c
+++ b/src/savefile.c
@@ -418,6 +418,8 @@ bool savefile_save(const char *path)
 			character_saved = false;
 		}
 		file_close(file);
+	} else {
+		character_saved = false;
 	}
 
 	if (character_saved) {


### PR DESCRIPTION
May improve the error handling that led to this report, http://angband.oook.cz/forum/showpost.php?p=157868&postcount=38 , of a savefile failure.