### PR TITLE
Allow an instance of a command to marked as a background command so …

### DIFF
--- a/src/cmd-core.h
+++ b/src/cmd-core.h
@@ -241,6 +241,12 @@ struct command {
 	/* Number of times to attempt to repeat command. */
 	int nrepeats;
 
+	/*
+	 * Whether this command should be skipped when looking for CMD_REPEAT's
+	 * target.
+	 */
+	bool is_background_command;
+
 	/* Arguments */
 	struct cmd_arg arg[CMD_MAX_ARGS];
 };

--- a/src/obj-ignore.c
+++ b/src/obj-ignore.c
@@ -677,10 +677,22 @@ void ignore_drop(struct player *p)
 
 			/* We're allowed to drop it. */
 			if (!square_isshop(cave, p->grid)) {
+				struct command *drop_cmd;
+
 				p->upkeep->dropping = true;
 				cmdq_push(CMD_DROP);
-				cmd_set_arg_item(cmdq_peek(), "item", obj);
-				cmd_set_arg_number(cmdq_peek(), "quantity", obj->number);
+				drop_cmd = cmdq_peek();
+				assert(drop_cmd);
+				cmd_set_arg_item(drop_cmd, "item", obj);
+				cmd_set_arg_number(drop_cmd, "quantity",
+					obj->number);
+				/*
+				 * This drop is a side effect:  whatever
+				 * command triggered it will be the target
+				 * for CMD_REPEAT rather than repeating the
+				 * drop.
+				 */
+				drop_cmd->is_background_command = true;
 			}
 		}
 	}

--- a/src/player-util.c
+++ b/src/player-util.c
@@ -1484,6 +1484,12 @@ void player_handle_post_move(struct player *p, bool eval_trap)
 	} else {
 		square_know_pile(cave, p->grid);
 		cmdq_push(CMD_AUTOPICKUP);
+		/*
+		 * The autopickup is a side effect of the move:  whatever
+		 * command triggered the move will be the target for CMD_REPEAT
+		 * rather than repeating the autopickup.
+		 */
+		cmdq_peek()->is_background_command = true;
 	}
 
 	/* Discover invisible traps, set off visible ones */


### PR DESCRIPTION
…it won't be used as the target for CMD_REPEAT.  Use that for CMD_AUTOPICKUP triggered by a move or CMD_DROP triggered by a change to inscriptions.  Resolves https://github.com/NickMcConnell/FAangband/issues/349 .