### PR TITLE
configure: remove stdint.h check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -99,7 +99,7 @@ AC_PATH_PROG(MV, mv)
 AC_PATH_PROG(CP, cp)
 
 AC_HEADER_DIRENT
-AC_CHECK_HEADERS([fcntl.h stdint.h])
+AC_CHECK_HEADERS([fcntl.h])
 AC_HEADER_STDBOOL
 AC_C_CONST
 AC_CHECK_FUNCS([mkdir setresgid setegid stat])

--- a/src/h-basic.h
+++ b/src/h-basic.h
@@ -21,14 +21,6 @@
 
 #else
 
-/**
- * Using C99, assume we have stdint and stdbool
- */
-# if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) \
-  || (defined(_MSC_VER) && _MSC_VER >= 1600L)
-#  define HAVE_STDINT_H 1
-# endif
-
 # if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
 #  define HAVE_STDbool_H
 # endif

--- a/src/z-queue.h
+++ b/src/z-queue.h
@@ -21,19 +21,6 @@
 
 #include "h-basic.h"
 
-#if (!defined(HAVE_STDINT_H))
-/* MSVC doesn't have stdint.h (which is C99), so we'll just
- * create the right pointer manually. */
-#ifndef _UINTPTR_T_DEFINED
-#ifdef UINT_PTR
-typedef UINT_PTR uintptr_t;
-#else
-/* an integer type with enough bits to hold a pointer */
-typedef unsigned long uintptr_t;
-#endif
-#endif
-#endif
-
 struct queue {
     uintptr_t *data;
     size_t size;


### PR DESCRIPTION
The only C99 compiler (to my knowledge) that ever shipped without stdint.h was MSVC versions prior to Visual Studio 2010. Given the age of that compiler, we can probably drop support for it by now and just assume a proper C99 environment.