### PR TITLE
Move logic for bookkeeping after a player's move from move_player() …

### DIFF
--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -1058,89 +1058,51 @@ void move_player(int dir, bool disarm)
 			else
 				msgt(MSG_HITWALL, "There is a wall blocking your way.");
 		}
-	} else if (square_isdamaging(cave, grid)) {
-		/* Some terrain can damage the player */
-		bool step = true;
-		struct feature *feat = square_feat(cave, grid);
-		int dam_taken = player_check_terrain_damage(player, grid);
-
-		/* Check if running, or going to cost more than a third of hp */
-		if (player->upkeep->running && dam_taken) {
-			if (!get_check(feat->run_msg)) {
-				player->upkeep->running = 0;
-				step = false;
-			}
-		} else {
-			if (dam_taken > player->chp / 3) {
-				step = get_check(feat->walk_msg);
-			}
-		}
-
-		/* Enter if OK or confirmed. */
-		if (step) {
-			/* Move player */
-			monster_swap(player->grid, grid);
-
-			/* Update view and search */
-			update_view(cave, player);
-			search(player);
-		}
 	} else {
 		/* See if trap detection status will change */
 		bool old_dtrap = square_isdtrap(cave, player->grid);
 		bool new_dtrap = square_isdtrap(cave, grid);
+		bool step = true;
 
 		/* Note the change in the detect status */
 		if (old_dtrap != new_dtrap)
 			player->upkeep->redraw |= (PR_DTRAP);
 
 		/* Disturb player if the player is about to leave the area */
-		if (player->upkeep->running && !player->upkeep->running_firststep &&
-			old_dtrap && !new_dtrap) {
+		if (player->upkeep->running
+				&& !player->upkeep->running_firststep
+				&& old_dtrap && !new_dtrap) {
 			disturb(player);
 			return;
 		}
 
-		/* Trap immune player learns that they are */
-		if (trap && player_of_has(player, OF_TRAP_IMMUNE)) {
-			equip_learn_flag(player, OF_TRAP_IMMUNE);
-		}
+		if (square_isdamaging(cave, grid)) {
+			/* Some terrain can damage the player */
+			struct feature *feat = square_feat(cave, grid);
+			int dam_taken =
+				player_check_terrain_damage(player, grid);
 
-		/* Move player */
-		monster_swap(player->grid, grid);
-
-		/* Handle store doors, or notice objects */
-		if (square_isshop(cave, grid)) {
-			if (player_is_shapechanged(player)) {
-				if (store_at(cave, grid)->sidx != STORE_HOME) {
-					msg("There is a scream and the door slams shut!");
+			/*
+			 * Check if running, or going to cost more than a
+			 * third of hp.
+			 */
+			if (player->upkeep->running && dam_taken) {
+				if (!get_check(feat->run_msg)) {
+					player->upkeep->running = 0;
+					step = false;
 				}
-				return;
+			} else {
+				if (dam_taken > player->chp / 3) {
+					step = get_check(feat->walk_msg);
+				}
 			}
-			disturb(player);
-			event_signal(EVENT_ENTER_STORE);
-			event_remove_handler_type(EVENT_ENTER_STORE);
-			event_signal(EVENT_USE_STORE);
-			event_remove_handler_type(EVENT_USE_STORE);
-			event_signal(EVENT_LEAVE_STORE);
-			event_remove_handler_type(EVENT_LEAVE_STORE);
-		} else {
-			square_know_pile(cave, grid);
-			cmdq_push(CMD_AUTOPICKUP);
 		}
 
-		/* Discover invisible traps, set off visible ones */
-		if (square_issecrettrap(cave, grid)) {
-			disturb(player);
-			hit_trap(grid, 0);
-		} else if (square_isdisarmabletrap(cave, grid) && !trapsafe) {
-			disturb(player);
-			hit_trap(grid, 0);
+		if (step) {
+			/* Move player */
+			monster_swap(player->grid, grid);
+			player_handle_post_move(player, true);
 		}
-
-		/* Update view and search */
-		update_view(cave, player);
-		search(player);
 	}
 
 	player->upkeep->running_firststep = false;

--- a/src/effect-handler-attack.c
+++ b/src/effect-handler-attack.c
@@ -1429,6 +1429,7 @@ bool effect_handler_EARTHQUAKE(effect_handler_context_t *context)
 
 			/* Move player */
 			monster_swap(pgrid, safe_grid);
+			player_handle_post_move(player, true);
 		}
 
 		/* Take some damage */
@@ -1682,6 +1683,7 @@ bool effect_handler_JUMP_AND_BITE(effect_handler_context_t *context)
 
 	/* Move player */
 	monster_swap(player->grid, grid);
+	player_handle_post_move(player, true);
 
 	/* Now bite it */
 	drain = MIN(mon->hp, amount);

--- a/src/effect-handler-general.c
+++ b/src/effect-handler-general.c
@@ -2510,8 +2510,11 @@ bool effect_handler_TELEPORT(effect_handler_context_t *context)
 	/* Sound */
 	sound(is_player ? MSG_TELEPORT : MSG_TPOTHER);
 
-	/* Move player */
+	/* Move player or monster */
 	monster_swap(start, spots->grid);
+	if (is_player) {
+		player_handle_post_move(player, true);
+	}
 
 	/* Clear any projection marker to prevent double processing */
 	sqinfo_off(square(cave, spots->grid)->info, SQUARE_PROJECT);
@@ -2548,6 +2551,7 @@ bool effect_handler_TELEPORT_TO(effect_handler_context_t *context)
 	int dis = 0, ctr = 0, dir = DIR_TARGET;
 	struct monster *t_mon = monster_target_monster(context);
 	bool dim_door = false;
+	bool player_moves = false;
 
 	context->ident = true;
 
@@ -2574,6 +2578,7 @@ bool effect_handler_TELEPORT_TO(effect_handler_context_t *context)
 		}
 
 		/* Player being teleported */
+		player_moves = true;
 		start = player->grid;
 
 		/* Check for a no teleport grid */
@@ -2643,6 +2648,9 @@ bool effect_handler_TELEPORT_TO(effect_handler_context_t *context)
 
 	/* Move player or monster */
 	monster_swap(start, land);
+	if (player_moves) {
+		player_handle_post_move(player, true);
+	}
 
 	/* Cancel target if necessary */
 	if (dim_door) {

--- a/src/player-util.h
+++ b/src/player-util.h
@@ -113,6 +113,7 @@ bool player_of_has(struct player *p, int flag);
 bool player_resists(struct player *p, int element);
 bool player_is_immune(struct player *p, int element);
 void player_place(struct chunk *c, struct player *p, struct loc grid);
+void player_handle_post_move(struct player *p, bool eval_trap);
 void disturb(struct player *p);
 void search(struct player *p);
 

--- a/src/project-mon.c
+++ b/src/project-mon.c
@@ -30,6 +30,7 @@
 #include "mon-timed.h"
 #include "mon-util.h"
 #include "player-calcs.h"
+#include "player-util.h"
 #include "project.h"
 #include "source.h"
 
@@ -180,6 +181,10 @@ void thrust_away(struct loc centre, struct loc target, int grids_away)
 				if (square_ispassable(cave, next)) {
 					/* Travel down the path. */
 					monster_swap(grid, next);
+					if (square(cave, grid)->mon < 0) {
+						player_handle_post_move(
+							player, true);
+					}
 
 					/* Jump to new location. */
 					grid = next;
@@ -201,6 +206,9 @@ void thrust_away(struct loc centre, struct loc target, int grids_away)
 			} else {
 				/* Travel down the path. */
 				monster_swap(grid, next);
+				if (square(cave, grid)->mon < 0) {
+					player_handle_post_move(player, true);
+				}
 
 				/* Jump to new location. */
 				grid = next;

--- a/src/trap.c
+++ b/src/trap.c
@@ -566,8 +566,15 @@ extern void hit_trap(struct loc grid, int delayed)
 				player->depth, 1));
 
 		/* Some traps drop you onto them */
-		if (trf_has(trap->kind->flags, TRF_PIT))
+		if (trf_has(trap->kind->flags, TRF_PIT)
+				&& !loc_eq(player->grid, trap->grid)) {
 			monster_swap(player->grid, trap->grid);
+			/*
+			 * Don't retrigger the trap, but handle the
+			 * other side effects of moving the player.
+			 */
+			player_handle_post_move(player, false);
+		}
 
 		/* Some traps disappear after activating, all have a chance to */
 		if (trf_has(trap->kind->flags, TRF_ONETIME) || one_in_(3)) {


### PR DESCRIPTION
…to player_handle_post_move() in player-util.c so it can be called in other cases when the player moves, mostly teleports.  Resolves robinjohnson's report, http://angband.oook.cz/forum/showthread.php?t=11184 , of objects not being touched in the grid landed on after casting "vampire strike".  In move_player() merge the code path handling damaging terrain with the main path so the trap detection area is handled the same for both paths.