### PR TITLE
In the documentation, use ^ (or Ctrl/ctrl) plus a lowercase letter …

### DIFF
--- a/docs/command.rst
+++ b/docs/command.rst
@@ -63,7 +63,7 @@ Drop an item (``d``)
   traps are considered objects for the purpose of determining if the space 
   is occupied. This command may take a quantity, and takes some energy.
 
-Ignore an item (``k``) or Ignore an item ('^D')
+Ignore an item (``k``) or Ignore an item ('^d')
   This ignores an item in your inventory or on the dungeon floor. If the
   selected pile contains multiple objects, you may specify a quantity. When
   ignored, the game will sometimes prompt you whether to ignore only this
@@ -163,7 +163,7 @@ Rest (``R``)
 Alter Commands
 ==============
 
-Tunnel (``T``) or Tunnel ('^T')
+Tunnel (``T``) or Tunnel ('^t')
   Tunnelling or mining is a very useful art. There are many kinds of rock,
   with varying hardness, including permanent rock (permanent), granite
   (very hard), quartz veins (hard), magma veins (soft), and rubble (very
@@ -467,12 +467,12 @@ List visible items (``]``)
 Message Commands
 ================
 
-Repeat level feeling ('^F')
+Repeat level feeling ('^f')
   Repeats the feeling about the monsters in the dungeon level that you got
   when you first entered the level.  If you have explored enough of the 
   level, you will also get a feeling about how good the treasures are.
 
-View previous messages ('^P')
+View previous messages ('^p')
   This command shows you all the recent messages. You can scroll through
   them, or exit with ESCAPE.
 
@@ -509,13 +509,13 @@ Check knowledge (``~``)
 Saving and Exiting Commands
 ===========================
 
-Save and Quit ('Ctrl-X')
+Save and Quit ('Ctrl-x')
   To save your game so that you can return to it later, use this command.
   Save files will also be generated (hopefully) if the game crashes due to
   a system error. After you die, you can use your savefile to play again
   with the same options and such.
 
-Save ('Ctrl-S')
+Save ('Ctrl-s')
   This command saves the game but doesn't exit Angband. Use this frequently
   if you are paranoid about having your computer crash (or your power go
   out) while you are playing.
@@ -545,7 +545,7 @@ Interact with keymaps - option submenu
 Interact with visuals - option submenu
   Allow you to interact with visuals. You may load or save visuals from
   user pref files, or modify the attr/char mappings for the monsters,
-  objects, and terrain features. You must use the "redraw" command ('^R')
+  objects, and terrain features. You must use the "redraw" command ('^r')
   to redraw the map after changing attr/char mappings. NOTE: It is
   generally easier to modify visuals via the "knowledge" menus.
 
@@ -574,9 +574,9 @@ Identify Symbol (``/``)
 
   There are three special symbols you can use with the Identify Symbol
   command to access specific parts of your monster memory. Typing
-  'Ctrl-A' when asked for a symbol will recall details about all
-  monsters, typing 'Ctrl-U' will recall details about all unique
-  monsters, and typing 'Ctrl-N' will recall details about all non-unique
+  'Ctrl-a' when asked for a symbol will recall details about all
+  monsters, typing 'Ctrl-u' will recall details about all unique
+  monsters, and typing 'Ctrl-n' will recall details about all non-unique
   monsters.
 
   If the character stands for a creature, you are asked if you want to
@@ -594,11 +594,11 @@ Game Version (``V``)
 Extra Commands
 ==============
 
-Toggle Choice Window ('^E')
+Toggle Choice Window ('^e')
   Toggles the display in any sub-windows (if available) which are
   displaying your inventory or equipment.
 
-Redraw Screen ('^R')
+Redraw Screen ('^r')
   This command adapts to various changes in global options, and redraws all
   of the windows. It is normally only necessary in abnormal situations,
   such as after changing the visual attr/char mappings, or enabling
@@ -619,14 +619,14 @@ Certain special keys may be intercepted by the operating system or the host
 machine, causing unexpected results. In general, these special keys are
 control keys, and often, you can disable their special effects.
 
-If you are playing on a UNIX or similar system, then Ctrl-C will interrupt
+If you are playing on a UNIX or similar system, then Ctrl-c will interrupt
 Angband. The second and third interrupt will induce a warning bell, and the
 fourth will induce both a warning bell and a special message, since the
-fifth will quit the game, after killing your character. Also, 'Ctrl-Z'
+fifth will quit the game, after killing your character. Also, 'Ctrl-z'
 will suspend the game, and return you to the original command shell, until
 you resume the game with the 'fg' command. There is now a compilation
 option to force the game to prevent the "double 'ctrl-z' escape death
-trick". The 'Ctrl-\\' and 'Ctrl-D' and 'Ctrl-S' keys should not be
+trick". The 'Ctrl-\\' and 'Ctrl-d' and 'Ctrl-s' keys should not be
 intercepted.
 
 It is often possible to specify "control-keys" without actually pressing

--- a/docs/playing.rst
+++ b/docs/playing.rst
@@ -112,32 +112,32 @@ Original Keyset Command Summary
 ``x``  (unused)                      ``X``  (unused)
 ``y``  (unused)                      ``Y``  (unused)
 ``z``  Zap a rod                     ``Z``  (unused)
-``!``  (unused)                      ``^A`` (special - debug command)
-``@``  (unused)                      ``^B`` (unused)
-``#``  (unused)                      ``^C`` (special - break)
-``$``  (unused)                      ``^D`` (unused)
-``%``  (unused)                      ``^E`` Toggle inven/equip window
-``^``  (special - control key)       ``^F`` Repeat level feeling
-``&``  (unused)                      ``^G`` Do autopickup
-``*``  Target monster or location    ``^H`` (unused)
-``(``  (unused)                      ``^I`` (special - tab)
-``)``  Dump screen to a file         ``^J`` (special - linefeed)
-``{``  Inscribe an object            ``^K`` (unused)
-``}``  Uninscribe an object          ``^L`` Center map
-``[``  Display visible monster list  ``^M`` (special - return)
-``]``  Display visible object list   ``^N`` (unused)
-``-``  (unused)                      ``^O`` Show previous message
-``_``  Enter store                   ``^P`` Show previous messages
-``+``  Alter grid                    ``^Q`` (unused)
-``=``  Set options                   ``^R`` Redraw the screen
-``;``  Walk (with pickup)            ``^S`` Save and don't quit
-``:``  Take notes                    ``^T`` (unused)
-``'``  Target closest monster        ``^U`` (unused)
-``"``  Enter a user pref command     ``^V`` (unused)
-``,``  Stay still (with pickup)      ``^W`` (special - wizard mode)
-``<``  Go up staircase               ``^X`` Save and quit
-``.``  Run                           ``^Y`` (unused)
-``>``  Go down staircase             ``^Z`` (unused)
+``!``  (unused)                      ``^a`` (special - debug command)
+``@``  (unused)                      ``^b`` (unused)
+``#``  (unused)                      ``^c`` (special - break)
+``$``  (unused)                      ``^d`` (unused)
+``%``  (unused)                      ``^e`` Toggle inven/equip window
+``^``  (special - control key)       ``^f`` Repeat level feeling
+``&``  (unused)                      ``^g`` Do autopickup
+``*``  Target monster or location    ``^h`` (unused)
+``(``  (unused)                      ``^i`` (special - tab)
+``)``  Dump screen to a file         ``^j`` (special - linefeed)
+``{``  Inscribe an object            ``^k`` (unused)
+``}``  Uninscribe an object          ``^l`` Center map
+``[``  Display visible monster list  ``^m`` (special - return)
+``]``  Display visible object list   ``^n`` (unused)
+``-``  (unused)                      ``^o`` Show previous message
+``_``  Enter store                   ``^p`` Show previous messages
+``+``  Alter grid                    ``^q`` (unused)
+``=``  Set options                   ``^r`` Redraw the screen
+``;``  Walk (with pickup)            ``^s`` Save and don't quit
+``:``  Take notes                    ``^t`` (unused)
+``'``  Target closest monster        ``^u`` (unused)
+``"``  Enter a user pref command     ``^v`` (unused)
+``,``  Stay still (with pickup)      ``^w`` (special - wizard mode)
+``<``  Go up staircase               ``^x`` Save and quit
+``.``  Run                           ``^y`` (unused)
+``>``  Go down staircase             ``^z`` (unused)
 ``\``  (special - bypass keymap)     ``~``  Check knowledge
  \`    (special - escape)            ``?``  Display help
 ``/``  Identify symbol
@@ -174,32 +174,32 @@ Roguelike Keyset Command Summary
  ``x``  Look around                   ``X``  Use an item
  ``y``  (walk - north west)           ``Y``  (run - north west)
  ``z``  Aim a wand (Zap)              ``Z``  Use a staff (Zap)
- ``!``  (unused)                      ``^A`` (special - debug command)
- ``@``  Center map                    ``^B`` (alter - south west)
- ``#``  (unused)                      ``^C`` (special - break)
- ``$``  (unused)                      ``^D`` Ignore an item
- ``%``  (unused)                      ``^E`` Toggle inven/equip window
- ``^``  (special - control key)       ``^F`` Repeat level feeling
- ``&``  (unused)                      ``^G`` Do autopickup
- ``*``  Target monster or location    ``^H`` (alter - west)
- ``(``  (unused)                      ``^I`` (special - tab)
- ``)``  Dump screen to a file         ``^J`` (alter - south)
- ``{``  Inscribe an object            ``^K`` (alter - north)
- ``}``  Uninscribe an object          ``^L`` (alter - east)
- ``[``  Display visible monster list  ``^M`` (special - return)
- ``]``  Display visible object list   ``^N`` (alter - south east)
- ``-``  Walk into a trap              ``^O`` Show previous message
- ``_``  Enter store                   ``^P`` Show previous messages
- ``+``  Alter grid                    ``^Q`` (unused)
- ``=``  Set options                   ``^R`` Redraw the screen
- ``;``  Walk (with pickup)            ``^S`` Save and don't quit
- ``:``  Take notes                    ``^T`` Dig a tunnel
- ``'``  Target closest monster        ``^U`` (alter - north east)
- ``"``  Enter a user pref command     ``^V`` Repeat previous command
- ``,``  Run                           ``^W`` (special - wizard mode)
- ``<``  Go up staircase               ``^X`` Save and quit
- ``.``  Stay still (with pickup)      ``^Y`` (alter - north west)
- ``>``  Go down staircase             ``^Z`` (unused)
+ ``!``  (unused)                      ``^a`` (special - debug command)
+ ``@``  Center map                    ``^b`` (alter - south west)
+ ``#``  (unused)                      ``^c`` (special - break)
+ ``$``  (unused)                      ``^d`` Ignore an item
+ ``%``  (unused)                      ``^e`` Toggle inven/equip window
+ ``^``  (special - control key)       ``^f`` Repeat level feeling
+ ``&``  (unused)                      ``^g`` Do autopickup
+ ``*``  Target monster or location    ``^h`` (alter - west)
+ ``(``  (unused)                      ``^i`` (special - tab)
+ ``)``  Dump screen to a file         ``^j`` (alter - south)
+ ``{``  Inscribe an object            ``^k`` (alter - north)
+ ``}``  Uninscribe an object          ``^l`` (alter - east)
+ ``[``  Display visible monster list  ``^m`` (special - return)
+ ``]``  Display visible object list   ``^n`` (alter - south east)
+ ``-``  Walk into a trap              ``^o`` Show previous message
+ ``_``  Enter store                   ``^p`` Show previous messages
+ ``+``  Alter grid                    ``^q`` (unused)
+ ``=``  Set options                   ``^r`` Redraw the screen
+ ``;``  Walk (with pickup)            ``^s`` Save and don't quit
+ ``:``  Take notes                    ``^t`` Dig a tunnel
+ ``'``  Target closest monster        ``^u`` (alter - north east)
+ ``"``  Enter a user pref command     ``^v`` Repeat previous command
+ ``,``  Run                           ``^w`` (special - wizard mode)
+ ``<``  Go up staircase               ``^x`` Save and quit
+ ``.``  Stay still (with pickup)      ``^y`` (alter - north west)
+ ``>``  Go down staircase             ``^z`` (unused)
  ``\``  (special - bypass keymap)     ``~``  Check knowledge
   \`    (special - escape)            ``?``  Display help
  ``/``  Identify symbol
@@ -214,14 +214,14 @@ Certain special keys may be intercepted by the operating system or the host
 machine, causing unexpected results. In general, these special keys are
 control keys, and often, you can disable their special effects.
 
-If you are playing on a UNIX or similar system, then 'Ctrl-C' will
+If you are playing on a UNIX or similar system, then 'Ctrl-c' will
 interrupt Angband. The second and third interrupt will induce a warning
 bell, and the fourth will induce both a warning bell and a special message,
 since the fifth will quit the game, after killing your character. Also,
-'Ctrl-Z' will suspend the game, and return you to the original command
+'Ctrl-z' will suspend the game, and return you to the original command
 shell, until you resume the game with the 'fg' command. There is now a
 compilation option to force the game to prevent the "double 'ctrl-z'
-escape death trick". The 'Ctrl-\\' and 'Ctrl-D' and 'Ctrl-S' keys
+escape death trick". The 'Ctrl-\\' and 'Ctrl-d' and 'Ctrl-s' keys
 should not be intercepted.
  
 It is often possible to specify "control-keys" without actually pressing

--- a/lib/help/commands.txt
+++ b/lib/help/commands.txt
@@ -2,6 +2,12 @@
 Original Keyset Command Summary
 ===============================
 
+^ followed by a letter is an abbreviation for pressing and releasing
+the letter key with the control key also depressed.  You may also press
+and release ^ and then press and release the letter key to activate the
+same command in case your system intercepts the control plus key
+combination and does not pass it on.
+
   a    Aim a wand                      A    Activate an object
   b    Browse a book                   B    -
   c    Close a door                    C    Character description
@@ -28,32 +34,32 @@ Original Keyset Command Summary
   x    -                               X    -
   y    -                               Y    -
   z    Zap a rod                       Z    -
-  !    -                               ^A   (special - debug command)
-  @    -                               ^B   -
-  #    -                               ^C   (special - break)
-  $    -                               ^D   -
-  %    -                               ^E   Toggle inven/equip window
-  ^    (special - control key)         ^F   Repeat level feeling
-  &    -                               ^G   Do autopickup
-  *    Target monster or location      ^H   -
-  (    -                               ^I   (special - tab)
-  )    Dump screen to a file           ^J   (special - linefeed)
-  {    Inscribe an object              ^K   -
-  }    Uninscribe an object            ^L   Center map
-  [    Display visible monster list    ^M   (special - return)
-  ]    Display visible object list     ^N   -
-  -    -                               ^O   Show previous message
-  _    Enter store                     ^P   Show previous messages
-  +    Alter grid                      ^Q   -
-  =    Set options                     ^R   Redraw the screen
-  ;    Walk (with pickup)              ^S   Save and don't quit
-  :    Take notes                      ^T   -
-  '    Target closest monster          ^U   -
-  "    Enter a user pref command       ^V   -
-  ,    Stay still (with pickup)        ^W   (special - wizard mode)
-  <    Go up staircase                 ^X   Save and quit
-  .    Run                             ^Y   -
-  >    Go down staircase               ^Z   -
+  !    -                               ^a   (special - debug command)
+  @    -                               ^b   -
+  #    -                               ^c   (special - break)
+  $    -                               ^d   -
+  %    -                               ^e   Toggle inven/equip window
+  ^    (special - control key)         ^f   Repeat level feeling
+  &    -                               ^g   Do autopickup
+  *    Target monster or location      ^h   -
+  (    -                               ^i   (special - tab)
+  )    Dump screen to a file           ^j   (special - linefeed)
+  {    Inscribe an object              ^k   -
+  }    Uninscribe an object            ^l   Center map
+  [    Display visible monster list    ^m   (special - return)
+  ]    Display visible object list     ^n   -
+  -    -                               ^o   Show previous message
+  _    Enter store                     ^p   Show previous messages
+  +    Alter grid                      ^q   -
+  =    Set options                     ^r   Redraw the screen
+  ;    Walk (with pickup)              ^s   Save and don't quit
+  :    Take notes                      ^t   -
+  '    Target closest monster          ^u   -
+  "    Enter a user pref command       ^v   -
+  ,    Stay still (with pickup)        ^w   (special - wizard mode)
+  <    Go up staircase                 ^x   Save and quit
+  .    Run                             ^y   -
+  >    Go down staircase               ^z   -
   \    (special - bypass keymap)        ~   Check knowledge
   `    (special - escape)               ?   Display help
   /    Identify symbol

--- a/lib/help/r_comm.txt
+++ b/lib/help/r_comm.txt
@@ -2,6 +2,12 @@
 Roguelike Keyset Command Summary
 ================================
 
+^ followed by a letter is an abbreviation for pressing and releasing
+the letter key with the control key also depressed.  You may also press
+and release ^ and then press and release the letter key to activate the
+same command in case your system intercepts the control plus key
+combination and does not pass it on.
+
   a    Zap a rod (Activate)            A    Activate an object
   b    (walk - south west)             B    (run - south west)
   c    Close a door                    C    Character description
@@ -28,32 +34,32 @@ Roguelike Keyset Command Summary
   x    Look around                     X    Use an item
   y    (walk - north west)             Y    (run - north west)
   z    Aim a wand (Zap)                Z    Use a staff (Zap)
-  !    -                               ^A   (special - debug command)
-  @    Center map                      ^B   (alter - south west)
-  #    -                               ^C   (special - break)
-  $    -                               ^D   Ignore an item
-  %    -                               ^E   Toggle inven/equip window
-  ^    (special - control key)         ^F   Repeat level feeling
-  &    -                               ^G   Do autopickup
-  *    Target monster or location      ^H   (alter - west)
-  (    -                               ^I   (special - tab)
-  )    Dump screen to a file           ^J   (alter - south)
-  {    Inscribe an object              ^K   (alter - north)
-  }    Uninscribe an object            ^L   (alter - east)
-  [    Display visible monster list    ^M   (special - return)
-  ]    Display visible object list     ^N   (alter - south east)
-  -    Walk into a trap                ^O   Show previous message
-  _    Enter store                     ^P   Show previous messages
-  +    Alter grid (steal for rogues)   ^Q   -
-  =    Set options                     ^R   Redraw the screen
-  ;    Walk (with pickup)              ^S   Save and don't quit
-  :    Take notes                      ^T   Dig a tunnel
-  '    Target closest monster          ^U   (alter - north east)
-  "    Enter a user pref command       ^V   Repeat previous command
-  ,    Run                             ^W   (special - wizard mode)
-  <    Go up staircase                 ^X   Save and quit
-  .    Stay still (with pickup)        ^Y   (alter - north west)
-  >    Go down staircase               ^Z   -
+  !    -                               ^a   (special - debug command)
+  @    Center map                      ^b   (alter - south west)
+  #    -                               ^c   (special - break)
+  $    -                               ^d   Ignore an item
+  %    -                               ^e   Toggle inven/equip window
+  ^    (special - control key)         ^f   Repeat level feeling
+  &    -                               ^g   Do autopickup
+  *    Target monster or location      ^h   (alter - west)
+  (    -                               ^i   (special - tab)
+  )    Dump screen to a file           ^j   (alter - south)
+  {    Inscribe an object              ^k   (alter - north)
+  }    Uninscribe an object            ^l   (alter - east)
+  [    Display visible monster list    ^m   (special - return)
+  ]    Display visible object list     ^n   (alter - south east)
+  -    Walk into a trap                ^o   Show previous message
+  _    Enter store                     ^p   Show previous messages
+  +    Alter grid (steal for rogues)   ^q   -
+  =    Set options                     ^r   Redraw the screen
+  ;    Walk (with pickup)              ^s   Save and don't quit
+  :    Take notes                      ^t   Dig a tunnel
+  '    Target closest monster          ^u   (alter - north east)
+  "    Enter a user pref command       ^v   Repeat previous command
+  ,    Run                             ^w   (special - wizard mode)
+  <    Go up staircase                 ^x   Save and quit
+  .    Stay still (with pickup)        ^y   (alter - north west)
+  >    Go down staircase               ^z   -
   \    (special - bypass keymap)       ~    Check knowledge
   `    (special - escape)              ?    Display help
   /    Identify symbol


### PR DESCRIPTION
…since at least one context, the curses interface on Cygwin, doesn't recognize control plus an uppercase letter (the native Windows interface, native Mac interface, and the X11, curses, SDL, and SDL2 interfaces on Linux treat control + lowercase and control + uppercase the same).  Resolves https://github.com/angband/angband/issues/5299 .