### PR TITLE
Suppress "You have ..." message for artifact jewelry when all …

### DIFF
--- a/src/obj-knowledge.c
+++ b/src/obj-knowledge.c
@@ -1123,7 +1123,7 @@ void player_know_object(struct player *p, struct object *obj)
 	}
 
 	if (object_non_curse_runes_known(obj) && tval_is_jewelry(obj)) {
-		seen = obj->kind->everseen;
+		seen = (obj->artifact) ? true : obj->kind->everseen;
 		object_flavor_aware(p, obj);
 	}
 


### PR DESCRIPTION
…non-curse runes are none.  Resolves https://github.com/angband/angband/issues/5339 and gives the same messaging for those artifacts as for non-jewelry artifacts.  Retain setting everseen on those artifacts so the behavior of object_flavor_is_aware() stays the same for jewelry artifacts.