### PR TITLE
Replace player argument to pick_and_place_distant_monster() with the …

### DIFF
--- a/src/game-world.c
+++ b/src/game-world.c
@@ -577,9 +577,10 @@ void process_world(struct chunk *c)
 	}
 
 	/* Check for creature generation */
-	if (one_in_(z_info->alloc_monster_chance))
-		(void)pick_and_place_distant_monster(c, player, z_info->max_sight + 5,
-											 true, player->depth);
+	if (one_in_(z_info->alloc_monster_chance)) {
+		(void)pick_and_place_distant_monster(c, player->grid,
+			z_info->max_sight + 5, true, player->depth);
+	}
 
 	/*** Damage (or healing) over Time ***/
 

--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -1289,8 +1289,9 @@ struct chunk *classic_gen(struct player *p, int min_height, int min_width) {
 	i = z_info->level_monster_min + randint1(8) + k;
 
 	/* Put some monsters in the dungeon */
-	for (; i > 0; i--)
-		pick_and_place_distant_monster(c, p, 0, true, c->depth);
+	for (; i > 0; i--) {
+		pick_and_place_distant_monster(c, p->grid, 0, true, c->depth);
+	}
 
 	/* Put some objects in rooms */
 	alloc_objects(c, SET_ROOM, TYP_OBJECT,
@@ -1552,8 +1553,9 @@ struct chunk *labyrinth_gen(struct player *p, int min_height, int min_width) {
 	alloc_objects(c, SET_CORR, TYP_TRAP, randint1(k), c->depth, 0);
 
 	/* Put some monsters in the dungeon */
-	for (i = z_info->level_monster_min + randint1(8) + k; i > 0; i--)
-		pick_and_place_distant_monster(c, p, 0, true, c->depth);
+	for (i = z_info->level_monster_min + randint1(8) + k; i > 0; i--) {
+		pick_and_place_distant_monster(c, p->grid, 0, true, c->depth);
+	}
 
 	/* Put some objects/gold in the dungeon */
 	alloc_objects(c, SET_BOTH, TYP_OBJECT, Rand_normal(k * 6, 2), c->depth,
@@ -2173,8 +2175,9 @@ struct chunk *cavern_gen(struct player *p, int min_height, int min_width) {
 	}
 
 	/* Put some monsters in the dungeon */
-	for (i = randint1(8) + k; i > 0; i--)
-		pick_and_place_distant_monster(c, p, 0, true, c->depth);
+	for (i = randint1(8) + k; i > 0; i--) {
+		pick_and_place_distant_monster(c, p->grid, 0, true, c->depth);
+	}
 
 	/* Put some objects/gold in the dungeon */
 	alloc_objects(c, SET_BOTH, TYP_OBJECT, Rand_normal(k, 2), c->depth + 5,
@@ -2659,8 +2662,10 @@ struct chunk *town_gen(struct player *p, int min_height, int min_width)
 	cave_illuminate(c_new, is_daytime());
 
 	/* Make some residents */
-	for (i = 0; i < residents; i++)
-		pick_and_place_distant_monster(c_new, p, 3, true, c_new->depth);
+	for (i = 0; i < residents; i++) {
+		pick_and_place_distant_monster(c_new, p->grid, 3, true,
+			c_new->depth);
+	}
 
 	return c_new;
 }
@@ -2882,8 +2887,9 @@ struct chunk *modified_gen(struct player *p, int min_height, int min_width) {
 	mon_restrict(NULL, c->depth, c->depth, true);
 
 	/* Put some monsters in the dungeon */
-	for (; i > 0; i--)
-		pick_and_place_distant_monster(c, p, 0, true, c->depth);
+	for (; i > 0; i--) {
+		pick_and_place_distant_monster(c, p->grid, 0, true, c->depth);
+	}
 
 	/* Put some objects in rooms */
 	alloc_objects(c, SET_ROOM, TYP_OBJECT,
@@ -3109,8 +3115,9 @@ struct chunk *moria_gen(struct player *p, int min_height, int min_width) {
 	mon_restrict("Moria dwellers", c->depth, c->depth, true);
 
 	/* Put some monsters in the dungeon */
-	for (; i > 0; i--)
-		pick_and_place_distant_monster(c, p, 0, true, c->depth);
+	for (; i > 0; i--) {
+		pick_and_place_distant_monster(c, p->grid, 0, true, c->depth);
+	}
 
 	/* Remove our restrictions. */
 	(void) mon_restrict(NULL, c->depth, c->depth, false);
@@ -3400,8 +3407,9 @@ struct chunk *hard_centre_gen(struct player *p, int min_height, int min_width)
 	}
 
 	/* Put some monsters in the dungeon */
-	for (i = randint1(8) + k; i > 0; i--)
-		pick_and_place_distant_monster(c, p, 0, true, c->depth);
+	for (i = randint1(8) + k; i > 0; i--) {
+		pick_and_place_distant_monster(c, p->grid, 0, true, c->depth);
+	}
 
 	/* Put some objects/gold in the dungeon */
 	alloc_objects(c, SET_BOTH, TYP_OBJECT, Rand_normal(k, 2), c->depth + 5,
@@ -3523,8 +3531,10 @@ struct chunk *lair_gen(struct player *p, int min_height, int min_width) {
 	i = randint1(4) + k;
 
 	/* Put some monsters in the dungeon */
-	for (; i > 0; i--)
-		pick_and_place_distant_monster(normal, p, 0, true, normal->depth);
+	for (; i > 0; i--) {
+		pick_and_place_distant_monster(normal, p->grid, 0, true,
+			normal->depth);
+	}
 
 	/* Add some magma streamers */
 	for (i = 0; i < dun->profile->str.mag; i++)
@@ -3715,15 +3725,19 @@ struct chunk *gauntlet_gen(struct player *p, int min_height, int min_width) {
 	i = z_info->level_monster_min + randint1(4) + k;
 
 	/* Place the monsters */
-	for (; i > 0; i--)
-		pick_and_place_distant_monster(left, p, 0, true, left->depth);
+	for (; i > 0; i--) {
+		pick_and_place_distant_monster(left, p->grid, 0, true,
+			left->depth);
+	}
 
 	/* Pick some of monsters for the right cavern */
 	i = z_info->level_monster_min + randint1(4) + k;
 
 	/* Place the monsters */
-	for (; i > 0; i--)
-		pick_and_place_distant_monster(right, p, 0, true, right->depth);
+	for (; i > 0; i--) {
+		pick_and_place_distant_monster(right, p->grid, 0, true,
+			right->depth);
+	}
 
 	/* Pick a larger number of monsters for the gauntlet */
 	i = (z_info->level_monster_min + randint1(6) + k);

--- a/src/mon-make.c
+++ b/src/mon-make.c
@@ -1467,16 +1467,16 @@ bool pick_and_place_monster(struct chunk *c, struct loc grid, int depth,
 
 /**
  * Picks a monster race, makes a new monster of that race, then attempts to
- * place it in the dungeon at least `dis` away from the player. The monster
- * race chosen will be appropriate for dungeon level equal to `depth`.
+ * place it in the dungeon at least `dis` away from the grid, to_avoid. The
+ * monster race chosen will be appropriate for dungeon level equal to `depth`.
  *
  * If `sleep` is true, the monster is placed with its default sleep value,
  * which is given in monster.txt.
  *
  * Returns true if we successfully place a monster.
  */
-bool pick_and_place_distant_monster(struct chunk *c, struct player *p, int dis,
-		bool sleep, int depth)
+bool pick_and_place_distant_monster(struct chunk *c, struct loc to_avoid,
+		int dis, bool sleep, int depth)
 {
 	struct loc grid;
 	int	attempts_left = 10000;
@@ -1496,11 +1496,11 @@ bool pick_and_place_distant_monster(struct chunk *c, struct player *p, int dis,
 			continue;
 
 		/* Accept far away grids */
-		if (distance(grid, p->grid) > dis) break;
+		if (distance(grid, to_avoid) > dis) break;
 	}
 
 	if (!attempts_left) {
-		if (OPT(p, cheat_xtra) || OPT(p, cheat_hear))
+		if (OPT(player, cheat_xtra) || OPT(player, cheat_hear))
 			msg("Warning! Could not allocate a new monster.");
 
 		return false;

--- a/src/mon-make.h
+++ b/src/mon-make.h
@@ -41,7 +41,7 @@ bool place_new_monster(struct chunk *c, struct loc grid,
 	struct monster_group_info group_info, uint8_t origin);
 bool pick_and_place_monster(struct chunk *c, struct loc grid, int depth,
 	bool sleep, bool group_okay, uint8_t origin);
-bool pick_and_place_distant_monster(struct chunk *c, struct player *p, int dis,
-									bool sleep, int depth);
+bool pick_and_place_distant_monster(struct chunk *c, struct loc to_avoid,
+	int dis, bool sleep, int depth);
 
 #endif /* MONSTER_MAKE_H */


### PR DESCRIPTION
…location to be avoided.  Resolves https://github.com/angband/angband/issues/5373 (get_mon_num() no longer uses the player global; list_object() does, as do the handling of the cheat options in pick_and_place_distant_monster(), but treat those as an unavoidable side effect that are present for all the monster placement routines during cave generation.