### PR TITLE
In savefile_load(), don't reset is_dead based on the current hit points. …

### DIFF
--- a/src/savefile.c
+++ b/src/savefile.c
@@ -643,10 +643,6 @@ bool savefile_load(const char *path, bool cheat_death)
 	ok = try_load(f, loaders);
 	file_close(f);
 
-	if (player->chp < 0) {
-		player->is_dead = true;
-	}
-
 	if (player->is_dead && cheat_death) {
 			player->is_dead = false;
 			player->chp = player->mhp;


### PR DESCRIPTION
Resolves https://github.com/angband/angband/issues/5420 (blackguard with negative hit points and bloodlust active is marked as dead if saved and then loaded).