### PR TITLE
Avoid runtime error ("applying zero offset to null pointer") in …

### DIFF
--- a/src/tests/monster/attack.c
+++ b/src/tests/monster/attack.c
@@ -17,6 +17,7 @@ int setup_tests(void **state) {
 	z_info = mem_zalloc(sizeof(struct angband_constants));
 	z_info->mon_blows_max = 2;
 	projections = test_projections;
+	l_list = &test_lore;
 	m->race = r;
 	r_info = r;
 	*state = m;


### PR DESCRIPTION
…monster/attack test when the test and Angband are compiled with -fsanitize=undefined.