### PR TITLE
Set up checking of the custom printf-like functions that can be enabled …

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Build
         run: |
           ./autogen.sh
-          ./configure --with-no-install --enable-test --enable-skip-old-int-typedefs
+          ./configure --with-no-install --enable-test --enable-skip-old-int-typedefs --enable-printf-style-checks
           make
           make tests
           ./run-tests
@@ -42,7 +42,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake ..
+          env CFLAGS=-Wall cmake -DUSE_PRINTF_STYLE_CHECKS=ON ..
           make
 
   ncurses:
@@ -61,7 +61,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DSUPPORT_GCU_FRONTEND=ON ..
+          env CFLAGS=-Wall cmake -DSUPPORT_GCU_FRONTEND=ON -DUSE_PRINTF_STYLE_CHECKS=ON ..
           make
 
   sdl:
@@ -80,7 +80,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DSUPPORT_SDL_FRONTEND=ON -DSUPPORT_SDL_SOUND=ON ..
+          env CFLAGS=-Wall cmake -DSUPPORT_SDL_FRONTEND=ON -DSUPPORT_SDL_SOUND=ON -DUSE_PRINTF_STYLE_CHECKS=ON ..
           make
 
   sdl2:
@@ -98,7 +98,7 @@ jobs:
       - name: Build
         run: |
           ./autogen.sh
-          ./configure --with-no-install --enable-sdl2 --enable-sdl2-mixer --enable-skip-old-int-typedefs
+          ./configure --with-no-install --enable-sdl2 --enable-sdl2-mixer --enable-skip-old-int-typedefs --enable-printf-style-checks
           make
 
   statbuild:
@@ -120,5 +120,5 @@ jobs:
       - name: Build
         run: |
           ./autogen.sh
-          env CFLAGS="-Wvla -Wlogical-op" ./configure --enable-more-gcc-warnings --with-no-install --enable-stats --enable-test --enable-sdl-mixer --enable-skip-old-int-typedefs
+          env CFLAGS="-Wvla -Wlogical-op" ./configure --enable-more-gcc-warnings --with-no-install --enable-stats --enable-test --enable-sdl-mixer --enable-skip-old-int-typedefs --enable-printf-style-checks
           make

--- a/.github/workflows/mac.yaml
+++ b/.github/workflows/mac.yaml
@@ -16,4 +16,4 @@ jobs:
       - name: Build
         run: |
           cd src
-          env OPT=-DSKIP_ANGBAND_OLD_INT_TYPEDEFS make -f Makefile.osx
+          env OPT="-DSKIP_ANGBAND_OLD_INT_TYPEDEFS -DUSE_FUNC_ATTR_FORMAT" make -f Makefile.osx

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,28 @@ find_package(Sphinx)
 CMAKE_DEPENDENT_OPTION(BUILD_DOC "Build the documentation" OFF "Sphinx_FOUND" OFF)
 SET(DOC_HTML_THEME "" CACHE STRING "If set and not an empty string, it is the builtin Sphinx HTML theme to use in place of the default theme in conf.py (currently the better theme).")
 
+# Provide option to trigger compiler warnings about the custom printf-style
+# varargs functions.
+INCLUDE(CheckCSourceCompiles)
+CHECK_C_SOURCE_COMPILES(
+	"
+		void f(const char *fmt, ...) __attribute__ ((format (printf, 1, 2)));
+		void f(const char *fmt, ...) {}
+		int main(int argc, char *argv[]) {
+			int i = 10;
+			f(\"%d\", i);
+			return 0;
+		}
+	"
+	HAVE_FUNC_ATTR_FORMAT
+)
+CMAKE_DEPENDENT_OPTION(USE_PRINTF_STYLE_CHECKS "Use extra compiler checks on custom printf-style functions" OFF "HAVE_FUNC_ATTR_FORMAT" OFF)
+IF(USE_PRINTF_STYLE_CHECKS)
+SET(ANGBAND_PRINTF_STYLE_CHECKS_OPTION "USE_FUNC_ATTR_FORMAT")
+ELSE()
+SET(ANGBAND_PRINTF_STYLE_CHECKS_OPTION "")
+ENDIF()
+
 IF ((SUPPORT_NCURSES_FRONTEND) AND (NOT SUPPORT_GCU_FRONTEND))
     SET(SUPPORT_GCU_FRONTEND ON)
 ENDIF()
@@ -432,6 +454,11 @@ ENDIF()
 TARGET_COMPILE_DEFINITIONS(OurExecutable PRIVATE "${ANGBAND_BUILD_ID_OPTION}")
 TARGET_COMPILE_DEFINITIONS(OurCoreLib PRIVATE "${ANGBAND_BUILD_ID_OPTION}")
 
+# Set the preprocessor directive to trigger extra checking of the printf-style
+# functions.
+TARGET_COMPILE_DEFINITIONS(OurExecutable PRIVATE "${ANGBAND_PRINTF_STYLE_CHECKS_OPTION}")
+TARGET_COMPILE_DEFINITIONS(OurCoreLib PRIVATE "${ANGBAND_PRINTF_STYLE_CHECKS_OPTION}")
+
 # Set up to generate documentation if requested.
 IF(BUILD_DOC)
     INCLUDE(src/cmake/modules/SphinxDocument.cmake)
@@ -776,6 +803,7 @@ TARGET_INCLUDE_DIRECTORIES(OurUnitTestLib PRIVATE
     ${ANGBAND_CORE_INCLUDE_DIRS}
 )
 TARGET_COMPILE_DEFINITIONS(OurUnitTestLib PRIVATE "${ANGBAND_BUILD_ID_OPTION}")
+TARGET_COMPILE_DEFINITIONS(OurUnitTestLib PRIVATE "${ANGBAND_PRINTF_STYLE_CHECKS_OPTION}")
 # Use the same definitions for the hardwired paths as were used (or would
 # be used if it wasn't the Windows front end) for the executable.
 TARGET_COMPILE_DEFINITIONS(OurUnitTestLib PRIVATE -D DEFAULT_CONFIG_PATH="${ANGBAND_CONFIG_PATH}")
@@ -814,6 +842,7 @@ FOREACH(ANGBAND_TEST_CASE ${ANGBAND_TEST_CASE_LIST})
         ${ANGBAND_UNIT_TEST_INCLUDE_DIRS}
     )
     TARGET_COMPILE_DEFINITIONS(${ANGBAND_TEST_CASE_NAME} PRIVATE "${ANGBAND_BUILD_ID_OPTION}")
+    TARGET_COMPILE_DEFINITIONS(${ANGBAND_TEST_CASE_NAME} PRIVATE "${ANGBAND_PRINTF_STYLE_CHECKS_OPTION}")
     TARGET_LINK_LIBRARIES(${ANGBAND_TEST_CASE_NAME} PRIVATE
         ${ANGBAND_CORE_LINK_LIBRARIES}
     )

--- a/configure.ac
+++ b/configure.ac
@@ -148,6 +148,25 @@ if test "$GCC" = "yes"; then
 	fi
 fi
 
+AC_ARG_ENABLE(printf-style-checks,
+	[AS_HELP_STRING([--enable-printf-style-checks], [enable compiler checks on custom functions that act like printf])],
+	[AS_CASE(${enableval},
+		[yes], [printf_style_checks=yes],
+		[no], [printf_style_checks=no],
+		[AC_MSG_ERROR([bad value ${enableval} for --enable-printf-style-checks])])],
+		[printf_style_checks=no])
+if test x"$printf_style_checks" = xyes ; then
+	AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+void f(const char *fmt, ...) __attribute__ ((format (printf, 1, 2)));
+void f(const char *fmt, ...) {}
+int main(int argc, char *argv[]) {
+	int i = 10;
+	f("%d", i);
+	return 0;
+}
+]])], [CPPFLAGS="$CPPFLAGS -DUSE_FUNC_ATTR_FORMAT"])
+fi
+
 AC_ARG_ENABLE(skip-old-int-typedefs,
 	[AS_HELP_STRING([--enable-skip-old-int-typedefs], [do not generate the u32b, s32b, ... typedefs in Angband's headers])],
 	[AS_CASE(${enableval},

--- a/src/z-file.h
+++ b/src/z-file.h
@@ -201,7 +201,15 @@ bool file_put(ang_file *f, const char *buf);
 /**
  * Format (using strnfmt) the given args, and then call file_put().
  */
-bool file_putf(ang_file *f, const char *fmt, ...);
+bool file_putf(ang_file *f, const char *fmt, ...)
+/*
+ * This is to automate format string checking with gcc and clang:  see
+ * see https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#Common-Function-Attributes .
+ */
+#ifdef USE_FUNC_ATTR_FORMAT
+	__attribute__ ((format (printf, 2, 3)))
+#endif
+;
 bool file_vputf(ang_file *f, const char *fmt, va_list vp);
 
 

--- a/src/z-form.h
+++ b/src/z-form.h
@@ -41,7 +41,15 @@ extern size_t vstrnfmt(char *buf, size_t max, const char *fmt, va_list vp);
 /**
  * Simple interface to "vstrnfmt()"
  */
-extern size_t strnfmt(char *buf, size_t max, const char *fmt, ...);
+extern size_t strnfmt(char *buf, size_t max, const char *fmt, ...)
+/*
+ * This and further instances below are to automate format string checking
+ * with gcc and clang:  see https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#Common-Function-Attributes .
+ */
+#ifdef USE_FUNC_ATTR_FORMAT
+	__attribute ((format (printf, 3, 4)))
+#endif
+;
 
 /**
  * Format arguments into a static resizing buffer
@@ -56,22 +64,37 @@ extern void vformat_kill(void);
 /**
  * Append a formatted string to another string
  */
-extern void strnfcat(char *str, size_t max, size_t *end, const char *fmt, ...);
+extern void strnfcat(char *str, size_t max, size_t *end, const char *fmt, ...)
+#ifdef USE_FUNC_ATTR_FORMAT
+	__attribute__ ((format (printf, 4, 5)))
+#endif
+;
 
 /**
  * Simple interface to "vformat()"
  */
-extern char *format(const char *fmt, ...);
+extern char *format(const char *fmt, ...)
+#ifdef USE_FUNC_ATTR_FORMAT
+	__attribute__ ((format (printf, 1, 2)))
+#endif
+;
 
 /**
  * Vararg interface to "plog()", using "format()"
  */
-extern void plog_fmt(const char *fmt, ...);
+extern void plog_fmt(const char *fmt, ...)
+#ifdef USE_FUNC_ATTR_FORMAT
+	__attribute__ ((format (printf, 1, 2)))
+#endif
+;
 
 /**
  * Vararg interface to "quit()", using "format()"
  */
-extern void quit_fmt(const char *fmt, ...);
-
+extern void quit_fmt(const char *fmt, ...)
+#ifdef USE_FUNC_ATTR_FORMAT
+	__attribute__ ((format (printf, 1, 2)))
+#endif
+;
 
 #endif /* INCLUDED_Z_FORM_H */

--- a/src/z-textblock.h
+++ b/src/z-textblock.h
@@ -29,8 +29,20 @@ textblock *textblock_new(void);
 void textblock_free(textblock *tb);
 
 
-void textblock_append(textblock *tb, const char *fmt, ...);
-void textblock_append_c(textblock *tb, uint8_t attr, const char *fmt, ...);
+void textblock_append(textblock *tb, const char *fmt, ...)
+/*
+ * This and further instances below are to automate format string checking
+ * with gcc and clang:  see https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#Common-Function-Attributes .
+ */
+#ifdef USE_FUNC_ATTR_FORMAT
+	__attribute ((format (printf, 2, 3)))
+#endif
+;
+void textblock_append_c(textblock *tb, uint8_t attr, const char *fmt, ...)
+#ifdef USE_FUNC_ATTR_FORMAT
+	__attribute ((format (printf, 3, 4)))
+#endif
+;
 void textblock_append_pict(textblock *tb, uint8_t attr, int c);
 void textblock_append_textblock(textblock *tb, const textblock *tba);
 
@@ -49,9 +61,21 @@ extern int text_out_indent;
 extern int text_out_pad;
 
 extern void text_out_to_file(uint8_t attr, const char *str);
-extern void text_out(const char *fmt, ...);
-extern void text_out_c(uint8_t a, const char *fmt, ...);
-extern void text_out_e(const char *fmt, ...);
+extern void text_out(const char *fmt, ...)
+#ifdef USE_FUNC_ATTR_FORMAT
+	__attribute ((format (printf, 1, 2)))
+#endif
+;
+extern void text_out_c(uint8_t a, const char *fmt, ...)
+#ifdef USE_FUNC_ATTR_FORMAT
+	__attribute ((format (printf, 2, 3)))
+#endif
+;
+extern void text_out_e(const char *fmt, ...)
+#ifdef USE_FUNC_ATTR_FORMAT
+	__attribute ((format (printf, 1, 2)))
+#endif
+;
 
 typedef void (*text_writer)(ang_file *f);
 errr text_lines_to_file(const char *path, text_writer writer);


### PR DESCRIPTION
… by setting the USE_FUNC_ATTR_FORMAT preprocessor directive or with configuration options to configure or cmake.  Turn on that checking in some of the Github workflows.  Attempts to help automate some of the auditing for the ongoing issue, https://github.com/angband/angband/issues/2950 .