### PR TITLE
For special artifacts, remove additional out-of-depth check on the …

### DIFF
--- a/lib/gamedata/object.txt
+++ b/lib/gamedata/object.txt
@@ -74,12 +74,11 @@
 # 'type' is for the base type of item, from object_base.txt.
 
 # 'level' defines how "advanced" the object is, when determining how easy it
-# is to use a wand, staff or rod.  In a similar vein, it affects how likely
-# a wand or staff can be recharged without backfiring.  If an object is the
-# base kind for an artifact, an extra out-of-depth check will be imposed when
-# attempting to generate an artifact whose base kind has a level greater than
-# the level assumed for the object generation.  For a chest, the level affects
-# the types of traps the chest may have.
+# is to successfully use a wand, staff or rod.  For an item with an activation,
+# it affects the chance of successfully activating the item.  In a similar
+# vein, it affects how likely a wand or staff can be recharged without
+# backfiring.  For a chest, the level affects the types of traps the chest
+# may have.
 
 # 'weight' is in tenth-pounds.
 

--- a/src/obj-make.c
+++ b/src/obj-make.c
@@ -620,15 +620,6 @@ static struct object *make_artifact_special(int level, int tval)
 		/* Artifact "rarity roll" */
 		if (randint1(100) > art->alloc_prob) continue;
 
-		/* Enforce minimum "object" level (loosely) */
-		if (kind->level > level) {
-			/* Get the "out-of-depth factor" */
-			int d = (kind->level - level) * 5;
-
-			/* Roll for out-of-depth creation */
-			if (randint0(d) != 0) continue;
-		}
-
 		/* Assign the template */
 		new_obj = object_new();
 		object_prep(new_obj, kind, art->alloc_min, RANDOMISE);


### PR DESCRIPTION
…kind's level.  Does make special artifacts more likely to appear out of depth.  Fix comment in object.txt that alluded to that check (and incorrectly said that it applied to all artifacts).