### PR TITLE
Refactor cmd_get_spell(), get_spell(), and get_spell_hook to allow …

### DIFF
--- a/src/cmd-core.h
+++ b/src/cmd-core.h
@@ -388,8 +388,9 @@ int cmd_get_string(struct command *cmd, const char *arg, const char **str,
 				   const char *initial, const char *title, const char *prompt);
 int cmd_get_spell(struct command *cmd, const char *arg, struct player *p,
 	int *spell, const char *verb, item_tester book_filter,
-	const char *error,
-	bool (*spell_filter)(const struct player *p, int spell));
+	const char *book_error,
+	bool (*spell_filter)(const struct player *p, int spell),
+	const char *spell_error);
 int cmd_get_effect_from_list(struct command *cmd, const char *arg, int *choice,
 	const char *prompt, struct effect *effect, int count,
 	bool allow_random);

--- a/src/cmd-obj.c
+++ b/src/cmd-obj.c
@@ -985,11 +985,13 @@ void do_cmd_cast(struct command *cmd)
 
 	/* Get arguments */
 	if (cmd_get_spell(cmd, "spell", player, &spell_index,
-			/* Verb */   "cast",
-			/* Book */   obj_can_cast_from,
-			/* Error */  "There are no spells you can cast.",
-			/* Filter */ spell_okay_to_cast) != CMD_OK)
+			/* Verb */ "cast",
+			/* Book */ obj_can_cast_from,
+			/* Book error */ "There are no spells you can cast.",
+			/* Filter */ spell_okay_to_cast,
+			/* Spell error */ "That book has no spells that you can cast.") != CMD_OK) {
 		return;
+	}
 
 	/* Get the spell */
 	spell = spell_by_index(player, spell_index);
@@ -1041,10 +1043,11 @@ void do_cmd_study_spell(struct command *cmd)
 		return;
 
 	if (cmd_get_spell(cmd, "spell", player, &spell_index,
-			/* Verb */   "study",
-			/* Book */   obj_can_study,
-			/* Error  */ "You cannot learn any new spells from the books you have.",
-			/* Filter */ spell_okay_to_study) != CMD_OK)
+			/* Verb */ "study",
+			/* Book */ obj_can_study,
+			/* Book error */ "You cannot learn any new spells from the books you have.",
+			/* Filter */ spell_okay_to_study,
+			/* Spell error */ "That book has no spells that you can learn.") != CMD_OK)
 		return;
 
 	spell_learn(spell_index);

--- a/src/game-input.c
+++ b/src/game-input.c
@@ -31,8 +31,9 @@ int (*get_spell_from_book_hook)(struct player *p, const char *verb,
 	struct object *book, const char *error,
 	bool (*spell_filter)(const struct player *p, int spell));
 int (*get_spell_hook)(struct player *p, const char *verb,
-	item_tester book_filter, cmd_code cmd, const char *error,
-	bool (*spell_filter)(const struct player *p, int spell));
+	item_tester book_filter, cmd_code cmd, const char *book_error,
+	bool (*spell_filter)(const struct player *p, int spell),
+	const char *spell_error, struct object **rtn_book);
 bool (*get_item_hook)(struct object **choice, const char *pmt, const char *str,
 					  cmd_code cmd, item_tester tester, int mode);
 bool (*get_curse_hook)(int *choice, struct object *obj, char *dice_string);
@@ -161,15 +162,32 @@ int get_spell_from_book(struct player *p, const char *verb,
 
 /**
  * Get a spell from the player.
+ *
+ * \param p is the player.
+ * \param verb is the string describing the action for which the spell is
+ * requested.  It is typically "cast" or "study".
+ * \param book_filter is the function (if any) to test that an object is
+ * appropriate for use as spellbook by the player.
+ * \param cmd is the command (if any) the request is called from.
+ * \param book_error is the message to display if no valid book is available.
+ * If NULL, no message will be displayed.
+ * \param spell_filter is the function to call to test if a spell is a valid
+ * selection for the request.
+ * \param spell_error is the message to display if no valid spell is available.
+ * If NULL, no message will be displayed.
+ * \param rtn_book if not NULL, is dereferenced and set to the book selected.
+ * \return the index of the spell selected or a negative value if the selection
+ * failed for any reason.
  */
 int get_spell(struct player *p, const char *verb,
-		item_tester book_filter, cmd_code cmd, const char *error,
-		bool (*spell_filter)(const struct player *p, int spell))
+		item_tester book_filter, cmd_code cmd, const char *book_error,
+		bool (*spell_filter)(const struct player *p, int spell),
+		const char *spell_error, struct object **rtn_book)
 {
 	/* Ask the UI for it */
 	if (get_spell_hook) {
-		return get_spell_hook(p, verb, book_filter, cmd, error,
-			spell_filter);
+		return get_spell_hook(p, verb, book_filter, cmd, book_error,
+			spell_filter, spell_error, rtn_book);
 	}
 	return -1;
 }

--- a/src/game-input.h
+++ b/src/game-input.h
@@ -49,8 +49,9 @@ extern int (*get_spell_from_book_hook)(struct player *p, const char *verb,
 	struct object *book, const char *error,
 	bool (*spell_filter)(const struct player *p, int spell));
 extern int (*get_spell_hook)(struct player *p, const char *verb,
-	item_tester book_filter, cmd_code cmd, const char *error,
-	bool (*spell_filter)(const struct player *p, int spell));
+	item_tester book_filter, cmd_code cmd, const char *book_error,
+	bool (*spell_filter)(const struct player *p, int spell),
+	const char *spell_error, struct object **rtn_book);
 extern bool (*get_item_hook)(struct object **choice, const char *pmt,
 							 const char *str, cmd_code cmd, item_tester tester,
 							 int mode);
@@ -75,8 +76,9 @@ int get_spell_from_book(struct player *p, const char *verb,
 	struct object *book, const char *error,
 	bool (*spell_filter)(const struct player *p, int spell));
 int get_spell(struct player *p, const char *verb,
-	item_tester book_filter, cmd_code cmd, const char *error,
-	bool (*spell_filter)(const struct player *p, int spell));
+	item_tester book_filter, cmd_code cmd, const char *book_error,
+	bool (*spell_filter)(const struct player *p, int spell),
+	const char *spell_error, struct object **rtn_book);
 bool get_item(struct object **choice, const char *pmt, const char *str,
 			  cmd_code cmd, item_tester tester, int mode);
 bool get_curse(int *choice, struct object *obj, char *dice_string);

--- a/src/ui-spell.c
+++ b/src/ui-spell.c
@@ -352,6 +352,8 @@ int textui_get_spell_from_book(struct player *p, const char *verb,
 		int spell_index = spell_menu_select(m, noun, verb);
 		spell_menu_destroy(m);
 		return spell_index;
+	} else if (error) {
+		msg("%s", error);
 	}
 
 	return -1;
@@ -361,8 +363,9 @@ int textui_get_spell_from_book(struct player *p, const char *verb,
  * Get a spell from the player.
  */
 int textui_get_spell(struct player *p, const char *verb,
-		item_tester book_filter, cmd_code cmd, const char *error,
-		bool (*spell_filter)(const struct player *p, int spell_index))
+		item_tester book_filter, cmd_code cmd, const char *book_error,
+		bool (*spell_filter)(const struct player *p, int spell_index),
+		const char *spell_error, struct object **rtn_book)
 {
 	char prompt[1024];
 	struct object *book;
@@ -371,9 +374,14 @@ int textui_get_spell(struct player *p, const char *verb,
 	strnfmt(prompt, sizeof prompt, "%s which book?", verb);
 	my_strcap(prompt);
 
-	if (!get_item(&book, prompt, error,
+	if (!get_item(&book, prompt, book_error,
 				  cmd, book_filter, (USE_INVEN | USE_FLOOR)))
 		return -1;
 
-	return textui_get_spell_from_book(p, verb, book, error, spell_filter);
+	if (rtn_book) {
+		*rtn_book = book;
+	}
+
+	return textui_get_spell_from_book(p, verb, book, spell_error,
+		spell_filter);
 }

--- a/src/ui-spell.h
+++ b/src/ui-spell.h
@@ -27,7 +27,8 @@ int textui_get_spell_from_book(struct player *p, const char *verb,
 	struct object *book, const char *error,
 	bool (*spell_filter)(const struct player *p, int spell_index));
 int textui_get_spell(struct player *p, const char *verb,
-	item_tester book_filter, cmd_code cmd, const char *error,
-	bool (*spell_filter)(const struct player *p, int spell_index));
+	item_tester book_filter, cmd_code cmd, const char *book_error,
+	bool (*spell_filter)(const struct player *p, int spell_index),
+	const char *spell_error, struct object **rtn_book);
 
 #endif /* INCLUDED_UI_SPELL_H */


### PR DESCRIPTION
…retrieving the book selected, recording it in the command in cmd_get_spell(), and to have a separate error message if the book selected has no spells available.  Generalize cmd_disable_repeat_floor_item() to test all command arguments using objects.  Resolves https://github.com/angband/angband/issues/5122 .

The conditions which can trigger the new error message are likely rare.  The situation I know of is:

1. Cast spell that is the only spell known in a book.
2. Get hit by an experience draining attack that causes the spell to be forgotten.
3. Repeat the previous command (i.e. the casting from step 1).