### PR TITLE
At character birth, don't start out aware of special artifact kinds. …

### DIFF
--- a/src/obj-knowledge.c
+++ b/src/obj-knowledge.c
@@ -1122,8 +1122,17 @@ void player_know_object(struct player *p, struct object *obj)
 		obj->known->ego = obj->ego;
 	}
 
-	if (object_non_curse_runes_known(obj) && tval_is_jewelry(obj)) {
-		seen = (obj->artifact) ? true : obj->kind->everseen;
+	if (tval_is_jewelry(obj)) {
+		if (object_non_curse_runes_known(obj)) {
+			seen = (obj->artifact) ? true : obj->kind->everseen;
+			object_flavor_aware(p, obj);
+		}
+	} else if (obj->kind->kidx >= z_info->ordinary_kind_max) {
+		/*
+		 * Become aware if it is a special artifact that isn't
+		 * jewelry.
+		 */
+		seen = true;
 		object_flavor_aware(p, obj);
 	}
 

--- a/src/obj-util.c
+++ b/src/obj-util.c
@@ -234,8 +234,13 @@ void flavor_init(void)
 		/* Skip "empty" objects */
 		if (!kind->name) continue;
 
-		/* No flavor yields aware */
-		if (!kind->flavor) kind->aware = true;
+		/*
+		 * No flavor and not kind that that only has one instance,
+		 * an artifact, yields aware
+		 */
+		if (!kind->flavor && kind->kidx < z_info->ordinary_kind_max) {
+			kind->aware = true;
+		}
 	}
 }
 


### PR DESCRIPTION
… Become aware of a special artifact kind that isn't jewelry when the artifact belonging to the kind is touched.  Resolves https://github.com/angband/angband/issues/5444 (the Arkenstone will show up as an unknown kind in the object list until it is touched).