### PR TITLE
Change default enter behavior in stores

### DIFF
--- a/src/ui-store.c
+++ b/src/ui-store.c
@@ -1003,7 +1003,19 @@ static bool store_menu_handle(struct menu *m, const ui_event *event, int oid)
 	struct store *store = ctx->store;
 	
 	if (event->type == EVT_SELECT) {
-		/* Nothing for now, except "handle" the event */
+		msg_flag = false;
+		if (store->sidx != STORE_HOME) {
+			prt("Purchase which item? (ESC to cancel, Enter to select)",
+				0, 0);
+		} else {
+			prt("Get which item? (Esc to cancel, Enter to select)",
+				0, 0);
+			}
+		/* the oid should be maintained when using enter to purchase */
+		prt("", 0, 0);
+		if (oid >= 0) {
+			store_purchase(ctx, oid, false);
+		}
 		return true;
 		/* In future, maybe we want a display a list of what you can do. */
 	} else if (event->type == EVT_MOUSE) {

--- a/src/ui-store.c
+++ b/src/ui-store.c
@@ -1003,8 +1003,8 @@ static bool store_menu_handle(struct menu *m, const ui_event *event, int oid)
 	struct store *store = ctx->store;
 	
 	if (event->type == EVT_SELECT) {
-		/* Hack -- there's no mouse event coordinates to use for menu_store_item, so fake one */
-		context_menu_store_item(ctx, oid, 0, m->active.row + oid);
+		/* Hack -- there's no mouse event coordinates to use for menu_store_item, so fake one as if mouse clicked on letter */
+		context_menu_store_item(ctx, oid, 1, m->active.row + oid);
 		ctx->flags |= (STORE_FRAME_CHANGE | STORE_GOLD_CHANGE);
 
 		/* Let the game handle any core commands (equipping, etc) */


### PR DESCRIPTION
This proposal changes what happens after a player presses the enter key within a store from the event being dropped to purchasing the item the cursor is under.

I don't know whether keeping the EVT_SELECT branch separate is cleaner than putting it as a parallel case with the EVT_KBRD handler, but if the eventual purpose is to launch a contextual menu, it seems better to keep it separate.

The justification for this change is twofold. First, the player can move the cursor in the store, but when the player decides to do anything (examine or purchase), they have to reselect the item. I think enter defaulting to purchasing is natural in lieu of a future menu to select examine or purchase. Secondly, this really helps playing the game on platforms without hardware keyboards (namely consoles and phones) but doesn't change any underlying behavior for PC players.

Related to this change is that I'd like to change the item quantity handling code to disallow free entry and limit it to numbers and the asterisk. Right now, any letter is treated as also meaning all and non-alphanumerics are just dropped. If it were fixed to entering numbers within the appropriate range, the movement keys could be used for incrementing and decrementing the quantity, which would also improve playability for non-PC players without keyboards (e.g. buying or dropping a max stack could be done by decrementing the default minimum quantity of 1 to reach the max quantity).