### PR TITLE
configure: remove printf format attribute check

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Build
         run: |
           ./autogen.sh
-          ./configure --with-no-install --enable-test --enable-skip-old-int-typedefs --enable-printf-style-checks
+          ./configure --with-no-install --enable-test --enable-skip-old-int-typedefs
           make
           make tests
           ./run-tests
@@ -98,7 +98,7 @@ jobs:
       - name: Build
         run: |
           ./autogen.sh
-          ./configure --with-no-install --enable-sdl2 --enable-sdl2-mixer --enable-skip-old-int-typedefs --enable-printf-style-checks
+          ./configure --with-no-install --enable-sdl2 --enable-sdl2-mixer --enable-skip-old-int-typedefs
           make
 
   statbuild:
@@ -120,5 +120,5 @@ jobs:
       - name: Build
         run: |
           ./autogen.sh
-          env CFLAGS="-Wvla -Wlogical-op" ./configure --enable-more-gcc-warnings --with-no-install --enable-stats --enable-test --enable-sdl-mixer --enable-skip-old-int-typedefs --enable-printf-style-checks
+          env CFLAGS="-Wvla -Wlogical-op" ./configure --enable-more-gcc-warnings --with-no-install --enable-stats --enable-test --enable-sdl-mixer --enable-skip-old-int-typedefs
           make

--- a/configure.ac
+++ b/configure.ac
@@ -149,25 +149,6 @@ if test "$GCC" = "yes"; then
 	fi
 fi
 
-AC_ARG_ENABLE(printf-style-checks,
-	[AS_HELP_STRING([--enable-printf-style-checks], [enable compiler checks on custom functions that act like printf])],
-	[AS_CASE(${enableval},
-		[yes], [printf_style_checks=yes],
-		[no], [printf_style_checks=no],
-		[AC_MSG_ERROR([bad value ${enableval} for --enable-printf-style-checks])])],
-		[printf_style_checks=no])
-if test x"$printf_style_checks" = xyes ; then
-	AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
-void f(const char *fmt, ...) __attribute__ ((format (printf, 1, 2)));
-void f(const char *fmt, ...) {}
-int main(int argc, char *argv[]) {
-	int i = 10;
-	f("%d", i);
-	return 0;
-}
-]])], [CPPFLAGS="$CPPFLAGS -DUSE_FUNC_ATTR_FORMAT"])
-fi
-
 AC_ARG_ENABLE(skip-old-int-typedefs,
 	[AS_HELP_STRING([--enable-skip-old-int-typedefs], [do not generate the u32b, s32b, ... typedefs in Angband's headers])],
 	[AS_CASE(${enableval},

--- a/src/h-basic.h
+++ b/src/h-basic.h
@@ -129,7 +129,11 @@
 # include <unistd.h>
 #endif
 
-
+#if defined(__GNUC__) || defined(__clang__)
+#define ATTRIBUTE __attribute__
+#else
+#define ATTRIBUTE(x)
+#endif
 
 /**
  * ------------------------------------------------------------------------

--- a/src/z-file.h
+++ b/src/z-file.h
@@ -243,16 +243,8 @@ bool file_put(ang_file *f, const char *buf);
  * Format (using strnfmt) the given args, and then call file_put().
  */
 bool file_putf(ang_file *f, const char *fmt, ...)
-/*
- * This is to automate format string checking with gcc and clang:  see
- * see https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#Common-Function-Attributes .
- */
-#ifdef USE_FUNC_ATTR_FORMAT
-	__attribute__ ((format (printf, 2, 3)))
-#endif
-;
+	ATTRIBUTE ((format (printf, 2, 3)));
 bool file_vputf(ang_file *f, const char *fmt, va_list vp);
-
 
 /** Byte-based IO */
 

--- a/src/z-form.h
+++ b/src/z-form.h
@@ -42,14 +42,7 @@ extern size_t vstrnfmt(char *buf, size_t max, const char *fmt, va_list vp);
  * Simple interface to "vstrnfmt()"
  */
 extern size_t strnfmt(char *buf, size_t max, const char *fmt, ...)
-/*
- * This and further instances below are to automate format string checking
- * with gcc and clang:  see https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#Common-Function-Attributes .
- */
-#ifdef USE_FUNC_ATTR_FORMAT
-	__attribute ((format (printf, 3, 4)))
-#endif
-;
+	ATTRIBUTE ((format (printf, 3, 4)));
 
 /**
  * Format arguments into a static resizing buffer
@@ -65,36 +58,24 @@ extern void vformat_kill(void);
  * Append a formatted string to another string
  */
 extern void strnfcat(char *str, size_t max, size_t *end, const char *fmt, ...)
-#ifdef USE_FUNC_ATTR_FORMAT
-	__attribute__ ((format (printf, 4, 5)))
-#endif
-;
+	ATTRIBUTE ((format (printf, 4, 5)));
 
 /**
  * Simple interface to "vformat()"
  */
 extern char *format(const char *fmt, ...)
-#ifdef USE_FUNC_ATTR_FORMAT
-	__attribute__ ((format (printf, 1, 2)))
-#endif
-;
+	ATTRIBUTE ((format (printf, 1, 2)));
 
 /**
  * Vararg interface to "plog()", using "format()"
  */
 extern void plog_fmt(const char *fmt, ...)
-#ifdef USE_FUNC_ATTR_FORMAT
-	__attribute__ ((format (printf, 1, 2)))
-#endif
-;
+	ATTRIBUTE ((format (printf, 1, 2)));
 
 /**
  * Vararg interface to "quit()", using "format()"
  */
 extern void quit_fmt(const char *fmt, ...)
-#ifdef USE_FUNC_ATTR_FORMAT
-	__attribute__ ((format (printf, 1, 2)))
-#endif
-;
+	ATTRIBUTE ((format (printf, 1, 2)));
 
 #endif /* INCLUDED_Z_FORM_H */

--- a/src/z-textblock.h
+++ b/src/z-textblock.h
@@ -30,19 +30,9 @@ void textblock_free(textblock *tb);
 
 
 void textblock_append(textblock *tb, const char *fmt, ...)
-/*
- * This and further instances below are to automate format string checking
- * with gcc and clang:  see https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#Common-Function-Attributes .
- */
-#ifdef USE_FUNC_ATTR_FORMAT
-	__attribute ((format (printf, 2, 3)))
-#endif
-;
+	ATTRIBUTE ((format (printf, 2, 3)));
 void textblock_append_c(textblock *tb, uint8_t attr, const char *fmt, ...)
-#ifdef USE_FUNC_ATTR_FORMAT
-	__attribute ((format (printf, 3, 4)))
-#endif
-;
+	ATTRIBUTE ((format (printf, 3, 4)));
 void textblock_append_pict(textblock *tb, uint8_t attr, int c);
 void textblock_append_textblock(textblock *tb, const textblock *tba);
 
@@ -62,20 +52,11 @@ extern int text_out_pad;
 
 extern void text_out_to_file(uint8_t attr, const char *str);
 extern void text_out(const char *fmt, ...)
-#ifdef USE_FUNC_ATTR_FORMAT
-	__attribute ((format (printf, 1, 2)))
-#endif
-;
+	ATTRIBUTE ((format (printf, 1, 2)));
 extern void text_out_c(uint8_t a, const char *fmt, ...)
-#ifdef USE_FUNC_ATTR_FORMAT
-	__attribute ((format (printf, 2, 3)))
-#endif
-;
+	ATTRIBUTE ((format (printf, 2, 3)));
 extern void text_out_e(const char *fmt, ...)
-#ifdef USE_FUNC_ATTR_FORMAT
-	__attribute ((format (printf, 1, 2)))
-#endif
-;
+	ATTRIBUTE ((format (printf, 1, 2)));
 
 typedef void (*text_writer)(ang_file *f);
 errr text_lines_to_file(const char *path, text_writer writer);


### PR DESCRIPTION
Having the configure script detect support for this by compiling a test program is a bit unnecessary - clang and gcc (~all versions) both support these attributes, and other compilers don't. We can just condition on the compiler type directly in src/h-basic.h and not have get the user to tell us whether their compiler supports a feature.