### PR TITLE
Comment the confusing p, mon, t_mon members of struct melee_effect_handler_context_s

### DIFF
--- a/src/mon-blows.h
+++ b/src/mon-blows.h
@@ -52,9 +52,9 @@ extern struct blow_method *blow_methods;
  * any initializers. Ideally, this should eventually used named initializers.
  */
 typedef struct melee_effect_handler_context_s {
-	struct player * const p;
-	struct monster * const mon;
-	struct monster * const t_mon;
+	struct player * const p;	/* Target (if player) */
+	struct monster * const mon;	/* Attacker */
+	struct monster * const t_mon;	/* Target (if other monster) */
 	const int rlev;
 	const struct blow_method *method;
 	const int ac;


### PR DESCRIPTION
Maybe these struct members are obvious to experienced angband devs, but for some reason confused me (regarding what was attacker, what was target) :)