### PR TITLE
Check for formats supported by SDL mixer.  Remove duplicated call to …

### DIFF
--- a/src/sound-core.c
+++ b/src/sound-core.c
@@ -352,9 +352,6 @@ errr init_sound(const char *soundstr, int argc, char **argv)
 	if (!hooks.open_audio_hook)
 		return 1;
 
-	if (!hooks.open_audio_hook())
-		return 1;
-
 	/* Enable sound */
 	event_add_handler(EVENT_SOUND, play_sound, NULL);
 


### PR DESCRIPTION
…the open_audio_hook in init_sound().  Attempts to mitigate https://github.com/angband/angband/issues/5313 (file descriptors left open by SDL when the mixer does not support the MP3 format).