### PR TITLE
z-virt: remove memory poisoning support

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -301,20 +301,6 @@ static void list_saves(void)
 	cleanup_savefile_getter(g);
 }
 
-
-static void debug_opt(const char *arg) {
-	if (streq(arg, "mem-poison-alloc"))
-		mem_flags |= MEM_POISON_ALLOC;
-	else if (streq(arg, "mem-poison-free"))
-		mem_flags |= MEM_POISON_FREE;
-	else {
-		puts("Debug flags:");
-		puts("  mem-poison-alloc: Poison all memory allocations");
-		puts("   mem-poison-free: Poison all freed memory");
-		exit(0);
-	}
-}
-
 /**
  * Simple "main" function for multiple platforms.
  *
@@ -433,10 +419,6 @@ int main(int argc, char *argv[])
 				change_path(arg);
 				continue;
 
-			case 'x':
-				debug_opt(arg);
-				continue;
-
 			case '-':
 				argv[i] = argv[0];
 				argc = argc - i;
@@ -452,7 +434,6 @@ int main(int argc, char *argv[])
 				puts("  -l             Lists all savefiles you can play");
 				puts("  -w             Resurrect dead character (marks savefile)");
 				puts("  -g             Request graphics mode");
-				puts("  -x<opt>        Debug options; see -xhelp");
 				puts("  -u<who>        Use your <who> savefile");
 				puts("  -d<dir>=<path> Override a specific directory with <path>. <path> can be:");
 				for (i = 0; i < (int)N_ELEMENTS(change_path_values); i++) {

--- a/src/z-virt.h
+++ b/src/z-virt.h
@@ -46,11 +46,4 @@ char *string_make(const char *str);
 void string_free(char *str);
 char *string_append(char *s1, const char *s2);
 
-enum {
-	MEM_POISON_ALLOC = 0x00000001,
-	MEM_POISON_FREE  = 0x00000002
-};
-
-extern unsigned int mem_flags;
-
 #endif /* INCLUDED_Z_VIRT_H */


### PR DESCRIPTION
This change:
1. Removes the -xmem-poison-* options
2. Removes the MEM_POISON_* flags used to implement them
3. Removes the extra memory overhead for allocation sizes in mem_alloc() and mem_realloc().

Since supporting MEM_POISON_* imposed one size_t of extra overhead on *every* allocation, the memory savings from this change are substantial.

I originally added these memory poisoning flags a bit over 10 years ago, but since that time valgrind has gotten a lot better and asan has become a thing. The malloc in glibc also does support far better memory poisoning configurable via env vars. Between those three much better options it makes little sense for Angband to pay an extra size_t on every allocation to support its own kind of poisoning.