### PR TITLE
When targeting, display information on remembered objects when blind.…

### DIFF
--- a/src/ui-target.c
+++ b/src/ui-target.c
@@ -359,7 +359,8 @@ static bool aux_reinit(struct chunk *c, struct player *p,
 		auxst->phrase2 = "on ";
 	} else {
 		/* Default */
-		auxst->phrase1 = "You see ";
+		auxst->phrase1 = (square_isseen(c, auxst->grid)) ?
+			"You see " : "You recall ";
 		auxst->phrase2 = "";
 	}
 
@@ -671,8 +672,7 @@ static bool aux_object(struct chunk *c, struct player *p,
 
 	/* Scan all sensed objects in the grid */
 	floor_num = scan_distant_floor(floor_list, floor_max, p, auxst->grid);
-	if (floor_num <= 0 || (p->timed[TMD_BLIND]
-			&& !loc_eq(auxst->grid, p->grid))) {
+	if (floor_num <= 0) {
 		mem_free(floor_list);
 		return result;
 	}


### PR DESCRIPTION
…  Change message from "You see" to "You recall" when targeting if the grid in question is not seen.  Resolves robinjohnson's report, http://angband.oook.cz/forum/showthread.php?t=11171 .