### PR TITLE
Make escaping from second level of action menu return to the first

### DIFF
--- a/src/ui-context.c
+++ b/src/ui-context.c
@@ -1193,8 +1193,9 @@ static bool cmd_menu(struct command_list *list, void *selection_p)
 				return cmd_menu(&cmds_all[list->list[menu.cursor].nested_cached_idx], selection_p);
 			}
 		}
-	}
-
+	} else if (evt.type == EVT_ESCAPE) {
+		textui_action_menu_choose();
+	} 
 	return false;
 }
 


### PR DESCRIPTION
Previously, escaping out of the nested action menu would exit the menu entirely. This changes it to return to the first menu level.

This allows the player to search for commands in the action menu without reentering the first menu each time.