### PR TITLE
Fix up handling of the SDL/SDL2 prefix when configuring

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -184,14 +184,14 @@ AC_ARG_ENABLE(sdl2test, [AS_HELP_STRING([--disable-sdl2test], [do not try to com
   if test "$SDL2_CONFIG" = "no" ; then
     no_sdl2=yes
   else
-    SDL2_CFLAGS=`$SDL2_CONFIG $sdl2conf_args --cflags`
-    SDL2_LIBS=`$SDL2_CONFIG $sdl2conf_args --libs`
+    SDL2_CFLAGS=`$SDL2_CONFIG $sdl2_args --cflags`
+    SDL2_LIBS=`$SDL2_CONFIG $sdl2_args --libs`
 
     sdl2_major_version=`$SDL2_CONFIG $sdl2_args --version | \
            sed 's/\([[0-9]]*\).\([[0-9]]*\).\([[0-9]]*\)/\1/'`
     sdl2_minor_version=`$SDL2_CONFIG $sdl2_args --version | \
            sed 's/\([[0-9]]*\).\([[0-9]]*\).\([[0-9]]*\)/\2/'`
-    sdl2_micro_version=`$SDL2_CONFIG $sdl2_config_args --version | \
+    sdl2_micro_version=`$SDL2_CONFIG $sdl2_args --version | \
            sed 's/\([[0-9]]*\).\([[0-9]]*\).\([[0-9]]*\)/\3/'`
     if test "x$enable_sdl2test" = "xyes" ; then
       ac_save_CFLAGS="$CFLAGS"
@@ -351,14 +351,14 @@ AC_ARG_ENABLE(sdltest, [AS_HELP_STRING([--disable-sdltest], [do not try to compi
   if test "$SDL_CONFIG" = "no" ; then
     no_sdl=yes
   else
-    SDL_CFLAGS=`$SDL_CONFIG $sdlconf_args --cflags`
-    SDL_LIBS=`$SDL_CONFIG $sdlconf_args --libs`
+    SDL_CFLAGS=`$SDL_CONFIG $sdl_args --cflags`
+    SDL_LIBS=`$SDL_CONFIG $sdl_args --libs`
 
     sdl_major_version=`$SDL_CONFIG $sdl_args --version | \
            sed 's/\([[0-9]]*\).\([[0-9]]*\).\([[0-9]]*\)/\1/'`
     sdl_minor_version=`$SDL_CONFIG $sdl_args --version | \
            sed 's/\([[0-9]]*\).\([[0-9]]*\).\([[0-9]]*\)/\2/'`
-    sdl_micro_version=`$SDL_CONFIG $sdl_config_args --version | \
+    sdl_micro_version=`$SDL_CONFIG $sdl_args --version | \
            sed 's/\([[0-9]]*\).\([[0-9]]*\).\([[0-9]]*\)/\3/'`
     if test "x$enable_sdltest" = "xyes" ; then
       ac_save_CFLAGS="$CFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -371,9 +371,7 @@ if test "$enable_sdl2" = "yes" || test "$enable_sdl2_mixer" = "yes"; then
 	if test "$SDL2_CONFIG" != "no"; then
 		hold_CPPFLAGS="${CPPFLAGS}"
 		hold_LIBS="${LIBS}"
-		SDL2_CFLAGS=`${SDL2_CONFIG} --cflags`
 		CPPFLAGS="${CPPFLAGS} ${SDL2_CFLAGS}"
-		SDL2_LIBS=`${SDL2_CONFIG} --libs`
 		LIBS="${LIBS} ${SDL2_LIBS}"
 		if test "$enable_sdl2" = "yes"; then
 			AC_CHECK_LIB(SDL2_image, IMG_LoadPNG_RW, with_sdl2=yes, with_sdl2=no)
@@ -418,9 +416,7 @@ if test "$enable_sdl" = "yes" || test "$enable_sdl_mixer" = "yes"; then
 	if test "$SDL_CONFIG" != "no"; then
 		hold_CPPFLAGS="${CPPFLAGS}"
 		hold_LIBS="${LIBS}"
-		SDL_CFLAGS=`${SDL_CONFIG} --cflags`
 		CPPFLAGS="${CPPFLAGS} ${SDL_CFLAGS}"
-		SDL_LIBS=`${SDL_CONFIG} --libs`
 		LIBS="${LIBS} ${SDL_LIBS}"
 		if test "$enable_sdl" = "yes"; then
 			AC_CHECK_LIB(SDL_image, IMG_LoadPNG_RW, with_sdl=yes, with_sdl=no)


### PR DESCRIPTION
I'm not sure how I missed upstreaming this fix during my original PR, so here is the second part.