### PR TITLE
Refactor the square_apparent_*() calls since, as is, they were not …

### DIFF
--- a/src/cave-square.c
+++ b/src/cave-square.c
@@ -1412,23 +1412,50 @@ int square_digging(struct chunk *c, struct loc grid) {
 	return 0;
 }
 
-const char *square_apparent_name(struct chunk *c, struct player *p, struct loc grid) {
-	int actual = square(player->cave, grid)->feat;
+/*
+ * Return the name for the terrain in a grid.  Accounts for the fact that
+ * some terrain mimics another terrain.
+ *
+ * \param c Is the chunk to use.  Usually it is the player's version of the
+ * chunk.
+ * \param grid Is the grid to use.
+ */
+const char *square_apparent_name(struct chunk *c, struct loc grid) {
+	int actual = square(c, grid)->feat;
 	char *mimic_name = f_info[actual].mimic;
 	int f = mimic_name ? lookup_feat(mimic_name) : actual;
 	return f_info[f].name;
 }
 
-const char *square_apparent_look_prefix(struct chunk *c, struct player *p, struct loc grid) {
-	int actual = square(player->cave, grid)->feat;
+/*
+ * Return the prefix, appropriate for describing looking at the grid in
+ * question, for the name returned by square_name().
+ *
+ * \param c Is the chunk to use.  Usually it is the player's version of the
+ * chunk.
+ * \param grid Is the grid to use.
+ *
+ * The prefix is usually an indefinite article.  It may be an empty string.
+ */
+const char *square_apparent_look_prefix(struct chunk *c, struct loc grid) {
+	int actual = square(c, grid)->feat;
 	char *mimic_name = f_info[actual].mimic;
 	int f = mimic_name ? lookup_feat(mimic_name) : actual;
 	return (f_info[f].look_prefix) ? f_info[f].look_prefix :
 		(is_a_vowel(f_info[f].name[0]) ? "an " : "a ");
 }
 
-const char *square_apparent_look_in_preposition(struct chunk *c, struct player *p, struct loc grid) {
-	int actual = square(player->cave, grid)->feat;
+/*
+ * Return a preposition, appropriate for describing the grid the viewer is on,
+ * for the name returned by square_name().  May return an empty string when
+ * the name doesn't require a preposition.
+ *
+ * \param c Is the chunk to use.  Usually it is the player's version of the
+ * chunk.
+ * \param grid Is the grid to use.
+ */
+const char *square_apparent_look_in_preposition(struct chunk *c, struct loc grid) {
+	int actual = square(c, grid)->feat;
 	char *mimic_name = f_info[actual].mimic;
 	int f = mimic_name ? lookup_feat(mimic_name) : actual;
 	return (f_info[f].look_in_preposition) ?

--- a/src/cave.h
+++ b/src/cave.h
@@ -434,9 +434,9 @@ void square_force_floor(struct chunk *c, struct loc grid);
 
 int square_shopnum(struct chunk *c, struct loc grid);
 int square_digging(struct chunk *c, struct loc grid);
-const char *square_apparent_name(struct chunk *c, struct player *p, struct loc grid);
-const char *square_apparent_look_prefix(struct chunk *c, struct player *p, struct loc grid);
-const char *square_apparent_look_in_preposition(struct chunk *c, struct player *p, struct loc grid);
+const char *square_apparent_name(struct chunk *c, struct loc grid);
+const char *square_apparent_look_prefix(struct chunk *c, struct loc grid);
+const char *square_apparent_look_in_preposition(struct chunk *c, struct loc grid);
 
 void square_memorize(struct chunk *c, struct loc grid);
 void square_forget(struct chunk *c, struct loc grid);

--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -587,7 +587,7 @@ static bool do_cmd_tunnel_aux(struct loc grid)
 			msg("You dig in the rubble.");
 		else
 			msg("You tunnel into the %s.",
-				square_apparent_name(cave, player, grid));
+				square_apparent_name(player->cave, grid));
 		more = true;
 	} else {
 		/* Don't automatically repeat if there's no hope. */
@@ -595,7 +595,7 @@ static bool do_cmd_tunnel_aux(struct loc grid)
 			msg("You dig in the rubble with little effect.");
 		} else {
 			msg("You chip away futilely at the %s.",
-				square_apparent_name(cave, player, grid));
+				square_apparent_name(player->cave, grid));
 		}
 	}
 

--- a/src/ui-context.c
+++ b/src/ui-context.c
@@ -533,8 +533,8 @@ int context_menu_cave(struct chunk *c, int y, int x, int adjacent, int mx,
 				   o_name), 0, 0);
 	} else {
 		/* Feature (apply mimic) */
-		const char *name = square_apparent_name(c, player, grid);
-		const char *prefix = square_apparent_look_prefix(c, player, grid);
+		const char *name = square_apparent_name(player->cave, grid);
+		const char *prefix = square_apparent_look_prefix(player->cave, grid);
 
 		prt(format("(Enter to select command, ESC to cancel) You see %s%s:", prefix, name), 0, 0);
 	}

--- a/src/ui-target.c
+++ b/src/ui-target.c
@@ -800,16 +800,16 @@ static bool aux_terrain(struct chunk *c, struct player *p,
 		return false;
 
 	/* Terrain feature if needed */
-	name = square_apparent_name(c, p, auxst->grid);
+	name = square_apparent_name(p->cave, auxst->grid);
 
 	/* Hack -- handle unknown grids */
 
 	/* Pick a preposition if needed */
 	lphrase2 = (*auxst->phrase2) ?
-		square_apparent_look_in_preposition(c, p, auxst->grid) : "";
+		square_apparent_look_in_preposition(p->cave, auxst->grid) : "";
 
 	/* Pick prefix for the name */
-	lphrase3 = square_apparent_look_prefix(c, p, auxst->grid);
+	lphrase3 = square_apparent_look_prefix(p->cave, auxst->grid);
 
 	/* Display a message */
 	if (p->wizard) {


### PR DESCRIPTION
…using the chunk or player arguments.  Drop the player argument and, when typically calling those functions, pass the player's chunk as the chunk.  Related to https://github.com/angband/angband/issues/4934 .