### PR TITLE
Always reload pref.prf when restarting.  Call reinit_hook before …

### DIFF
--- a/src/ui-game.c
+++ b/src/ui-game.c
@@ -919,10 +919,10 @@ void play_game(enum game_mode_type mode)
 		cleanup_angband();
 		init_display();
 		init_angband();
-		textui_init();
 		if (reinit_hook != NULL) {
 			(*reinit_hook)();
 		}
+		textui_init();
 		if (mode == GAME_LOAD) {
 			mode = GAME_NEW;
 		}

--- a/src/ui-init.c
+++ b/src/ui-init.c
@@ -45,11 +45,11 @@ void textui_init(void)
 {
 	uint32_t default_window_flag[ANGBAND_TERM_MAX];
 
-	if (!play_again) {
-		/* Initialize graphics info and basic pref data */
-		event_signal_message(EVENT_INITSTATUS, 0, "Loading basic pref file...");
-		(void)process_pref_file("pref.prf", false, false);
+	/* Initialize graphics info and basic pref data */
+	event_signal_message(EVENT_INITSTATUS, 0, "Loading basic pref file...");
+	(void)process_pref_file("pref.prf", false, false);
 
+	if (!play_again) {
 		/* Sneakily init command list */
 		cmd_init();
 


### PR DESCRIPTION
…textui_init() when restarting to mimic the normal start procedure in main.c and main-win.c.  Resolves https://github.com/angband/angband/issues/4687 .