### PR TITLE
Use ubuntu-latest for the Nintendo release workflows since ubuntu-18.…

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -340,7 +340,7 @@ jobs:
   _3ds:
     needs: [setup, docconvert]
     name: Nintendo 3DS
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     container: devkitpro/devkitarm
     steps:
       - name: Download Artifact with Configuration Information
@@ -447,7 +447,7 @@ jobs:
   nds:
     needs: [setup, docconvert]
     name: Nintendo DS
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     container: devkitpro/devkitarm
     steps:
       - name: Download Artifact with Configuration Information


### PR DESCRIPTION
…04 is deprecated.