### PR TITLE
Allow more menus to use the rogue-like movement keys for navigation. …

### DIFF
--- a/src/effect-handler-general.c
+++ b/src/effect-handler-general.c
@@ -1908,7 +1908,8 @@ bool effect_handler_DISENCHANT(effect_handler_context_t *context)
 	/* Artifacts have a 60% chance to resist */
 	if (obj->artifact && (randint0(100) < 60)) {
 		/* Message */
-		msg("Your %s (%c) resist%s disenchantment!", o_name, I2A(i),
+		msg("Your %s (%c) resist%s disenchantment!", o_name,
+			gear_to_label(player, obj),
 			((obj->number != 1) ? "" : "s"));
 
 		return true;
@@ -1934,7 +1935,8 @@ bool effect_handler_DISENCHANT(effect_handler_context_t *context)
 	}
 
 	/* Message */
-	msg("Your %s (%c) %s disenchanted!", o_name, I2A(i),
+	msg("Your %s (%c) %s disenchanted!", o_name,
+		gear_to_label(player, obj),
 		((obj->number != 1) ? "were" : "was"));
 
 	/* Recalculate bonuses */

--- a/src/mon-blows.c
+++ b/src/mon-blows.c
@@ -227,8 +227,9 @@ static void steal_player_item(melee_effect_handler_context_t *context)
 				(split ? "one of your" : "your"), o_name);
 		} else {
 			/* Message */
-			msg("%s %s (%c) was stolen!", (split ? "One of your" : "Your"),
-				o_name, I2A(index));
+			msg("%s %s (%c) was stolen!",
+				(split ? "One of your" : "Your"), o_name,
+				gear_to_label(context->p, obj));
 
 			/* Steal and carry */
 			stolen = gear_object_for_use(context->p, obj, 1,
@@ -805,12 +806,13 @@ static void melee_effect_handler_EAT_FOOD(melee_effect_handler_context_t *contex
 		if (obj->number == 1) {
 			object_desc(o_name, sizeof(o_name), obj, ODESC_BASE,
 				context->p);
-			msg("Your %s (%c) was eaten!", o_name, I2A(index));
+			msg("Your %s (%c) was eaten!", o_name,
+				gear_to_label(context->p, obj));
 		} else {
 			object_desc(o_name, sizeof(o_name), obj,
 				ODESC_PREFIX | ODESC_BASE, context->p);
 			msg("One of your %s (%c) was eaten!", o_name,
-				I2A(index));
+				gear_to_label(context->p, obj));
 		}
 
 		/* Steal and eat */

--- a/src/obj-gear.c
+++ b/src/obj-gear.c
@@ -442,11 +442,14 @@ bool minus_ac(struct player *p)
  */
 char gear_to_label(struct player *p, struct object *obj)
 {
+	/* Skip rogue-like cardinal direction movement keys. */
+	const char labels[] =
+		 "abcdefgimnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 	int i;
 
 	/* Equipment is easy */
 	if (object_is_equipped(p->body, obj)) {
-		return I2A(equipped_item_slot(p->body, obj));
+		return labels[equipped_item_slot(p->body, obj)];
 	}
 
 	/* Check the quiver */
@@ -459,7 +462,7 @@ char gear_to_label(struct player *p, struct object *obj)
 	/* Check the inventory */
 	for (i = 0; i < z_info->pack_size; i++) {
 		if (p->upkeep->inven[i] == obj) {
-			return I2A(i);
+			return labels[i];
 		}
 	}
 
@@ -991,7 +994,7 @@ void inven_wield(struct object *obj, int slot)
 		ODESC_PREFIX | ODESC_FULL, player);
 
 	/* Message */
-	msgt(MSG_WIELD, fmt, o_name, I2A(slot));
+	msgt(MSG_WIELD, fmt, o_name, gear_to_label(player, wielded));
 
 	/* Sticky flag geats a special mention */
 	if (of_has(wielded->flags, OF_STICKY)) {

--- a/src/ui-birth.c
+++ b/src/ui-birth.c
@@ -501,9 +501,10 @@ static void init_birth_menu(struct menu *menu, int n_choices,
 	/* Initialise a basic menu */
 	menu_init(menu, MN_SKIN_SCROLL, &birth_iter);
 
-	/* A couple of behavioural flags - we want selections letters in
-	   lower case and a double tap to act as a selection. */
-	menu->selections = lower_case;
+	/* A couple of behavioural flags - we want selections as letters
+	   skipping the rogue-like cardinal direction movements and a
+	   double tap to act as a selection. */
+	menu->selections = all_letters_nohjkl;
 	menu->flags = MN_DBL_TAP;
 
 	/* Copy across the game's suggested initial selection, etc. */

--- a/src/ui-curse.c
+++ b/src/ui-curse.c
@@ -122,7 +122,7 @@ static int curse_menu(struct object *obj, char *dice_string)
 			  format(" Remove which curse (spell strength %s)?", dice_string),
 			  sizeof(header));
 	m->header = header;
-	m->selections = lower_case;
+	m->selections = all_letters_nohjkl;
 	m->flags = (MN_PVT_TAGS);
 	m->browse_hook = curse_menu_browser;
 

--- a/src/ui-effect.c
+++ b/src/ui-effect.c
@@ -40,7 +40,7 @@ static struct menu *effect_menu_new(struct effect *effect, int count,
 	char **ms;
 	char buf[80];
 
-	m->selections = lower_case;
+	m->selections = all_letters_nohjkl;
 
 	/* Collect a string for each effect. */
 	if (count > 0) {

--- a/src/ui-equip-cmp.c
+++ b/src/ui-equip-cmp.c
@@ -311,16 +311,16 @@ void equip_cmp_display(void)
 		{ "Sorry, could not display.  Press any key.",
 			handle_input_bail, true, false },
 		/* EQUIP_CMP_MENU_NEW_PAGE */
-		{ "[Up/Down arrow, p/PgUp, n/PgDn to move; ? for help; ESC to "
+		{ "[k/up, j/down, p/PgUp, n/PgDn to move; ? for help; ESC to "
 			"exit]", handle_input_equip_cmp_general, true, true },
 		/* EQUIP_CMP_MENU_SAME_PAGE */
-		{ "[Up/Down arrow, p/PgUp, n/PgDn to move; ? for help; ESC to "
+		{ "[k/up, j/down, p/PgUp, n/PgDn to move; ? for help; ESC to "
 			"exit]", handle_input_equip_cmp_general, false, false },
 		/* EQUIP_CMP_MENU_SEL0 */
-		{ "[Up/Down arrow, p/PgUp, n/PgDn to move; return to accept]",
+		{ "[k/up, j/down, p/PgUp, n/PgDn to move; return to accept]",
 			handle_input_equip_cmp_select, true, true },
 		/* EQUIP_CMP_MENU_SEL1 */
-		{ "[Up/Down arrow, p/PgUp, n/PgDn to move; return to accept]",
+		{ "[k/up, j/down, p/PgUp, n/PgDn to move; return to accept]",
 			handle_input_equip_cmp_select, true, true },
 	};
 	int istate;
@@ -403,31 +403,31 @@ static void display_equip_cmp_help(void)
 	irow = 1;
 	prt("Movement/scrolling ---------------------------------", irow, 0);
 	++irow;
-	prt("Down arrow  one line down    Up arrow    one line up", irow, 0);
+	prt("j, down  one line down    k, up    one line up", irow, 0);
 	++irow;
-	prt("n, PgDn     one page down    p, PgUp     one page up", irow, 0);
+	prt("n, PgDn  one page down    p, PgUp  one page up", irow, 0);
 	++irow;
-	prt("space       one page down", irow, 0);
+	prt("space    one page down", irow, 0);
 	++irow;
 	prt("Filtering/searching/sorting ------------------------", irow, 0);
 	++irow;
-	prt("q           quick filter     !           use opposite quick", irow, 0);
+	prt("q        quick filter     !        use opposite quick", irow, 0);
 	++irow;
-	prt("c           cycle through sources of items", irow, 0);
+	prt("c        cycle through sources of items", irow, 0);
 	++irow;
-	prt("r           reverse", irow, 0);
+	prt("r        reverse", irow, 0);
 	++irow;
 	prt("Information ----------------------------------------", irow, 0);
 	++irow;
-	prt("v           cycle through attribute views", irow, 0);
+	prt("v        cycle through attribute views", irow, 0);
 	++irow;
-	prt("I, x        select one or two items for details", irow, 0);
+	prt("I, x     select one or two items for details", irow, 0);
 	++irow;
 	prt("Other ----------------------------------------------", irow, 0);
 	++irow;
-	prt("d           dump to file     R           reset display", irow, 0);
+	prt("d        dump to file     R        reset display", irow, 0);
 	++irow;
-	prt("ESC         exit", irow, 0);
+	prt("ESC      exit", irow, 0);
 	++irow;
 
 	Term_get_size(&wid, &hgt);
@@ -515,10 +515,12 @@ static int handle_input_equip_cmp_general(ui_event in, int istate,
 			action = ACT_CTX_EQUIPCMP_PREV_PAGE;
 			break;
 
+		case 'j':
 		case ARROW_DOWN:
 			action = ACT_CTX_EQUIPCMP_NEXT_LINE;
 			break;
 
+		case 'k':
 		case ARROW_UP:
 			action = ACT_CTX_EQUIPCMP_PREV_LINE;
 			break;
@@ -916,19 +918,19 @@ static void display_equip_cmp_sel_help(void)
 
 	Term_clear();
 	irow = 1;
-	prt("Down arrow  move selection one line down", irow, 0);
+	prt("j, down   move selection one line down", irow, 0);
 	++irow;
-	prt("Up arrow    move selection one line up", irow, 0);
+	prt("k, up     move selection one line up", irow, 0);
 	++irow;
-	prt("n, PgDn     move selection one page up", irow, 0);
+	prt("n, PgDn   move selection one page up", irow, 0);
 	++irow;
-	prt("p, PgUp     move selection one page up", irow, 0);
+	prt("p, PgUp   move selection one page up", irow, 0);
 	++irow;
-	prt("x           stop selection; if first item, escapes", irow, 0);
+	prt("x         stop selection; if first item, escapes", irow, 0);
 	++irow;
-	prt("return      select current item", irow, 0);
+	prt("return    select current item", irow, 0);
 	++irow;
-	prt("ESC         leave selection process", irow, 0);
+	prt("ESC       leave selection process", irow, 0);
 	++irow;
 
 	Term_get_size(&wid, &hgt);
@@ -971,10 +973,12 @@ static int handle_input_equip_cmp_select(ui_event in, int istate,
 			action = ACT_CTX_EQUIPCMP_SELECT_PREV_PAGE;
 			break;
 
+		case 'j':
 		case ARROW_DOWN:
 			action = ACT_CTX_EQUIPCMP_SELECT_NEXT_LINE;
 			break;
 
+		case 'k':
 		case ARROW_UP:
 			action = ACT_CTX_EQUIPCMP_SELECT_PREV_LINE;
 			break;

--- a/src/ui-history.c
+++ b/src/ui-history.c
@@ -96,12 +96,14 @@ void history_display(void)
 				break;
 			}
 
+			case 'j':
 			case ARROW_DOWN: {
 				size_t scroll_to = first_item + 1;
 				first_item = (scroll_to < max_item ? scroll_to : max_item);
 				break;
 			}
 
+			case 'k':
 			case ARROW_UP: {
 				int scroll_to = first_item - 1;
 				first_item = (scroll_to >= 0 ? scroll_to : 0);

--- a/src/ui-knowledge.c
+++ b/src/ui-knowledge.c
@@ -772,16 +772,11 @@ static void display_knowledge(const char *title, int *obj_list, int o_count,
 	int wid, hgt;
 	int i;
 	int prev_g = -1;
-
-	int omode = OPT(player, rogue_like_commands);
 	ui_event ke;
 
 	/* Get size */
 	Term_get_size(&wid, &hgt);
 	browser_rows = hgt - 8;
-
-	/* Disable the roguelike commands for the duration */
-	OPT(player, rogue_like_commands) = false;
 
 	/* Determine if using tiles or not */
 	if (tiles) tiles = (current_graphics_mode->grafID != 0);
@@ -1059,9 +1054,6 @@ static void display_knowledge(const char *title, int *obj_list, int o_count,
 			redraw = true;
 		}
 	}
-
-	/* Restore roguelike option */
-	OPT(player, rogue_like_commands) = omode;
 
 	/* Prompt */
 	if (!grp_cnt)
@@ -2326,10 +2318,10 @@ static const char *feat_prompt(int oid)
 {
 	(void)oid;
 		switch (f_uik_lighting) {
-				case LIGHTING_LIT:  return ", 'l/L' for lighting (lit)";
-                case LIGHTING_TORCH: return ", 'l/L' for lighting (torch)";
-				case LIGHTING_LOS:  return ", 'l/L' for lighting (LOS)";
-				default:	return ", 'l/L' for lighting (dark)";
+				case LIGHTING_LIT:  return ", 't/T' for lighting (lit)";
+                case LIGHTING_TORCH: return ", 't/T' for lighting (torch)";
+				case LIGHTING_LOS:  return ", 't/T' for lighting (LOS)";
+				default:	return ", 't/T' for lighting (dark)";
 		}		
 }
 
@@ -2339,14 +2331,14 @@ static const char *feat_prompt(int oid)
 static void f_xtra_act(struct keypress ch, int oid)
 {
 	/* XXX must be a better way to cycle this */
-	if (ch.code == 'l') {
+	if (ch.code == 't') {
 		switch (f_uik_lighting) {
 				case LIGHTING_LIT:  f_uik_lighting = LIGHTING_TORCH; break;
                 case LIGHTING_TORCH: f_uik_lighting = LIGHTING_LOS; break;
 				case LIGHTING_LOS:  f_uik_lighting = LIGHTING_DARK; break;
 				default:	f_uik_lighting = LIGHTING_LIT; break;
 		}		
-	} else if (ch.code == 'L') {
+	} else if (ch.code == 'T') {
 		switch (f_uik_lighting) {
 				case LIGHTING_DARK:  f_uik_lighting = LIGHTING_LOS; break;
                 case LIGHTING_LOS: f_uik_lighting = LIGHTING_TORCH; break;
@@ -2511,7 +2503,7 @@ static void trap_lore(int oid)
 static const char *trap_prompt(int oid)
 {
 	(void)oid;
-	return ", 'l' to cycle lighting";
+	return ", 't' to cycle lighting";
 }
 
 /**
@@ -2520,14 +2512,14 @@ static const char *trap_prompt(int oid)
 static void t_xtra_act(struct keypress ch, int oid)
 {
 	/* XXX must be a better way to cycle this */
-	if (ch.code == 'l') {
+	if (ch.code == 't') {
 		switch (t_uik_lighting) {
 				case LIGHTING_LIT:  t_uik_lighting = LIGHTING_TORCH; break;
                 case LIGHTING_TORCH: t_uik_lighting = LIGHTING_LOS; break;
 				case LIGHTING_LOS:  t_uik_lighting = LIGHTING_DARK; break;
 				default:	t_uik_lighting = LIGHTING_LIT; break;
 		}		
-	} else if (ch.code == 'L') {
+	} else if (ch.code == 'T') {
 		switch (t_uik_lighting) {
 				case LIGHTING_DARK:  t_uik_lighting = LIGHTING_LOS; break;
                 case LIGHTING_LOS: t_uik_lighting = LIGHTING_TORCH; break;
@@ -3049,7 +3041,6 @@ static void do_cmd_knowledge_shapechange(const char *name, int row)
 	struct menu* m;
 	struct player_shape **sarray;
 	const char **narray;
-	int omode;
 	int h, mark, mark_old;
 	bool displaying, redraw;
 	struct player_shape *s;
@@ -3087,10 +3078,6 @@ static void do_cmd_knowledge_shapechange(const char *name, int row)
 
 	screen_save();
 	clear_from(0);
-
-	/* Disable the roguelike commands for the duration */
-	omode = OPT(player, rogue_like_commands);
-	OPT(player, rogue_like_commands) = false;
 
 	h = 0;
 	mark = 0;
@@ -3169,9 +3156,6 @@ static void do_cmd_knowledge_shapechange(const char *name, int row)
 			shape_lore(sarray[mark]);
 		}
 	}
-
-	/* Restore roguelike option */
-	OPT(player, rogue_like_commands) = omode;
 
 	screen_load();
 
@@ -3266,7 +3250,7 @@ void textui_knowledge_init(void)
 	menu_setpriv(menu, N_ELEMENTS(knowledge_actions), knowledge_actions);
 
 	menu->title = "Display current knowledge";
-	menu->selections = lower_case;
+	menu->selections = all_letters_nohjkl;
 	/* Shortcuts to get the contents of the stores by number; does prevent
 	 * the normal use of 4 and 6 to go to the previous or next menu */
 	menu->cmd_keys = "12345678";
@@ -3498,21 +3482,25 @@ void do_cmd_messages(void)
 
 				case ARROW_LEFT:
 				case '4':
+				case 'h':
 					q = (q >= wid / 2) ? (q - wid / 2) : 0;
 					break;
 
 				case ARROW_RIGHT:
 				case '6':
+				case 'l':
 					q = q + wid / 2;
 					break;
 
 				case ARROW_UP:
 				case '8':
+				case 'k':
 					if (i + 1 < n) i += 1;
 					break;
 
 				case ARROW_DOWN:
 				case '2':
+				case 'j':
 				case KC_ENTER:
 					i = (i >= 1) ? (i - 1) : 0;
 					break;

--- a/src/ui-menu.c
+++ b/src/ui-menu.c
@@ -38,6 +38,7 @@ const uint8_t curs_attrs[2][2] =
 const char lower_case[] = "abcdefghijklmnopqrstuvwxyz";
 const char upper_case[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 const char all_letters[] = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const char all_letters_nohjkl[] = "abcdefgimnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
 /**
  * Forward declarations

--- a/src/ui-menu.h
+++ b/src/ui-menu.h
@@ -55,6 +55,7 @@ extern const uint8_t curs_attrs[2][2];
 extern const char lower_case[];			/* abc..z */
 extern const char upper_case[];			/* ABC..Z */
 extern const char all_letters[];		/* abc..zABC..Z */
+extern const char all_letters_nohjkl[];		/* abc..gim..zABC..Z */
 
 
 /*

--- a/src/ui-object.c
+++ b/src/ui-object.c
@@ -289,7 +289,7 @@ static void build_obj_list(int last, struct object **list, item_tester tester,
 		/* Acceptable items get a label */
 		if (object_test(tester, obj) ||	(obj && tval_is_money(obj) && gold_ok))
 			strnfmt(items[num_obj].label, sizeof(items[num_obj].label), "%c) ",
-					quiver ? I2D(i) : I2A(i));
+				quiver ? I2D(i) : all_letters_nohjkl[i]);
 
 		/* Unacceptable items are still sometimes shown */
 		else if ((!obj && show_empty) || in_term)
@@ -422,7 +422,7 @@ static void show_obj_list(olist_detail_t mode)
 		/* Quiver may take multiple lines */
 		for (j = 0; j < quiver_slots; j++, i++) {
 			const char *fmt = "in Quiver: %d missile%s";
-			char letter = I2A(in_term ? i - 1 : i);
+			char letter = all_letters_nohjkl[in_term ? i - 1 : i];
 
 			/* Number of missiles in this "slot" */
 			if (j == quiver_slots - 1)
@@ -765,7 +765,8 @@ static void menu_header(void)
 		/* List choices */
 		if (i1 <= i2) {
 			/* Build the header */
-			strnfmt(tmp_val, sizeof(tmp_val), " %c-%c,", I2A(i1), I2A(i2));
+			strnfmt(tmp_val, sizeof(tmp_val), " %c-%c,",
+				all_letters_nohjkl[i1], all_letters_nohjkl[i2]);
 
 			/* Append */
 			my_strcat(out_val, tmp_val, sizeof(out_val));
@@ -792,7 +793,8 @@ static void menu_header(void)
 		/* List choices */
 		if (e1 <= e2) {
 			/* Build the header */
-			strnfmt(tmp_val, sizeof(tmp_val), " %c-%c,", I2A(e1), I2A(e2));
+			strnfmt(tmp_val, sizeof(tmp_val), " %c-%c,",
+				all_letters_nohjkl[e1], all_letters_nohjkl[e2]);
 
 			/* Append */
 			my_strcat(out_val, tmp_val, sizeof(out_val));
@@ -844,7 +846,8 @@ static void menu_header(void)
 		/* List choices */
 		if (throwing_num) {
 			/* Build the header */
-			strnfmt(tmp_val, sizeof(tmp_val),  " a-%c,", I2A(throwing_num - 1));
+			strnfmt(tmp_val, sizeof(tmp_val),  " a-%c,",
+				all_letters_nohjkl[throwing_num - 1]);
 
 			/* Append */
 			my_strcat(out_val, tmp_val, sizeof(out_val));
@@ -871,7 +874,8 @@ static void menu_header(void)
 		/* List choices */
 		if (f1 <= f2) {
 			/* Build the header */
-			strnfmt(tmp_val, sizeof(tmp_val), " %c-%c,", I2A(f1), I2A(f2));
+			strnfmt(tmp_val, sizeof(tmp_val), " %c-%c,",
+				all_letters_nohjkl[f1], all_letters_nohjkl[f2]);
 
 			/* Append */
 			my_strcat(out_val, tmp_val, sizeof(out_val));
@@ -1007,7 +1011,7 @@ static void item_menu_browser(int oid, void *data, const region *local_area)
 		/* Quiver may take multiple lines */
 		for (j = 0; j < quiver_slots; j++, i++) {
 			const char *fmt = "in Quiver: %d missile%s\n";
-			char letter = I2A(i);
+			char letter = all_letters_nohjkl[i];
 
 			/* Number of missiles in this "slot" */
 			if (j == quiver_slots - 1)
@@ -1058,7 +1062,7 @@ static struct object *item_menu(cmd_code cmd, int prompt_size, int mode)
 	if (player->upkeep->command_wrk == USE_QUIVER)
 		m->selections = "0123456789";
 	else
-		m->selections = lower_case;
+		m->selections = all_letters_nohjkl;
 	m->switch_keys = "/|-";
 	m->flags = (MN_PVT_TAGS | MN_INSCRIP_TAGS);
 	m->browse_hook = item_menu_browser;
@@ -1620,7 +1624,7 @@ void textui_cmd_ignore_menu(struct object *obj)
 		return;
 
 	m = menu_dynamic_new();
-	m->selections = lower_case;
+	m->selections = all_letters_nohjkl;
 
 	/* Basic ignore option */
 	if (!(obj->known->notice & OBJ_NOTICE_IGNORE)) {

--- a/src/ui-options.c
+++ b/src/ui-options.c
@@ -303,6 +303,7 @@ static const menu_iter option_toggle_iter = {
  */
 static void option_toggle_menu(const char *name, int page)
 {
+	static const char selections[] = "abcdefgimopquvwzABCDEFGHIJKLMOPQUVWZ";
 	int i;
 	
 	struct menu *m = menu_new(MN_SKIN_SCROLL, &option_toggle_iter);
@@ -310,7 +311,7 @@ static void option_toggle_menu(const char *name, int page)
 	/* for all menus */
 	m->prompt = "Set option (y/n/t), select with movement keys or index";
 	m->cmd_keys = "YyNnTt";
-	m->selections = "abcdefghijklmopqrsuvwxz";
+	m->selections = selections;
 	m->flags = MN_DBL_TAP;
 
 	/* We add 10 onto the page amount to indicate we're at birth */
@@ -321,7 +322,6 @@ static void option_toggle_menu(const char *name, int page)
 	} else if (page == OPT_PAGE_BIRTH + 10 || page == OP_INTERFACE) {
 		m->prompt = "Set option (y/n/t), 's' to save, 'r' to restore, 'x' to reset";
 		m->cmd_keys = "YyNnTtSsRrXx";
-		m->selections = "abcdefghijklmopquvwzABC";
 		/* Provide a context menu for equivalents to 's', 'r', .... */
 		m->context_hook = use_option_context_menu;
 		if (page == OPT_PAGE_BIRTH + 10) {
@@ -1965,6 +1965,7 @@ void do_cmd_options_item(const char *title, int row)
 				 N_ELEMENTS(extra_item_options) + 1, NULL);
 
 	menu.title = title;
+	menu.selections = all_letters_nohjkl;
 	menu_layout(&menu, &SCREEN_REGION);
 
 	screen_save();
@@ -2003,8 +2004,8 @@ static menu_action option_actions[] =
 	{ 0, 't', "Save autoinscriptions to pref file", do_dump_autoinsc },
 	{ 0, 'u', "Save char screen options to pref file", do_dump_charscreen_opt },
 	{ 0, 0, NULL, NULL },
-	{ 0, 'l', "Load a user pref file", options_load_pref_file },
-	{ 0, 'k', "Edit keymaps (advanced)", do_cmd_keymaps },
+	{ 0, 'p', "Load a user pref file", options_load_pref_file },
+	{ 0, 'e', "Edit keymaps (advanced)", do_cmd_keymaps },
 	{ 0, 'c', "Edit colours (advanced)", do_cmd_colors },
 	{ 0, 'v', "Save visuals (advanced)", do_cmd_visuals },
 };

--- a/src/ui-player-properties.c
+++ b/src/ui-player-properties.c
@@ -30,7 +30,7 @@
 
 static char view_ability_tag(struct menu *menu, int oid)
 {
-	return I2A(oid);
+	return all_letters_nohjkl[oid];
 }
 
 /**
@@ -117,8 +117,8 @@ void textui_view_ability_menu(struct player_ability *ability_list,
 
 	/* Prompt choices */
 	strnfmt(buf, sizeof(buf),
-			"Race and class abilities (%c-%c, ESC=exit): ",
-			I2A(0), I2A(num_abilities - 1));
+		"Race and class abilities (%c-%c, ESC=exit): ",
+		all_letters_nohjkl[0], all_letters_nohjkl[num_abilities - 1]);
 
 	/* Set up the menu */
 	menu_init(&menu, MN_SKIN_SCROLL, &menu_f);

--- a/src/ui-spell.c
+++ b/src/ui-spell.c
@@ -234,7 +234,7 @@ static struct menu *spell_menu_new(const struct object *obj,
 	/* Set flags */
 	m->header = "Name                             Lv Mana Fail Info";
 	m->flags = MN_CASELESS_TAGS;
-	m->selections = lower_case;
+	m->selections = all_letters_nohjkl;
 	m->browse_hook = spell_menu_browser;
 	m->cmd_keys = "?";
 

--- a/src/ui-spoil.c
+++ b/src/ui-spoil.c
@@ -61,7 +61,7 @@ void do_cmd_spoilers(void)
 	if (!spoil_menu) {
 		spoil_menu = menu_new_action(spoil_actions,
 			N_ELEMENTS(spoil_actions));
-		spoil_menu->selections = lower_case;
+		spoil_menu->selections = all_letters_nohjkl;
 		spoil_menu->title = "Create spoilers";
 	}
 

--- a/src/ui-store.c
+++ b/src/ui-store.c
@@ -778,21 +778,21 @@ static void store_menu_set_selections(struct menu *menu, bool knowledge_menu)
 		if (OPT(player, rogue_like_commands)) {
 			/* These two can't intersect! */
 			menu->cmd_keys = "?|Ieilx";
-			menu->selections = "abcdfghjkmnopqrstuvwyz134567";
+			menu->selections = "abcdfghmnopqrstuvwyzABCDEFGHJKLMNOPQRSTUVWXYZ";
 		} else {
 			/* These two can't intersect! */
 			menu->cmd_keys = "?|Ieil";
-			menu->selections = "abcdfghjkmnopqrstuvwxyz13456";
+			menu->selections = "abcdfghjkmnopqrstuvwxyzABCDEFGHJKLMNOPQRSTUVWXYZ";
 		}
 	} else {
 		if (OPT(player, rogue_like_commands)) {
 			/* These two can't intersect! */
 			menu->cmd_keys = "\x04\x05\x10?={|}~CEIPTdegilpswx"; /* \x10 = ^p , \x04 = ^D, \x05 = ^E */
-			menu->selections = "abcfmnoqrtuvyz13456790ABDFGH";
+			menu->selections = "abcfmnoqrtuvyzABDFGHJKLMNOQRSUVWXYZ";
 		} else {
 			/* These two can't intersect! */
 			menu->cmd_keys = "\x05\x010?={|}~CEIbdegiklpstwx"; /* \x05 = ^E, \x10 = ^p */
-			menu->selections = "acfhjmnoqruvyz13456790ABDFGH";
+			menu->selections = "acfhjmnoqruvyzABDFGHJKLMNOPQRSTUVWXYZ";
 		}
 	}
 }

--- a/tests/birth/new-game-1/input
+++ b/tests/birth/new-game-1/input
@@ -1,6 +1,6 @@
 key space
-key i
-key i
+key m
+key m
 key c
 key c
 key a


### PR DESCRIPTION
… Related to https://github.com/angband/angband/issues/5298 .

Potential issues:

- If players have memorized certain key combinations (or use stored keymaps) to access the changed menus, those may be outdated by this change.
- For most of the changed menus, I exclude the h, j, k, and l from being possible menu entries regardless of whether the rogue-like key option is enabled or not.  That was done because it means less code and, less importantly, make it possible to use the same shortcut letter if switching between the two settings for that option.  The code for stores' menus which only excludes h, j, k, and l if the rogue-like option is on was left as is.
- There's at least one context menu that doesn't fully allow the navigation with the rogue-like navigation keys:  in an item manipulation context menu, 'k' is (as it was in the code before this change) used for the "Drop all" option.