### PR TITLE
Since left bitwise shift and overflow of signed integers can give …

### DIFF
--- a/src/main-sdl2.c
+++ b/src/main-sdl2.c
@@ -2297,7 +2297,8 @@ static void handle_menu_purpose(struct window *window,
 	{
 		elems[num_elems].caption = window_flag_desc[num_elems];
 		elems[num_elems].data.value.term_flag_value.subwindow = subwindow;
-		elems[num_elems].data.value.term_flag_value.flag = 1L << num_elems;
+		elems[num_elems].data.value.term_flag_value.flag =
+			((uint32_t) 1) << num_elems;
 		elems[num_elems].data.type = BUTTON_DATA_TERM_FLAG;
 		elems[num_elems].on_render = render_button_menu_pw;
 		elems[num_elems].on_menu = handle_menu_pw;

--- a/src/main-x11.c
+++ b/src/main-x11.c
@@ -597,7 +597,7 @@ static unsigned int xkb_mask_modifier( XkbDescPtr xkb, const char *name )
 		modStr = XGetAtomName( xkb->dpy, xkb->names->vmods[i] );
 		if (modStr) {
 			if (streq(name, modStr))
-				XkbVirtualModsToReal( xkb, 1 << i, &mask );
+				XkbVirtualModsToReal( xkb, 1U << i, &mask );
 
 			XFree(modStr);
 		}

--- a/src/mon-move.c
+++ b/src/mon-move.c
@@ -1716,8 +1716,8 @@ static bool monster_check_active(struct monster *mon)
 static void monster_reduce_sleep(struct monster *mon)
 {
 	int stealth = player->state.skills[SKILL_STEALTH];
-	int player_noise = 1 << (30 - stealth);
-	int notice = randint0(1024);
+	uint32_t player_noise = ((uint32_t) 1) << (30 - stealth);
+	uint32_t notice = (uint32_t) randint0(1024);
 	struct monster_lore *lore = get_lore(mon->race);
 
 	/* Aggravation */

--- a/src/player-attack.c
+++ b/src/player-attack.c
@@ -972,7 +972,7 @@ void py_attack(struct player *p, struct loc grid)
 
 	/* Reward BGs with 5% of max SPs, min 1/2 point */
 	if (player_has(p, PF_COMBAT_REGEN)) {
-		int32_t sp_gain = (int32_t)(MAX(p->msp, 10) << 16) / 20;
+		int32_t sp_gain = (((int32_t)MAX(p->msp, 10)) * 16384) / 5;
 		player_adjust_mana_precise(p, sp_gain);
 	}
 

--- a/src/player-util.c
+++ b/src/player-util.c
@@ -187,7 +187,7 @@ void take_hit(struct player *p, int dam, const char *kb_str)
 	if (player_has(p, PF_COMBAT_REGEN)  && !streq(kb_str, "poison")
 		&& !streq(kb_str, "a fatal wound") && !streq(kb_str, "starvation")) {
 		/* lose X% of hitpoints get X% of spell points */
-		int32_t sp_gain = (MAX((int32_t)p->msp, 10) << 16)
+		int32_t sp_gain = (((int32_t)MAX(p->msp, 10)) * 65536)
 			/ (int32_t)p->mhp * dam;
 		player_adjust_mana_precise(p, sp_gain);
 	}
@@ -420,7 +420,7 @@ void player_regen_mana(struct player *p)
 
 	/* SP degen heals BGs at double efficiency vs casting */
 	if (sp_gain < 0  && player_has(p, PF_COMBAT_REGEN)) {
-		convert_mana_to_hp(p, -sp_gain << 2);
+		convert_mana_to_hp(p, -sp_gain * 2);
 	}
 
 	/* Notice changes */
@@ -435,14 +435,15 @@ void player_adjust_hp_precise(struct player *p, int32_t hp_gain)
 {
 	int16_t old_16 = p->chp;
 	/* Load it all into 4 byte format */
-	int32_t old_32 = (((int32_t) old_16) << 16) + p->chp_frac;
-	int32_t new_32 = old_32 + hp_gain;
+	int32_t old_32 = ((int32_t) old_16) * 65536 + p->chp_frac, new_32;
 
 	/* Check for overflow */
-	if (new_32 < old_32 && hp_gain > 0) {
-		new_32 = INT32_MAX;
-	} else if (new_32 > old_32 && hp_gain < 0) {
-		new_32 = INT32_MIN;
+	if (hp_gain >= 0) {
+		new_32 = (old_32 < INT32_MAX - hp_gain) ?
+			old_32 + hp_gain : INT32_MAX;
+	} else {
+		new_32 = (old_32 > INT32_MIN - hp_gain) ?
+			old_32 + hp_gain : INT32_MIN;
 	}
 
 	/* Break it back down */
@@ -487,17 +488,21 @@ int32_t player_adjust_mana_precise(struct player *p, int32_t sp_gain)
 {
 	int16_t old_16 = p->csp;
 	/* Load it all into 4 byte format*/
-	int32_t old_32 = (((int32_t) p->csp) << 16) + p->csp_frac, new_32;
+	int32_t old_32 = ((int32_t) p->csp) * 65536 + p->csp_frac, new_32;
 
 	if (sp_gain == 0) return 0;
 
-	new_32 = old_32 + sp_gain;
-
 	/* Check for overflow */
-	if (new_32 < old_32 && sp_gain > 0) {
-		new_32 = INT32_MAX;
-		sp_gain = 0;
-	} else if (new_32 > old_32 && sp_gain < 0) {
+	if (sp_gain > 0) {
+		if (old_32 < INT32_MAX - sp_gain) {
+			new_32 = old_32 + sp_gain;
+		} else {
+			new_32 = INT32_MAX;
+			sp_gain = 0;
+		}
+	} else if (old_32 > INT32_MIN - sp_gain) {
+		new_32 = old_32 + sp_gain;
+	} else {
 		new_32 = INT32_MIN;
 		sp_gain = 0;
 	}
@@ -542,7 +547,7 @@ int32_t player_adjust_mana_precise(struct player *p, int32_t sp_gain)
 
 	if (sp_gain == 0) {
 		/* Recalculate */
-		new_32 = (((int32_t) p->csp) << 16) + p->csp_frac;
+		new_32 = ((int32_t) p->csp) * 65536 + p->csp_frac;
 		sp_gain = new_32 - old_32;
 	}
 
@@ -555,13 +560,13 @@ void convert_mana_to_hp(struct player *p, int32_t sp_long) {
 	if (sp_long <= 0 || p->msp == 0 || p->mhp == p->chp) return;
 
 	/* Total HP from max */
-	hp_gain = (int32_t)((p->mhp - p->chp) << 16);
+	hp_gain = ((int32_t)(p->mhp - p->chp)) * 65536;
 	hp_gain -= (int32_t)p->chp_frac;
 
 	/* Spend X% of SP get X/2% of lost HP. E.g., at 50% HP get X/4% */
 	/* Gain stays low at msp<10 because MP gains are generous at msp<10 */
 	/* sp_ratio is max sp to spent sp, doubled to suit target rate. */
-	sp_ratio = (MAX(10, (int32_t)p->msp) << 16) * 2 / sp_long;
+	sp_ratio = (((int32_t)MAX(10, (int32_t)p->msp)) * 131072) / sp_long;
 
 	/* Limit max healing to 25% of damage; ergo spending > 50% msp
 	 * is inefficient */

--- a/src/ui-display.c
+++ b/src/ui-display.c
@@ -2314,10 +2314,15 @@ static void subwindow_set_flags(int win_idx, uint32_t new_flags)
 	/* Deal with the changed flags by seeing what's changed */
 	for (i = 0; i < 32; i++)
 		/* Only process valid flags */
-		if (window_flag_desc[i])
-			if ((new_flags & (1L << i)) != (window_flag[win_idx] & (1L << i)))
-				subwindow_flag_changed(win_idx, (1L << i),
-									   (new_flags & (1L << i)) != 0);
+		if (window_flag_desc[i]) {
+			uint32_t flag = ((uint32_t) 1) << i;
+
+			if ((new_flags & flag) !=
+					(window_flag[win_idx] & flag)) {
+				subwindow_flag_changed(win_idx, flag,
+						(new_flags & flag) != 0);
+			}
+		}
 
 	/* Store the new flags */
 	window_flag[win_idx] = new_flags;

--- a/src/ui-entry.c
+++ b/src/ui-entry.c
@@ -76,7 +76,7 @@ struct bound_player_ability {
 enum {
 	ENTRY_FLAG_TIMED_AUX = 1,
 	/* Used internally; not set from within the configuration files. */
-	ENTRY_FLAG_TEMPLATE_ONLY = (1 << 20)
+	ENTRY_FLAG_TEMPLATE_ONLY = (1UL << 20)
 };
 struct entry_flag {
 	const char *name;

--- a/src/ui-options.c
+++ b/src/ui-options.c
@@ -430,7 +430,7 @@ static void do_cmd_options_win(const char *name, int row)
 				if ((i == y) && (j == x)) a = COLOUR_L_BLUE;
 
 				/* Active flag */
-				if (new_flags[j] & (1L << i)) c = L'X';
+				if (new_flags[j] & ((uint32_t) 1 << i)) c = L'X';
 
 				/* Flag value */
 				Term_putch(35 + j * 5, i + 5, a, c);
@@ -455,12 +455,14 @@ static void do_cmd_options_win(const char *name, int row)
 				&& (choicex > 0) && (choicex < ANGBAND_TERM_MAX)
 				&& !(ke.mouse.x % 5)) {
 				if ((choicey == y) && (choicex == x)) {
+					uint32_t flag = ((uint32_t) 1) << y;
+
 					/* Toggle flag (off) */
-					if (new_flags[x] & (1L << y))
-						new_flags[x] &= ~(1L << y);
+					if (new_flags[x] & flag)
+						new_flags[x] &= ~flag;
 					/* Toggle flag (on) */
 					else
-						new_flags[x] |= (1L << y);
+						new_flags[x] |= flag;
 				} else {
 					y = choicey;
 					x = (ke.mouse.x - 35)/5;
@@ -478,12 +480,12 @@ static void do_cmd_options_win(const char *name, int row)
 					bell();
 
 				/* Toggle flag (off) */
-				else if (new_flags[x] & (1L << y))
-					new_flags[x] &= ~(1L << y);
+				else if (new_flags[x] & (((uint32_t) 1) << y))
+					new_flags[x] &= ~(((uint32_t) 1) << y);
 
 				/* Toggle flag (on) */
 				else
-					new_flags[x] |= (1L << y);
+					new_flags[x] |= (((uint32_t) 1) << y);
 
 				/* Continue */
 				continue;

--- a/src/ui-prefs.c
+++ b/src/ui-prefs.c
@@ -364,7 +364,7 @@ void option_dump(ang_file *fff)
 			if (!window_flag_desc[j]) continue;
 
 			/* Only dump the flag if true */
-			if (window_flag[i] & (1L << j)) {
+			if (window_flag[i] & (((uint32_t) 1) << j)) {
 				file_putf(fff, "# Window '%s', Flag '%s'\n",
 						  angband_term_name[i], window_flag_desc[j]);
 				file_putf(fff, "window:%d:%d:1\n", i, j);
@@ -1049,9 +1049,9 @@ static enum parser_error parse_prefs_window(struct parser *p)
 	{
 		int value = parser_getuint(p, "value");
 		if (value)
-			d->window_flags[window] |= (1L << flag);
+			d->window_flags[window] |= (((uint32_t) 1) << flag);
 		else
-			d->window_flags[window] &= ~(1L << flag);
+			d->window_flags[window] &= ~(((uint32_t) 1) << flag);
 	}
 
 	d->loaded_window_flag[window] = true;


### PR DESCRIPTION
…undefined behavior, rework hitpoint and mana calculations for portability.  Avoids runtime error message from the undefined behavior sanitizer when Angband and the test cases are compiled with -fsanitize=undefined.  For similar portability concerns, use unsigned arithmetic when computing bit mask values.

Finishes off what https://github.com/angband/angband/pull/5357 was trying to address.