### PR TITLE
tests: fix missing braces in unit test harness

### DIFF
--- a/src/tests/unit-test.h
+++ b/src/tests/unit-test.h
@@ -61,10 +61,11 @@ extern int teardown_tests(void *data);
 #define require(x) \
 	do { \
 		if (!(x)) { \
-			if (verbose) \
+			if (verbose) { \
 				showfail(); \
 				printf("    %s:%d: requirement '%s' failed\n", \
 			           suite_name, __LINE__, #x); \
+			} \
 			return 1; \
 		} \
 	} while (0)


### PR DESCRIPTION
The missing pair of braces cause the test harness to always print its verbose failure message even when verbose is disabled.