### PR TITLE
Correct redrawn grid for target closest ("'").  Found while looking …

### DIFF
--- a/src/ui-target.c
+++ b/src/ui-target.c
@@ -950,6 +950,7 @@ void textui_target_closest(void)
 	if (target_set_closest(TARGET_KILL, NULL)) {
 		bool visibility;
 		struct loc target;
+		int tmx, tmy;
 
 		target_get(&target);
 
@@ -958,7 +959,8 @@ void textui_target_closest(void)
 		Term_get_cursor(&visibility);
 		(void)Term_set_cursor(true);
 		move_cursor_relative(target.y, target.x);
-		Term_redraw_section(target.y, target.x, target.y, target.x);
+		Term_locate(&tmx, &tmy);
+		Term_redraw_section(tmx, tmy, tmx, tmy);
 
 		/* TODO: what's an appropriate amount of time to spend highlighting */
 		Term_xtra(TERM_XTRA_DELAY, 150);


### PR DESCRIPTION
…for a possible cause of the memory corruption causing https://github.com/angband/angband/issues/5334 but haven't seen that incorrect coordinate triggering out-of-bound writes or reads.