### PR TITLE
ui-term: remove icky corner hack

### DIFF
--- a/src/main-gcu.c
+++ b/src/main-gcu.c
@@ -1191,9 +1191,6 @@ static errr term_data_init_gcu(term_data *td, int rows, int cols, int y, int x)
 	/* Initialize the term */
 	term_init(t, cols, rows, 256);
 
-	/* Avoid bottom right corner */
-	t->icky_corner = true;
-
 	/* Erase with "white space" */
 	t->attr_blank = COLOUR_WHITE;
 	t->char_blank = ' ';

--- a/src/main-xxx.c
+++ b/src/main-xxx.c
@@ -564,9 +564,6 @@ static void term_data_link(int i)
 	/* moved whenever text is drawn on the screen.  See "ui-term.c". */
 	/* t->soft_cursor = true; */
 
-	/* Avoid the "corner" of the window XXX XXX XXX */
-	/* t->icky_corner = true; */
-
 	/* Use "Term_pict()" for all attr/char pairs XXX XXX XXX */
 	/* See the "Term_pict_xxx()" function above. */
 	/* t->always_pict = true; */

--- a/src/ui-term.c
+++ b/src/ui-term.c
@@ -179,12 +179,6 @@
  * any characters are drawn on top of it.  This flag is used for all
  * "graphic" systems which handle the cursor by "drawing" it.
  *
- * The "icky_corner" flag indicates that the bottom right "corner"
- * of the windows are "icky", and "printing" anything there may
- * induce "messy" behavior, such as "scrolling".  This flag is used
- * for most old "dumb terminal" systems.
- *
- *
  * The "term" structure contains the following function "hooks":
  *
  *   Term->init_hook = Init the term
@@ -1702,15 +1696,6 @@ bool smlcurs = true;
  * flushing the output, if needed, to avoid a "flickery" refresh.  It
  * would be nice to *always* hide the cursor during the refresh, but
  * this might be expensive (and/or ugly) on some machines.
- *
- * The "Term->icky_corner" flag is used to avoid calling "Term_wipe()"
- * or "Term_pict()" or "Term_text()" on the bottom right corner of the
- * window, which might induce "scrolling" or other nasty stuff on old
- * dumb terminals.  This flag is handled very efficiently.  We assume
- * that the "Term_curs()" call will prevent placing the cursor in the
- * corner, if needed, though I doubt such placement is ever a problem.
- * Currently, the use of "Term->icky_corner" and "Term->soft_cursor"
- * together may result in undefined behavior.
  */
 errr Term_fresh(void)
 {
@@ -1860,11 +1845,6 @@ errr Term_fresh(void)
 		} else {
 			pr_drw = NULL;
 		}
-
-		/* Handle "icky corner" */
-		if ((Term->icky_corner) && (y2 >= h - 1) && (Term->x2[h - 1] > w - 2))
-			Term->x2[h - 1] = w - 2;
-
 
 		/*
 		 * Make the stored y bounds for the modified region empty.

--- a/src/ui-term.h
+++ b/src/ui-term.h
@@ -86,9 +86,6 @@ struct term_win
  *	- Flag "fixed_shape"
  *	  This "term" is not allowed to resize
  *
- *	- Flag "icky_corner"
- *	  This "term" has an "icky" corner grid
- *
  *	- Flag "soft_cursor"
  *	  This "term" uses a "software" cursor
  *
@@ -176,7 +173,6 @@ struct term
 	bool mapped_flag;
 	bool total_erase;
 	bool fixed_shape;
-	bool icky_corner;
 	bool soft_cursor;
 	bool always_pict;
 	bool higher_pict;


### PR DESCRIPTION
This hack prevents drawing in the bottom-right cell of the terminal. The reason this behavior existed was because some curses implementations (like SVr4) could not actually draw to the bottom right corner. However ncurses, on which we depend, *does* successfully draw to the bottom-right in that situation, so we don't need the icky_corner hack any more.

See http://ncurses.scripts.mit.edu/?p=ncurses.git;a=blob;f=ncurses/base/lib_addch.c;h=4b16a476c90aad7cb9b40cc844b6085a3ead1481;hb=HEAD#l133 for a bit of historical background.

Note that calling mvaddch() / mvaddstr() on the bottom right corner *does* return an error, even in ncurses, but it also draws the character. Luckily main-gcu.c ignores the return of these functions :)