### PR TITLE
Workflows:  change runner for Windows releases to ubuntu-22.04; need …

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -192,7 +192,7 @@ jobs:
   windows:
     needs: [setup, docconvert]
     name: Windows
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Download Artifact with Configuration Information
         uses: actions/download-artifact@v2


### PR DESCRIPTION
…feedback from users on Windows that this does not introduce runtime problems since ubuntu-20.04 apparently caused the result to not work on Windows 8.1 (see https://github.com/angband/angband/commit/071bb5a47ca67c733c0a2c85d0a318660085483a )