### PR TITLE
Fix effects info for SHORT_BEAM length

### DIFF
--- a/src/effects-info.c
+++ b/src/effects-info.c
@@ -510,7 +510,7 @@ textblock *effect_describe(const struct effect *e, const char *prefix,
 			strnfmt(desc, sizeof(desc), edesc,
 				projections[e->subtype].player_desc,
 				e->radius +
-					(e->other ? e->other / player->lev : 0),
+					(e->other ? player->lev / e->other : 0),
 				dice_string);
 			break;
 


### PR DESCRIPTION
This fixes the info text for short beam effects, matching the length calculation in `effect_handler_SHORT_BEAM`:

```
bool effect_handler_SHORT_BEAM(effect_handler_context_t *context)
{
...
	int rad = context->radius + (addons ? player->lev / context->other : 0);
```