### PR TITLE
For including the Windows sound module, test for SOUND_SDL or …

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -5500,10 +5500,14 @@ static bool cocoa_get_file(const char *suggested_name, char *path, size_t len)
  */
 static void cocoa_reinit(void)
 {
-#if defined(SOUND) && !defined(SOUND_SDL) && !defined(SOUND_SDL2)
 	/* Initialize sound. */
+#ifdef SOUND
+#if defined(SOUND_SDL) || defined(SOUND_SDL2)
+	init_sound("sdl", 0, NULL);
+#else
 	init_sound("cocoa", 0, NULL);
-#endif
+#endif /* else SOUND_SDL || SOUND_SDL2 */
+#endif /* SOUND */
 }
 
 /**

--- a/src/main-win.c
+++ b/src/main-win.c
@@ -81,7 +81,7 @@
 
 #define uint unsigned int
 
-#if (defined(WINDOWS) && !defined(USE_SDL)) && !defined(USE_SDL2)
+#if defined(WINDOWS) && !defined(USE_SDL) && !defined(USE_SDL2)
 
 #include "sound.h"
 #include "snd-win.h"
@@ -1111,7 +1111,7 @@ static bool init_graphics(void)
 	return (can_use_graphics);
 }
 
-#ifdef SOUND
+#if defined(SOUND) && !defined(SOUND_SDL) && !defined(SOUND_SDL2)
 
 /* Supported file types */
 enum {
@@ -1282,7 +1282,7 @@ errr init_sound_win(struct sound_hooks *hooks, int argc, char **argv)
 	/* Success */
 	return (0);
 }
-#endif /* SOUND */
+#endif /* SOUND && !SOUND_SDL && !SOUND_SDL2 */
 
 
 /**
@@ -5025,8 +5025,14 @@ static void init_stuff(void)
  */
 static void win_reinit(void)
 {
-	/* Initialise sound. */
+/* Initialise sound. */
+#ifdef SOUND
+#if defined(SOUND_SDL) || defined(SOUND_SOUND_SDL2)
+	init_sound("sdl", 0, NULL);
+#else
 	init_sound("win", 0, NULL);
+#endif /* else SOUND_SDL || SOUND_SDL2 */
+#endif /* SOUND */
 
 	/*
 	 * Watch for these events to set up and tear down protection against

--- a/src/sound-core.c
+++ b/src/sound-core.c
@@ -24,7 +24,7 @@
 #include "snd-sdl.h"
 #endif
 
-#if (!defined(WIN32_CONSOLE_MODE) && defined(WINDOWS) && defined(SOUND) && !defined(USE_SDL) && !defined(USE_SDL2))
+#if (!defined(WIN32_CONSOLE_MODE) && defined(WINDOWS) && defined(SOUND) && !defined(SOUND_SDL) && !defined(SOUND_SDL2))
 #include "snd-win.h"
 #endif
 
@@ -62,7 +62,7 @@ static const struct sound_module sound_modules[] =
 #if defined(SOUND_SDL) || defined(SOUND_SDL2)
 	{ "sdl", "SDL_mixer sound module", init_sound_sdl },
 #endif /* SOUND_SDL || SOUND_SDL2 */
-#if (!defined(WIN32_CONSOLE_MODE) && defined(WINDOWS) && defined(SOUND) && !defined(USE_SDL) && !defined(USE_SDL2))
+#if (!defined(WIN32_CONSOLE_MODE) && defined(WINDOWS) && defined(SOUND) && !defined(SOUND_SDL) && !defined(SOUND_SDL2))
 	{ "win", "Windows sound module", init_sound_win },
 #endif
 #if (defined(MACH_O_CARBON) && defined(SOUND) && !defined(SOUND_SDL) && !defined(SOUND_SDL2))


### PR DESCRIPTION
…SOUND_SDL2 rather than USE_SDL or USE_SDL2 since the latter are what are currently set when using SDL sound.  In the Windows and Mac front ends, match up the preprocessor defines guarding init_sound() to what's in sound-core.c and allow, at least in principle, the use of SDL sound with those front ends.