### PR TITLE
Have READ_MINDS effect return true even if no minds are in range.  …

### DIFF
--- a/src/effect-handler-general.c
+++ b/src/effect-handler-general.c
@@ -1243,10 +1243,9 @@ bool effect_handler_READ_MINDS(effect_handler_context_t *context)
 	if (found) {
 		msg("Images form in your mind!");
 		context->ident = true;
-		return true;
 	}
 
-	return false;
+	return true;
 }
 
 /**


### PR DESCRIPTION
…That way it is similar to other detection or mapping effects.  See PowerWyrm's post here, http://angband.oook.cz/forum/showpost.php?p=158657&postcount=128 .  context->ident is still only set to true if there are minds in range (which is different than how the detection effects do it).