### PR TITLE
Broaden the possible grids for teleport destinations, allowing grids …

### DIFF
--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -1115,7 +1115,15 @@ void move_player(int dir, bool disarm)
 		if (step) {
 			/* Move player */
 			monster_swap(player->grid, grid);
-			player_handle_post_move(player, true);
+			player_handle_post_move(player, true, false);
+			cmdq_push(CMD_AUTOPICKUP);
+			/*
+			 * The autopickup is a side effect of the move:
+			 * whatever command triggered the move will be the
+			 * target for CMD_REPEAT rather than repeating the
+			 * autopickup.
+			 */
+			cmdq_peek()->is_background_command = true;
 		}
 	}
 

--- a/src/effect-handler-attack.c
+++ b/src/effect-handler-attack.c
@@ -1429,7 +1429,7 @@ bool effect_handler_EARTHQUAKE(effect_handler_context_t *context)
 
 			/* Move player */
 			monster_swap(pgrid, safe_grid);
-			player_handle_post_move(player, true);
+			player_handle_post_move(player, true, true);
 		}
 
 		/* Take some damage */
@@ -1683,7 +1683,7 @@ bool effect_handler_JUMP_AND_BITE(effect_handler_context_t *context)
 
 	/* Move player */
 	monster_swap(player->grid, grid);
-	player_handle_post_move(player, true);
+	player_handle_post_move(player, true, false);
 
 	/* Now bite it */
 	drain = MIN(mon->hp + 1, amount);

--- a/src/game-world.c
+++ b/src/game-world.c
@@ -765,8 +765,12 @@ void process_world(struct chunk *c)
 
 		/* Activate the recall */
 		if (!player->word_recall) {
-			/* Disturbing! */
+			/*
+			 * Disturbing!  Also, flush the command queue to avoid
+			 * losing an action on the new level
+			 */
 			disturb(player);
+			cmdq_flush();
 
 			/* Determine the level */
 			if (player->depth) {

--- a/src/player-util.h
+++ b/src/player-util.h
@@ -113,7 +113,8 @@ bool player_of_has(struct player *p, int flag);
 bool player_resists(struct player *p, int element);
 bool player_is_immune(struct player *p, int element);
 void player_place(struct chunk *c, struct player *p, struct loc grid);
-void player_handle_post_move(struct player *p, bool eval_trap);
+void player_handle_post_move(struct player *p, bool eval_trap,
+		bool is_involuntary);
 void disturb(struct player *p);
 void search(struct player *p);
 

--- a/src/project-mon.c
+++ b/src/project-mon.c
@@ -183,7 +183,7 @@ void thrust_away(struct loc centre, struct loc target, int grids_away)
 					monster_swap(grid, next);
 					if (square(cave, grid)->mon < 0) {
 						player_handle_post_move(
-							player, true);
+							player, true, true);
 					}
 
 					/* Jump to new location. */
@@ -207,7 +207,8 @@ void thrust_away(struct loc centre, struct loc target, int grids_away)
 				/* Travel down the path. */
 				monster_swap(grid, next);
 				if (square(cave, grid)->mon < 0) {
-					player_handle_post_move(player, true);
+					player_handle_post_move(player, true,
+						true);
 				}
 
 				/* Jump to new location. */

--- a/src/trap.c
+++ b/src/trap.c
@@ -575,9 +575,10 @@ extern void hit_trap(struct loc grid, int delayed)
 			monster_swap(player->grid, trap->grid);
 			/*
 			 * Don't retrigger the trap, but handle the
-			 * other side effects of moving the player.
+			 * other side effects of an involuntary move of the
+			 * player.
 			 */
-			player_handle_post_move(player, false);
+			player_handle_post_move(player, false, true);
 		}
 
 		/* Some traps disappear after activating, all have a chance to */


### PR DESCRIPTION
…with objects and more passable terrain.  Addresses the concern expressed in http://angband.oook.cz/forum/showthread.php?t=11066 and https://github.com/draconisPW/PWMAngband/issues/522 .  To avoid losing an action because of autopickup after a teleport, only queue an autopickup after a normal move.  Likewise, disturb and flush the command queue for involuntary moves by the player.  Does open the possibility of artifact loss (teleport, land on artifact, hit by teleport level).