### PR TITLE
Have square_digging() return the dig field in the feature structure …

### DIFF
--- a/src/cave-square.c
+++ b/src/cave-square.c
@@ -1407,7 +1407,7 @@ int square_shopnum(struct chunk *c, struct loc grid) {
 }
 
 int square_digging(struct chunk *c, struct loc grid) {
-	if (square_isdiggable(c, grid))
+	if (square_isdiggable(c, grid) || square_iscloseddoor(cave, grid))
 		return f_info[square(c, grid)->feat].dig;
 	return 0;
 }


### PR DESCRIPTION
…for closed doors since terrain.txt and do_cmd_tunnel_test() allow tunneling of closed doors.  Avoids a crash in do_cmd_tunnel_aux() if a closed door is tunneled and the application has been compiled with address sanitization.