### PR TITLE
Also check for nearby unlocked doors when deciding whether to prompt …

### DIFF
--- a/src/cave-square.c
+++ b/src/cave-square.c
@@ -780,6 +780,14 @@ bool square_islockeddoor(struct chunk *c, struct loc grid)
 }
 
 /**
+ * True if the square is a closed, unlocked door.
+ */
+bool square_isunlockeddoor(struct chunk *c, struct loc grid)
+{
+	return square_iscloseddoor(c, grid) && square_door_power(c, grid) == 0;
+}
+
+/**
  * True if there is a player trap (known or unknown) in this square.
  */
 bool square_isplayertrap(struct chunk *c, struct loc grid)

--- a/src/cave.h
+++ b/src/cave.h
@@ -371,6 +371,7 @@ bool square_iswebbed(struct chunk *c, struct loc grid);
 bool square_seemslikewall(struct chunk *c, struct loc grid);
 bool square_isinteresting(struct chunk *c, struct loc grid);
 bool square_islockeddoor(struct chunk *c, struct loc grid);
+bool square_isunlockeddoor(struct chunk *c, struct loc grid);
 bool square_isplayertrap(struct chunk *c, struct loc grid);
 bool square_isvisibletrap(struct chunk *c, struct loc grid);
 bool square_issecrettrap(struct chunk *c, struct loc grid);

--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -832,12 +832,13 @@ void do_cmd_disarm(struct command *cmd)
 	err = cmd_get_arg_direction(cmd, "direction", &dir);
 	if (err || dir == DIR_UNKNOWN) {
 		struct loc grid1;
-		int n_traps, n_chests;
+		int n_traps, n_chests, n_unldoor;
 
-		n_traps = count_feats(&grid1, square_isdisarmabletrap, true);
+		n_traps = count_feats(&grid1, square_isdisarmabletrap, false);
 		n_chests = count_chests(&grid1, CHEST_TRAPPED);
+		n_unldoor = count_feats(&grid1, square_isunlockeddoor, false);
 
-		if (n_traps + n_chests == 1) {
+		if (n_traps + n_chests + n_unldoor == 1) {
 			dir = motion_dir(player->grid, grid1);
 			cmd_set_arg_direction(cmd, "direction", dir);
 		} else if (cmd_get_direction(cmd, "direction", &dir, n_chests > 0)) {


### PR DESCRIPTION
…for a direction in the disarm/lock command.  Since the player's square isn't allowed as the target for disarming a floor trap or locking a door, don't include floor traps or unlocked doors at that location in the counts used to decide whether to prompt for a direction.  May have some bearing on the discussion starting with this post, http://angband.oook.cz/forum/showpost.php?p=158136&postcount=2 .