### PR TITLE
Don't modify names in projections array while parsing player_property…

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -1011,12 +1011,13 @@ static errr finish_parse_player_prop(struct parser *p) {
 			assert(N_ELEMENTS(list_element_names) < 65536);
 			n = (uint16_t) N_ELEMENTS(list_element_names);
 			for (i = 0; i < n - 1; i++) {
-				char *name = projections[i].name;
+				char *name = string_make(projections[i].name);
 				new->index = i;
 				new->type = string_make(embryo->ability.type);
 				new->desc = string_make(format("%s %s.", embryo->ability.desc, name));
 				my_strcap(name);
 				new->name = string_make(format("%s %s", name, embryo->ability.name));
+				string_free(name);
 				new->value = embryo->ability.value;
 				boundui_cursor = embryo->boundui;
 				while (boundui_cursor) {


### PR DESCRIPTION
….txt (that's a side effect of a change in 4.2.1).  Affects randart generation since brand names are compared to projection names when deciding whether to add a resistance.

Note that applying this could break an in progress randart game if the randart file isn't available (the randart file will be regenerated from the stored seed, but, because of the change here, that may not give the same set as was gotten at birth).