### PR TITLE
Fix regression (with rogue-like keyset, unable to access ignore via …

### DIFF
--- a/src/ui-event.h
+++ b/src/ui-event.h
@@ -124,6 +124,16 @@ typedef enum
 
 
 /**
+ * Given a control character X, turn it into its uppercase ASCII equivalent.
+ * Prefer using UN_KTRL() over this except for inscription testing and menu
+ * shortcuts where there are clashes for the rogue-like keyset (UN_KTRL()
+ * for the rogue-like ignore command, '^d', gives 'd' which clashes with the
+ * drop command).
+ */
+#define UN_KTRL_CAP(X) \
+	((X) + 64)
+
+/**
  * Keyset mappings for various keys.
  */
 #define ARROW_DOWN    0x80

--- a/src/ui-game.c
+++ b/src/ui-game.c
@@ -454,8 +454,12 @@ unsigned char cmd_lookup_key_unktrl(cmd_code lookup_cmd, int mode)
 {
 	unsigned char c = cmd_lookup_key(lookup_cmd, mode);
 
+	/*
+	 * Because UN_KTRL('ctrl-d') (i.e. rogue-like ignore command) gives 'd'
+	 * which is the drop command in both keysets, use UN_KTRL_CAP().
+	 */
 	if (c < 0x20)
-		c = UN_KTRL(c);
+		c = UN_KTRL_CAP(c);
 
 	return c;
 }

--- a/src/ui-object.c
+++ b/src/ui-object.c
@@ -624,9 +624,13 @@ bool get_item_allow(const struct object *obj, unsigned char ch, cmd_code cmd,
 
 	unsigned n;
 
-	/* Hack - Only shift the command key if it actually needs to be shifted. */
+	/*
+	 * Hack - Only shift the command key if it actually needs to be shifted.
+	 * Because UN_KTRL('ctrl-d') (i.e. rogue-like ignore command) gives 'd'
+	 * which is the drop command in both keysets, use UN_KTRL_CAP().
+	 */
 	if (ch < 0x20)
-		ch = UN_KTRL(ch);
+		ch = UN_KTRL_CAP(ch);
 
 	/* The inscription to look for */
 	verify_inscrip[1] = ch;
@@ -714,11 +718,7 @@ static bool get_tag(struct object **tagged_obj, char tag, cmd_code cmd,
 				return true;
 			}
 
-			cmdkey = cmd_lookup_key(cmd, mode);
-
-			/* Hack - Only shift the command key if it actually needs to be. */
-			if (cmdkey < 0x20)
-				cmdkey = UN_KTRL(cmdkey);
+			cmdkey = cmd_lookup_key_unktrl(cmd, mode);
 
 			/* Check the special tags */
 			if ((s[1] == cmdkey) && (s[2] == tag)) {


### PR DESCRIPTION
…the object context menu and '!D' inscription no longer works to prompt before ignoring) introduced by https://github.com/angband/angband/pull/5409 .  Resolves https://github.com/angband/angband/issues/5436 .