### PR TITLE
Only identify teleport away/scare/dispel/sleep/turn effects if the …

### DIFF
--- a/src/project-mon.c
+++ b/src/project-mon.c
@@ -400,11 +400,11 @@ static void project_monster_teleport_away(project_monster_handler_context_t *con
 		context->teleport_distance = context->dam;
 		context->hurt_msg = MON_MSG_DISAPPEAR;
 		monster_wake(context->mon, false, 100);
+		if (context->seen) context->obvious = true;
 	} else {
 		context->skipped = true;
 	}
 
-	context->obvious = true;
 	context->dam = 0;
 }
 
@@ -420,16 +420,17 @@ static void project_monster_teleport_away(project_monster_handler_context_t *con
  */
 static void project_monster_scare(project_monster_handler_context_t *context, int flag)
 {
-    if (context->seen) rf_on(context->lore->flags, flag);
+	if (context->seen) rf_on(context->lore->flags, flag);
 
 	if (rf_has(context->mon->race->flags, flag)) {
-        context->mon_timed[MON_TMD_FEAR] = adjust_radius(context, context->dam);
+		context->mon_timed[MON_TMD_FEAR] =
+			adjust_radius(context, context->dam);
 		monster_wake(context->mon, false, 100);
+		if (context->seen) context->obvious = true;
 	} else {
 		context->skipped = true;
 	}
 
-	context->obvious = true;
 	context->dam = 0;
 }
 
@@ -451,12 +452,11 @@ static void project_monster_dispel(project_monster_handler_context_t *context, i
 	if (rf_has(context->mon->race->flags, flag)) {
 		context->hurt_msg = MON_MSG_SHUDDER;
 		context->die_msg = MON_MSG_DISSOLVE;
+		if (context->seen) context->obvious = true;
 	} else {
 		context->skipped = true;
 		context->dam = 0;
 	}
-
-	context->obvious = true;
 }
 
 /**
@@ -484,9 +484,9 @@ static void project_monster_sleep(project_monster_handler_context_t *context, in
 		context->dam += context->dam / 2;
 	}
 	context->mon_timed[MON_TMD_SLEEP] = context->dam;
+	if (context->dam > 0 && context->seen) context->obvious = true;
 	context->dam = 0;
 
-	context->obvious = true;
 }
 
 /* Acid */
@@ -818,18 +818,19 @@ static void project_monster_handler_TURN_EVIL(project_monster_handler_context_t 
 /* Turn living (Use "dam" as "power") */
 static void project_monster_handler_TURN_LIVING(project_monster_handler_context_t *context)
 {
-    if (context->seen) {
+	if (context->seen) {
 		rf_on(context->lore->flags, RF_NONLIVING);
 		rf_on(context->lore->flags, RF_UNDEAD);
 	}
 
 	if (monster_is_living(context->mon)) {
-        context->mon_timed[MON_TMD_FEAR] = adjust_radius(context, context->dam);
+		context->mon_timed[MON_TMD_FEAR] =
+			adjust_radius(context, context->dam);
+		if (context->seen) context->obvious = true;
 	} else {
 		context->skipped = true;
 	}
 
-	context->obvious = true;
 	context->dam = 0;
 }
 
@@ -1222,7 +1223,7 @@ static void project_m_apply_side_effects(project_monster_handler_context_t *cont
 							  i,
 							  context->mon_timed[i],
 							  context->flag | MON_TMD_FLG_NOTIFY);
-				context->obvious = true;
+				if (context->seen) context->obvious = true;
 			}
 		}
 	}


### PR DESCRIPTION
…affected monster is seen.  Add a message ("You have/see ...") for newly identified items that aren't single-use items.  Resolves https://github.com/angband/angband/issues/5319 .