### PR TITLE
Don't disturb player for changes in timed effects whose source is a player action and,

### DIFF
--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -1550,7 +1550,7 @@ void do_cmd_mon_command(struct command *cmd)
 		case CMD_READ_SCROLL: {
 			/* Actually 'r'elease monster */
 			mon_clear_timed(mon, MON_TMD_COMMAND, MON_TMD_FLG_NOTIFY);
-			player_clear_timed(player, TMD_COMMAND, true);
+			player_clear_timed(player, TMD_COMMAND, true, false);
 			break;
 		}
 		case CMD_CAST: {

--- a/src/cmd-wizard.c
+++ b/src/cmd-wizard.c
@@ -951,19 +951,19 @@ void do_cmd_wiz_cure_all(struct command *cmd)
 	player->csp_frac = 0;
 
 	/* Cure stuff */
-	(void) player_clear_timed(player, TMD_BLIND, true);
-	(void) player_clear_timed(player, TMD_CONFUSED, true);
-	(void) player_clear_timed(player, TMD_POISONED, true);
-	(void) player_clear_timed(player, TMD_AFRAID, true);
-	(void) player_clear_timed(player, TMD_PARALYZED, true);
-	(void) player_clear_timed(player, TMD_IMAGE, true);
-	(void) player_clear_timed(player, TMD_STUN, true);
-	(void) player_clear_timed(player, TMD_CUT, true);
-	(void) player_clear_timed(player, TMD_SLOW, true);
-	(void) player_clear_timed(player, TMD_AMNESIA, true);
+	(void) player_clear_timed(player, TMD_BLIND, true, false);
+	(void) player_clear_timed(player, TMD_CONFUSED, true, false);
+	(void) player_clear_timed(player, TMD_POISONED, true, false);
+	(void) player_clear_timed(player, TMD_AFRAID, true, false);
+	(void) player_clear_timed(player, TMD_PARALYZED, true, false);
+	(void) player_clear_timed(player, TMD_IMAGE, true, false);
+	(void) player_clear_timed(player, TMD_STUN, true, false);
+	(void) player_clear_timed(player, TMD_CUT, true, false);
+	(void) player_clear_timed(player, TMD_SLOW, true, false);
+	(void) player_clear_timed(player, TMD_AMNESIA, true, false);
 
 	/* No longer hungry */
-	player_set_timed(player, TMD_FOOD, PY_FOOD_FULL - 1, false);
+	player_set_timed(player, TMD_FOOD, PY_FOOD_FULL - 1, false, false);
 
 	/* Flag what needs to be updated or redrawn */
 	player->upkeep->update |= PU_TORCH | PU_UPDATE_VIEW | PU_MONSTERS;

--- a/src/effect-handler-attack.c
+++ b/src/effect-handler-attack.c
@@ -1240,15 +1240,15 @@ bool effect_handler_DESTRUCTION(effect_handler_context_t *context)
 		msg("There is a searing blast of light!");
 		equip_learn_element(player, ELEM_LIGHT);
 		if (!player_resists(player, ELEM_LIGHT)) {
-			(void)player_inc_timed(player, TMD_BLIND, 10 + randint1(10), true,
-								   true);
+			(void)player_inc_timed(player, TMD_BLIND,
+				10 + randint1(10), true, true, true);
 		}
 	} else if (elem == ELEM_DARK) {
 		msg("Darkness seems to crush you!");
 		equip_learn_element(player, ELEM_DARK);
 		if (!player_resists(player, ELEM_DARK)) {
-			(void)player_inc_timed(player, TMD_BLIND, 10 + randint1(10), true,
-								   true);
+			(void)player_inc_timed(player, TMD_BLIND,
+				10 + randint1(10), true, true, true);
 		}
 	}
 
@@ -1414,15 +1414,15 @@ bool effect_handler_EARTHQUAKE(effect_handler_context_t *context)
 				case 2: {
 					msg("You are bashed by rubble!");
 					damage = damroll(10, 4);
-					(void)player_inc_timed(player, TMD_STUN, randint1(50),
-										   true, true);
+					(void)player_inc_timed(player, TMD_STUN,
+						randint1(50), true, true, true);
 					break;
 				}
 				case 3: {
 					msg("You are crushed between the floor and ceiling!");
 					damage = damroll(10, 4);
-					(void)player_inc_timed(player, TMD_STUN, randint1(50),
-										   true, true);
+					(void)player_inc_timed(player, TMD_STUN,
+						randint1(50), true, true, true);
 					break;
 				}
 			}
@@ -1698,7 +1698,7 @@ bool effect_handler_JUMP_AND_BITE(effect_handler_context_t *context)
 	/* Heal and nourish */
 	effect_simple(EF_HEAL_HP, context->origin, format("%d", drain), 0, 0, 0,
 				  0, 0, NULL);
-	player_inc_timed(player, TMD_FOOD, drain, false, false);
+	player_inc_timed(player, TMD_FOOD, drain, false, false, false);
 
 	if (dead) {
 		/* Cancel the targeting of the dead creature. */

--- a/src/effect-handler-general.c
+++ b/src/effect-handler-general.c
@@ -1303,9 +1303,6 @@ bool effect_handler_DETECT_TRAPS(effect_handler_context_t *context)
 					/* Know the trap */
 					obj->known->pval = obj->pval;
 
-					/* Notice it */
-					disturb(player);
-
 					/* We found something to detect */
 					detect = true;
 				}

--- a/src/effect-handler-general.c
+++ b/src/effect-handler-general.c
@@ -441,21 +441,27 @@ bool effect_handler_NOURISH(effect_handler_context_t *context)
 	amount *= z_info->food_value;
 	if (context->subtype == 0) {
 		/* Increase food level by amount */
-		player_inc_timed(player, TMD_FOOD, MAX(amount, 0), false, false);
+		player_inc_timed(player, TMD_FOOD, MAX(amount, 0), false,
+			context->origin.what != SRC_PLAYER || !context->aware,
+			false);
 	} else if (context->subtype == 1) {
 		/* Decrease food level by amount */
-		player_dec_timed(player, TMD_FOOD, MAX(amount, 0), false);
+		player_dec_timed(player, TMD_FOOD, MAX(amount, 0), false,
+			context->origin.what != SRC_PLAYER || !context->aware);
 	} else if (context->subtype == 2) {
 		/* Set food level to amount, vomiting if necessary */
 		bool message = player->timed[TMD_FOOD] > amount;
 		if (message) {
 			msg("You vomit!");
 		}
-		player_set_timed(player, TMD_FOOD, MAX(amount, 0), false);
+		player_set_timed(player, TMD_FOOD, MAX(amount, 0), false,
+			context->origin.what != SRC_PLAYER || !context->aware);
 	} else if (context->subtype == 3) {
 		/* Increase food level to amount if needed */
 		if (player->timed[TMD_FOOD] < amount) {
-			player_set_timed(player, TMD_FOOD, MAX(amount + 1, 0), false);
+			player_set_timed(player, TMD_FOOD, MAX(amount + 1, 0),
+				false, context->origin.what != SRC_PLAYER
+				|| !context->aware);
 		}
 	} else {
 		return false;
@@ -480,7 +486,8 @@ bool effect_handler_CRUNCH(effect_handler_context_t *context)
 bool effect_handler_CURE(effect_handler_context_t *context)
 {
 	int type = context->subtype;
-	(void) player_clear_timed(player, type, true);
+	(void) player_clear_timed(player, type, true,
+		context->origin.what != SRC_PLAYER || !context->aware);
 	context->ident = true;
 	return true;
 }
@@ -491,7 +498,8 @@ bool effect_handler_CURE(effect_handler_context_t *context)
 bool effect_handler_TIMED_SET(effect_handler_context_t *context)
 {
 	int amount = effect_calculate_value(context, false);
-	player_set_timed(player, context->subtype, MAX(amount, 0), true);
+	player_set_timed(player, context->subtype, MAX(amount, 0), true,
+		context->origin.what != SRC_PLAYER || !context->aware);
 	context->ident = true;
 	return true;
 
@@ -557,9 +565,13 @@ bool effect_handler_TIMED_INC(effect_handler_context_t *context)
 	}
 
 	if (!player->timed[context->subtype] || !context->other) {
-		player_inc_timed(player, context->subtype, MAX(amount, 0), true, true);
+		player_inc_timed(player, context->subtype, MAX(amount, 0), true,
+			context->origin.what != SRC_PLAYER || !context->aware,
+			true);
 	} else {
-		player_inc_timed(player, context->subtype, context->other, true, true);
+		player_inc_timed(player, context->subtype, context->other, true,
+			context->origin.what != SRC_PLAYER || !context->aware,
+			true);
 	}
 	return true;
 }
@@ -574,9 +586,14 @@ bool effect_handler_TIMED_INC_NO_RES(effect_handler_context_t *context)
 	int amount = effect_calculate_value(context, false);
 
 	if (!player->timed[context->subtype] || !context->other)
-		player_inc_timed(player, context->subtype, MAX(amount, 0), true, false);
+		player_inc_timed(player, context->subtype, MAX(amount, 0),
+			true,
+			context->origin.what != SRC_PLAYER || !context->aware,
+			false);
 	else
-		player_inc_timed(player, context->subtype, context->other, true, false);
+		player_inc_timed(player, context->subtype, context->other, true,
+			context->origin.what != SRC_PLAYER || !context->aware,
+			false);
 	context->ident = true;
 	return true;
 }
@@ -608,7 +625,8 @@ bool effect_handler_TIMED_DEC(effect_handler_context_t *context)
 	int amount = effect_calculate_value(context, false);
 	if (context->other)
 		amount = player->timed[context->subtype] / context->other;
-	(void) player_dec_timed(player, context->subtype, MAX(amount, 0), true);
+	(void) player_dec_timed(player, context->subtype, MAX(amount, 0), true,
+		context->origin.what != SRC_PLAYER || !context->aware);
 	context->ident = true;
 	return true;
 }
@@ -2923,7 +2941,8 @@ bool effect_handler_DARKEN_AREA(effect_handler_context_t *context)
 	/* Hack - blind the player directly if player-cast */
 	if (context->origin.what == SRC_PLAYER &&
 		!player_resists(player, ELEM_DARK)) {
-		(void)player_inc_timed(player, TMD_BLIND, 3 + randint1(5), true, true);
+		(void)player_inc_timed(player, TMD_BLIND, 3 + randint1(5),
+			true, !context->aware, true);
 	}
 
 	/* Assume seen */
@@ -3249,7 +3268,9 @@ bool effect_handler_TAP_DEVICE(effect_handler_context_t *context)
 
 			msg("You feel your head clear.");
 			used = true;
-			player_inc_timed(player, TMD_STUN, randint1(2), true, true);
+			player_inc_timed(player, TMD_STUN, randint1(2), true,
+				context->origin.what != SRC_PLAYER
+				|| !context->aware, true);
 
 			player->upkeep->redraw |= (PR_MANA);
 		} else {
@@ -3321,7 +3342,7 @@ bool effect_handler_COMMAND(effect_handler_context_t *context)
 	}
 
 	/* Player is commanding */
-	player_set_timed(player, TMD_COMMAND, MAX(amount, 0), false);
+	player_set_timed(player, TMD_COMMAND, MAX(amount, 0), false, false);
 
 	/* Monster is commanded */
 	mon_inc_timed(mon, MON_TMD_COMMAND, MAX(amount, 0), 0);

--- a/src/game-world.c
+++ b/src/game-world.c
@@ -327,7 +327,8 @@ static void decrease_timeouts(void)
 				if (!los(cave, player->grid, mon->grid)) {
 					/* Out of sight is out of mind */
 					mon_clear_timed(mon, MON_TMD_COMMAND, MON_TMD_FLG_NOTIFY);
-					player_clear_timed(player, TMD_COMMAND, true);
+					player_clear_timed(player, TMD_COMMAND,
+						true, true);
 				} else {
 					/* Keep monster timer aligned */
 					mon_dec_timed(mon, MON_TMD_COMMAND, decr, 0);
@@ -336,7 +337,7 @@ static void decrease_timeouts(void)
 			}
 		}
 		/* Decrement the effect */
-		player_dec_timed(player, i, decr, false);
+		player_dec_timed(player, i, decr, false, true);
 	}
 
 	/* Curse effects always decrement by 1 */
@@ -658,19 +659,22 @@ void process_world(struct chunk *c)
 			if (i < 1) i = 1;
 
 			/* Digest some food */
-			player_dec_timed(player, TMD_FOOD, i, false);
+			player_dec_timed(player, TMD_FOOD, i, false, true);
 		}
 
 		/* Fast metabolism */
 		if (player->timed[TMD_HEAL]) {
-			player_dec_timed(player, TMD_FOOD, 8 * z_info->food_value, false);
+			player_dec_timed(player, TMD_FOOD,
+				8 * z_info->food_value, false, true);
 			if (player->timed[TMD_FOOD] < PY_FOOD_HUNGRY) {
-				player_set_timed(player, TMD_HEAL, 0, true);
+				player_set_timed(player, TMD_HEAL, 0, true,
+					true);
 			}
 		}
 	} else {
 		/* Digest quickly when gorged */
-		player_dec_timed(player, TMD_FOOD, 5000 / z_info->food_value, false);
+		player_dec_timed(player, TMD_FOOD, 5000 / z_info->food_value,
+			false, true);
 		player->upkeep->update |= PU_BONUS;
 	}
 
@@ -683,8 +687,8 @@ void process_world(struct chunk *c)
 			disturb(player);
 
 			/* Faint (bypass free action) */
-			(void)player_inc_timed(player, TMD_PARALYZED, 1 + randint0(5),
-								   true, false);
+			(void)player_inc_timed(player, TMD_PARALYZED,
+				1 + randint0(5), true, true, false);
 		}
 	} else if (player_timed_grade_eq(player, TMD_FOOD, "Starving")) {
 		/* Calculate damage */
@@ -1011,7 +1015,7 @@ void on_new_level(void)
  */
 static void on_leave_level(void) {
 	/* Cancel any command */
-	player_clear_timed(player, TMD_COMMAND, false);
+	player_clear_timed(player, TMD_COMMAND, false, false);
 
 	/* Don't allow command repeat if moved away from item used. */
 	cmd_disable_repeat_floor_item();

--- a/src/mon-attack.c
+++ b/src/mon-attack.c
@@ -705,7 +705,10 @@ bool make_attack_normal(struct monster *mon, struct player *p)
 				}
 
 				/* Apply the cut */
-				if (amt) (void)player_inc_timed(p, TMD_CUT, amt, true, true);
+				if (amt) {
+					(void)player_inc_timed(p, TMD_CUT, amt,
+						true, true, true);
+				}
 			}
 
 			/* Handle stun */
@@ -726,8 +729,10 @@ bool make_attack_normal(struct monster *mon, struct player *p)
 				}
 
 				/* Apply the stun */
-				if (amt)
-					(void)player_inc_timed(p, TMD_STUN, amt, true, true);
+				if (amt) {
+					(void)player_inc_timed(p, TMD_STUN, amt,
+						true, true, true);
+				}
 			}
 
 			string_free(act);

--- a/src/mon-blows.c
+++ b/src/mon-blows.c
@@ -465,7 +465,8 @@ static void melee_effect_timed(melee_effect_handler_context_t *context,
 		context->obvious = true;
 	} else {
 		/* Increase timer for type. */
-		if (player_inc_timed(context->p, type, amount, true, true)) {
+		if (player_inc_timed(context->p, type, amount, true, true,
+				true)) {
 			context->obvious = true;
 		}
 
@@ -579,9 +580,10 @@ static void melee_effect_handler_POISON(melee_effect_handler_context_t *context)
 		return;
 
 	/* Take "poison" effect */
-	if (player_inc_timed(context->p, TMD_POISONED, 5 + randint1(context->rlev),
-						 true, true))
+	if (player_inc_timed(context->p, TMD_POISONED,
+			5 + randint1(context->rlev), true, true, true)) {
 		context->obvious = true;
+	}
 
 	/* Learn about the player */
 	update_smart_learn(context->mon, context->p, 0, 0, ELEM_POIS);
@@ -1057,8 +1059,8 @@ static void melee_effect_handler_HALLU(melee_effect_handler_context_t *context)
 	if (monster_damage_target(context, true)) return;
 
 	/* Increase "image" */
-	if (player_inc_timed(context->p, TMD_IMAGE, 3 + randint1(context->rlev / 2),
-						 true, true))
+	if (player_inc_timed(context->p, TMD_IMAGE,
+			3 + randint1(context->rlev / 2), true, true, true))
 		context->obvious = true;
 
 	/* Learn about the player */
@@ -1077,8 +1079,9 @@ static void melee_effect_handler_BLACK_BREATH(melee_effect_handler_context_t *co
 
 	/* Increase Black Breath counter a *small* amount, maybe */
 	if (one_in_(5) && player_inc_timed(context->p, TMD_BLACKBREATH,
-									   context->damage / 10, true, false))
+			context->damage / 10, true, true, false)) {
 		context->obvious = true;
+	}
 }
 
 /**

--- a/src/mon-make.c
+++ b/src/mon-make.c
@@ -343,7 +343,7 @@ void delete_monster_idx(int m_idx)
 
 	/* Hack -- remove any command status */
 	if (mon->m_timed[MON_TMD_COMMAND]) {
-		(void) player_clear_timed(player, TMD_COMMAND, true);
+		(void) player_clear_timed(player, TMD_COMMAND, true, true);
 	}
 
 	/* Monster is gone from square and group */

--- a/src/mon-util.c
+++ b/src/mon-util.c
@@ -1110,7 +1110,7 @@ static void player_kill_monster(struct monster *mon, struct player *p,
 
 	/* Bloodlust bonus */
 	if (p->timed[TMD_BLOODLUST]) {
-		player_inc_timed(p, TMD_BLOODLUST, 10, false, false);
+		player_inc_timed(p, TMD_BLOODLUST, 10, false, false, true);
 		player_over_exert(p, PY_EXERT_CONF, 5, 3);
 		player_over_exert(p, PY_EXERT_HALLU, 5, 10);
 	}
@@ -1529,7 +1529,8 @@ void steal_monster_item(struct monster *mon, int midx)
 			msg("You vanish into the shadows!");
 			effect_simple(EF_TELEPORT, source_player(), near, 0, 0, 0, 0, 0,
 						  NULL);
-			(void) player_clear_timed(player, TMD_ATT_RUN, false);
+			(void) player_clear_timed(player, TMD_ATT_RUN, false,
+				false);
 		}
 	} else {
 		/* Get the thief details */

--- a/src/player-attack.c
+++ b/src/player-attack.c
@@ -645,7 +645,7 @@ static void blow_side_effects(struct player *p, struct monster *mon)
 {
 	/* Confusion attack */
 	if (p->timed[TMD_ATT_CONF]) {
-		player_clear_timed(p, TMD_ATT_CONF, true);
+		player_clear_timed(p, TMD_ATT_CONF, true, false);
 
 		mon_inc_timed(mon, MON_TMD_CONF, (10 + randint0(p->lev) / 10),
 					  MON_TMD_FLG_NOTIFY);
@@ -1187,7 +1187,7 @@ static void ranged_helper(struct player *p,	struct object *obj, int dir,
 
 	/* Terminate piercing */
 	if (p->timed[TMD_POWERSHOT]) {
-		player_clear_timed(p, TMD_POWERSHOT, true);
+		player_clear_timed(p, TMD_POWERSHOT, true, false);
 	}
 
 	/* Drop (or break) near that location */

--- a/src/player-timed.h
+++ b/src/player-timed.h
@@ -92,11 +92,14 @@ extern struct timed_effect_data timed_effects[TMD_MAX];
 
 int timed_name_to_idx(const char *name);
 bool player_timed_grade_eq(struct player *p, int idx, const char *match);
-bool player_set_timed(struct player *p, int idx, int v, bool notify);
+bool player_set_timed(struct player *p, int idx, int v, bool notify,
+	bool can_disturb);
 bool player_inc_check(struct player *p, int idx, bool lore);
 bool player_inc_timed(struct player *p, int idx, int v, bool notify,
-					  bool check);
-bool player_dec_timed(struct player *p, int idx, int v, bool notify);
-bool player_clear_timed(struct player *p, int idx, bool notify);
+	bool can_disturb, bool check);
+bool player_dec_timed(struct player *p, int idx, int v, bool notify,
+	bool can_disturb);
+bool player_clear_timed(struct player *p, int idx, bool notify,
+	bool can_disturb);
 
 #endif /* !PLAYER_TIMED_H */

--- a/src/player-util.c
+++ b/src/player-util.c
@@ -734,16 +734,16 @@ void player_over_exert(struct player *p, int flag, int chance, int amount)
 			msg("You faint from the effort!");
 
 			/* Bypass free action */
-			(void)player_inc_timed(p, TMD_PARALYZED, randint1(amount),
-								   true, false);
+			(void)player_inc_timed(p, TMD_PARALYZED,
+				randint1(amount), true, true, false);
 		}
 	}
 
 	/* Scrambled stats */
 	if (flag & PY_EXERT_SCRAMBLE) {
 		if (randint0(100) < chance) {
-			(void)player_inc_timed(p, TMD_SCRAMBLE, randint1(amount),
-								   true, true);
+			(void)player_inc_timed(p, TMD_SCRAMBLE,
+				randint1(amount), true, true, true);
 		}
 	}
 
@@ -752,15 +752,15 @@ void player_over_exert(struct player *p, int flag, int chance, int amount)
 		if (randint0(100) < chance) {
 			msg("Wounds appear on your body!");
 			(void)player_inc_timed(p, TMD_CUT, randint1(amount),
-								   true, false);
+				true, true, false);
 		}
 	}
 
 	/* Confusion */
 	if (flag & PY_EXERT_CONF) {
 		if (randint0(100) < chance) {
-			(void)player_inc_timed(p, TMD_CONFUSED, randint1(amount),
-								   true, true);
+			(void)player_inc_timed(p, TMD_CONFUSED,
+				randint1(amount), true, true, true);
 		}
 	}
 
@@ -768,7 +768,7 @@ void player_over_exert(struct player *p, int flag, int chance, int amount)
 	if (flag & PY_EXERT_HALLU) {
 		if (randint0(100) < chance) {
 			(void)player_inc_timed(p, TMD_IMAGE, randint1(amount),
-								   true, true);
+				true, true, true);
 		}
 	}
 
@@ -777,7 +777,7 @@ void player_over_exert(struct player *p, int flag, int chance, int amount)
 		if (randint0(100) < chance) {
 			msg("You feel suddenly lethargic.");
 			(void)player_inc_timed(p, TMD_SLOW, randint1(amount),
-								   true, false);
+				true, true, false);
 		}
 	}
 
@@ -919,7 +919,7 @@ void player_resume_normal_shape(struct player *p)
 	msg("You resume your usual shape.");
 
 	/* Kill vampire attack */
-	(void) player_clear_timed(p, TMD_ATT_VAMP, true);
+	(void) player_clear_timed(p, TMD_ATT_VAMP, true, false);
 
 	/* Update */
 	p->upkeep->update |= (PU_BONUS);

--- a/src/project-player.c
+++ b/src/project-player.c
@@ -169,13 +169,15 @@ static int project_player_handler_FIRE(project_player_handler_context_t *context
 		}
 		if (randint0(context->dam) > 500) {
 			if (player_inc_timed(player, TMD_BLIND,
-								 randint1(context->dam / 100), true, true)) {
+					randint1(context->dam / 100), true,
+					true, true)) {
 				msg("Your eyes fill with smoke!");
 			}
 		}
 		if (randint0(context->dam) > 500) {
 			if (player_inc_timed(player, TMD_POISONED,
-								 randint1(context->dam / 10), true, true)) {
+					randint1(context->dam / 10), true,
+					true, true)) {
 				msg("You are assailed by poisonous fumes!");
 			}
 		}
@@ -213,8 +215,9 @@ static int project_player_handler_POIS(project_player_handler_context_t *context
 	int xtra = 0;
 
 	if (!player_inc_timed(player, TMD_POISONED, 10 + randint1(context->dam),
-						  true, true))
+			true, true, true)) {
 		msg("You resist the effect!");
+	}
 
 	/* Occasional side-effects for powerful poison attacks */
 	if (context->power >= 60) {
@@ -244,13 +247,14 @@ static int project_player_handler_LIGHT(project_player_handler_context_t *contex
 		return 0;
 	}
 
-	(void)player_inc_timed(player, TMD_BLIND, 2 + randint1(5), true, true);
+	(void)player_inc_timed(player, TMD_BLIND, 2 + randint1(5), true, true,
+		true);
 
 	/* Confusion for strong unresisted light */
 	if (context->dam > 300) {
 		msg("You are dazzled!");
 		(void)player_inc_timed(player, TMD_CONFUSED,
-							   2 + randint1(context->dam / 100), true, true);
+			2 + randint1(context->dam / 100), true, true, true);
 	}
 	return 0;
 }
@@ -262,7 +266,8 @@ static int project_player_handler_DARK(project_player_handler_context_t *context
 		return 0;
 	}
 
-	(void)player_inc_timed(player, TMD_BLIND, 2 + randint1(5), true, true);
+	(void)player_inc_timed(player, TMD_BLIND, 2 + randint1(5), true, true,
+		true);
 
 	/* Unresisted dark from powerful monsters is bad news */
 	if (context->power >= 70) {
@@ -280,15 +285,15 @@ static int project_player_handler_DARK(project_player_handler_context_t *context
 		/* Slowing */
 		if (randint0(context->dam) > 200) {
 			msg("You feel unsure of yourself in the darkness.");
-			(void)player_inc_timed(player, TMD_SLOW, context->dam / 100, true,
-								   false);
+			(void)player_inc_timed(player, TMD_SLOW,
+				context->dam / 100, true, true, false);
 		}
 
 		/* Amnesia */
 		if (randint0(context->dam) > 300) {
 			msg("Darkness penetrates your mind!");
-			(void)player_inc_timed(player, TMD_AMNESIA, context->dam / 100,
-								   true, false);
+			(void)player_inc_timed(player, TMD_AMNESIA,
+				context->dam / 100, true, true, false);
 		}
 	}
 	return 0;
@@ -305,7 +310,8 @@ static int project_player_handler_SOUND(project_player_handler_context_t *contex
 	if (!player_of_has(player, OF_PROT_STUN)) {
 		int duration = 5 + randint1(context->dam / 3);
 		if (duration > 35) duration = 35;
-		(void)player_inc_timed(player, TMD_STUN, duration, true, true);
+		(void)player_inc_timed(player, TMD_STUN, duration, true, true,
+			true);
 	} else {
 		equip_learn_flag(player, OF_PROT_STUN);
 	}
@@ -314,7 +320,7 @@ static int project_player_handler_SOUND(project_player_handler_context_t *contex
 	if (context->dam > 300) {
 		msg("The noise disorients you.");
 		(void)player_inc_timed(player, TMD_CONFUSED,
-							   2 + randint1(context->dam / 100), true, true);
+			2 + randint1(context->dam / 100), true, true, true);
 	}
 	return 0;
 }
@@ -328,7 +334,7 @@ static int project_player_handler_SHARD(project_player_handler_context_t *contex
 
 	/* Cuts */
 	(void)player_inc_timed(player, TMD_CUT, randint1(context->dam), true,
-						   false);
+		true, false);
 	return 0;
 }
 
@@ -348,7 +354,8 @@ static int project_player_handler_NEXUS(project_player_handler_context_t *contex
 	if (randint0(100) < player->state.skills[SKILL_SAVE]) {
 		msg("You avoid the effect!");
 	} else {
-		player_inc_timed(player, TMD_SCRAMBLE, randint0(20) + 20, true, true);
+		player_inc_timed(player, TMD_SCRAMBLE, randint0(20) + 20, true,
+			true, true);
 	}
 
 	if (one_in_(3) && mon) { /* Teleport to */
@@ -409,10 +416,12 @@ static int project_player_handler_CHAOS(project_player_handler_context_t *contex
 	}
 
 	/* Hallucination */
-	(void)player_inc_timed(player, TMD_IMAGE, randint1(10), true, false);
+	(void)player_inc_timed(player, TMD_IMAGE, randint1(10), true, true,
+		false);
 
 	/* Confusion */
-	(void)player_inc_timed(player, TMD_CONFUSED, 10 + randint0(20), true, true);
+	(void)player_inc_timed(player, TMD_CONFUSED, 10 + randint0(20), true,
+		true, true);
 
 	/* Life draining */
 	if (!player_of_has(player, OF_HOLD_LIFE)) {
@@ -440,10 +449,12 @@ static int project_player_handler_DISEN(project_player_handler_context_t *contex
 static int project_player_handler_WATER(project_player_handler_context_t *context)
 {
 	/* Confusion */
-	(void)player_inc_timed(player, TMD_CONFUSED, 5 + randint1(5), true, true);
+	(void)player_inc_timed(player, TMD_CONFUSED, 5 + randint1(5), true,
+		true, true);
 
 	/* Stun */
-	(void)player_inc_timed(player, TMD_STUN, randint1(40), true, true);
+	(void)player_inc_timed(player, TMD_STUN, randint1(40), true, true,
+		true);
 	return 0;
 }
 
@@ -453,13 +464,16 @@ static int project_player_handler_ICE(project_player_handler_context_t *context)
 		inven_damage(player, PROJ_COLD, MIN(context->dam * 5, 300));
 
 	/* Cuts */
-	if (!player_resists(player, ELEM_SHARD))
-		(void)player_inc_timed(player, TMD_CUT, damroll(5, 8), true, false);
-	else
+	if (!player_resists(player, ELEM_SHARD)) {
+		(void)player_inc_timed(player, TMD_CUT, damroll(5, 8), true,
+			true, false);
+	} else {
 		msg("You resist the effect!");
+	}
 
 	/* Stun */
-	(void)player_inc_timed(player, TMD_STUN, randint1(15), true, true);
+	(void)player_inc_timed(player, TMD_STUN, randint1(15), true, true,
+		true);
 	return 0;
 }
 
@@ -474,13 +488,15 @@ static int project_player_handler_GRAVITY(project_player_handler_context_t *cont
 	}
 
 	/* Slow */
-	(void)player_inc_timed(player, TMD_SLOW, 4 + randint0(4), true, false);
+	(void)player_inc_timed(player, TMD_SLOW, 4 + randint0(4), true, true,
+		false);
 
 	/* Stun */
 	if (!player_of_has(player, OF_PROT_STUN)) {
 		int duration = 5 + randint1(context->dam / 3);
 		if (duration > 35) duration = 35;
-		(void)player_inc_timed(player, TMD_STUN, duration, true, true);
+		(void)player_inc_timed(player, TMD_STUN, duration, true, true,
+			true);
 	} else {
 		equip_learn_flag(player, OF_PROT_STUN);
 	}
@@ -490,7 +506,8 @@ static int project_player_handler_GRAVITY(project_player_handler_context_t *cont
 static int project_player_handler_INERTIA(project_player_handler_context_t *context)
 {
 	/* Slow */
-	(void)player_inc_timed(player, TMD_SLOW, 4 + randint0(4), true, false);
+	(void)player_inc_timed(player, TMD_SLOW, 4 + randint0(4), true, true,
+		false);
 	return 0;
 }
 
@@ -505,7 +522,8 @@ static int project_player_handler_FORCE(project_player_handler_context_t *contex
 	}
 
 	/* Stun */
-	(void)player_inc_timed(player, TMD_STUN, randint1(20), true, true);
+	(void)player_inc_timed(player, TMD_STUN, randint1(20), true, true,
+		true);
 
 	/* Thrust player away. */
 	thrust_away(centre, context->grid, 3 + context->dam / 20);
@@ -539,7 +557,8 @@ static int project_player_handler_PLASMA(project_player_handler_context_t *conte
 	if (!player_of_has(player, OF_PROT_STUN)) {
 		int duration = 5 + randint1(context->dam * 3 / 4);
 		if (duration > 35) duration = 35;
-		(void)player_inc_timed(player, TMD_STUN, duration, true, true);
+		(void)player_inc_timed(player, TMD_STUN, duration, true, true,
+			true);
 	} else {
 		equip_learn_flag(player, OF_PROT_STUN);
 	}
@@ -585,7 +604,8 @@ static int project_player_handler_DARK_WEAK(project_player_handler_context_t *co
 		return 0;
 	}
 
-	(void)player_inc_timed(player, TMD_BLIND, 3 + randint1(5), true, true);
+	(void)player_inc_timed(player, TMD_BLIND, 3 + randint1(5), true, true,
+		true);
 	return 0;
 }
 

--- a/src/tests/effects/chain.c
+++ b/src/tests/effects/chain.c
@@ -224,7 +224,7 @@ static int test_random2_execute(void *state) {
 
 	if (ec) {
 		restore_to_full_health();
-		player_clear_timed(player, TMD_BOLD, false);
+		player_clear_timed(player, TMD_BOLD, false, false);
 		completed = effect_do(ec, source_player(), NULL, &ident, true,
 			0, 0, false, NULL);
 		free_effect(ec);
@@ -279,7 +279,7 @@ static int test_random_stats(void *state) {
 
 			if (i >= nsim) break;
 			restore_to_full_health();
-			player_clear_timed(player, TMD_BOLD, false);
+			player_clear_timed(player, TMD_BOLD, false, false);
 			completed = effect_do(ec, source_player(), NULL,
 				&ident, true, 0, 0, false, NULL);
 			if (!completed) break;
@@ -324,7 +324,7 @@ static int test_nested_random_execute(void *state) {
 
 	if (ec) {
 		restore_to_full_health();
-		player_clear_timed(player, TMD_BOLD, false);
+		player_clear_timed(player, TMD_BOLD, false, false);
 		completed = effect_do(ec, source_player(), NULL, &ident, true,
 			0, 0, false, NULL);
 		free_effect(ec);
@@ -422,7 +422,7 @@ static int test_select2_execute(void *state) {
 		struct command cmd;
 
 		restore_to_full_health();
-		player_clear_timed(player, TMD_BOLD, false);
+		player_clear_timed(player, TMD_BOLD, false, false);
 		memset(&cmd, 0, sizeof(cmd));
 		cmd_set_arg_choice(&cmd, "list_index", choice);
 		completed = effect_do(ec, source_player(), NULL, &ident, true,
@@ -487,7 +487,7 @@ static int test_nested_select_execute(void *state) {
 
 	if (ec) {
 		restore_to_full_health();
-		player_clear_timed(player, TMD_BOLD, false);
+		player_clear_timed(player, TMD_BOLD, false, false);
 		completed = effect_do(ec, source_player(), NULL, &ident, true,
 			0, 0, false, NULL);
 		free_effect(ec);

--- a/src/tests/object/slays.c
+++ b/src/tests/object/slays.c
@@ -281,7 +281,7 @@ static bool set_temporary_brand(struct player *p, int idx)
 	int tmd_idx = brand_index_to_timed_index(idx);
 
 	if (tmd_idx < 0) return false;
-	(void) player_set_timed(player, tmd_idx, 100, false);
+	(void) player_set_timed(player, tmd_idx, 100, false, false);
 	return true;
 }
 
@@ -290,7 +290,7 @@ static bool clear_temporary_brand(struct player *p, int idx)
 	int tmd_idx = brand_index_to_timed_index(idx);
 
 	if (tmd_idx < 0) return false;
-	(void) player_clear_timed(player, tmd_idx, false);
+	(void) player_clear_timed(player, tmd_idx, false, false);
 	return true;
 }
 
@@ -310,7 +310,7 @@ static bool set_temporary_slay(struct player *p, int idx)
 	int tmd_idx = slay_index_to_timed_index(idx);
 
 	if (tmd_idx < 0) return false;
-	(void) player_set_timed(player, tmd_idx, 100, false);
+	(void) player_set_timed(player, tmd_idx, 100, false, false);
 	return true;
 }
 
@@ -319,7 +319,7 @@ static bool clear_temporary_slay(struct player *p, int idx)
 	int tmd_idx = slay_index_to_timed_index(idx);
 
 	if (tmd_idx < 0) return false;
-	(void) player_clear_timed(player, tmd_idx, false);
+	(void) player_clear_timed(player, tmd_idx, false, false);
 	return true;
 }
 

--- a/src/wiz-debug.c
+++ b/src/wiz-debug.c
@@ -40,17 +40,17 @@ void wiz_cheat_death(void)
 	player->csp_frac = 0;
 
 	/* Healing */
-	(void)player_clear_timed(player, TMD_BLIND, true);
-	(void)player_clear_timed(player, TMD_CONFUSED, true);
-	(void)player_clear_timed(player, TMD_POISONED, true);
-	(void)player_clear_timed(player, TMD_AFRAID, true);
-	(void)player_clear_timed(player, TMD_PARALYZED, true);
-	(void)player_clear_timed(player, TMD_IMAGE, true);
-	(void)player_clear_timed(player, TMD_STUN, true);
-	(void)player_clear_timed(player, TMD_CUT, true);
+	(void)player_clear_timed(player, TMD_BLIND, true, false);
+	(void)player_clear_timed(player, TMD_CONFUSED, true, false);
+	(void)player_clear_timed(player, TMD_POISONED, true, false);
+	(void)player_clear_timed(player, TMD_AFRAID, true, false);
+	(void)player_clear_timed(player, TMD_PARALYZED, true, false);
+	(void)player_clear_timed(player, TMD_IMAGE, true, false);
+	(void)player_clear_timed(player, TMD_STUN, true, false);
+	(void)player_clear_timed(player, TMD_CUT, true, false);
 
 	/* Prevent starvation */
-	player_set_timed(player, TMD_FOOD, PY_FOOD_MAX - 1, false);
+	player_set_timed(player, TMD_FOOD, PY_FOOD_MAX - 1, false, false);
 
 	/* Cancel recall */
 	if (player->word_recall)


### PR DESCRIPTION
if using an object is involved, the object is identified.  Resolves https://github.com/angband/angband/issues/5360 .  See also this post, http://angband.oook.cz/forum/showpost.php?p=150444&postcount=148 .  Alters the prototypes for player_set_timed(), player_inc_timed(), player_dec_timed(), and player_clear_timed().  For related reasons, also don't disturb the player when a chest trap is detected.

The messaging from a keymap with chained commands can be suboptimal.  A paladin with a keymap to cast Bless and Heroism will see "You feel like a hero!" on the top line of the main window if both spells are successfully cast.  Both spell messages are in the message log, but, because of multiple message_flush() calls during the process of menu display for the commands, the messages won't be concatenated on the top line.  If firing a keymap could directly fill the command queue rather than pushing keystrokes into the input buffer, that could be avoided.  That would require a degree of introspection (presumably from the array of cmd_info structures in ui-game.c) not currently available into each command's arguments and the order they're requested.