### PR TITLE
Fix places where monster_is_mimicking() was used as a synonym for mon…

### DIFF
--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -294,11 +294,11 @@ void do_cmd_open(struct command *cmd)
 	/* Monster */
 	mon = square_monster(cave, grid);
 	if (mon) {
-		/* Mimics surprise the player */
-		if (monster_is_mimicking(mon)) {
+		/* Camouflaged monsters surprise the player */
+		if (monster_is_camouflaged(mon)) {
 			become_aware(cave, mon);
 
-			/* Mimic wakes up and becomes aware*/
+			/* Camouflaged monster wakes up and becomes aware */
 			monster_wake(mon, false, 100);
 		} else {
 			/* Message */
@@ -1028,10 +1028,10 @@ void move_player(int dir, bool disarm)
 	/* Many things can happen on movement */
 	if (m_idx > 0) {
 		/* Attack monsters */
-		if (monster_is_mimicking(mon)) {
+		if (monster_is_camouflaged(mon)) {
 			become_aware(cave, mon);
 
-			/* Mimic wakes up and becomes aware*/
+			/* Camouflaged monster wakes up and becomes aware */
 			monster_wake(mon, false, 100);
 		} else {
 			py_attack(player, grid);
@@ -1138,8 +1138,8 @@ static bool do_cmd_walk_test(struct loc grid)
 	int m_idx = square(cave, grid)->mon;
 	struct monster *mon = cave_monster(cave, m_idx);
 
-	/* Allow attack on visible monsters if unafraid */
-	if (m_idx > 0 && monster_is_visible(mon) &&	!monster_is_mimicking(mon)) {
+	/* Allow attack on obvious monsters if unafraid */
+	if (m_idx > 0 && monster_is_obvious(mon)) {
 		/* Handle player fear */
 		if (player_of_has(player, OF_AFRAID)) {
 			/* Extract monster name (or "it") */

--- a/src/mon-move.c
+++ b/src/mon-move.c
@@ -994,14 +994,14 @@ bool multiply_monster(const struct monster *mon)
 		result = place_new_monster(cave, grid, mon->race, false, false,
 			info, ORIGIN_DROP_BREED);
 		/*
-		 * Fix so multiplying a revealed mimic creates another
-		 * revealed mimic.
+		 * Fix so multiplying a revealed camouflaged monster creates
+		 * another revealed camouflaged monster.
 		 */
 		if (result) {
 			struct monster *child = square_monster(cave, grid);
 
-			if (child && monster_is_mimicking(child)
-					&& !monster_is_mimicking(mon)) {
+			if (child && monster_is_camouflaged(child)
+					&& !monster_is_camouflaged(mon)) {
 				become_aware(cave, child);
 			}
 		}
@@ -1343,8 +1343,8 @@ static bool monster_turn_try_push(struct monster *mon, const char *m_name,
 			rf_on(lore->flags, RF_MOVE_BODY);
 		}
 
-		/* Reveal mimics */
-		if (monster_is_mimicking(mon1))
+		/* Reveal camouflaged monsters */
+		if (monster_is_camouflaged(mon1))
 			become_aware(cave, mon1);
 
 		/* Note if visible */

--- a/src/mon-util.c
+++ b/src/mon-util.c
@@ -467,7 +467,7 @@ void update_mon(struct monster *mon, struct chunk *c, bool full)
 			mflag_off(mon->mflag, MFLAG_VIEW);
 
 			/* Disturb on disappearance */
-			if (OPT(player, disturb_near) && !monster_is_mimicking(mon))
+			if (OPT(player, disturb_near) && !monster_is_camouflaged(mon))
 				disturb(player);
 
 			/* Re-draw monster list window */
@@ -584,16 +584,16 @@ void monster_swap(struct loc grid1, struct loc grid2)
 		mon = cave_monster(cave, m1);
 
 		/* Update monster */
-		if (monster_is_mimicking(mon)) {
+		if (monster_is_camouflaged(mon)) {
 			/*
-			 * Become aware if the player can see the mimic before
-			 * or after the swap.
+			 * Become aware if the player can see the grid with
+			 * the camouflaged monster before or after the swap.
 			 */
 			if (monster_is_in_view(mon) ||
 				(m2 >= 0 && los(cave, pgrid, grid2)) ||
 				(m2 < 0 && los(cave, grid1, grid2))) {
 				become_aware(cave, mon);
-			} else {
+			} else if (monster_is_mimicking(mon)) {
 				move_mimicked_object(cave, mon, grid1, grid2);
 				player->upkeep->redraw |= (PR_ITEMLIST);
 			}
@@ -631,16 +631,16 @@ void monster_swap(struct loc grid1, struct loc grid2)
 		mon = cave_monster(cave, m2);
 
 		/* Update monster */
-		if (monster_is_mimicking(mon)) {
+		if (monster_is_camouflaged(mon)) {
 			/*
-			 * Become aware if the player can see the mimic before
-			 * or after the swap.
+			 * Become aware if the player can see the grid with
+			 * the camouflaged monster before or after the swap.
 			 */
 			if (monster_is_in_view(mon) ||
 				(m1 >= 0 && los(cave, pgrid, grid1)) ||
 				(m1 < 0 && los(cave, grid2, grid1))) {
 				become_aware(cave, mon);
-			} else {
+			} else if (monster_is_mimicking(mon)) {
 				move_mimicked_object(cave, mon, grid2, grid1);
 				player->upkeep->redraw |= (PR_ITEMLIST);
 			}
@@ -1223,7 +1223,7 @@ bool mon_take_nonplayer_hit(int dam, struct monster *t_mon,
 		/* Delete the monster */
 		delete_monster_idx(t_mon->midx);
 		return true;
-	} else if (!monster_is_mimicking(t_mon)) {
+	} else if (!monster_is_camouflaged(t_mon)) {
 		/* Give detailed messages if visible */
 		if (hurt_msg != MON_MSG_NONE) {
 			add_monster_message(t_mon, hurt_msg, false);

--- a/src/project-mon.c
+++ b/src/project-mon.c
@@ -1074,7 +1074,7 @@ static bool project_m_monster_attack(project_monster_handler_context_t *context,
 		delete_monster_idx(m_idx);
 
 		mon_died = true;
-	} else if (!monster_is_mimicking(mon)) {
+	} else if (!monster_is_camouflaged(mon)) {
 		/* Give detailed messages if visible or destroyed */
 		if ((hurt_msg != MON_MSG_NONE) && seen)
 			add_monster_message(mon, hurt_msg, false);
@@ -1360,7 +1360,7 @@ void project_m(struct source origin, int r, struct loc grid, int dam, int typ,
 	context.lore = lore;
 
 	/* See visible monsters */
-	if (monster_is_mimicking(mon)) {
+	if (monster_is_camouflaged(mon)) {
 		if (monster_is_in_view(mon)) {
 			seen = true;
 			context.seen = true;

--- a/src/ui-map.c
+++ b/src/ui-map.c
@@ -230,7 +230,7 @@ void grid_data_as_text(struct grid_data *g, int *ap, wchar_t *cp, int *tap,
 		if (g->hallucinate) {
 			/* Just pick a random monster to display. */
 			hallucinatory_monster(&a, &c);
-		} else if (!monster_is_mimicking(cave_monster(cave, g->m_idx)))	{
+		} else if (!monster_is_camouflaged(cave_monster(cave, g->m_idx)))	{
 			struct monster *mon = cave_monster(cave, g->m_idx);
 
 			uint8_t da;

--- a/src/ui-target.c
+++ b/src/ui-target.c
@@ -1030,11 +1030,27 @@ static int draw_path(uint16_t path_n, struct loc *path_g, wchar_t *c, int *a,
 			colour = COLOUR_L_DARK;
 		} else if (mon && monster_is_visible(mon)) {
 			/* Mimics act as objects */
-			if (monster_is_camouflaged(mon)) 
+			if (monster_is_mimicking(mon)) {
 				colour = COLOUR_YELLOW;
-			else
+			} else if (!monster_is_camouflaged(mon)) {
 				/* Visible monsters are red. */
 				colour = COLOUR_L_RED;
+			} else if (obj) {
+				/*
+				 * The camouflaged monster is on a grid with
+				 * an object; make it act like an object.
+				 */
+				colour = COLOUR_YELLOW;
+			} else if (!square_isprojectable(cave, grid)) {
+				/* The camouflaged monster looks like a wall. */
+				colour = COLOUR_BLUE;
+			} else {
+				/*
+				 * The camouflaged monster looks like an
+				 * unoccupied square.
+				 */
+				colour = COLOUR_WHITE;
+			}
 		} else if (obj)
 			/* Known objects are yellow. */
 			colour = COLOUR_YELLOW;


### PR DESCRIPTION
…ster_is_camouflaged().  Resolves part of https://github.com/angband/angband/issues/3691 (lurkers being visible before being revealed in the Shockbolt, Gervais, and original tiles).