### PR TITLE
For fiery terrain, targeted earthquakes, and curse removal, damage …

### DIFF
--- a/src/effect-handler-attack.c
+++ b/src/effect-handler-attack.c
@@ -1357,7 +1357,7 @@ bool effect_handler_EARTHQUAKE(effect_handler_context_t *context)
 		}
 	}
 
-	/* First, affect the player (if necessary) */
+	/* First, determine the effects on the player (if necessary) */
 	if (hurt) {
 		/* Check around the player */
 		for (i = 0; i < 8; i++) {
@@ -1431,9 +1431,6 @@ bool effect_handler_EARTHQUAKE(effect_handler_context_t *context)
 			monster_swap(pgrid, safe_grid);
 			player_handle_post_move(player, true, true);
 		}
-
-		/* Take some damage */
-		if (damage) take_hit(player, damage, "an earthquake");
 	}
 
 
@@ -1549,6 +1546,12 @@ bool effect_handler_EARTHQUAKE(effect_handler_context_t *context)
 			}
 		}
 	}
+
+	/*
+	 * Apply damage to player; done here so messages are ordered properly
+	 * if the player dies.
+	 */
+	if (damage) take_hit(player, damage, "an earthquake");
 
 	/* Fully update the visuals */
 	player->upkeep->update |= (PU_UPDATE_VIEW | PU_MONSTERS);

--- a/src/effect-handler-general.c
+++ b/src/effect-handler-general.c
@@ -202,7 +202,6 @@ static bool uncurse_object(struct object *obj, int strength, char *dice_string)
 			struct object *destroyed;
 			bool none_left = false;
 			msg("There is a bang and a flash!");
-			take_hit(player, damroll(5, 5), "Failed uncursing");
 			if (object_is_carried(player, obj)) {
 				destroyed = gear_object_for_use(player, obj,
 					1, false, &none_left);
@@ -215,6 +214,7 @@ static bool uncurse_object(struct object *obj, int strength, char *dice_string)
 			} else {
 				square_delete_object(cave, obj->grid, obj, true, true);
 			}
+			take_hit(player, damroll(5, 5), "Failed uncursing");
 		} else {
 			/* Non-destructive failure */
 			msg("The removal fails.");

--- a/src/player-util.c
+++ b/src/player-util.c
@@ -832,11 +832,11 @@ void player_take_terrain_damage(struct player *p, struct loc grid)
 	}
 
 	/* Damage the player and inventory */
-	take_hit(p, dam_taken, square_feat(cave, grid)->die_msg);
 	if (square_isfiery(cave, grid)) {
 		msg(square_feat(cave, grid)->hurt_msg);
 		inven_damage(p, PROJ_FIRE, dam_taken);
 	}
+	take_hit(p, dam_taken, square_feat(cave, grid)->die_msg);
 }
 
 /**


### PR DESCRIPTION
…player last so messages are ordered properly if the player dies.  Avoids "You die. The lava burns you!" and "The ground shakes! The ceiling caves in! You die. The white jelly wails out in pain! The white jelly is embedded in the rock!".