### PR TITLE
Drop Term_redraw_section() call in response to target closest ("'"): …

### DIFF
--- a/src/ui-target.c
+++ b/src/ui-target.c
@@ -958,8 +958,6 @@ void textui_target_closest(void)
 		Term_get_cursor(&visibility);
 		(void)Term_set_cursor(true);
 		move_cursor_relative(target.y, target.x);
-		Term_redraw_section(target.y, target.x, target.y, target.x);
-
 		/* TODO: what's an appropriate amount of time to spend highlighting */
 		Term_xtra(TERM_XTRA_DELAY, 150);
 		(void)Term_set_cursor(visibility);


### PR DESCRIPTION
… the coordinates have been wrong (cave rather than terminal) for years with no complaints and current front ends appear to work fine without it (tested on Debian 11; Windows front end under Wine).