### PR TITLE
tests: run unit tests against in-tree data files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ DISTCLEAN = config.status config.log docs/.deps \
 REPOCLEAN = aclocal.m4 autom4te.cache configure src/autoconf.h.in version
 
 .PHONY: tests manual manual-optional dist
+check: tests
 tests:
 	$(MAKE) -C src tests
 

--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -1,6 +1,6 @@
 # Makefile for tests - builds unit-test binaries
 
-CFLAGS+=-I../ -I. -g
+CFLAGS+=-I../ -I. -g -DSRCROOT=\"$(realpath ../..)\"
 LDFLAGS+=-lm
 
 all : run

--- a/src/tests/test-utils.c
+++ b/src/tests/test-utils.c
@@ -23,6 +23,10 @@ errr init_sound_sdl(struct sound_hooks *hooks, int argc, char **argv)
 
 #endif
 
+#ifndef SRCROOT
+#error Unit tests must be built with SRCROOT set to the directory above src
+#endif
+
 /*
  * Call this to initialise Angband's file paths before calling init_angband()
  * or similar.
@@ -30,9 +34,9 @@ errr init_sound_sdl(struct sound_hooks *hooks, int argc, char **argv)
 void set_file_paths(void) {
 	char configpath[512], libpath[512], datapath[512];
 
-	my_strcpy(configpath, DEFAULT_CONFIG_PATH, sizeof(configpath));
-	my_strcpy(libpath, DEFAULT_LIB_PATH, sizeof(libpath));
-	my_strcpy(datapath, DEFAULT_DATA_PATH, sizeof(datapath));
+	my_strcpy(configpath, SRCROOT PATH_SEP "lib", sizeof(configpath));
+	my_strcpy(libpath, SRCROOT PATH_SEP "lib", sizeof(libpath));
+	my_strcpy(datapath, SRCROOT PATH_SEP "lib", sizeof(datapath));
 
 	configpath[511] = libpath[511] = datapath[511] = '\0';
 


### PR DESCRIPTION
Before this change, unit tests ran against the production data files on disk (if the game was installed in $PREFIX) and otherwise just errored out. That made the build non-hermetic and in particular made the test suite not work in CI environments.

This change has the unit tests always look in $SRCROOT/lib for their data files instead.

It also adds a "check" target, as an alias to "tests", since "make check" is basically standard and some package managers (like apk) default to running it.