### PR TITLE
Workflows: use actions/checkout@v3 to avoid Node.js 12 (per …

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -16,7 +16,7 @@ jobs:
           sudo apt-get install gcc automake autoconf make libx11-dev
 
       - name: Clone Project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build
         run: |
@@ -36,7 +36,7 @@ jobs:
           sudo apt-get install gcc make cmake libx11-dev
 
       - name: Clone Project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build
         run: |
@@ -55,7 +55,7 @@ jobs:
           sudo apt-get install gcc make cmake libncursesw5-dev
 
       - name: Clone Project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build
         run: |
@@ -74,7 +74,7 @@ jobs:
           sudo apt-get install gcc make cmake libsdl-image1.2-dev libsdl-ttf2.0-dev libsdl-mixer1.2-dev
 
       - name: Clone Project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build
         run: |
@@ -93,7 +93,7 @@ jobs:
           sudo apt-get install gcc autoconf automake make libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev
 
       - name: Clone Project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build
         run: |
@@ -111,7 +111,7 @@ jobs:
           sudo apt-get install gcc autoconf automake make libsqlite3-dev libsdl1.2-dev libsdl-mixer1.2-dev
 
       - name: Clone Project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Build with some extra warnings.  Add some that are only supported in
       # more recent versions of GCC that the configure script won't enable.

--- a/.github/workflows/mac.yaml
+++ b/.github/workflows/mac.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Clone Project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build
         run: |

--- a/.github/workflows/msbuild.yaml
+++ b/.github/workflows/msbuild.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1.1
 
       - name: Clone Project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build
         run: |

--- a/.github/workflows/msys2.yaml
+++ b/.github/workflows/msys2.yaml
@@ -25,7 +25,7 @@ jobs:
             mingw-w64-x86_64-ncurses
 
       - name: Clone Project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build
         run: |
@@ -53,7 +53,7 @@ jobs:
             mingw-w64-x86_64-SDL2_image
 
       - name: Clone Project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build
         run: |

--- a/.github/workflows/nintendo.yaml
+++ b/.github/workflows/nintendo.yaml
@@ -13,13 +13,13 @@ jobs:
     container: devkitpro/devkitarm
     steps:
       - name: Clone Project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Extract Names from Makefile
         id: get_names
         run: |
             progname=`sed -E -n -e 's/^[[:blank:]]*PROGNAME[[:blank:]]+=[[:blank:]]+//p' src/Makefile.src || tr ' #' '\t\t' | tail -1 | cut -f 1`
-            echo "::set-output name=progname::$progname"
+            echo "progname=$progname" >> $GITHUB_OUTPUT
 
       - name: Build Nintendo 3DS (3dsx)
         shell: bash
@@ -70,7 +70,7 @@ jobs:
     container: devkitpro/devkitarm
     steps:
       - name: Clone Project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build
         shell: bash

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -16,7 +16,7 @@ jobs:
           sudo apt-get install gcc-mingw-w64 automake autoconf make
 
       - name: Clone Project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build
         run: |


### PR DESCRIPTION
… https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ ) and replace set-output per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/