### PR TITLE
When stepping on a trapped square, only disturb if the trap fires.  …

### DIFF
--- a/src/player-util.c
+++ b/src/player-util.c
@@ -1496,21 +1496,9 @@ void player_handle_post_move(struct player *p, bool eval_trap,
 	}
 
 	/* Discover invisible traps, set off visible ones */
-	if (eval_trap) {
-		if (square_issecrettrap(cave, p->grid)) {
-			disturb(p);
-			hit_trap(p->grid, 0);
-		} else if (square_isdisarmabletrap(cave, p->grid)) {
-			if (player_is_trapsafe(p)) {
-				/* Trap immune player learns that they are */
-				if (player_of_has(p, OF_TRAP_IMMUNE)) {
-					equip_learn_flag(p, OF_TRAP_IMMUNE);
-				}
-			} else {
-				disturb(p);
-				hit_trap(p->grid, 0);
-			}
-		}
+	if (eval_trap && square_isplayertrap(cave, p->grid)
+			&& !square_isdisabledtrap(cave, p->grid)) {
+		hit_trap(p->grid, 0);
 	}
 
 	/* Update view and search */

--- a/src/trap.c
+++ b/src/trap.c
@@ -489,9 +489,6 @@ extern void hit_trap(struct loc grid, int delayed)
 	struct trap *trap;
 	struct effect *effect;
 
-	/* The player is safe from all traps */
-	if (player_is_trapsafe(player)) return;
-
 	/* Look at the traps in this grid */
 	for (trap = square_trap(cave, grid); trap; trap = trap->next) {
 		int flag;
@@ -505,14 +502,18 @@ extern void hit_trap(struct loc grid, int delayed)
 		    delayed != -1)
 			continue;
 
+		if (player_is_trapsafe(player)) {
+			/* Trap immune player learns the rune */
+			if (player_of_has(player, OF_TRAP_IMMUNE)) {
+				equip_learn_flag(player, OF_TRAP_IMMUNE);
+			}
+			/* Trap becomes visible. */
+			trf_on(trap->flags, TRF_VISIBLE);
+			continue;
+		}
+
 		/* Disturb the player */
 		disturb(player);
-
-		/* Trap immune player learns the rune */
-		if (player_of_has(player, OF_TRAP_IMMUNE)) {
-			equip_learn_flag(player, OF_TRAP_IMMUNE);
-			break;
-		}
 
 		/* Give a message */
 		if (trap->kind->msg)


### PR DESCRIPTION
…If the player is trap safe, reveal the trap and learn the trap immunity rune if appropriate.  Resolves https://github.com/angband/angband/issues/5367 .  The prior version always disturbed the player for secret traps and, if not-trapsafe, for visible traps.  It also did not reveal hidden traps for trapsafe players and would only learn the trap immunity rune for those players when stepping on a visible trap.