### PR TITLE
Move more special cases hard coded in player-timed.c to being …

### DIFF
--- a/lib/gamedata/player_timed.txt
+++ b/lib/gamedata/player_timed.txt
@@ -56,19 +56,99 @@
 #        preferences in the user's files) and the sound played when the
 #        message is displayed (configured globally by lib/customize/sound.prf;
 #        also configurable by preferences in the user's files)
-# fail - determines what makes the effect fail.
+# fail - determines what makes the effect fail; may be specified more than
+#        once - the effect will fail if any of the conditions are met
 #        param one:
 #          1 - object flag
 #          2 - resist
 #          3 - vulnerability
 #          4 - player flag
+#          5 - presence of timed effect
 #        param two:
 #          the actual flag that causes the failure; for an object flag, the
 #          flag must match the first argument to one of the OF() macros in
 #          list-object-flags.h; for a player flag, the flag must match the
 #          first argument to one of the PF() macros in list-player-flags.h; for
 #          a resist or vulnerability, the flag must match the argument to one
-#          of the ELEM() macros in list-elements.h
+#          of the ELEM() macros in list-elements.h; for a timed effect, the
+#          flag must match the argument to TMD() macros list-player-timed.h
+# on-begin-effect - (optional) specifies an effect to be invoked when the
+#                   timed effect starts; can be used more than once - the
+#                   additional effects will be executed in the order in which
+#                   they appear
+#                   param one: name of the effect (argument to one of the
+#                       EFFECT() macros in list-effects.h)
+#                   param two: name of the subtype of the effect; can be
+#                       omitted
+#                   param three: radius of the effect; can be omitted and
+#                       must be omitted if the subtype is omitted
+#                   param four: the "other" parameter for the effect; can be
+#                       omitted and must be omitted if the subtype or radius is
+#                       omitted
+# on-end-effect - (optional) specifies an effect to be invoked when the timed
+#                 effect lapses; can be used more than once - the additional
+#                 effects will be executed in the order in which they appear
+#                 param one: name of the effect (argument to one of the
+#                     EFFECT() macros in list-effects.h)
+#                 param two: name of the subtype of the effect; can be omitted
+#                 param three: radius of the effect; can be omitted and must
+#                     be omitted if the subtype is omitted
+#                 param four: the "other" parameter for the effect; can be
+#                     omitted and must be omitted if the subtype or radius is
+#                     omitted
+# effect-yx - (optional) specifies the y and x parameters of the most recently
+#             set effect (i.e. from a prior on-begin-effect or on-end-effect
+#             directive)
+#             param one: is the value of the y parameter for the effect
+#             param two: is the value of hte x parameter for the effect
+# effect-dice - (optional) specifies the dice string for the most recently
+#               set effect (i.e. from a prior on-begin-effect or on-end-effect
+#               directive)
+# effect-expr - (optional) defines an expression for the dice string of the
+#               most recently set effect (i.e. from a prior on-begin-effect
+#               or on-end-effect directive); requires that the dice string has
+#               been set for the effect with a effect-dice directive
+#               param one: is the name of the variable to substitute with the
+#                   value of the expression; variable names must be all
+#                   capital letters and a reference to a variable in a dice
+#                   string starts with a $; if the dice string does not contain
+#                   a reference to the given variable, parsing of the game's
+#                   data files will stop with an error
+#               param two: set the name of the base value to modify with the
+#                   operations in the third parameter; the name can be one of
+#                   those listed below; if it does not match any in the list,
+#                   the base value will be zero
+#                     PLAYER_LEVEL - the player's level
+#                     DUNGEON_LEVEL - the dungeon's level
+#                     MAX_SIGHT - the maximum sight range, in grids
+#                     WEAPON_DAMAGE - a random roll for the base damage (only
+#                         the weapon's dice and damage modifiers are included;
+#                         no damage modifiers from the player or equipment
+#                         other than the weapon are used) of the player's
+#                         equipped weapon; if the player has no equipped
+#                         weapon, the value of this is zero
+#                    PLAYER_HP - the player's current number of hit points
+#                    MONSTER_PERCENT_HP_GONE - ((maximum hit points for the
+#                         player's target monster - current hit poinst for the
+#                         player's target monster) * 100) / maximum hit points
+#                         for the player's target monster or 0 if the player
+#                         doesn't currently have a targeted monster
+#               param three: sets the operations to perform on the base value to
+#                   get the value substituted into the dice expression; for
+#                   instance, "* 2 / 3" would multiply the base value by 2 then
+#                   divide that result by three, discarding any remainder;
+#                   operators that are allowed are '+' (addition),
+#                   '-' (subtraction), '*' (multiplication), '/' (integer
+#                   division; discards remainder), and 'n' or 'N' (either negate
+#                   the result from before the operator); integer constants
+#                   in the operations must be between -32768 and 32767;
+#                   operators and integer constants in the operations should be
+#                   separated by single spaces
+# effect-msg - (optional) appends to the message associated with the most
+#              recently set effect (i.e. from a prior on-begin-effect or
+#              on-end-effect directive); how that  message is used depends on
+#              the effect - typically it may be printed during the effect or
+#              is used as a death message
 # resist - (optional) when this timed property is active, the recipient gains
 #          a temporary resistance to the named element
 # brand - (optional) when this timed property is active, the recipient gains
@@ -84,6 +164,28 @@
 #                exact synonym, except for duration; if the second parameter is
 #                zero, the timed property has other effects that are not
 #                implied by the named object property
+# lower-bound - (optional) overrides the default lower bound of zero for the
+#               timed effect; the lower bound must be non-negative, less
+#               than 32768, and less than or equal to the maximum for any of
+#               the timed effect's grades; if the lower bound is greater than
+#               zero, the timed effect is always active (so a message set by
+#               on-end or an effect by on-begin-effect or on-end-effect will
+#               not be used)
+# flags - (optional) specifies one or more flags for the timed effect; can
+#         appear more than once with all the flags specified accumulating;
+#         more than one flag can be specified each time it is used - the names
+#         of the flags must be separated by spaces or '|'; the flag names or
+#         that are understood are:
+#         NONSTACKING - any attempt to increase the timed effect while it is
+#             already active will not increase the duration; this is a stronger
+#             restriction than having the timed effect fail because of the
+#             timed effect itself, primarily because NONSTACKING also affects
+#             cases, like TIMED_INC_NO_RES effects, where the failure check is
+#             bypassed; NONSTACKING is also handled differently than failing
+#             for the timed effect itself in terms of lore checks (if a timed
+#             effect is NONSTACKING, lore for a monster won't show that a
+#             the monster's attack inflicting that status is resisted solely
+#             because the character is already subject to the timed effect)
 
 name:FAST
 desc:haste
@@ -111,6 +213,7 @@ grade:r:10000:Paralyzed!:You are paralysed!
 on-end:You can move again.
 msgt:PARALYZED
 fail:1:FREE_ACT
+flags:NONSTACKING
 
 name:CONFUSED
 desc:confusion
@@ -145,6 +248,7 @@ on-increase:You are more poisoned!
 on-decrease:You are less poisoned.
 msgt:POISONED
 fail:2:POIS
+fail:5:OPP_POIS
 
 name:CUT
 desc:wounds
@@ -178,6 +282,7 @@ grade:y:15:Hungry:You are still hungry.:You are getting hungry.
 grade:G:90:Fed:You are no longer hungry.:You are no longer full.
 grade:g:100:Full:You are full!:
 msgt:HUNGRY
+lower-bound:1
 
 name:PROTEVIL
 desc:protection from evil
@@ -320,6 +425,8 @@ desc:sprinting
 grade:G:10000:Sprint:You start sprinting.
 on-end:You suddenly stop sprinting.
 msgt:SPEED
+on-end-effect:TIMED_INC_NO_RES:SLOW
+effect-dice:100
 
 name:BOLD
 desc:fearlessness
@@ -336,6 +443,8 @@ on-end:Your body reasserts its true nature.
 on-increase:You are more scrambled!
 msgt:SCRAMBLE
 fail:2:NEXUS
+on-begin-effect:SCRAMBLE_STATS
+on-end-effect:UNSCRAMBLE_STATS
 
 name:TRAPSAFE
 desc:safety from traps

--- a/src/effect-handler-general.c
+++ b/src/effect-handler-general.c
@@ -3515,3 +3515,26 @@ bool effect_handler_CLEAR_VALUE(effect_handler_context_t *context)
 	set_value = 0;
 	return true;
 }
+
+/**
+ * Scramble the player's stats.  This is only intended for use by the
+ * timed effect, TMD_SCRAMBLE.  Other effect chains wanting to incur a
+ * scrambling effect should use TIMED_INC:SCRAMBLE or TIMED_INC_NO_RES:SCRAMBLE.
+ */
+bool effect_handler_SCRAMBLE_STATS(effect_handler_context_t *context)
+{
+	player_scramble_stats(player);
+	return true;
+}
+
+/**
+ * Unscramble the player's stats.  This is only intended for use by the
+ * timed effect, TMD_SCRAMBLE.  Other effect chains wanting to undo a
+ * scrambling effect should use CURE:SCRAMBLE (or perhaps TIMED_DEC:SCRAMBLE
+ * to merely reduce the duration of an existing scramble effect).
+ */
+bool effect_handler_UNSCRAMBLE_STATS(effect_handler_context_t *context)
+{
+	player_fix_scramble(player);
+	return true;
+}

--- a/src/list-effects.h
+++ b/src/list-effects.h
@@ -121,3 +121,5 @@ EFFECT(WONDER,						true,	NULL,		0,		EFINFO_NONE,	"creates random and unpredicta
 EFFECT(SELECT,						false,	NULL,		0,		EFINFO_NONE,	"selects one of ",	"")
 EFFECT(SET_VALUE,					false,	NULL,		0,		EFINFO_NONE,	"",					"")
 EFFECT(CLEAR_VALUE,					false,	NULL,		0,		EFINFO_NONE,	"",					"")
+EFFECT(SCRAMBLE_STATS,					false,  NULL,		0,		EFINFO_NONE,	"", 					"")
+EFFECT(UNSCRAMBLE_STATS,				false,	NULL,		0,		EFINFO_NONE,	"",					"")

--- a/src/obj-curse.c
+++ b/src/obj-curse.c
@@ -157,26 +157,33 @@ bool append_object_curse(struct object *obj, int pick, int power)
 	}
 
 	/* Reject curses with effects foiled by an existing object property */
-	if (c->obj->effect && c->obj->effect->index == effect_lookup("TIMED_INC")) {
+	if (c->obj->effect && c->obj->effect->index
+			== effect_lookup("TIMED_INC")) {
 		int idx = c->obj->effect->subtype;
-		struct timed_effect_data *status;
-		assert(idx < TMD_MAX);
-		status = &timed_effects[idx];
-		if (status->fail_code == TMD_FAIL_FLAG_OBJECT) {
-			if (of_has(obj->flags, status->fail)) {
-				check_object_curses(obj);
-				return false;
+		const struct timed_failure *f;
+
+		assert(idx >= 0 && idx < TMD_MAX);
+		f = timed_effects[idx].fail;
+		while (f) {
+			if (f->code == TMD_FAIL_FLAG_OBJECT) {
+				if (of_has(obj->flags, f->idx)) {
+					check_object_curses(obj);
+					return false;
+				}
+			} else if (f->code == TMD_FAIL_FLAG_RESIST) {
+				assert(f->idx >= 0 && f->idx < ELEM_MAX);
+				if (obj->el_info[f->idx].res_level > 0) {
+					check_object_curses(obj);
+					return false;
+				}
+			} else if (f->code == TMD_FAIL_FLAG_VULN) {
+				assert(f->idx >= 0 && f->idx < ELEM_MAX);
+				if (obj->el_info[f->idx].res_level < 0) {
+					check_object_curses(obj);
+					return false;
+				}
 			}
-		} else if (status->fail_code == TMD_FAIL_FLAG_RESIST) {
-			if (obj->el_info[status->fail].res_level > 0) {
-				check_object_curses(obj);
-				return false;
-			}
-		} else if (status->fail_code == TMD_FAIL_FLAG_VULN) {
-			if (obj->el_info[status->fail].res_level < 0) {
-				check_object_curses(obj);
-				return false;
-			}
+			f = f->next;
 		}
 	}
 
@@ -258,26 +265,33 @@ bool artifact_curse_conflicts(struct artifact *art, int pick)
 	int i;
 
 	/* Reject curses with effects foiled by an existing artifact property */
-	if (c->obj->effect && c->obj->effect->index == effect_lookup("TIMED_INC")) {
+	if (c->obj->effect && c->obj->effect->index
+			== effect_lookup("TIMED_INC")) {
 		int idx = c->obj->effect->subtype;
-		struct timed_effect_data *status;
-		assert(idx < TMD_MAX);
-		status = &timed_effects[idx];
-		if (status->fail_code == TMD_FAIL_FLAG_OBJECT) {
-			if (of_has(art->flags, status->fail)) {
-				check_artifact_curses(art);
-				return true;
+		const struct timed_failure *f;
+
+		assert(idx >= 0 && idx < TMD_MAX);
+		f = timed_effects[idx].fail;
+		while (f) {
+			if (f->code == TMD_FAIL_FLAG_OBJECT) {
+				if (of_has(art->flags, f->idx)) {
+					check_artifact_curses(art);
+					return true;
+				}
+			} else if (f->code == TMD_FAIL_FLAG_RESIST) {
+				assert(f->idx >= 0 && f->idx < ELEM_MAX);
+				if (art->el_info[f->idx].res_level > 0) {
+					check_artifact_curses(art);
+					return true;
+				}
+			} else if (f->code == TMD_FAIL_FLAG_VULN) {
+				assert(f->idx >= 0 && f->idx < ELEM_MAX);
+				if (art->el_info[f->idx].res_level < 0) {
+					check_artifact_curses(art);
+					return true;
+				}
 			}
-		} else if (status->fail_code == TMD_FAIL_FLAG_RESIST) {
-			if (art->el_info[status->fail].res_level > 0) {
-				check_artifact_curses(art);
-				return true;
-			}
-		} else if (status->fail_code == TMD_FAIL_FLAG_VULN) {
-			if (art->el_info[status->fail].res_level < 0) {
-				check_artifact_curses(art);
-				return true;
-			}
+			f = f->next;
 		}
 	}
 

--- a/src/player-timed.c
+++ b/src/player-timed.c
@@ -20,6 +20,7 @@
 #include "angband.h"
 #include "cave.h"
 #include "datafile.h"
+#include "effects.h"
 #include "init.h"
 #include "mon-util.h"
 #include "obj-gear.h"
@@ -52,7 +53,7 @@ const char *list_player_flag_names[] = {
 };
 
 struct timed_effect_data timed_effects[TMD_MAX] = {
-	#define TMD(a, b, c)	{ #a, b, c, 0, NULL, NULL, NULL, NULL, 0, 0, 0, NULL, OF_NONE, false, -1, -1, -1 },
+	#define TMD(a, b, c)	{ #a, b, c, NULL, NULL, NULL, NULL, 0, NULL, NULL, NULL, NULL, 0, 0, OF_NONE, false, -1, -1, -1 },
 	#include "list-player-timed.h"
 	#undef TMD
 };
@@ -88,6 +89,8 @@ static const char *list_timed_effect_names[] = {
 
 static enum parser_error parse_player_timed_name(struct parser *p)
 {
+	struct timed_effect_parse_state *ps =
+		(struct timed_effect_parse_state*) parser_priv(p);
 	const char *name = parser_getstr(p, "name");
 	int index;
 
@@ -100,133 +103,200 @@ static enum parser_error parse_player_timed_name(struct parser *p)
 		return PARSE_ERROR_INVALID_SPELL_NAME;
 	}
 
-	struct timed_effect_data *t = &timed_effects[index];
-
-	t->index = index;
-	parser_setpriv(p, t);
+	assert(ps);
+	ps->t = &timed_effects[index];
+	ps->e = NULL;
 
 	return PARSE_ERROR_NONE;
 }
 
 static enum parser_error parse_player_timed_desc(struct parser *p)
 {
-	struct timed_effect_data *t = parser_priv(p);
-	assert(t);
+	struct timed_effect_parse_state *ps =
+		(struct timed_effect_parse_state*) parser_priv(p);
 
-	t->desc = string_append(t->desc, parser_getstr(p, "text"));
+	assert(ps);
+	if (!ps->t) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	ps->t->desc = string_append(ps->t->desc, parser_getstr(p, "text"));
 	return PARSE_ERROR_NONE;
 }
 
 static enum parser_error parse_player_timed_end_message(struct parser *p)
 {
-	struct timed_effect_data *t = parser_priv(p);
-	assert(t);
+	struct timed_effect_parse_state *ps =
+		(struct timed_effect_parse_state*) parser_priv(p);
 
-	t->on_end = string_append(t->on_end, parser_getstr(p, "text"));
+	assert(ps);
+	if (!ps->t) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	ps->t->on_end = string_append(ps->t->on_end, parser_getstr(p, "text"));
 	return PARSE_ERROR_NONE;
 }
 
 static enum parser_error parse_player_timed_increase_message(struct parser *p)
 {
-	struct timed_effect_data *t = parser_priv(p);
-	assert(t);
+	struct timed_effect_parse_state *ps =
+		(struct timed_effect_parse_state*) parser_priv(p);
 
-	t->on_increase = string_append(t->on_increase, parser_getstr(p, "text"));
+	assert(ps);
+	if (!ps->t) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	ps->t->on_increase = string_append(ps->t->on_increase,
+		parser_getstr(p, "text"));
 	return PARSE_ERROR_NONE;
 }
 
 static enum parser_error parse_player_timed_decrease_message(struct parser *p)
 {
-	struct timed_effect_data *t = parser_priv(p);
-	assert(t);
+	struct timed_effect_parse_state *ps =
+		(struct timed_effect_parse_state*) parser_priv(p);
 
-	t->on_decrease = string_append(t->on_decrease, parser_getstr(p, "text"));
+	assert(ps);
+	if (!ps->t) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	ps->t->on_decrease = string_append(ps->t->on_decrease,
+		parser_getstr(p, "text"));
 	return PARSE_ERROR_NONE;
 }
 
 static enum parser_error parse_player_timed_message_type(struct parser *p)
 {
-	struct timed_effect_data *t = parser_priv(p);
-	assert(t);
+	struct timed_effect_parse_state *ps =
+		(struct timed_effect_parse_state*) parser_priv(p);
 
-	t->msgt = message_lookup_by_name(parser_getsym(p, "type"));
-
-	return t->msgt < 0 ?
-				PARSE_ERROR_INVALID_MESSAGE :
-				PARSE_ERROR_NONE;
+	assert(ps);
+	if (!ps->t) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	ps->t->msgt = message_lookup_by_name(parser_getsym(p, "type"));
+	return ps->t->msgt < 0 ?
+		PARSE_ERROR_INVALID_MESSAGE : PARSE_ERROR_NONE;
 }
 
 static enum parser_error parse_player_timed_fail(struct parser *p)
 {
-	struct timed_effect_data *t = parser_priv(p);
-	assert(t);
-
-	t->fail_code = parser_getuint(p, "code");
-
+	struct timed_effect_parse_state *ps =
+		(struct timed_effect_parse_state*) parser_priv(p);
 	const char *name = parser_getstr(p, "flag");
-	if (t->fail_code == TMD_FAIL_FLAG_OBJECT) {
-		int flag = lookup_flag(list_obj_flag_names, name);
-		if (flag == FLAG_END)
-			return PARSE_ERROR_INVALID_FLAG;
-		else
-			t->fail = flag;
-	} else if (t->fail_code == TMD_FAIL_FLAG_PLAYER) {
-		int flag = lookup_flag(list_player_flag_names, name);
-		if (flag == FLAG_END)
-			return PARSE_ERROR_INVALID_FLAG;
-		else
-			t->fail = flag;
-	} else if ((t->fail_code == TMD_FAIL_FLAG_RESIST) ||
-			   (t->fail_code == TMD_FAIL_FLAG_VULN)) {
-		size_t i = 0;
-		while (list_element_names[i] && !streq(list_element_names[i], name))
-			i++;
+	struct timed_failure *f;
+	int code, idx;
 
-		if (i == ELEM_MAX)
+	assert(ps);
+	if (!ps->t) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+
+	code = parser_getuint(p, "code");
+	switch (code) {
+	case TMD_FAIL_FLAG_OBJECT:
+		idx = lookup_flag(list_obj_flag_names, name);
+		if (idx == FLAG_END) {
 			return PARSE_ERROR_INVALID_FLAG;
-		else
-			t->fail = i;
-	} else {
+		}
+		break;
+
+	case TMD_FAIL_FLAG_PLAYER:
+		idx = lookup_flag(list_player_flag_names, name);
+		if (idx == FLAG_END) {
+			return PARSE_ERROR_INVALID_FLAG;
+		}
+		break;
+
+	case TMD_FAIL_FLAG_RESIST:
+	case TMD_FAIL_FLAG_VULN:
+		idx = 0;
+		while (list_element_names[idx]
+				&& !streq(list_element_names[idx], name)) {
+			idx++;
+		}
+		if (idx == ELEM_MAX) {
+			return PARSE_ERROR_INVALID_FLAG;
+		}
+		break;
+
+	case TMD_FAIL_FLAG_TIMED_EFFECT:
+		if (grab_name("timed effect", name,
+				list_timed_effect_names,
+				N_ELEMENTS(list_timed_effect_names),
+				&idx)) {
+			return PARSE_ERROR_INVALID_FLAG;
+		}
+		break;
+
+	default:
 		return PARSE_ERROR_INVALID_FLAG;
 	}
+
+	f = mem_alloc(sizeof(*f));
+	f->next = ps->t->fail;
+	f->code = code;
+	f->idx= idx;
+	ps->t->fail = f;
 
 	return PARSE_ERROR_NONE;
 }
 
 static enum parser_error parse_player_timed_grade(struct parser *p)
 {
-	struct timed_effect_data *t = parser_priv(p);
-	struct timed_grade *current = t->grade;
-	struct timed_grade *l = mem_zalloc(sizeof(*l));
-    const char *color = parser_getsym(p, "color");
-    int attr = 0;
-	assert(t);
+	struct timed_effect_parse_state *ps =
+		(struct timed_effect_parse_state*) parser_priv(p);
+	const char *color = parser_getsym(p, "color");
+	int grade_max = parser_getint(p, "max");
+	struct timed_grade *current, *l;
+	int attr, food_scl;
+
+	assert(ps);
+	if (!ps->t) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	/*
+	 * The maximum has to be greater than zero so it doesn't interfere
+	 * with the implicit "off" grade which has a maximum of 0.  Because
+	 * a timed effect duration is stored as an int16_t in struct player,
+	 * also guarantee that the maximum is compatible with that.
+	 */
+	food_scl = (streq(ps->t->name, "FOOD")) ? (int) z_info->food_value : 1;
+	if (grade_max <= 0 || grade_max > 32767 / food_scl) {
+		return PARSE_ERROR_INVALID_VALUE;
+	}
 
 	/* Make a zero grade structure if there isn't one */
+	current = ps->t->grade;
 	if (!current) {
-		t->grade = mem_zalloc(sizeof(struct timed_grade));
-		current = t->grade;
+		ps->t->grade = mem_zalloc(sizeof(struct timed_grade));
+		current = ps->t->grade;
 	}
 
 	/* Move to the highest grade so far */
 	while (current->next) {
 		current = current->next;
+		/* Enforce that the grades appear in ascending order. */
+		if (grade_max * food_scl <= current->max) {
+			return PARSE_ERROR_INVALID_VALUE;
+		}
 	}
 
 	/* Add the new one */
+	l = mem_zalloc(sizeof(*l));
 	current->next = l;
 	l->grade = current->grade + 1;
 
-    if (strlen(color) > 1) {
+	if (strlen(color) > 1) {
 		attr = color_text_to_attr(color);
-    } else {
+	} else {
 		attr = color_char_to_attr(color[0]);
 	}
-    if (attr < 0)
+	if (attr < 0) {
 		return PARSE_ERROR_INVALID_COLOR;
-    l->color = attr;
+	}
+	l->color = attr;
 
-	l->max = parser_getint(p, "max");
+	l->max = grade_max;
 	l->name = string_make(parser_getsym(p, "name"));
 
 	/* Name may be a dummy (eg hunger)*/
@@ -248,8 +318,8 @@ static enum parser_error parse_player_timed_grade(struct parser *p)
 	}
 
 	/* Set food constants and deal with percentages */
-	if (streq(t->name, "FOOD")) {
-		l->max *= z_info->food_value;
+	if (food_scl != 1) {
+		l->max *= food_scl;
 		if (l->name) {
 			if (streq(l->name, "Starving")) {
 				PY_FOOD_STARVE = l->max;
@@ -272,68 +342,281 @@ static enum parser_error parse_player_timed_grade(struct parser *p)
 
 static enum parser_error parse_player_timed_resist(struct parser *p)
 {
-	struct timed_effect_data *t = parser_priv(p);
+	struct timed_effect_parse_state *ps =
+		(struct timed_effect_parse_state*) parser_priv(p);
 	const char *name = parser_getsym(p, "elem");
 	int idx = (name) ? proj_name_to_idx(name) : -1;
 
-	assert(t);
-	if (idx < 0 || idx >= ELEM_MAX) return PARSE_ERROR_INVALID_VALUE;
-	t->temp_resist = idx;
+	assert(ps);
+	if (!ps->t) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	if (idx < 0 || idx >= ELEM_MAX) {
+		return PARSE_ERROR_INVALID_VALUE;
+	}
+	ps->t->temp_resist = idx;
 	return PARSE_ERROR_NONE;
 }
 
 static enum parser_error parse_player_timed_brand(struct parser *p)
 {
-	struct timed_effect_data *t = parser_priv(p);
+	struct timed_effect_parse_state *ps =
+		(struct timed_effect_parse_state*) parser_priv(p);
 	const char *name = parser_getsym(p, "name");
 	int idx = z_info->brand_max;
 
-	assert(t);
+	assert(ps);
+	if (!ps->t) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
 	if (name) {
 		for (idx = 1; idx < z_info->brand_max; ++idx) {
 			if (streq(name, brands[idx].code)) break;
 		}
 	}
-	if (idx == z_info->brand_max) return PARSE_ERROR_UNRECOGNISED_BRAND;
-	t->temp_brand = idx;
+	if (idx == z_info->brand_max) {
+		return PARSE_ERROR_UNRECOGNISED_BRAND;
+	}
+	ps->t->temp_brand = idx;
 	return PARSE_ERROR_NONE;
 }
 
 static enum parser_error parse_player_timed_slay(struct parser *p)
 {
-	struct timed_effect_data *t = parser_priv(p);
+	struct timed_effect_parse_state *ps =
+		(struct timed_effect_parse_state*) parser_priv(p);
 	const char *name = parser_getsym(p, "name");
 	int idx = z_info->slay_max;
 
-	assert(t);
+	assert(ps);
+	if (!ps->t) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
 	if (name) {
 		for (idx = 1; idx < z_info->slay_max; ++idx) {
 			if (streq(name, slays[idx].code)) break;
 		}
 	}
-	if (idx == z_info->slay_max) return PARSE_ERROR_UNRECOGNISED_SLAY;
-	t->temp_slay = idx;
+	if (idx == z_info->slay_max) {
+		return PARSE_ERROR_UNRECOGNISED_SLAY;
+	}
+	ps->t->temp_slay = idx;
 	return PARSE_ERROR_NONE;
 }
 
 static enum parser_error parse_player_timed_flag_synonym(struct parser *p)
 {
-	struct timed_effect_data *t = parser_priv(p);
+	struct timed_effect_parse_state *ps =
+		(struct timed_effect_parse_state*) parser_priv(p);
 	const char *code = parser_getsym(p, "code");
 	bool is_exact = parser_getint(p, "exact") != 0;
 	int idx = (code) ? code_index_in_array(obj_flags, code) : OF_NONE;
 
-	assert(t);
-	if (idx <= OF_NONE) return PARSE_ERROR_INVALID_OBJ_PROP_CODE;
-	t->oflag_dup = idx;
-	t->oflag_syn = is_exact;
+	assert(ps);
+	if (!ps->t) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	if (idx <= OF_NONE) {
+		return PARSE_ERROR_INVALID_OBJ_PROP_CODE;
+	}
+	ps->t->oflag_dup = idx;
+	ps->t->oflag_syn = is_exact;
+	return PARSE_ERROR_NONE;
+}
+
+static enum parser_error parse_player_timed_on_begin_effect(struct parser *p)
+{
+	struct timed_effect_parse_state *ps =
+		(struct timed_effect_parse_state*) parser_priv(p);
+	struct effect *effect;
+
+	assert(ps);
+	if (!ps->t) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	/* Go to the next vacant effect and set it to the new one. */
+	ps->e = mem_zalloc(sizeof(*effect));
+	if (ps->t->on_begin_effect) {
+		effect = ps->t->on_begin_effect;
+		while (effect->next) effect = effect->next;
+		effect->next = ps->e;
+	} else {
+		ps->t->on_begin_effect = ps->e;
+	}
+	/* Fill in the details. */
+	return grab_effect_data(p, ps->e);
+}
+
+static enum parser_error parse_player_timed_on_end_effect(struct parser *p)
+{
+	struct timed_effect_parse_state *ps =
+		(struct timed_effect_parse_state*) parser_priv(p);
+	struct effect *effect;
+
+	assert(ps);
+	if (!ps->t) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	/* Go to the next vacant effect and set it to the new one */
+	ps->e = mem_zalloc(sizeof(*effect));
+	if (ps->t->on_end_effect) {
+		effect = ps->t->on_end_effect;
+		while (effect->next) effect = effect->next;
+		effect->next = ps->e;
+	} else {
+		ps->t->on_end_effect = ps->e;
+	}
+	/* Fill in the detail */
+	return grab_effect_data(p, ps->e);
+}
+
+static enum parser_error parse_player_timed_effect_yx(struct parser *p)
+{
+	struct timed_effect_parse_state *ps =
+		(struct timed_effect_parse_state*) parser_priv(p);
+
+	assert(ps);
+	if (!ps->e) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	ps->e->y = parser_getint(p, "y");
+	ps->e->x = parser_getint(p, "x");
+	return PARSE_ERROR_NONE;
+}
+
+static enum parser_error parse_player_timed_effect_dice(struct parser *p)
+{
+	struct timed_effect_parse_state *ps =
+		(struct timed_effect_parse_state*) parser_priv(p);
+	dice_t *dice;
+	const char *string;
+
+	assert(ps);
+	if (!ps->e) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	dice = dice_new();
+	if (dice == NULL) {
+		return PARSE_ERROR_INVALID_DICE;
+	}
+	string = parser_getstr(p, "dice");
+	if (dice_parse_string(dice, string)) {
+		dice_free(ps->e->dice);
+		ps->e->dice = dice;
+	} else {
+		dice_free(dice);
+		return PARSE_ERROR_INVALID_DICE;
+	}
+	return PARSE_ERROR_NONE;
+}
+
+static enum parser_error parse_player_timed_effect_expr(struct parser *p)
+{
+	struct timed_effect_parse_state *ps =
+		(struct timed_effect_parse_state*) parser_priv(p);
+	expression_t *expression;
+	expression_base_value_f function;
+	const char *name, *base, *expr;
+	enum parser_error result;
+
+	assert(ps);
+	if (!ps->e || !ps->e->dice) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	name = parser_getsym(p, "name");
+	base = parser_getsym(p, "base");
+	expr = parser_getstr(p, "expr");
+	expression = expression_new();
+	if (expression == NULL) {
+		return PARSE_ERROR_INVALID_EXPRESSION;
+	}
+	function = effect_value_base_by_name(base);
+	expression_set_base_value(expression, function);
+	if (expression_add_operations_string(expression, expr) < 0) {
+		result = PARSE_ERROR_BAD_EXPRESSION_STRING;
+	} else if (dice_bind_expression(ps->e->dice, name, expression) < 0) {
+		result = PARSE_ERROR_UNBOUND_EXPRESSION;
+	} else {
+		result = PARSE_ERROR_NONE;
+	}
+	/*
+	 * The dice object makes a deep copy of the expression, so we can
+	 * free it.
+	 */
+	expression_free(expression);
+	return result;
+}
+
+static enum parser_error parse_player_timed_effect_msg(struct parser *p)
+{
+	struct timed_effect_parse_state *ps =
+		(struct timed_effect_parse_state*) parser_priv(p);
+
+	assert(ps);
+	if (!ps->e) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	ps->e->msg = string_append(ps->e->msg, parser_getstr(p, "text"));
+	return PARSE_ERROR_NONE;
+}
+
+static enum parser_error parse_player_timed_effect_flags(struct parser *p)
+{
+	struct timed_effect_parse_state *ps =
+		(struct timed_effect_parse_state*) parser_priv(p);
+	char *flags, *s;
+
+	assert(ps);
+	if (!ps->t) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	if (!parser_hasval(p, "flags")) {
+		return PARSE_ERROR_NONE;
+	}
+	flags = string_make(parser_getstr(p, "flags"));
+	s = strtok(flags, " |");
+	while (s) {
+		if (streq(s, "NONSTACKING")) {
+			ps->t->flags |= TMD_FLAG_NONSTACKING;
+		} else {
+			string_free(flags);
+			return PARSE_ERROR_INVALID_FLAG;
+		}
+		s = strtok(NULL, " |");
+	}
+	string_free(flags);
+	return PARSE_ERROR_NONE;
+}
+
+static enum parser_error parse_player_timed_effect_lower_bound(struct parser *p)
+{
+	struct timed_effect_parse_state *ps =
+		(struct timed_effect_parse_state*) parser_priv(p);
+	int bound = parser_getint(p, "bound");
+
+	assert(ps);
+	if (!ps->t) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	/*
+	 * Don't allow negative lower bounds (breaks the logic for testing
+	 * whether a timed effect is active).  Also, since int16_t is used to
+	 * store a timed effect's duration in struct player, don't allow
+	 * lower bounds that aren't compatible with that.
+	 */
+	if (bound < 0 || bound > 32767) {
+		return PARSE_ERROR_INVALID_VALUE;
+	}
+	ps->t->lower_bound = bound;
 	return PARSE_ERROR_NONE;
 }
 
 static struct parser *init_parse_player_timed(void)
 {
 	struct parser *p = parser_new();
-	parser_setpriv(p, NULL);
+	struct timed_effect_parse_state *ps = mem_zalloc(sizeof(*ps));
+
+	parser_setpriv(p, ps);
 	parser_reg(p, "name str name", parse_player_timed_name);
 	parser_reg(p, "desc str text", parse_player_timed_desc);
 	parser_reg(p, "on-end str text", parse_player_timed_end_message);
@@ -347,6 +630,20 @@ static struct parser *init_parse_player_timed(void)
 	parser_reg(p, "slay sym name", parse_player_timed_slay);
 	parser_reg(p, "flag-synonym sym code int exact",
 		parse_player_timed_flag_synonym);
+	parser_reg(p,
+		"on-begin-effect sym eff ?sym type ?int radius ?int other",
+		parse_player_timed_on_begin_effect);
+	parser_reg(p,
+		"on-end-effect sym eff ?sym type ?int radius ?int other",
+		parse_player_timed_on_end_effect);
+	parser_reg(p, "effect-yx int y int x", parse_player_timed_effect_yx);
+	parser_reg(p, "effect-dice str dice", parse_player_timed_effect_dice);
+	parser_reg(p, "effect-expr sym name sym base str expr",
+		parse_player_timed_effect_expr);
+	parser_reg(p, "effect-msg str text", parse_player_timed_effect_msg);
+	parser_reg(p, "flags ?str flags", parse_player_timed_effect_flags);
+	parser_reg(p, "lower-bound int bound",
+		parse_player_timed_effect_lower_bound);
 	return p;
 }
 
@@ -357,39 +654,68 @@ static errr run_parse_player_timed(struct parser *p)
 
 static errr finish_parse_player_timed(struct parser *p)
 {
+	struct timed_effect_parse_state *ps =
+		(struct timed_effect_parse_state*) parser_priv(p);
+
+	mem_free(ps);
 	parser_destroy(p);
 	return 0;
 }
 
 static void cleanup_player_timed(void)
 {
+	/*
+	 * Besides cleaning up any dynamically allocated resources, revert
+	 * any fields set during parsing to their default values so the
+	 * timed_effects array is back to where it started after its static
+	 * initialization.
+	 */
 	for (size_t i = 0; i < TMD_MAX; i++) {
 		struct timed_effect_data *effect = &timed_effects[i];
+		struct timed_failure *f = effect->fail;
 		struct timed_grade *grade = effect->grade;
+
+		while (f) {
+			struct timed_failure *next = f->next;
+
+			mem_free(f);
+			f = next;
+		}
+		effect->fail = NULL;
 
 		while (grade) {
 			struct timed_grade *next = grade->next;
 			string_free(grade->name);
-			if (grade->up_msg) string_free(grade->up_msg);
-			if (grade->down_msg) string_free(grade->down_msg);
+			string_free(grade->up_msg);
+			string_free(grade->down_msg);
 			mem_free(grade);
 			grade = next;
 		}
 		effect->grade = NULL;
 
 		string_free(effect->desc);
+		effect->desc = NULL;
 
-		if (effect->on_end)
-			string_free(effect->on_end);
-		if (effect->on_increase)
-			string_free(effect->on_increase);
-		if (effect->on_decrease)
-			string_free(effect->on_decrease);
-
-		effect->desc        = NULL;
-		effect->on_end      = NULL;
+		string_free(effect->on_end);
+		effect->on_end = NULL;
+		string_free(effect->on_increase);
 		effect->on_increase = NULL;
+		string_free(effect->on_decrease);
 		effect->on_decrease = NULL;
+		effect->msgt = 0;
+
+		free_effect(effect->on_begin_effect);
+		effect->on_begin_effect = NULL;
+		free_effect(effect->on_end_effect);
+		effect->on_end_effect = NULL;
+
+		effect->flags = 0;
+		effect->lower_bound = 0;
+		effect->oflag_dup = OF_NONE;
+		effect->oflag_syn = false;
+		effect->temp_resist = -1;
+		effect->temp_brand = -1;
+		effect->temp_slay = -1;
 	}
 }
 
@@ -401,62 +727,6 @@ struct file_parser player_timed_parser = {
 	cleanup_player_timed
 };
 
-
-/**
- * ------------------------------------------------------------------------
- * Utilities for more complex or anomolous effects
- * ------------------------------------------------------------------------ */
-/**
- * Swap stats at random to temporarily scramble the player's stats.
- */
-static void player_scramble_stats(struct player *p)
-{
-	int max1, cur1, max2, cur2, i, j, swap;
-
-	/* Fisher-Yates shuffling algorithm */
-	for (i = STAT_MAX - 1; i > 0; --i) {
-		j = randint0(i);
-
-		max1 = p->stat_max[i];
-		cur1 = p->stat_cur[i];
-		max2 = p->stat_max[j];
-		cur2 = p->stat_cur[j];
-
-		p->stat_max[i] = max2;
-		p->stat_cur[i] = cur2;
-		p->stat_max[j] = max1;
-		p->stat_cur[j] = cur1;
-
-		/* Record what we did */
-		swap = p->stat_map[i];
-		p->stat_map[i] = p->stat_map[j];
-		p->stat_map[j] = swap;
-	}
-
-	return;
-}
-
-/**
- * Undo scrambled stats when effect runs out.
- */
-static void player_fix_scramble(struct player *p)
-{
-	/* Figure out what stats should be */
-	int new_cur[STAT_MAX];
-	int new_max[STAT_MAX];
-
-	for (int i = 0; i < STAT_MAX; i++) {
-		new_cur[p->stat_map[i]] = p->stat_cur[i];
-		new_max[p->stat_map[i]] = p->stat_max[i];
-	}
-
-	/* Apply new stats and clear the stat_map */
-	for (int i = 0; i < STAT_MAX; i++) {
-		p->stat_cur[i] = new_cur[i];
-		p->stat_max[i] = new_max[i];
-		p->stat_map[i] = i;
-	}
-}
 
 /**
  * Return true if the player timed effect matches the given string
@@ -524,7 +794,7 @@ bool player_set_timed(struct player *p, int idx, int v, bool notify,
 	struct object *weapon = equipped_item_by_slot_name(p, "weapon");
 
 	/* Lower bound */
-	v = MAX(v, (idx == TMD_FOOD) ? 1 : 0);
+	v = MAX(v, effect->lower_bound);
 
 	/* No change */
 	if (p->timed[idx] == v) {
@@ -572,7 +842,7 @@ bool player_set_timed(struct player *p, int idx, int v, bool notify,
 			effect->msgt, p);
 		notify = true;
 	} else if ((new_grade->grade < current_grade->grade) &&
-			   (new_grade->down_msg)) {
+			(new_grade->down_msg)) {
 		print_custom_message(weapon, new_grade->down_msg,
 			effect->msgt, p);
 		notify = true;
@@ -592,22 +862,34 @@ bool player_set_timed(struct player *p, int idx, int v, bool notify,
 		}
 	}
 
-	/* Handle stat swap */
-	if (idx == TMD_SCRAMBLE) {
-		if (p->timed[idx] == 0) {
-			player_scramble_stats(p);
-		} else if (v == 0) {
-			player_fix_scramble(p);
+	/*
+	 * Dispatch effects for transitions.  Use source_player() as the
+	 * origin if can_disturb is not true; otherwise, use source_none().
+	 * That way any TIMED_INC or TIMED_INC_NO_RES effects in the effect
+	 * chains will honor can_disturb.
+	 */
+	if (v > 0 && !p->timed[idx]) {
+		/* The effect starts. */
+		if (effect->on_begin_effect) {
+			bool ident = false;
+
+			(void) effect_do(effect->on_begin_effect,
+				can_disturb ? source_none() : source_player(),
+				NULL, &ident, true, 0, 0, 0, NULL);
+		}
+	} else if (v == 0) {
+		/* The effect lapses. */
+		if (effect->on_end_effect) {
+			bool ident = false;
+
+			(void) effect_do(effect->on_end_effect,
+				can_disturb ? source_none() : source_player(),
+				NULL, &ident, true, 0, 0, 0, NULL);
 		}
 	}
 
 	/* Use the value */
 	p->timed[idx] = v;
-
-	/* Sort out the sprint effect */
-	if (idx == TMD_SPRINT && v == 0) {
-		player_inc_timed(p, TMD_SLOW, 100, true, true, false);
-	}
 
 	if (notify) {
 		/* Disturb */
@@ -639,69 +921,108 @@ bool player_set_timed(struct player *p, int idx, int v, bool notify,
 bool player_inc_check(struct player *p, int idx, bool lore)
 {
 	struct timed_effect_data *effect = &timed_effects[idx];
+	struct timed_failure *f = effect->fail;
 
-	/* Check that @ can be affected by this effect */
-	if (!effect->fail_code) {
-		return true;
-	}
+	while (f) {
+		switch (f->code) {
+		case TMD_FAIL_FLAG_OBJECT:
+			/* Effect is inhibited by an object flag */
+			if (lore) {
+				if (of_has(p->known_state.flags, f->idx)) {
+					return false;
+				}
+			} else {
+				/*
+				 * If the effect is from a monster action,
+				 * extra stuff happens.
+				 */
+				struct monster *mon = cave->mon_current > 0 ?
+					cave_monster(cave, cave->mon_current) :
+					NULL;
 
-	/* If we're only doing this for monster lore purposes */
-	if (lore) {
-		if (((effect->fail_code == TMD_FAIL_FLAG_OBJECT) &&
-			 (of_has(p->known_state.flags, effect->fail))) ||
-			((effect->fail_code == TMD_FAIL_FLAG_RESIST) &&
-			 (p->known_state.el_info[effect->fail].res_level > 0)) ||
-			((effect->fail_code == TMD_FAIL_FLAG_VULN) &&
-			 (p->known_state.el_info[effect->fail].res_level < 0))) {
-			return false;
-		} else {
-			return true;
-		}
-	}
-
-	/* Determine whether an effect can be prevented by a flag */
-	if (effect->fail_code == TMD_FAIL_FLAG_OBJECT) {
-		/* If the effect is from a monster action, extra stuff happens */
-		struct monster *mon = cave->mon_current > 0 ?
-				cave_monster(cave, cave->mon_current) : NULL;
-
-		/* Effect is inhibited by an object flag */
-		equip_learn_flag(p, effect->fail);
-
-		if (mon) {
-			update_smart_learn(mon, p, effect->fail, 0, -1);
-		}
-
-		if (player_of_has(p, effect->fail)) {
-			if (mon) {
-				msg("You resist the effect!");
+				equip_learn_flag(p, f->idx);
+				if (mon) {
+					update_smart_learn(mon, p, f->idx,
+						0, -1);
+				}
+				if (player_of_has(p, f->idx)) {
+					if (mon) {
+						msg("You resist the effect!");
+					}
+					return false;
+				}
 			}
-			return false;
+			break;
+
+		case TMD_FAIL_FLAG_RESIST:
+			/* Effect is inhibited by a resist */
+			assert(f->idx >= 0 && f->idx < ELEM_MAX);
+			if (lore) {
+				if (p->known_state.el_info[f->idx].res_level > 0) {
+					return false;
+				}
+			} else {
+				equip_learn_element(p, f->idx);
+				if (p->state.el_info[f->idx].res_level > 0) {
+					return false;
+				}
+			}
+			break;
+
+		case TMD_FAIL_FLAG_VULN:
+			/*
+			 * Effect is inhibited by a vulnerability
+			 * the asymmetry with resists is OK for now - NRM
+			 */
+			assert(f->idx >= 0 && f->idx < ELEM_MAX);
+			if (lore) {
+				if (p->known_state.el_info[f->idx].res_level < 0) {
+					return false;
+				}
+			} else {
+				equip_learn_element(p, f->idx);
+				if (p->state.el_info[f->idx].res_level < 0) {
+					return false;
+				}
+			}
+			break;
+
+		case TMD_FAIL_FLAG_PLAYER:
+			/* Effect is inhibited by a player flag */
+			if (lore) {
+				if (pf_has(p->known_state.pflags, f->idx)) {
+					return false;
+				}
+			} else {
+				if (player_has(p, f->idx)) {
+					return false;
+				}
+			}
+			break;
+
+		case TMD_FAIL_FLAG_TIMED_EFFECT:
+			/*
+			 * Effect is inhibited by a timed effect.  If timed
+			 * effect is active, it is known to the player, so
+			 * there's no difference between whether this is
+			 * solely a lore check or not.
+			 */
+			assert(f->idx >= 0 && f->idx < TMD_MAX);
+			if (p->timed[f->idx]) {
+				return false;
+			}
+			break;
+
+		default:
+			/* Should never happen. */
+			assert(0);
+			break;
 		}
-	} else if (effect->fail_code == TMD_FAIL_FLAG_RESIST) {
-		/* Effect is inhibited by a resist */
-		equip_learn_element(p, effect->fail);
-		if (p->state.el_info[effect->fail].res_level > 0) {
-			return false;
-		}
-	} else if (effect->fail_code == TMD_FAIL_FLAG_VULN) {
-		/* Effect is inhibited by a vulnerability
-		 * the asymmetry with resists is OK for now - NRM */
-		equip_learn_element(p, effect->fail);
-		if (p->state.el_info[effect->fail].res_level < 0) {
-			return false;
-		}
-	} else if (effect->fail_code == TMD_FAIL_FLAG_PLAYER) {
-		/* Effect is inhibited by a player flag */
-		if (player_has(p, effect->fail)) {
-			return false;
-		}
+
+		f = f->next;
 	}
 
-	/* Special cases */
-	if (effect->index == TMD_POISONED && p->timed[TMD_OPP_POIS])
-		return false;
-
+	/* Nothing prevents this effect from incrementing. */
 	return true;
 }
 
@@ -730,8 +1051,12 @@ bool player_inc_timed(struct player *p, int idx, int v, bool notify,
 	assert(idx < TMD_MAX);
 
 	if (check == false || player_inc_check(p, idx, false) == true) {
-		/* Paralysis should be non-cumulative */
-		if (idx == TMD_PARALYZED && p->timed[TMD_PARALYZED] > 0) {
+		if ((timed_effects[idx].flags & TMD_FLAG_NONSTACKING)
+				&& p->timed[idx] > 0) {
+			/*
+			 * Block the increase if the effect is nonstacking and
+			 * already active.
+			 */
 			return false;
 		} else {
 			return player_set_timed(p,

--- a/src/player-timed.h
+++ b/src/player-timed.h
@@ -40,7 +40,16 @@ enum {
 	TMD_FAIL_FLAG_OBJECT = 1,
 	TMD_FAIL_FLAG_RESIST,
 	TMD_FAIL_FLAG_VULN,
-	TMD_FAIL_FLAG_PLAYER
+	TMD_FAIL_FLAG_PLAYER,
+	TMD_FAIL_FLAG_TIMED_EFFECT
+};
+
+/**
+ * Bits in timed_effect_data's flags field
+ */
+enum {
+	/* Increases to duration will be blocked if effect is already active */
+	TMD_FLAG_NONSTACKING = 0x01,
 };
 
 struct timed_grade {
@@ -53,6 +62,12 @@ struct timed_grade {
 	struct timed_grade *next;
 };
 
+struct timed_failure {
+	struct timed_failure *next;
+	int code; /* one of the TMD_FAIL_FLAG_* constants */
+	int idx; /* index for object or player flag, timed effect, element */
+};
+
 /**
  * Data struct
  */
@@ -61,20 +76,37 @@ struct timed_effect_data {
 	uint32_t flag_redraw;
 	uint32_t flag_update;
 
-	int index;
 	char *desc;
 	char *on_end;
 	char *on_increase;
 	char *on_decrease;
 	int msgt;
-	int fail_code;
-	int fail;
+	struct timed_failure *fail;
 	struct timed_grade *grade;
+	/* This effect chain is triggered when the timed effect starts. */
+	struct effect *on_begin_effect;
+	/* This effect chain is triggered when the timed effect lapses. */
+	struct effect *on_end_effect;
+	bitflag flags;
+	int lower_bound;
 	int oflag_dup;
 	bool oflag_syn;
 	int temp_resist;
 	int temp_brand;
 	int temp_slay;
+};
+
+/**
+ * Holds state while parsing.  Exposed for use by unit test cases.
+ */
+struct timed_effect_parse_state {
+	/* Points to timed effect being populated.  May be NULL. */
+	struct timed_effect_data *t;
+	/*
+	 * Points to the most recent effect chain being modified in the timed
+	 * effect.  May be NULL.
+	 */
+	struct effect* e;
 };
 
 /**

--- a/src/player-util.h
+++ b/src/player-util.h
@@ -68,6 +68,8 @@ void take_hit(struct player *p, int dam, const char *kb_str);
 void death_knowledge(struct player *p);
 int energy_per_move(struct player *p);
 int16_t modify_stat_value(int value, int amount);
+void player_scramble_stats(struct player *p);
+void player_fix_scramble(struct player *p);
 void player_regen_hp(struct player *p);
 void player_regen_mana(struct player *p);
 void player_adjust_hp_precise(struct player *p, int32_t hp_gain);

--- a/src/tests/parse/ptimed.c
+++ b/src/tests/parse/ptimed.c
@@ -2,6 +2,7 @@
 /* Exercise the parser used for player_timed.txt. */
 
 #include "unit-test.h"
+#include "effects.h"
 #include "init.h"
 #include "message.h"
 #include "object.h"
@@ -9,6 +10,7 @@
 #include "parser.h"
 #include "player.h"
 #include "player-timed.h"
+#include "project.h"
 #include "z-color.h"
 #include "z-rand.h"
 #include "z-virt.h"
@@ -94,16 +96,84 @@ static void clear_grades(struct timed_effect_data* t) {
 	t->grade = NULL;
 }
 
+static int test_missing_record_header0(void *state)
+{
+	struct parser *p = (struct parser*) state;
+	struct timed_effect_parse_state *ps =
+		(struct timed_effect_parse_state*) parser_priv(p);
+	enum parser_error r;
+
+	notnull(ps);
+	null(ps->t);
+	r = parser_parse(p, "desc:haste");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "on-end:You feel yourself slow down.");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "on-increase:You are more confused!");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "on-decrease:You feel a little less confused.");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "msgt:SPEED");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "fail:1:FREE_ACT");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p,
+		"grade:G:10000:Haste:You feel yourself moving faster!");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "resist:ACID");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "brand:ACID_3");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "slay:ANIMAL_2");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "flag-synonym:PROT_FEAR:0");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "on-begin-effect:SCRAMBLE_STATS");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "on-end-effect:UNSCRAMBLE_STATS");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "effect-yx:10:20");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "effect-dice:2d20");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "effect-expr:B:PLAYER_HP:/ 4");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "effect-msg:despair");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "flags:NONSTACKING");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "lower-bound:1");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	ok;
+}
+
 static int test_name0(void *state) {
 	struct parser *p = (struct parser*) state;
 	enum parser_error r = parser_parse(p, "name:FOOD");
-	struct timed_effect_data *t;
+	struct timed_effect_parse_state *ps;
 
 	eq(r, PARSE_ERROR_NONE);
-	t = (struct timed_effect_data*) parser_priv(p);
-	notnull(t);
-	require(streq(t->name, "FOOD"));
-	require(t->index == (int) (t - timed_effects));
+	ps = (struct timed_effect_parse_state*) parser_priv(p);
+	notnull(ps);
+	notnull(ps->t);
+	eq(ps->t, timed_effects + TMD_FOOD);
+	notnull(ps->t->name);
+	require(streq(ps->t->name, "FOOD"));
+	null(ps->t->desc);
+	null(ps->t->on_end);
+	null(ps->t->on_increase);
+	null(ps->t->on_decrease);
+	eq(ps->t->msgt, 0);
+	null(ps->t->fail);
+	null(ps->t->on_begin_effect);
+	null(ps->t->on_end_effect);
+	eq(ps->t->flags, 0);
+	eq(ps->t->lower_bound, 0);
+	eq(ps->t->oflag_dup, OF_NONE);
+	eq(ps->t->oflag_syn, false);
+	eq(ps->t->temp_resist, -1);
+	eq(ps->t->temp_brand, -1);
+	eq(ps->t->temp_slay, -1);
 	ok;
 }
 
@@ -118,15 +188,17 @@ static int test_badname0(void *state) {
 static int test_desc0(void *state) {
 	struct parser *p = (struct parser*) state;
 	enum parser_error r = parser_parse(p, "desc:nourishment");
-	struct timed_effect_data *t;
+	struct timed_effect_parse_state *ps;
 
 	eq(r, PARSE_ERROR_NONE);
-	t = (struct timed_effect_data*) parser_priv(p);
-	notnull(t);
-	require(streq(t->desc, "nourishment"));
+	ps = (struct timed_effect_parse_state*) parser_priv(p);
+	notnull(ps);
+	notnull(ps->t)
+	notnull(ps->t->desc);
+	require(streq(ps->t->desc, "nourishment"));
 	r = parser_parse(p, "desc: (i.e. food)");
 	eq(r, PARSE_ERROR_NONE);
-	require(streq(t->desc, "nourishment (i.e. food)"));
+	require(streq(ps->t->desc, "nourishment (i.e. food)"));
 	ok;
 }
 
@@ -134,15 +206,17 @@ static int test_endmsg0(void *state) {
 	struct parser *p = (struct parser*) state;
 	enum parser_error r = parser_parse(p,
 		"on-end:You no longer feel safe from evil!");
-	struct timed_effect_data *t;
+	struct timed_effect_parse_state *ps;
 
 	eq(r, PARSE_ERROR_NONE);
-	t = (struct timed_effect_data*) parser_priv(p);
-	notnull(t);
-	require(streq(t->on_end, "You no longer feel safe from evil!"));
+	ps = (struct timed_effect_parse_state*) parser_priv(p);
+	notnull(ps);
+	notnull(ps->t);
+	notnull(ps->t->on_end);
+	require(streq(ps->t->on_end, "You no longer feel safe from evil!"));
 	r = parser_parse(p, "on-end:  They'll be after you soon.");
 	eq(r, PARSE_ERROR_NONE);
-	require(streq(t->on_end, "You no longer feel safe from evil!  "
+	require(streq(ps->t->on_end, "You no longer feel safe from evil!  "
 		"They'll be after you soon."));
 	ok;
 }
@@ -151,16 +225,17 @@ static int test_incmsg0(void *state) {
 	struct parser *p = (struct parser*) state;
 	enum parser_error r = parser_parse(p,
 		"on-increase:You feel even safer from evil!");
-	struct timed_effect_data *t;
+	struct timed_effect_parse_state *ps;
 
 	eq(r, PARSE_ERROR_NONE);
-	t = (struct timed_effect_data*) parser_priv(p);
-	notnull(t);
-	require(streq(t->on_increase, "You feel even safer from evil!"));
+	ps = (struct timed_effect_parse_state*) parser_priv(p);
+	notnull(ps);
+	notnull(ps->t);
+	require(streq(ps->t->on_increase, "You feel even safer from evil!"));
 	r = parser_parse(p,
 		"on-increase:  And the shadows seem to lighten and shrink.");
 	eq(r, PARSE_ERROR_NONE);
-	require(streq(t->on_increase, "You feel even safer from evil!  "
+	require(streq(ps->t->on_increase, "You feel even safer from evil!  "
 		"And the shadows seem to lighten and shrink."));
 	ok;
 }
@@ -169,16 +244,18 @@ static int test_decmsg0(void *state) {
 	struct parser *p = (struct parser*) state;
 	enum parser_error r = parser_parse(p,
 		"on-decrease:You feel less safe from evil!");
-	struct timed_effect_data *t;
+	struct timed_effect_parse_state *ps;
 
 	eq(r, PARSE_ERROR_NONE);
-	t = (struct timed_effect_data*) parser_priv(p);
-	notnull(t);
-	require(streq(t->on_decrease, "You feel less safe from evil!"));
+	ps = (struct timed_effect_parse_state*) parser_priv(p);
+	notnull(ps);
+	notnull(ps->t);
+	notnull(ps->t->on_decrease);
+	require(streq(ps->t->on_decrease, "You feel less safe from evil!"));
 	r = parser_parse(p,
 		"on-decrease:  And the shadows seem to lengthen and darken.");
 	eq(r, PARSE_ERROR_NONE);
-	require(streq(t->on_decrease, "You feel less safe from evil!  "
+	require(streq(ps->t->on_decrease, "You feel less safe from evil!  "
 		"And the shadows seem to lengthen and darken."));
 	ok;
 }
@@ -186,12 +263,13 @@ static int test_decmsg0(void *state) {
 static int test_msgt0(void *state) {
 	struct parser *p = (struct parser*) state;
 	enum parser_error r = parser_parse(p, "msgt:HUNGRY");
-	struct timed_effect_data *t;
+	struct timed_effect_parse_state *ps;
 
 	eq(r, PARSE_ERROR_NONE);
-	t = (struct timed_effect_data*) parser_priv(p);
-	notnull(t);
-	eq(t->msgt, MSG_HUNGRY);
+	ps = (struct timed_effect_parse_state*) parser_priv(p);
+	notnull(ps);
+	notnull(ps->t);
+	eq(ps->t->msgt, MSG_HUNGRY);
 	ok;
 }
 
@@ -206,25 +284,35 @@ static int test_badmsgt0(void *state) {
 static int test_fail0(void *state) {
 	struct parser *p = (struct parser*) state;
 	enum parser_error r = parser_parse(p, "fail:1:FREE_ACT");
-	struct timed_effect_data *t;
+	struct timed_effect_parse_state *ps;
 
 	eq(r, PARSE_ERROR_NONE);
-	t = (struct timed_effect_data*) parser_priv(p);
-	notnull(t);
-	eq(t->fail_code, TMD_FAIL_FLAG_OBJECT);
-	eq(t->fail, OF_FREE_ACT);
 	r = parser_parse(p, "fail:2:FIRE");
 	eq(r, PARSE_ERROR_NONE);
-	eq(t->fail_code, TMD_FAIL_FLAG_RESIST);
-	eq(t->fail, ELEM_FIRE);
 	r = parser_parse(p, "fail:3:POIS");
 	eq(r, PARSE_ERROR_NONE);
-	eq(t->fail_code, TMD_FAIL_FLAG_VULN);
-	eq(t->fail, ELEM_POIS);
 	r = parser_parse(p, "fail:4:NO_MANA");
 	eq(r, PARSE_ERROR_NONE);
-	eq(t->fail_code, TMD_FAIL_FLAG_PLAYER);
-	eq(t->fail, PF_NO_MANA);
+	r = parser_parse(p, "fail:5:SLOW");
+	eq(r, PARSE_ERROR_NONE);
+	ps = (struct timed_effect_parse_state*) parser_priv(p);
+	notnull(ps);
+	notnull(ps->t);
+	notnull(ps->t->fail);
+	eq(ps->t->fail->code, TMD_FAIL_FLAG_TIMED_EFFECT);
+	eq(ps->t->fail->idx, TMD_SLOW);
+	notnull(ps->t->fail->next);
+	eq(ps->t->fail->next->code, TMD_FAIL_FLAG_PLAYER);
+	eq(ps->t->fail->next->idx, PF_NO_MANA);
+	notnull(ps->t->fail->next->next);
+	eq(ps->t->fail->next->next->code, TMD_FAIL_FLAG_VULN);
+	eq(ps->t->fail->next->next->idx, ELEM_POIS);
+	notnull(ps->t->fail->next->next->next);
+	eq(ps->t->fail->next->next->next->code, TMD_FAIL_FLAG_RESIST);
+	eq(ps->t->fail->next->next->next->idx, ELEM_FIRE);
+	notnull(ps->t->fail->next->next->next->next);
+	eq(ps->t->fail->next->next->next->next->code, TMD_FAIL_FLAG_OBJECT);
+	eq(ps->t->fail->next->next->next->next->idx, OF_FREE_ACT);
 	ok;
 }
 
@@ -239,7 +327,9 @@ static int test_badfail0(void *state) {
 	eq(r, PARSE_ERROR_INVALID_FLAG);
 	r = parser_parse(p, "fail:4:XYZZY");
 	eq(r, PARSE_ERROR_INVALID_FLAG);
-	r = parser_parse(p, "fail:5:FIRE");
+	r = parser_parse(p, "fail:5:XYZZY");
+	eq(r, PARSE_ERROR_INVALID_FLAG);
+	r = parser_parse(p, "fail:6:FIRE");
 	eq(r, PARSE_ERROR_INVALID_FLAG);
 	r = parser_parse(p, "fail:10:FIRE");
 	eq(r, PARSE_ERROR_INVALID_FLAG);
@@ -315,13 +405,14 @@ static int test_grade0(void *state) {
 	};
 	char buffer[256], color[32];
 	enum parser_error r;
-	struct timed_effect_data *t;
+	struct timed_effect_parse_state *ps;
 	const struct timed_grade *last_grade;
 	int i, scale;
 
-	t = (struct timed_effect_data*) parser_priv(p);
-	notnull(t);
-	clear_grades(t);
+	ps = (struct timed_effect_parse_state*) parser_priv(p);
+	notnull(ps);
+	notnull(ps->t);
+	clear_grades(ps->t);
 
 	for (i = 0; i < (int) N_ELEMENTS(test_grades); ++i) {
 		/*
@@ -387,10 +478,12 @@ static int test_grade0(void *state) {
 		eq(r, PARSE_ERROR_NONE);
 	}
 
-	t = (struct timed_effect_data*) parser_priv(p);
-	notnull(t);
-	scale = (streq(t->name, "FOOD")) ? z_info->food_value : 1;
-	last_grade = t->grade;
+	ps = (struct timed_effect_parse_state*) parser_priv(p);
+	notnull(ps);
+	notnull(ps->t);
+	scale = (ps->t->name && streq(ps->t->name, "FOOD"))
+		? z_info->food_value : 1;
+	last_grade = ps->t->grade;
 	notnull(last_grade);
 	/* Skip the zero grade at the start. */
 	last_grade = last_grade->next;
@@ -426,15 +519,34 @@ static int test_grade0(void *state) {
 	ok;
 }
 
+static int test_badgrade0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "name:FAST");
+
+	eq(r, PARSE_ERROR_NONE);
+	/* Try with out of bounds values for the grade maximum. */
+	r = parser_parse(p, "grade:G:-1:Haste:Grade maximum below zero");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	r = parser_parse(p, "grade:G:32768:Haste:Grade maximum too larage");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	/* Try with non-increasing values for the grade maximums. */
+	r = parser_parse(p, "grade:G:50:Haste:Valid grade");
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "grade:R:25:Haste:Grade out of order");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	ok;
+}
+
 static int test_resist0(void *state) {
 	struct parser *p = (struct parser*) state;
 	enum parser_error r = parser_parse(p, "resist:COLD");
-	struct timed_effect_data *t;
+	struct timed_effect_parse_state *ps;
 
 	eq(r, PARSE_ERROR_NONE);
-	t = (struct timed_effect_data*) parser_priv(p);
-	notnull(t);
-	eq(t->temp_resist, ELEM_COLD);
+	ps = (struct timed_effect_parse_state*) parser_priv(p);
+	notnull(ps);
+	notnull(ps->t);
+	eq(ps->t->temp_resist, ELEM_COLD);
 	ok;
 }
 
@@ -450,7 +562,7 @@ static int test_brand0(void *state) {
 	struct parser *p = (struct parser*) state;
 	char buffer[128];
 	enum parser_error r;
-	struct timed_effect_data *t;
+	struct timed_effect_parse_state *ps;
 	int i;
 
 	for (i = (int) N_ELEMENTS(test_brands) - 1; i >= 0; --i) {
@@ -458,9 +570,10 @@ static int test_brand0(void *state) {
 			 test_brands[i]);
 		r = parser_parse(p, buffer);
 		eq(r, PARSE_ERROR_NONE);
-		t = (struct timed_effect_data*) parser_priv(p);
-		notnull(t);
-		require(streq(test_brands[i], brands[t->temp_brand].code));
+		ps = (struct timed_effect_parse_state*) parser_priv(p);
+		notnull(ps);
+		notnull(ps->t);
+		require(streq(test_brands[i], brands[ps->t->temp_brand].code));
 	}
 	ok;
 }
@@ -477,7 +590,7 @@ static int test_slay0(void *state) {
 	struct parser *p = (struct parser*) state;
 	char buffer[128];
 	enum parser_error r;
-	struct timed_effect_data *t;
+	struct timed_effect_parse_state *ps;
 	int i;
 
 	for (i = (int) N_ELEMENTS(test_slays) - 1; i >= 0; --i) {
@@ -485,9 +598,10 @@ static int test_slay0(void *state) {
 			 test_slays[i]);
 		r = parser_parse(p, buffer);
 		eq(r, PARSE_ERROR_NONE);
-		t = (struct timed_effect_data*) parser_priv(p);
-		notnull(t);
-		require(streq(test_slays[i], slays[t->temp_slay].code));
+		ps = (struct timed_effect_parse_state*) parser_priv(p);
+		notnull(ps);
+		notnull(ps->t);
+		require(streq(test_slays[i], slays[ps->t->temp_slay].code));
 	}
 	ok;
 }
@@ -503,17 +617,18 @@ static int test_badslay0(void *state) {
 static int test_flagsyn0(void *state) {
 	struct parser *p = (struct parser*) state;
 	enum parser_error r = parser_parse(p, "flag-synonym:SUST_STR:0");
-	struct timed_effect_data *t;
+	struct timed_effect_parse_state *ps;
 
 	eq(r, PARSE_ERROR_NONE);
-	t = (struct timed_effect_data*) parser_priv(p);
-	notnull(t);
-	eq(t->oflag_dup, OF_SUST_STR);
-	eq(t->oflag_syn, false);
+	ps = (struct timed_effect_parse_state*) parser_priv(p);
+	notnull(ps);
+	notnull(ps->t);
+	eq(ps->t->oflag_dup, OF_SUST_STR);
+	eq(ps->t->oflag_syn, false);
 	r = parser_parse(p, "flag-synonym:TELEPATHY:1");
 	eq(r, PARSE_ERROR_NONE);
-	eq(t->oflag_dup, OF_TELEPATHY);
-	eq(t->oflag_syn, true);
+	eq(ps->t->oflag_dup, OF_TELEPATHY);
+	eq(ps->t->oflag_syn, true);
 	ok;
 }
 
@@ -525,12 +640,394 @@ static int test_badflagsyn0(void *state) {
 	ok;
 }
 
+static int test_missing_effect0(void *state) {
+	struct parser *p = (struct parser*) state;
+	struct timed_effect_parse_state *ps =
+		(struct timed_effect_parse_state*) parser_priv(p);
+	enum parser_error r;
+
+	notnull(ps);
+	null(ps->e);
+	r = parser_parse(p, "effect-yx:10:20");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "effect-dice:2d20");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "effect-expr:B:PLAYER_HP:/ 4");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "effect-msg:despair");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	ok;
+}
+
+static int test_begineffect0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "on-begin-effect:DAMAGE");
+	struct timed_effect_parse_state *ps;
+	struct effect *e;
+
+	eq(r, PARSE_ERROR_NONE);
+	ps = (struct timed_effect_parse_state*) parser_priv(p);
+	notnull(ps);
+	notnull(ps->t);
+	notnull(ps->t->on_begin_effect);
+	e = ps->t->on_begin_effect;
+	while (e->next) e = e->next;
+	eq(e->index, EF_DAMAGE);
+	null(e->dice);
+	eq(e->y, 0);
+	eq(e->x, 0);
+	eq(e->subtype, 0);
+	eq(e->radius, 0);
+	eq(e->other, 0);
+	null(e->msg);
+	ptreq(e, ps->e);
+
+	/* Check effect with type and subtype. */
+	r = parser_parse(p, "on-begin-effect:CURE:BLIND");
+	eq(r, PARSE_ERROR_NONE);
+	ps = (struct timed_effect_parse_state*) parser_priv(p);
+	notnull(ps);
+	notnull(ps->t);
+	notnull(ps->t->on_begin_effect);
+	e = ps->t->on_begin_effect;
+	while (e->next) e = e->next;
+	eq(e->index, EF_CURE);
+	null(e->dice);
+	eq(e->y, 0);
+	eq(e->x, 0);
+	eq(e->subtype, TMD_BLIND);
+	eq(e->radius, 0);
+	eq(e->other, 0);
+	null(e->msg);
+	ptreq(e, ps->e);
+
+	/* Check effect with type, subtype, and radius. */
+	r = parser_parse(p, "on-begin-effect:BALL:COLD:3");
+	eq(r, PARSE_ERROR_NONE);
+	ps = (struct timed_effect_parse_state*) parser_priv(p);
+	notnull(ps);
+	notnull(ps->t);
+	notnull(ps->t->on_begin_effect);
+	e = ps->t->on_begin_effect;
+	while (e->next) e = e->next;
+	eq(e->index, EF_BALL);
+	null(e->dice);
+	eq(e->y, 0);
+	eq(e->x, 0);
+	eq(e->subtype, PROJ_COLD);
+	eq(e->radius, 3);
+	eq(e->other, 0);
+	null(e->msg);
+	ptreq(e, ps->e);
+
+	/* Check effect with type, subtype, radius, and other. */
+	r = parser_parse(p, "on-begin-effect:SPOT:LIGHT_WEAK:2:10");
+	eq(r, PARSE_ERROR_NONE);
+	ps = (struct timed_effect_parse_state*) parser_priv(p);
+	notnull(ps);
+	notnull(ps->t);
+	notnull(ps->t->on_begin_effect);
+	e = ps->t->on_begin_effect;
+	while (e->next) e = e->next;
+	eq(e->index, EF_SPOT);
+	null(e->dice);
+	eq(e->y, 0);
+	eq(e->x, 0);
+	eq(e->subtype, PROJ_LIGHT_WEAK);
+	eq(e->radius, 2);
+	eq(e->other, 10);
+	null(e->msg);
+	ptreq(e, ps->e);
+
+	ok;
+}
+
+static int test_badbegineffect0(void *state) {
+	struct parser *p = (struct parser*) state;
+
+	/* Check with unrecognized effect. */
+	enum parser_error r = parser_parse(p, "on-begin-effect:XYZZY");
+
+	eq(r, PARSE_ERROR_INVALID_EFFECT);
+	/* Check with bad subtype. */
+	r = parser_parse(p, "on-begin-effect:CURE:XYZZY");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	ok;
+}
+
+static int test_endeffect0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "on-end-effect:DAMAGE");
+	struct timed_effect_parse_state *ps;
+	struct effect *e;
+
+	eq(r, PARSE_ERROR_NONE);
+	ps = (struct timed_effect_parse_state*) parser_priv(p);
+	notnull(ps);
+	notnull(ps->t);
+	notnull(ps->t->on_end_effect);
+	e = ps->t->on_end_effect;
+	while (e->next) e = e->next;
+	eq(e->index, EF_DAMAGE);
+	null(e->dice);
+	eq(e->y, 0);
+	eq(e->x, 0);
+	eq(e->subtype, 0);
+	eq(e->radius, 0);
+	eq(e->other, 0);
+	null(e->msg);
+	ptreq(e, ps->e);
+
+	/* Check effect with type and subtype. */
+	r = parser_parse(p, "on-end-effect:CURE:BLIND");
+	eq(r, PARSE_ERROR_NONE);
+	ps = (struct timed_effect_parse_state*) parser_priv(p);
+	notnull(ps);
+	notnull(ps->t);
+	notnull(ps->t->on_end_effect);
+	e = ps->t->on_end_effect;
+	while (e->next) e = e->next;
+	eq(e->index, EF_CURE);
+	null(e->dice);
+	eq(e->y, 0);
+	eq(e->x, 0);
+	eq(e->subtype, TMD_BLIND);
+	eq(e->radius, 0);
+	eq(e->other, 0);
+	null(e->msg);
+	ptreq(e, ps->e);
+
+	/* Check effect with type, subtype, and radius. */
+	r = parser_parse(p, "on-end-effect:BALL:COLD:3");
+	eq(r, PARSE_ERROR_NONE);
+	ps = (struct timed_effect_parse_state*) parser_priv(p);
+	notnull(ps);
+	notnull(ps->t);
+	notnull(ps->t->on_end_effect);
+	e = ps->t->on_end_effect;
+	while (e->next) e = e->next;
+	eq(e->index, EF_BALL);
+	null(e->dice);
+	eq(e->y, 0);
+	eq(e->x, 0);
+	eq(e->subtype, PROJ_COLD);
+	eq(e->radius, 3);
+	eq(e->other, 0);
+	null(e->msg);
+	ptreq(e, ps->e);
+
+	/* Check effect with type, subtype, radius, and other. */
+	r = parser_parse(p, "on-end-effect:SPOT:LIGHT_WEAK:2:10");
+	eq(r, PARSE_ERROR_NONE);
+	ps = (struct timed_effect_parse_state*) parser_priv(p);
+	notnull(ps);
+	notnull(ps->t);
+	notnull(ps->t->on_end_effect);
+	e = ps->t->on_end_effect;
+	while (e->next) e = e->next;
+	eq(e->index, EF_SPOT);
+	null(e->dice);
+	eq(e->y, 0);
+	eq(e->x, 0);
+	eq(e->subtype, PROJ_LIGHT_WEAK);
+	eq(e->radius, 2);
+	eq(e->other, 10);
+	null(e->msg);
+	ptreq(e, ps->e);
+
+	ok;
+}
+
+static int test_badendeffect0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Check with unrecognized effect. */
+	enum parser_error r = parser_parse(p, "on-begin-effect:XYZZY");
+
+	eq(r, PARSE_ERROR_INVALID_EFFECT);
+	/* Check with bad subtype. */
+	r = parser_parse(p, "on-begin-effect:CURE:XYZZY");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	ok;
+}
+
+static int test_effectyx0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "on-begin-effect:DAMAGE");
+	struct timed_effect_parse_state *ps;
+	struct effect *e;
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "effect-yx:10:20");
+	eq(r, PARSE_ERROR_NONE);
+	ps = (struct timed_effect_parse_state*) parser_priv(p);
+	notnull(ps);
+	notnull(ps->t);
+	notnull(ps->t->on_begin_effect);
+	e = ps->t->on_begin_effect;
+	while (e->next) e = e->next;
+	eq(e->y, 10);
+	eq(e->x, 20);
+	ok;
+}
+
+static int test_effectdice0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "on-end-effect:DAMAGE");
+	struct timed_effect_parse_state *ps;
+	struct effect *e;
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "effect-dice:5+2d20");
+	eq(r, PARSE_ERROR_NONE);
+	ps = (struct timed_effect_parse_state*) parser_priv(p);
+	notnull(ps);
+	notnull(ps->t);
+	notnull(ps->t->on_end_effect);
+	e = ps->t->on_end_effect;
+	while (e->next) e = e->next;
+	notnull(e->dice);
+	eq(dice_test_values(e->dice, 5, 2, 20, 0), true);
+	/* Try setting again to see if memory is leaked. */
+	r = parser_parse(p, "effect-dice:3+4d5");
+	eq(r, PARSE_ERROR_NONE);
+	notnull(e->dice);
+	eq(dice_test_values(e->dice, 3, 4, 5, 0), true);
+	ok;
+}
+
+static int test_badeffectdice0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "on-begin-effect:DAMAGE");
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "effect-dice:2+1d3+1d4");
+	eq(r, PARSE_ERROR_INVALID_DICE);
+	ok;
+}
+
+static int test_effectexpr0(void* state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "on-begin-effect:DAMAGE");
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "effect-dice:4d$S");
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "effect-expr:S:DUNGEON_LEVEL:+ 19 / 20");
+	eq(r, PARSE_ERROR_NONE);
+	ok;
+}
+
+static int test_badeffectexpr0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "on-end-effect:DAMAGE");
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "effect-dice:$B+d$S");
+	eq(r, PARSE_ERROR_NONE);
+	/* Try an expression with an invalid operations string. */
+	r = parser_parse(p, "effect-expr:B:PLAYER_LEVEL:^ 2");
+	eq(r, PARSE_ERROR_BAD_EXPRESSION_STRING);
+	/* Try to bind an expression to a variable that isn't in the dice. */
+	r = parser_parse(p, "effect-expr:N:PLAYER_LEVEL:/ 5 + 1");
+	eq(r, PARSE_ERROR_UNBOUND_EXPRESSION);
+	ok;
+}
+
+static int test_effectmsg0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "on-begin-effect:DAMAGE");
+	struct timed_effect_parse_state *ps;
+	struct effect *e;
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "effect-msg:despair");
+	eq(r, PARSE_ERROR_NONE);
+	ps = (struct timed_effect_parse_state*) parser_priv(p);
+	notnull(ps);
+	notnull(ps->t);
+	notnull(ps->t->on_begin_effect);
+	e = ps->t->on_begin_effect;
+	while (e->next) e = e->next;
+	notnull(e->msg);
+	require(streq(e->msg, "despair"));
+	/* Check that multiple directives are concatenated. */
+	r = parser_parse(p, "effect-msg: and loneliness");
+	eq(r, PARSE_ERROR_NONE);
+	notnull(e->msg);
+	require(streq(e->msg, "despair and loneliness"));
+	ok;
+}
+
+static int test_flags0(void *state) {
+	struct parser *p = (struct parser*) state;
+	struct timed_effect_parse_state *ps =
+		(struct timed_effect_parse_state*) parser_priv(p);
+	enum parser_error r;
+
+	notnull(ps);
+	notnull(ps->t);
+	ps->t->flags = 0;
+
+	/* Check that specifying no flags works. */
+	r = parser_parse(p, "flags:");
+	eq(r, PARSE_ERROR_NONE);
+	eq(ps->t->flags, 0);
+
+	r = parser_parse(p, "flags:NONSTACKING");
+	eq(r, PARSE_ERROR_NONE);
+	eq(ps->t->flags, TMD_FLAG_NONSTACKING);
+
+	ok;
+}
+
+static int test_badflags0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "flags:XYZZY");
+
+	eq(r, PARSE_ERROR_INVALID_FLAG);
+	ok;
+}
+
+static int test_lowerbound0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "lower-bound:10");
+	struct timed_effect_parse_state *ps;
+
+	eq(r, PARSE_ERROR_NONE);
+	ps = (struct timed_effect_parse_state*) parser_priv(p);
+	notnull(ps);
+	notnull(ps->t);
+	eq(ps->t->lower_bound, 10);
+	ok;
+}
+
+static int test_badlowerbound0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "lower-bound:-1");
+
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	r = parser_parse(p, "lower-bound:-10");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	r = parser_parse(p, "lower-bound:32768");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	r = parser_parse(p, "lower-bound:65535");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	ok;
+}
+
 const char *suite_name = "parse/ptimed";
 
 /*
- * test_name0() has to be before any of the other tests besides test_badname0().
+ * test_missing_record_header0() has to be before test_name0().
+ * test_name0() has to be before any of the other tests besides
+ * test_missing_effect0() has to be before test_begineffect0(),
+ * test_badbegineffect0(), test_endeffect0(), test_badendeffect0(),
+ * test_effectyx0(), test_effectdice0(), test_badeffectdice0(),
+ * test_effectexpr0(), test_badeffectexpr0(), and test_effectmsg0().
+ * test_missing_record_header0() and  test_badname0().
  */
 struct test tests[] = {
+	{ "missing_record_header0", test_missing_record_header0 },
 	{ "name0", test_name0 },
 	{ "badname0", test_badname0 },
 	{ "desc0", test_desc0 },
@@ -542,6 +1039,7 @@ struct test tests[] = {
 	{ "fail0", test_fail0 },
 	{ "badfail0", test_badfail0 },
 	{ "grade0", test_grade0 },
+	{ "badgrad0", test_badgrade0 },
 	{ "resist0", test_resist0 },
 	{ "badresist0", test_badresist0 },
 	{ "brand0", test_brand0 },
@@ -550,5 +1048,20 @@ struct test tests[] = {
 	{ "badslay0", test_badslay0 },
 	{ "flagsyn0", test_flagsyn0 },
 	{ "badflagsyn0", test_badflagsyn0 },
+	{ "missing_effect0", test_missing_effect0 },
+	{ "begineffect0", test_begineffect0 },
+	{ "badbegineffect0", test_badbegineffect0 },
+	{ "endeffect0", test_endeffect0 },
+	{ "badendeffect0", test_badendeffect0 },
+	{ "effectyx0", test_effectyx0 },
+	{ "effectdice0", test_effectdice0 },
+	{ "badeffectdice0", test_badeffectdice0 },
+	{ "effectexpr0", test_effectexpr0 },
+	{ "badeffectexpr0", test_badeffectexpr0 },
+	{ "effectmsg0", test_effectmsg0 },
+	{ "flags0", test_flags0 },
+	{ "badflags0", test_badflags0 },
+	{ "lowerbound0", test_lowerbound0 },
+	{ "badlowerbound0", test_badlowerbound0 },
 	{ NULL, NULL }
 };


### PR DESCRIPTION
…specified in player_timed.txt.  Resolves https://github.com/angband/angband/issues/5434 .  Have lore checks through player_inc_check() for a timed effects protected against by a player flag or TMD_OPP_POIS possibly return false, based on the player's state, rather than always returning true.  Resolves https://github.com/angband/angband/issues/5431 .  For out of order directives during parsing, prefer PARSE_ERROR_MISSING_RECORD_HEADER errors rather than assertion checks as the former should give someone modding the game more information (at least the line number in player_timed.txt triggering the error).