### PR TITLE
Nintendo workflows:  work around issues when used for FAAngband:  …

### DIFF
--- a/.github/workflows/nintendo.yaml
+++ b/.github/workflows/nintendo.yaml
@@ -15,6 +15,12 @@ jobs:
       - name: Clone Project
         uses: actions/checkout@v2
 
+      - name: Extract Names from Makefile
+        id: get_names
+        run: |
+            progname=`sed -E -n -e 's/^[[:blank:]]*PROGNAME[[:blank:]]+=[[:blank:]]+//p' src/Makefile.src || tr ' #' '\t\t' | tail -1 | cut -f 1`
+            echo "::set-output name=progname::$progname"
+
       - name: Build Nintendo 3DS (3dsx)
         shell: bash
         run: |
@@ -44,12 +50,18 @@ jobs:
           cp -rv bin/makerom /usr/local/bin
           popd
 
+      # The quoting to get progname may be too simple-minded:  what if there
+      # are single quotes in the steps.*.outputs.* stuff.  Restrict what's
+      # passed to cxitool's --name option to at most 8 characters since that
+      # is a limitation of that tool.
       - name: Build Nintendo 3DS (cia)
         shell: bash
         run: |
+          progname='${{ steps.get_names.outputs.progname }}'
+          procname=`echo "$progname" | head -c 8`
           pushd src/
-          cxitool --name angband angband.3dsx angband.cxi
-          makerom -v -f cia -o angband.cia -target t -i angband.cxi:0:0 -ignoresign -icon src/nds/icon.smdh
+          cxitool --name "$procname" "$progname".3dsx "$progname".cxi
+          makerom -v -f cia -o $"progname".cia -target t -i "$progname".cxi:0:0 -ignoresign -icon src/nds/icon.smdh
           popd
 
   nds:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -409,14 +409,20 @@ jobs:
           cp -rv bin/makerom /usr/local/bin
           popd
 
+      # The quoting to get progname may be too simple-minded:  what if there
+      # are single quotes in the steps.*.outputs.* stuff.  Restrict what's
+      # passed to cxitool's --name option to at most 8 characters since that
+      # is a limitation of that tool.
       - name: Build Nintendo 3DS (cia)
         id: create_nintendo_3ds_cia
         shell: bash
         run: |
           pushd src/
-          test -e ${{ steps.store_config.outputs.progname }}.3dsx
-          cxitool --name ${{ steps.store_config.outputs.progname }} ${{ steps.store_config.outputs.progname }}.3dsx ${{ steps.store_config.outputs.progname }}.cxi
-          makerom -v -f cia -o ${{ steps.store_config.outputs.progname }}.cia -target t -i ${{ steps.store_config.outputs.progname }}.cxi:0:0 -ignoresign -icon icon.smdh
+          progname='${{ steps.store_config.outputs.progname }}'
+          procname=`echo "$progname" | head -c 8`
+          test -e "$progname".3dsx
+          cxitool --name "$procname" "$progname".3dsx "$progname".cxi
+          makerom -v -f cia -o "$progname".cia -target t -i "$progname".cxi:0:0 -ignoresign -icon icon.smdh
           test -e ${{ steps.store_config.outputs.progname }}.cia
           popd
 


### PR DESCRIPTION
…cxitool's --name option is limited to at most 8 characters and get PROGNAME from Makefile.src rather than assuming "angband" in nintendo.yaml.