### PR TITLE
In Makefile.msys2.sdl2, link with libjxl and its dependencies …

### DIFF
--- a/src/Makefile.msys2.sdl2
+++ b/src/Makefile.msys2.sdl2
@@ -32,6 +32,8 @@ VIDEO_sdl2 := -DUSE_SDL2 \
 	-lLerc \
 	-lzstd \
 	-llzma \
+	-ljxl \
+	-lhwy \
 	-lwebp \
 	-lfreetype \
 	-lharfbuzz \


### PR DESCRIPTION
…(brought in as a dependency of SDL2_image in version 2.6.0).