### PR TITLE
Drop use of Mix_Init() to test for sound file compatibility …

### DIFF
--- a/src/main-win.c
+++ b/src/main-win.c
@@ -1156,9 +1156,9 @@ static bool load_sound_win(const char *filename, int file_type, struct sound_dat
 				mciSendCommand(0, MCI_OPEN, MCI_OPEN_ELEMENT | MCI_WAIT, (size_t)(&sample->op));
 			}
 
-			data->loaded = (0 != sample->op.wDeviceID);
-
-			if (!data->loaded) {
+			if (0 != sample->op.wDeviceID) {
+				data->status = SOUND_ST_LOADED;
+			} else {
 				mem_free(sample);
 				sample = NULL;
 			}
@@ -1170,12 +1170,11 @@ static bool load_sound_win(const char *filename, int file_type, struct sound_dat
 
 			sample->filename = mem_zalloc(strlen(filename) + 1);
 			my_strcpy(sample->filename, filename, strlen(filename) + 1);
-			data->loaded = true;
+			data->status = SOUND_ST_LOADED;
 			break;
 
 		default:
 			plog_fmt("Sound: Oops - Unsupported file type");
-			data->loaded = false;
 			break;
 	}
 
@@ -1247,7 +1246,7 @@ static bool unload_sound_win(struct sound_data *data)
 
 		mem_free(sample);
 		data->plat_data = NULL;
-		data->loaded = false;
+		data->status = SOUND_ST_UNKNOWN;
 	}
 
 	return true;

--- a/src/sound-core.c
+++ b/src/sound-core.c
@@ -147,8 +147,13 @@ static void load_sound(struct sound_data *sound_data)
 			my_strcpy(filename_buf, path, filename_buf_size);
 			filename_buf = string_append(filename_buf, supported_sound_files[i].extension);
 
-			if (file_exists(filename_buf))
-				load_success = hooks.load_sound_hook(filename_buf, supported_sound_files[i].type, sound_data);
+			if (file_exists(filename_buf)) {
+				sound_data->status = SOUND_ST_ERROR;
+				load_success = hooks.load_sound_hook(
+					filename_buf,
+					supported_sound_files[i].type,
+					sound_data);
+			}
 
 			mem_free(filename_buf);
 			i++;
@@ -315,11 +320,11 @@ static void play_sound(game_event_type type, game_event_data *data, void *user)
 		assert((sound_id >= 0) && (sound_id < next_sound_id));
 
 		/* Ensure the sound is loaded before we play it */
-		if (!sounds[sound_id].loaded)
+		if (sounds[sound_id].status == SOUND_ST_UNKNOWN)
 			load_sound(&sounds[sound_id]);
 
 		/* Only bother playing it if the platform can */
-		if (sounds[sound_id].loaded)
+		if (sounds[sound_id].status == SOUND_ST_LOADED)
 			hooks.play_sound_hook(&sounds[sound_id]);
 	}
 }

--- a/src/sound.h
+++ b/src/sound.h
@@ -24,13 +24,15 @@
  *
  *  hash :      Used to speed up searches
  *
- *  loaded :    The platform's sound module sets this flag if it has enough
- *              information to play the sound (this may mean the sound data
- *              is loaded into memory, or that the full filename has been
- *              stored in the platform data. It is up to the platform's
- *              sound module to determine what 'loaded' means. The core
- *              sound module uses this flag to check if the sound needs to
- *              be 'loaded' before attempting to play it.
+ *  status:     If nothing has yet been done with the sound, this will be
+ *              SOUND_ST_UNKNOWN.  If the sound file exists but the platform's
+ *              sound module did not have enough information to be able to play
+ *              the sound (that is up to the platform's module; it could mean
+ *              that the sound has been loaded into memory or that the full
+ *              file name has been stored in the platform's data), this will be
+ *              SOUND_ST_ERROR.  Otherwise, this will be SOUND_ST_LOADED.
+ *              The core sound module will check if status is SOUND_ST_LOADED
+ *              before attempting to play it.
 
  *  plat_data : Platform specific structure used to store any additional
  *              data the platform's sound module needs in order to play the
@@ -39,10 +41,16 @@
 
 #define SOUND_PRF_FORMAT	"sound sym type str sounds"
 
+enum sound_status {
+	SOUND_ST_UNKNOWN = 0,
+	SOUND_ST_ERROR,
+	SOUND_ST_LOADED
+};
+
 struct sound_data {
 	char *name;
 	uint32_t hash;
-	bool loaded;
+	enum sound_status status;
 	void *plat_data;
 };
 


### PR DESCRIPTION
…(introduced by https://github.com/angband/angband/commit/a318f619c8f8d78994263235dda18a83dde15435 ; breaks OGG support and doesn't work to check for compatibility in all environments - see PowerWyrm's posts, http://angband.oook.cz/forum/showpost.php?p=158644&postcount=125 and http://angband.oook.cz/forum/showpost.php?p=158662&postcount=129 ).  To mitigate the resource leaks in https://github.com/angband/angband/issues/5313 , use a three-way state for each sample (unknown, error, or loaded) and don't try to reload a sample if it reaches the error state.