### PR TITLE
Fix so an invalid monster spell name for the message-vis, message-…

### DIFF
--- a/src/mon-init.c
+++ b/src/mon-init.c
@@ -584,7 +584,7 @@ static enum parser_error parse_mon_spell_name(struct parser *p) {
 	const char *name = parser_getstr(p, "name");
 	int index;
 	s->next = h;
-	if (grab_name("monster spell", name, r_info_spell_flags, N_ELEMENTS(r_info_spell_flags), &index))
+	if (grab_name("monster spell", name, r_info_spell_flags, N_ELEMENTS(r_info_spell_flags) - 1, &index))
 		return PARSE_ERROR_INVALID_SPELL_NAME;
 	s->index = index;
 	s->level = mem_zalloc(sizeof(*(s->level)));
@@ -1422,7 +1422,7 @@ static enum parser_error parse_monster_msg_vis(struct parser *p) {
 
 	if (!r) return PARSE_ERROR_MISSING_RECORD_HEADER;
 	if (grab_name("monster spell", spell, r_info_spell_flags,
-			N_ELEMENTS(r_info_spell_flags), &s_idx))
+			N_ELEMENTS(r_info_spell_flags) - 1, &s_idx))
 			return PARSE_ERROR_INVALID_SPELL_NAME;
 	add_alternate_spell_message(r, s_idx, MON_ALTMSG_SEEN, msg);
 
@@ -1438,7 +1438,7 @@ static enum parser_error parse_monster_msg_invis(struct parser *p) {
 
 	if (!r) return PARSE_ERROR_MISSING_RECORD_HEADER;
 	if (grab_name("monster spell", spell, r_info_spell_flags,
-			N_ELEMENTS(r_info_spell_flags), &s_idx))
+			N_ELEMENTS(r_info_spell_flags) - 1, &s_idx))
 			return PARSE_ERROR_INVALID_SPELL_NAME;
 	add_alternate_spell_message(r, s_idx, MON_ALTMSG_UNSEEN, msg);
 
@@ -1454,7 +1454,7 @@ static enum parser_error parse_monster_msg_miss(struct parser *p) {
 
 	if (!r) return PARSE_ERROR_MISSING_RECORD_HEADER;
 	if (grab_name("monster spell", spell, r_info_spell_flags,
-			N_ELEMENTS(r_info_spell_flags), &s_idx))
+			N_ELEMENTS(r_info_spell_flags) - 1, &s_idx))
 			return PARSE_ERROR_INVALID_SPELL_NAME;
 	add_alternate_spell_message(r, s_idx, MON_ALTMSG_MISS, msg);
 

--- a/src/tests/parse/r-info.c
+++ b/src/tests/parse/r-info.c
@@ -334,6 +334,14 @@ static int test_messagevis0(void *state) {
 	ok;
 }
 
+static int test_messagevis_bad0(void *state) {
+	enum parser_error r = parser_parse(state,
+		"message-vis:XYZZY:{name} waves its tentacles menacingly.");
+
+	eq(r, PARSE_ERROR_INVALID_SPELL_NAME);
+	ok;
+}
+
 static int test_messageinvis0(void *state) {
 	enum parser_error r = parser_parse(state,
 		"message-invis:BLINK");
@@ -343,6 +351,14 @@ static int test_messageinvis0(void *state) {
 	mr = parser_priv(state);
 	require(mr);
 	require(has_alternate_message(mr, RSF_BLINK, MON_ALTMSG_UNSEEN, ""));
+	ok;
+}
+
+static int test_messageinvis_bad0(void *state) {
+	enum parser_error r = parser_parse(state,
+		"message-invis:XYZZY:Something whispers.");
+
+	eq(r, PARSE_ERROR_INVALID_SPELL_NAME);
 	ok;
 }
 
@@ -356,6 +372,14 @@ static int test_messagemiss0(void *state) {
 	require(mr);
 	require(has_alternate_message(mr, RSF_BOULDER, MON_ALTMSG_MISS,
 		"{name} throws a boulder and misses."));
+	ok;
+}
+
+static int test_messagemiss_bad0(void *state) {
+	enum parser_error r = parser_parse(state,
+		"message-miss:XYZZY:{name} bobbles the ball and drops it.");
+
+	eq(r, PARSE_ERROR_INVALID_SPELL_NAME);
 	ok;
 }
 
@@ -381,7 +405,10 @@ struct test tests[] = {
 	{ "spell-freq0", test_spell_freq0 },
 	{ "spells0", test_spells0 },
 	{ "message-vis0", test_messagevis0 },
+	{ "message-vis-bad0", test_messagevis_bad0 },
 	{ "message-invis0", test_messageinvis0 },
+	{ "message-invis-bad0", test_messageinvis_bad0 },
 	{ "message-miss0", test_messagemiss0 },
+	{ "message-miss-bad0", test_messagemiss_bad0 },
 	{ NULL, NULL }
 };


### PR DESCRIPTION
…invis, and message-miss directives in monster.txt or the name directive in monster_spell.txt does not cause a null pointer to be dereferenced in grab_name().  Add test cases to exercise that for monster.txt.