### PR TITLE
Factor in player trap immunity for failed attempts to disable chest …

### DIFF
--- a/src/obj-chest.c
+++ b/src/obj-chest.c
@@ -716,8 +716,13 @@ bool do_cmd_disarm_chest(struct object *obj)
 		msg("You failed to disarm the chest.");
 	} else {
 		/* Failure -- Set off the trap */
-		msg("You set off a trap!");
-		chest_trap(obj);
+		if (!player_is_trapsafe(player)) {
+			msg("You set off a trap!");
+			chest_trap(obj);
+		} else if (player_of_has(player, OF_TRAP_IMMUNE)) {
+			/* Learn trap immunity. */
+			equip_learn_flag(player, OF_TRAP_IMMUNE);
+		}
 	}
 
 	/* Result */


### PR DESCRIPTION
…traps.  That's for consistency with how floor traps are handled, how trap immunity is used when opening chests, and in response to the discussion starting with this post, http://angband.oook.cz/forum/showpost.php?p=158389&postcount=107 .