### PR TITLE
Fix two comments

### DIFF
--- a/src/main-gcu.c
+++ b/src/main-gcu.c
@@ -773,7 +773,7 @@ static void handle_extended_color_tables(void) {
 			for (i = 0; i < BASIC_COLORS; i++) {
 				/*
 				 * Scale components to a range of 0 - 1000 per
-				 * per init_color()'s documentation.
+				 * init_color()'s documentation.
 				 */
 				init_color(i,
 					(angband_color_table[i][1] * 1001) / 256,

--- a/src/player-util.c
+++ b/src/player-util.c
@@ -1518,10 +1518,6 @@ void player_handle_post_move(struct player *p, bool eval_trap)
 /*
  * Something has happened to disturb the player.
  *
- * The first arg indicates a major disturbance, which affects search.
- *
- * The second arg is currently unused, but could induce output flush.
- *
  * All disturbance cancels repeated commands, resting, and running.
  *
  * XXX-AS: Make callers either pass in a command


### PR DESCRIPTION
1) Repeated word in a comment in main-gcu.c.
2) In disturb()'s comments, remove references to two arguments that are no longer present.