### PR TITLE
SDL2: update MSYS2 compilation for upstream changes (libbrotli change…

### DIFF
--- a/src/Makefile.msys2.sdl2
+++ b/src/Makefile.msys2.sdl2
@@ -28,14 +28,17 @@ VIDEO_sdl2 := -DUSE_SDL2 \
 	$(shell sdl2-config --static-libs) \
 	-lSDL2_ttf -lSDL2_image \
 	-ltiff \
+	-ljbig \
+	-lLerc \
 	-lzstd \
 	-llzma \
 	-lwebp \
 	-lfreetype \
 	-lharfbuzz \
+	-lDwrite \
 	-lfreetype \
-	-lbrotlidec-static \
-	-lbrotlicommon-static \
+	-lbrotlidec \
+	-lbrotlicommon \
 	-lgraphite2 \
 	-lpng \
 	-ldeflate \


### PR DESCRIPTION
… was committted on 2021/10/6).  Resolves https://github.com/angband/angband/issues/5303 .