### PR TITLE
Fix regression for earthquake effects:  damage to player conflated …

### DIFF
--- a/src/effect-handler-attack.c
+++ b/src/effect-handler-attack.c
@@ -1451,6 +1451,7 @@ bool effect_handler_EARTHQUAKE(effect_handler_context_t *context)
 				if (!flags_test(mon->race->flags, RF_SIZE, RF_KILL_WALL,
 								RF_PASS_WALL, FLAG_END)) {
 					char m_name[80];
+					int m_dam;
 
 					/* Assume not safe */
 					safe_grids = 0;
@@ -1489,17 +1490,17 @@ bool effect_handler_EARTHQUAKE(effect_handler_context_t *context)
 					msg("%s wails out in pain!", m_name);
 
 					/* Take damage from the quake */
-					damage = (safe_grids ? damroll(4, 8) : (mon->hp + 1));
+					m_dam = (safe_grids ? damroll(4, 8) : (mon->hp + 1));
 
 					/* Monster is certainly awake, not thinking about player */
 					monster_wake(mon, false, 0);
 
 					/* If the quake finished the monster off, show message */
-					if (mon->hp < damage && mon->hp >= 0)
+					if (mon->hp < m_dam && mon->hp >= 0)
 						msg("%s is embedded in the rock!", m_name);
 
 					/* Apply damage directly */
-					mon->hp -= damage;
+					mon->hp -= m_dam;
 
 					/* Delete (not kill) "dead" monsters */
 					if (mon->hp < 0) {


### PR DESCRIPTION
…with damage to monsters; introduced by https://github.com/angband/angband/commit/e1762948fa857f883068c81e717ba89d0d47c1ab .  Thanks to PowerWyrm for the report, http://angband.oook.cz/forum/showthread.php?t=11287 .