### PR TITLE
Modify text when player is aware of a monster via detection or telepathy

### DIFF
--- a/src/ui-target.c
+++ b/src/ui-target.c
@@ -342,6 +342,8 @@ static ui_event target_recall_loop_object(struct object *obj, int y, int x,
 static bool aux_reinit(struct chunk *c, struct player *p,
 		struct target_aux_state *auxst)
 {
+	struct monster *mon;
+
 	/* Set the default event to focus on the player. */
 	auxst->press.type = EVT_KBRD;
 	auxst->press.key.code = 'p';
@@ -359,8 +361,17 @@ static bool aux_reinit(struct chunk *c, struct player *p,
 		auxst->phrase2 = "on ";
 	} else {
 		/* Default */
-		auxst->phrase1 = (square_isseen(c, auxst->grid)) ?
-			"You see " : "You recall ";
+		if (square_isseen(c, auxst->grid)) {
+			auxst->phrase1 = "You see ";
+		} else {
+			mon = square_monster(c, auxst->grid);
+			if (mon && monster_is_obvious(mon)) {
+				/* Monster is visible because of detection or telepathy */
+				auxst->phrase1 = "You sense ";
+			} else {
+				auxst->phrase1 = "You recall ";
+			}
+		}
 		auxst->phrase2 = "";
 	}
 


### PR DESCRIPTION
commit 496fc1c51d5276100d924c5a64ca1585f676c205 changed the "You see" message
when examining a square to "You recall" if the square wasn't visible in order
to avoid "seeing" while blind.

This has the unfortunate side effect of using "You recall" when detecting or using
telepathy.

Detect whether a visible monster is on the square that wouldn't have otherwise
been seen and infer that it was viewable via detection or telepathy.  This
unfortunately doesn't handle non-monsters viewable this way (such as doors via
"Read Minds" or shop entrances), but it clears up the common case of monsters