### PR TITLE
For the Mac front end, only allow saving or the send command menu …

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -6111,9 +6111,10 @@ static void cocoa_reinit(void)
     {
         /*
          * we only want to be able to send commands during an active game
-         * after the birth screens
+         * after the birth screens when the core is waiting for a player
+	 * command
          */
-        return !!game_in_progress && character_generated;
+        return !!game_in_progress && character_generated && inkey_flag;
     }
     else return YES;
 }


### PR DESCRIPTION
…actions when the core game is waiting for a player command.  That's in line with the Windows and SDL front ends and prevents saving while at the "You die. [more]" prompt (i.e. before is_dead is set).