### PR TITLE
Use angle brackets rather than double quotes for including locale.h …

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -34,10 +34,10 @@
 /**
  * locale junk
  */
-#include "locale.h"
+#include <locale.h>
 
 #if !defined(WINDOWS)
-#include "langinfo.h"
+#include <langinfo.h>
 #endif
 
 /**


### PR DESCRIPTION
…and langinfo.h:  matches the usage in the Mac OS X and Debian man pages for setlocale() and nl_langinfo().