### PR TITLE
Return early from process_world() if the player takes fatal damage.  …

### DIFF
--- a/src/game-world.c
+++ b/src/game-world.c
@@ -586,8 +586,12 @@ void process_world(struct chunk *c)
 	/*** Damage (or healing) over Time ***/
 
 	/* Take damage from poison */
-	if (player->timed[TMD_POISONED])
+	if (player->timed[TMD_POISONED]) {
 		take_hit(player, 1, "poison");
+		if (player->is_dead) {
+			return;
+		}
+	}
 
 	/* Take damage from cuts, worse from serious cuts */
 	if (player->timed[TMD_CUT]) {
@@ -605,6 +609,9 @@ void process_world(struct chunk *c)
 
 		/* Take damage */
 		take_hit(player, i, "a fatal wound");
+		if (player->is_dead) {
+			return;
+		}
 	}
 
 	/* Side effects of diminishing bloodlust */
@@ -612,6 +619,9 @@ void process_world(struct chunk *c)
 		player_over_exert(player, PY_EXERT_HP | PY_EXERT_CUT | PY_EXERT_SLOW,
 						  MAX(0, 10 - player->timed[TMD_BLOODLUST]),
 						  player->chp / 10);
+		if (player->is_dead) {
+			return;
+		}
 	}
 
 	/* Timed healing */
@@ -697,6 +707,9 @@ void process_world(struct chunk *c)
 
 		/* Take damage */
 		take_hit(player, i, "starvation");
+		if (player->is_dead) {
+			return;
+		}
 	}
 
 	/* Regenerate Hit Points if needed */


### PR DESCRIPTION
…Avoids sequences of messages like, "You die.  You are no longer poisoned.".