### PR TITLE
configure: remove skip-old-int-typedefs option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -168,18 +168,6 @@ int main(int argc, char *argv[]) {
 ]])], [CPPFLAGS="$CPPFLAGS -DUSE_FUNC_ATTR_FORMAT"])
 fi
 
-AC_ARG_ENABLE(skip-old-int-typedefs,
-	[AS_HELP_STRING([--enable-skip-old-int-typedefs], [do not generate the u32b, s32b, ... typedefs in Angband's headers])],
-	[AS_CASE(${enableval},
-		[yes], [skip_old_int_typedefs=yes],
-		[no], [skip_old_int_typedefs=no],
-		[AC_MSG_ERROR([bad value ${enableval} for --enable-skip-old-int-typedefs])])],
-	[skip_old_int_typedefs=no])
-
-if test x"$skip_old_int_typedefs" = xyes ; then
-	AC_DEFINE(SKIP_ANGBAND_OLD_INT_TYPEDEFS, 1, [Define to skip generating the u32b, s32b, ... typedefs])
-fi
-
 MY_PROG_MAKE_SYSVINC
 MY_PROG_MAKE_SINCLUDE
 

--- a/src/h-basic.h
+++ b/src/h-basic.h
@@ -151,20 +151,6 @@
 
 typedef int errr;
 
-#ifndef SKIP_ANGBAND_OLD_INT_TYPEDEFS
-/* Use guaranteed-size types */
-typedef uint8_t byte;
-
-typedef uint16_t u16b;
-typedef int16_t s16b;
-
-typedef uint32_t u32b;
-typedef int32_t s32b;
-
-typedef uint64_t u64b;
-typedef int64_t s64b;
-#endif
-
 /** Debugging macros ***/
 
 #define DSTRINGIFY(x) #x


### PR DESCRIPTION
These typedefs aren't used anywhere in the source and it's hard to conceive of a situation where one would want to enable them, given that they have been fully replaced with standard C types.