### PR TITLE
Broaden the possible grids for teleport destinations, ...

### DIFF
--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -1110,7 +1110,8 @@ void move_player(int dir, bool disarm)
 		if (step) {
 			/* Move player */
 			monster_swap(player->grid, grid);
-			player_handle_post_move(player, true);
+			player_handle_post_move(player, true, false);
+			cmdq_push(CMD_AUTOPICKUP);
 		}
 	}
 

--- a/src/effect-handler-attack.c
+++ b/src/effect-handler-attack.c
@@ -1429,7 +1429,7 @@ bool effect_handler_EARTHQUAKE(effect_handler_context_t *context)
 
 			/* Move player */
 			monster_swap(pgrid, safe_grid);
-			player_handle_post_move(player, true);
+			player_handle_post_move(player, true, true);
 		}
 
 		/* Take some damage */
@@ -1683,7 +1683,7 @@ bool effect_handler_JUMP_AND_BITE(effect_handler_context_t *context)
 
 	/* Move player */
 	monster_swap(player->grid, grid);
-	player_handle_post_move(player, true);
+	player_handle_post_move(player, true, false);
 
 	/* Now bite it */
 	drain = MIN(mon->hp + 1, amount);

--- a/src/effect-handler-general.c
+++ b/src/effect-handler-general.c
@@ -107,6 +107,55 @@ struct monster *monster_target_monster(effect_handler_context_t *context)
 }
 
 /**
+ * Check that a grid is sufficient for use as teleport destination.
+ *
+ * \param c is the chunk to examine.
+ * \param grid is the grid to test.
+ * \param is_player_moving is true if a player is being teleported; it is
+ * false if a monster is being teleported.
+ * \return true if the specified grid is sufficient for use as a telepoort
+ * destination; otherwise, return false
+ *
+ * In 4.2.4, the sufficient requirements were a floor grid with no players
+ * or monsters, no player traps, no webs, and no objects.  Post 4.2.4,
+ * the requirements are:
+ *     1) passable but not damaging nor automatically triggers a transition
+ *         to a different level or environment (i.e. a shop)
+ *     2) does not already have a player or monster
+ *     3) does not have webs
+ *     3) if a player is moving, it does not have player traps
+ *     4) if a monster is moving, it does not have a glyph of warding
+ * There's some discussion here,
+ * http://angband.oook.cz/forum/showthread.php?t=11066
+ */
+static bool has_teleport_destination_prereqs(struct chunk *c, struct loc grid,
+		bool is_player_moving)
+{
+	if (is_player_moving) {
+		if (!square_ispassable(c, grid)) {
+			return false;
+		}
+		if (square_isplayertrap(c, grid)) {
+			return false;
+		}
+	} else {
+		if (!square_is_monster_walkable(c, grid)) {
+			return false;
+		}
+		if (square_iswarded(c, grid)) {
+			return false;
+		}
+	}
+	if (square(c, grid)->mon
+			|| square_isdamaging(c, grid)
+			|| square_iswebbed(c, grid)
+			|| square_isshop(c, grid)) {
+		return false;
+	}
+	return true;
+}
+
+/**
  * Selects items that have at least one removable curse.
  */
 static bool item_tester_uncursable(const struct object *obj)
@@ -2453,11 +2502,8 @@ bool effect_handler_TELEPORT(effect_handler_context_t *context)
 			/* Must move */
 			if (d == 0) continue;
 
-			/* Require "naked" floor space */
-			if (!square_isempty(cave, grid)) continue;
-
-			/* No monster teleport onto glyph of warding */
-			if (!is_player && square_iswarded(cave, grid)) continue;
+			if (!has_teleport_destination_prereqs(cave, grid,
+					is_player)) continue;
 
 			/* No teleporting into vaults and such, unless there's no choice */
 			if (square_isvault(cave, grid)) {
@@ -2533,7 +2579,8 @@ bool effect_handler_TELEPORT(effect_handler_context_t *context)
 	/* Move player or monster */
 	monster_swap(start, spots->grid);
 	if (is_player) {
-		player_handle_post_move(player, true);
+		player_handle_post_move(player, true,
+			context->origin.what == SRC_MONSTER);
 	}
 
 	/* Clear any projection marker to prevent double processing */
@@ -2653,8 +2700,8 @@ bool effect_handler_TELEPORT_TO(effect_handler_context_t *context)
 			if (square_in_bounds_fully(cave, land)) break;
 		}
 
-		/* Accept "naked" floor grids */
-		if (square_isempty(cave, land)) break;
+		if (has_teleport_destination_prereqs(cave, land,
+				player_moves)) break;
 
 		/* Occasionally advance the distance */
 		if (++ctr > (4 * dis * dis + 4 * dis + 1)) {
@@ -2669,7 +2716,8 @@ bool effect_handler_TELEPORT_TO(effect_handler_context_t *context)
 	/* Move player or monster */
 	monster_swap(start, land);
 	if (player_moves) {
-		player_handle_post_move(player, true);
+		player_handle_post_move(player, true,
+			context->origin.what == SRC_MONSTER);
 	}
 
 	/* Cancel target if necessary */

--- a/src/player-util.c
+++ b/src/player-util.c
@@ -1463,8 +1463,11 @@ void player_place(struct chunk *c, struct player *p, struct loc grid)
  * \param p is the player that was moved.
  * \param eval_trap, if true, will cause evaluation (possibly affecting the
  * player) of the traps in the grid.
+ * \param is_involuntary, if true, will do appropriate actions (disturb and
+ * flush the command queue) for a move not expected by the player.
  */
-void player_handle_post_move(struct player *p, bool eval_trap)
+void player_handle_post_move(struct player *p, bool eval_trap,
+		bool is_involuntary)
 {
 	/* Handle store doors, or notice objects */
 	if (square_isshop(cave, p->grid)) {
@@ -1475,6 +1478,9 @@ void player_handle_post_move(struct player *p, bool eval_trap)
 			return;
 		}
 		disturb(p);
+		if (is_involuntary) {
+			cmdq_flush();
+		}
 		event_signal(EVENT_ENTER_STORE);
 		event_remove_handler_type(EVENT_ENTER_STORE);
 		event_signal(EVENT_USE_STORE);
@@ -1482,8 +1488,11 @@ void player_handle_post_move(struct player *p, bool eval_trap)
 		event_signal(EVENT_LEAVE_STORE);
 		event_remove_handler_type(EVENT_LEAVE_STORE);
 	} else {
+		if (is_involuntary) {
+			disturb(player);
+			cmdq_flush();
+		}
 		square_know_pile(cave, p->grid);
-		cmdq_push(CMD_AUTOPICKUP);
 	}
 
 	/* Discover invisible traps, set off visible ones */

--- a/src/player-util.h
+++ b/src/player-util.h
@@ -113,7 +113,8 @@ bool player_of_has(struct player *p, int flag);
 bool player_resists(struct player *p, int element);
 bool player_is_immune(struct player *p, int element);
 void player_place(struct chunk *c, struct player *p, struct loc grid);
-void player_handle_post_move(struct player *p, bool eval_trap);
+void player_handle_post_move(struct player *p, bool eval_trap,
+		bool is_involuntary);
 void disturb(struct player *p);
 void search(struct player *p);
 

--- a/src/project-mon.c
+++ b/src/project-mon.c
@@ -183,7 +183,7 @@ void thrust_away(struct loc centre, struct loc target, int grids_away)
 					monster_swap(grid, next);
 					if (square(cave, grid)->mon < 0) {
 						player_handle_post_move(
-							player, true);
+							player, true, true);
 					}
 
 					/* Jump to new location. */
@@ -207,7 +207,8 @@ void thrust_away(struct loc centre, struct loc target, int grids_away)
 				/* Travel down the path. */
 				monster_swap(grid, next);
 				if (square(cave, grid)->mon < 0) {
-					player_handle_post_move(player, true);
+					player_handle_post_move(player, true,
+						true);
 				}
 
 				/* Jump to new location. */

--- a/src/trap.c
+++ b/src/trap.c
@@ -575,9 +575,10 @@ extern void hit_trap(struct loc grid, int delayed)
 			monster_swap(player->grid, trap->grid);
 			/*
 			 * Don't retrigger the trap, but handle the
-			 * other side effects of moving the player.
+			 * other side effects of an involuntary move of the
+			 * player.
 			 */
-			player_handle_post_move(player, false);
+			player_handle_post_move(player, false, true);
 		}
 
 		/* Some traps disappear after activating, all have a chance to */


### PR DESCRIPTION
…allowing grids with objects and more passable terrain.  Addresses the concern expressed in http://angband.oook.cz/forum/showthread.php?t=11066 and https://github.com/draconisPW/PWMAngband/issues/522 .  To avoid losing an action because of autopickup after a teleport, only queue an autopickup after a normal move.  Likewise, disturb and flush command queue for involuntary moves by the player.  Does open the possibility of artifact loss (telport, land on artifact, hit by teleport level).