### PR TITLE
SDL: remember last root size for the font browser and restore it when…

### DIFF
--- a/src/main-sdl.c
+++ b/src/main-sdl.c
@@ -491,6 +491,10 @@ static size_t FontBrowserRootSz = 0;
  */
 static char *FontBrowserLastDir = NULL;
 /*
+ * Value for the length of the root portion of FontBrowserLastDir
+ */
+static size_t FontBrowserLastRootSz = 0;
+/*
  * Array of the unabbreviated directory names in the current directory being
  * browsed by the 'Font Browser' panel
  */
@@ -1855,6 +1859,7 @@ static void HelpFontBrowserClose(void)
 	/* Remember the directory where the browser was. */
 	string_free(FontBrowserLastDir);
 	FontBrowserLastDir = FontBrowserCurDir;
+	FontBrowserLastRootSz = FontBrowserRootSz;
 	FontBrowserCurDir = NULL;
 	FontBrowserRootSz = 0;
 
@@ -2895,6 +2900,7 @@ static void ActivateFontBrowser(sdl_Button *sender)
 		}
 	} else if (FontBrowserLastDir) {
 		FontBrowserCurDir = string_make(FontBrowserLastDir);
+		FontBrowserRootSz = FontBrowserLastRootSz;
 	}
 	if (!FontBrowserCurDir) {
 		size_t sz1, sz2;


### PR DESCRIPTION
… restoring the last directory browsed; resolves PowerWyrm's report here, http://angband.oook.cz/forum/showthread.php?t=11358 , of closing the font browser at the root directory and then reopening it and having the up button available for use