### PR TITLE
Make file_parser structures from init.c public so they can be used by…

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -698,7 +698,7 @@ static enum parser_error parse_constants_player(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
-struct parser *init_parse_constants(void) {
+static struct parser *init_parse_constants(void) {
 	struct angband_constants *z = mem_zalloc(sizeof *z);
 	struct parser *p = parser_new();
 
@@ -730,7 +730,7 @@ static void cleanup_constants(void)
 	mem_free(z_info);
 }
 
-static struct file_parser constants_parser = {
+struct file_parser constants_parser = {
 	"constants",
 	init_parse_constants,
 	run_parse_constants,
@@ -841,7 +841,7 @@ static void cleanup_world(void)
 	}
 }
 
-static struct file_parser world_parser = {
+struct file_parser world_parser = {
 	"world",
 	init_parse_world,
 	run_parse_world,
@@ -1080,7 +1080,7 @@ static void cleanup_player_prop(void)
 	}
 }
 
-static struct file_parser player_property_parser = {
+struct file_parser player_property_parser = {
 	"player_property",
 	init_parse_player_prop,
 	run_parse_player_prop,
@@ -1127,7 +1127,7 @@ static enum parser_error parse_names_word(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
-struct parser *init_parse_names(void) {
+static struct parser *init_parse_names(void) {
 	struct parser *p = parser_new();
 	struct names_parse *n = mem_zalloc(sizeof *n);
 	n->section = 0;
@@ -1176,7 +1176,7 @@ static void cleanup_names(void)
 	mem_free(name_sections);
 }
 
-static struct file_parser names_parser = {
+struct file_parser names_parser = {
 	"names",
 	init_parse_names,
 	run_parse_names,
@@ -1581,7 +1581,7 @@ static enum parser_error parse_trap_msg_xtra(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
-struct parser *init_parse_trap(void) {
+static struct parser *init_parse_trap(void) {
     struct parser *p = parser_new();
     parser_setpriv(p, NULL);
     parser_reg(p, "name sym name str desc", parse_trap_name);
@@ -1663,7 +1663,7 @@ static void cleanup_trap(void)
 	mem_free(trap_info);
 }
 
-static struct file_parser trap_parser = {
+struct file_parser trap_parser = {
     "trap",
     init_parse_trap,
     run_parse_trap,
@@ -1857,7 +1857,7 @@ static enum parser_error parse_feat_resist_flag(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
-struct parser *init_parse_feat(void) {
+static struct parser *init_parse_feat(void) {
 	struct parser *p = parser_new();
 	parser_setpriv(p, NULL);
 	parser_reg(p, "name str name", parse_feat_name);
@@ -1943,7 +1943,7 @@ static void cleanup_feat(void) {
 	mem_free(f_info);
 }
 
-static struct file_parser feat_parser = {
+struct file_parser feat_parser = {
 	"terrain",
 	init_parse_feat,
 	run_parse_feat,
@@ -2071,7 +2071,7 @@ static void cleanup_body(void)
 	}
 }
 
-static struct file_parser body_parser = {
+struct file_parser body_parser = {
 	"body",
 	init_parse_body,
 	run_parse_body,
@@ -2125,7 +2125,7 @@ static enum parser_error parse_history_phrase(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
-struct parser *init_parse_history(void) {
+static struct parser *init_parse_history(void) {
 	struct parser *p = parser_new();
 	parser_setpriv(p, NULL);
 	parser_reg(p, "chart uint chart int next int roll", parse_history_chart);
@@ -2191,7 +2191,7 @@ static void cleanup_history(void)
 	}
 }
 
-static struct file_parser history_parser = {
+struct file_parser history_parser = {
 	"history",
 	init_parse_history,
 	run_parse_history,
@@ -2435,7 +2435,7 @@ static enum parser_error parse_p_race_values(struct parser *p) {
 	return t ? PARSE_ERROR_INVALID_VALUE : PARSE_ERROR_NONE;
 }
 
-struct parser *init_parse_p_race(void) {
+static struct parser *init_parse_p_race(void) {
 	struct parser *p = parser_new();
 	parser_setpriv(p, NULL);
 	parser_reg(p, "name str name", parse_p_race_name);
@@ -2493,7 +2493,7 @@ static void cleanup_p_race(void)
 	}
 }
 
-static struct file_parser p_race_parser = {
+struct file_parser p_race_parser = {
 	"p_race",
 	init_parse_p_race,
 	run_parse_p_race,
@@ -2602,7 +2602,7 @@ static void cleanup_realm(void)
 	}
 }
 
-static struct file_parser realm_parser = {
+struct file_parser realm_parser = {
 	"realm",
 	init_parse_realm,
 	run_parse_realm,
@@ -2981,7 +2981,7 @@ static void cleanup_shape(void)
 	}
 }
 
-static struct file_parser shape_parser = {
+struct file_parser shape_parser = {
 	"shape",
 	init_parse_shape,
 	run_parse_shape,
@@ -3723,7 +3723,7 @@ static enum parser_error parse_class_desc(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
-struct parser *init_parse_class(void) {
+static struct parser *init_parse_class(void) {
 	struct parser *p = parser_new();
 	parser_setpriv(p, NULL);
 	parser_reg(p, "name str name", parse_class_name);
@@ -3824,7 +3824,7 @@ static void cleanup_class(void)
 	}
 }
 
-static struct file_parser class_parser = {
+struct file_parser class_parser = {
 	"class",
 	init_parse_class,
 	run_parse_class,
@@ -3887,7 +3887,7 @@ static enum parser_error parse_flavor_kind(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
-struct parser *init_parse_flavor(void) {
+static struct parser *init_parse_flavor(void) {
 	struct parser *p = parser_new();
 	parser_setpriv(p, NULL);
 
@@ -3948,7 +3948,7 @@ static enum parser_error parse_hint(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
-struct parser *init_parse_hints(void) {
+static struct parser *init_parse_hints(void) {
 	struct parser *p = parser_new();
 	parser_reg(p, "H str text", parse_hint);
 	return p;
@@ -3977,7 +3977,7 @@ static void cleanup_hints(void)
 	}
 }
 
-static struct file_parser hints_parser = {
+struct file_parser hints_parser = {
 	"hints",
 	init_parse_hints,
 	run_parse_hints,

--- a/src/init.h
+++ b/src/init.h
@@ -153,26 +153,31 @@ extern char *ANGBAND_DIR_SCORES;
 extern char *ANGBAND_DIR_ARCHIVE;
 
 extern struct parser *init_parse_artifact(void);
-extern struct parser *init_parse_class(void);
 extern struct parser *init_parse_ego(void);
-extern struct parser *init_parse_feat(void);
-extern struct parser *init_parse_history(void);
 extern struct parser *init_parse_object(void);
 extern struct parser *init_parse_object_base(void);
 extern struct parser *init_parse_pain(void);
-extern struct parser *init_parse_p_race(void);
 extern struct parser *init_parse_pit(void);
 extern struct parser *init_parse_monster(void);
 extern struct parser *init_parse_vault(void);
-extern struct parser *init_parse_constants(void);
-extern struct parser *init_parse_flavor(void);
-extern struct parser *init_parse_names(void);
-extern struct parser *init_parse_hints(void);
-extern struct parser *init_parse_trap(void);
 extern struct parser *init_parse_chest_trap(void);
 extern struct parser *init_parse_quest(void);
 
+/* These are public primarily to facilitate writing test cases */
+extern struct file_parser body_parser;
+extern struct file_parser class_parser;
+extern struct file_parser constants_parser;
+extern struct file_parser feat_parser;
 extern struct file_parser flavor_parser;
+extern struct file_parser hints_parser;
+extern struct file_parser history_parser;
+extern struct file_parser names_parser;
+extern struct file_parser player_property_parser;
+extern struct file_parser p_race_parser;
+extern struct file_parser realm_parser;
+extern struct file_parser shape_parser;
+extern struct file_parser trap_parser;
+extern struct file_parser world_parser;
 
 errr grab_effect_data(struct parser *p, struct effect *effect);
 extern void init_file_paths(const char *config, const char *lib, const char *data);

--- a/src/tests/parse/body.c
+++ b/src/tests/parse/body.c
@@ -1,0 +1,183 @@
+/* parse/body */
+/* Exercise parsing used for body.txt. */
+
+#include "unit-test.h"
+#include "init.h"
+#include "obj-gear.h"
+#include "z-virt.h"
+
+int setup_tests(void **state) {
+	*state = body_parser.init();
+	/* body_parser.finish() needs z_info. */
+	z_info = mem_zalloc(sizeof(*z_info));
+	return !*state;
+}
+
+int teardown_tests(void *state) {
+	struct parser *p = (struct parser*) state;
+	int r = 0;
+
+	if (body_parser.finish(p)) {
+		r = 1;
+	}
+	body_parser.cleanup();
+	mem_free(z_info);
+	return r;
+}
+
+static int test_missing_record_header0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r;
+
+	null(parser_priv(p));
+	r = parser_parse(p, "slot:WEAPON:weapon");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	ok;
+}
+
+static int test_body0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "body:Test Body 1");
+	struct player_body *b;
+
+	eq(r, PARSE_ERROR_NONE);
+	b = (struct player_body*) parser_priv(p);
+	notnull(b);
+	notnull(b->name);
+	require(streq(b->name, "Test Body 1"));
+	eq(b->count, 0);
+	null(b->slots);
+	ok;
+}
+
+static int test_slot0(void *state) {
+	struct parser *p = (struct parser*) state;
+	struct player_body *b = (struct player_body*) parser_priv(p);
+	struct equip_slot *s;
+	enum parser_error r;
+	uint16_t old_count;
+
+	notnull(b);
+	old_count = b->count;
+	r = parser_parse(p, "slot:WEAPON:weapon");
+	eq(r, PARSE_ERROR_NONE);
+	b = (struct player_body*) parser_priv(p);
+	notnull(b);
+	eq(b->count, old_count + 1);
+	s = b->slots;
+	notnull(s);
+	while (s->next) s = s->next;
+	eq(s->type, EQUIP_WEAPON);
+	notnull(s->name);
+	require(streq(s->name, "weapon"));
+	null(s->obj);
+	/* Try adding another slot. */
+	r = parser_parse(p, "slot:BOW:shooting");
+	eq(r, PARSE_ERROR_NONE);
+	b = (struct player_body*) parser_priv(p);
+	notnull(b);
+	eq(b->count, old_count + 2);
+	s = b->slots;
+	notnull(s);
+	while (s->next) s = s->next;
+	eq(s->type, EQUIP_BOW);
+	notnull(s->name);
+	require(streq(s->name, "shooting"));
+	null(s->obj);
+	ok;
+}
+
+static int test_slot_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Try a bad type of slot. */
+	enum parser_error r = parser_parse(p, "slot:XYZZY:left nostril");
+
+	eq(r, PARSE_ERROR_INVALID_FLAG);
+	ok;
+}
+
+static int test_complete0(void *state) {
+	const char *lines[] = {
+		"body:Humanoid",
+		"slot:WEAPON:weapon",
+		"slot:RING:right hand",
+		"slot:RING:left hand",
+		"slot:LIGHT:light",
+		"slot:BODY_ARMOR:body",
+		"slot:CLOAK:back",
+		"slot:HAT:head"
+	};
+	struct parser *p = (struct parser*) state;
+	struct player_body *b;
+	struct equip_slot *s;
+	int i;
+
+	for (i = 0; i < (int) N_ELEMENTS(lines); ++i) {
+		enum parser_error r = parser_parse(p, lines[i]);
+
+		eq(r, PARSE_ERROR_NONE);
+	}
+	b = (struct player_body*) parser_priv(p);
+	notnull(b);
+	require(streq(b->name, "Humanoid"));
+	s = b->slots;
+	notnull(s);
+	eq(s->type, EQUIP_WEAPON);
+	notnull(s->name);
+	require(streq(s->name, "weapon"));
+	null(s->obj);
+	s = s->next;
+	notnull(s);
+	eq(s->type, EQUIP_RING);
+	notnull(s->name);
+	require(streq(s->name, "right hand"));
+	null(s->obj);
+	s = s->next;
+	notnull(s);
+	eq(s->type, EQUIP_RING);
+	notnull(s->name);
+	require(streq(s->name, "left hand"));
+	null(s->obj);
+	s = s->next;
+	notnull(s);
+	eq(s->type, EQUIP_LIGHT);
+	notnull(s->name);
+	require(streq(s->name, "light"));
+	null(s->obj);
+	s = s->next;
+	notnull(s);
+	eq(s->type, EQUIP_BODY_ARMOR);
+	notnull(s->name);
+	require(streq(s->name, "body"));
+	null(s->obj);
+	s = s->next;
+	notnull(s);
+	eq(s->type, EQUIP_CLOAK);
+	notnull(s->name);
+	require(streq(s->name, "back"));
+	null(s->obj);
+	s = s->next;
+	notnull(s);
+	eq(s->type, EQUIP_HAT);
+	notnull(s->name);
+	require(streq(s->name, "head"));
+	null(s->obj);
+	s = s->next;
+	null(s);
+	ok;
+}
+
+const char *suite_name = "parse/body";
+/*
+ * test_missing_record_header0() has to be before test_body0() and
+ * test_complete0().
+ * test_slot0() and test_slot_bad0() have to be after test_body0().
+ */
+struct test tests[] = {
+	{ "missing_record_header0", test_missing_record_header0 },
+	{ "body0", test_body0 },
+	{ "slot0", test_slot0 },
+	{ "slot_bad0", test_slot_bad0 },
+	{ "complete0", test_complete0 },
+	{ NULL, NULL }
+};

--- a/src/tests/parse/f-info.c
+++ b/src/tests/parse/f-info.c
@@ -11,7 +11,7 @@
 
 
 int setup_tests(void **state) {
-	*state = init_parse_feat();
+	*state = feat_parser.init();
 	return !*state;
 }
 
@@ -49,6 +49,24 @@ static int test_missing_header_record0(void *state) {
 	r = parser_parse(p, "flags:LOS | PASSABLE");
 	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
 	r = parser_parse(p, "info:8:0");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "desc:A door that is already open.");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "walk-msg:It looks dangerous.  Really enter? ");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "run-msg:Lava blocks your path.  Step into it? ");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "hurt-msg:The lava burns you!");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "die-msg:burning to a cinder in lava");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "confused-msg:bangs into a door");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "look-prefix:the entrance to the");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "look-in-preposition:at");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "resist-flag:IM_FIRE");
 	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
 	ok;
 }
@@ -173,6 +191,15 @@ static int test_flags0(void *state) {
 	flag_on_dbg(eflags, TF_SIZE, TF_PERMANENT, "eflags", "TF_PERMANENT");
 	flag_on_dbg(eflags, TF_SIZE, TF_DOWNSTAIR, "eflags", "TF_DOWNSTAIR");
 	require(flag_is_equal(f->flags, eflags, TF_SIZE));
+	ok;
+}
+
+static int test_flags_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Try an unrecognized flag. */
+	enum parser_error r = parser_parse(p, "flags:XYZZY");
+
+	eq(r, PARSE_ERROR_INVALID_FLAG);
 	ok;
 }
 
@@ -350,6 +377,7 @@ struct test tests[] = {
 	{ "mimic0", test_mimic0 },
 	{ "priority0", test_priority0 },
 	{ "flags0", test_flags0 },
+	{ "flags_bad0", test_flags_bad0 },
 	{ "info0", test_info0 },
 	{ "desc0", test_desc0 },
 	{ "walk_msg0", test_walk_msg0 },

--- a/src/tests/parse/flavor.c
+++ b/src/tests/parse/flavor.c
@@ -17,7 +17,7 @@ struct object_kind dummy_kinds[] = {
 };
 
 int setup_tests(void **state) {
-	*state = init_parse_flavor();
+	*state = flavor_parser.init();
 	/*
 	 * Do minimal setup so sval lookups work for the tests of fixed flavors.
 	 */
@@ -110,13 +110,24 @@ static int test_fixed0(void *state) {
 	ok;
 }
 
+static int test_kind_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Try an invalid tval. */
+	enum parser_error r = parser_parse(p, "kind:xyzzy:'");
+
+	eq(r, PARSE_ERROR_UNRECOGNISED_TVAL);
+	ok;
+}
+
 const char *suite_name = "parse/flavor";
 /*
- * test_flavor0() and test_fixed0() have to be after test_kind0().
+ * test_flavor0() and test_fixed0() have to be after test_kind0().  Run
+ * test_kind_bad0() to avoid potential effects on the other tests.
  */
 struct test tests[] = {
 	{ "kind0", test_kind0 },
 	{ "flavor0", test_flavor0 },
 	{ "fixed0", test_fixed0 },
+	{ "kind_bad0", test_kind_bad0 },
 	{ NULL, NULL }
 };

--- a/src/tests/parse/h-info.c
+++ b/src/tests/parse/h-info.c
@@ -7,7 +7,7 @@
 #include "player.h"
 
 int setup_tests(void **state) {
-	*state = init_parse_history();
+	*state = history_parser.init();
 	return !*state;
 }
 

--- a/src/tests/parse/hints.c
+++ b/src/tests/parse/hints.c
@@ -1,0 +1,46 @@
+/* parse/hints */
+/* Exercise parsing used for hints.txt. */
+
+#include "unit-test.h"
+#include "init.h"
+#include "hint.h"
+
+NOSETUP
+NOTEARDOWN
+
+static int test_complete0(void *state) {
+	const char *lines[] = {
+		"H:+10 speed means you move twice as fast as normal.",
+		"H:The stores change their stock every so often.",
+		"H:Never be too afraid to run away."
+	};
+	struct parser *p = hints_parser.init();
+	struct hint *h;
+	int i, rtn;
+
+	notnull(p);
+	for (i = 0; i < (int) N_ELEMENTS(lines); ++i) {
+		enum parser_error r = parser_parse(p, lines[i]);
+
+		eq(r, PARSE_ERROR_NONE);
+	}
+	rtn = hints_parser.finish(p);
+	eq(rtn, 0);
+
+	h = hints;
+	for (i = (int) N_ELEMENTS(lines) - 1; i >= 0; --i) {
+		notnull(h);
+		notnull(h->hint);
+		require(streq(h->hint, lines[i] + 2));
+		h = h->next;
+	}
+
+	hints_parser.cleanup();
+	ok;
+}
+
+const char *suite_name = "parse/hints";
+struct test tests[] = {
+	{ "complete0", test_complete0 },
+	{ NULL, NULL }
+};

--- a/src/tests/parse/names.c
+++ b/src/tests/parse/names.c
@@ -3,6 +3,7 @@
 #include "unit-test.h"
 #include "init.h"
 #include "randname.h"
+#include "z-form.h"
 
 struct name {
 	struct name *next;
@@ -16,7 +17,7 @@ struct names_parse {
 };
 
 int setup_tests(void **state) {
-	*state = init_parse_names();
+	*state = names_parser.init();
 	return !*state;
 }
 
@@ -67,6 +68,19 @@ static int test_word1(void *state) {
 	ok;
 }
 
+static int test_section_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	char buffer[80];
+	size_t nc;
+	enum parser_error r;
+
+	nc = strnfmt(buffer, sizeof(buffer), "section:%d", RANDNAME_NUM_TYPES);
+	require(nc < sizeof(buffer) - 1);
+	r = parser_parse(p, buffer);
+	eq(r, PARSE_ERROR_OUT_OF_BOUNDS);
+	ok;
+}
+
 const char *suite_name = "parse/names";
 struct test tests[] = {
 	{ "section0", test_section0 },
@@ -75,5 +89,6 @@ struct test tests[] = {
 	{ "section1", test_section1 },
 	{ "word1", test_word1 },
 
+	{ "section_bad0", test_section_bad0 },
 	{ NULL, NULL }
 };

--- a/src/tests/parse/p-info.c
+++ b/src/tests/parse/p-info.c
@@ -8,7 +8,7 @@
 
 
 int setup_tests(void **state) {
-	*state = init_parse_p_race();
+	*state = p_race_parser.init();
 	return !*state;
 }
 

--- a/src/tests/parse/partrap.c
+++ b/src/tests/parse/partrap.c
@@ -1,0 +1,901 @@
+/* parse/partrap */
+/* Exercise parsing used for trap.txt. */
+
+#include "unit-test.h"
+
+struct chunk;
+#include "effects.h"
+#include "init.h"
+#include "object.h"
+#include "player.h"
+#include "player-timed.h"
+#include "project.h"
+#include "trap.h"
+#include "z-color.h"
+
+int setup_tests(void **state) {
+	*state = trap_parser.init();
+	/* trap_parser.finish() needs z_info. */
+	z_info = mem_zalloc(sizeof(*z_info));
+	return !*state;
+}
+
+int teardown_tests(void *state) {
+	struct parser *p = (struct parser*) state;
+	int r = 0;
+
+	if (trap_parser.finish(p)) {
+		r = 1;
+	}
+	trap_parser.cleanup();
+	mem_free(z_info);
+	return r;
+}
+
+static int test_missing_header_record0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r;
+
+	null(parser_priv(p));
+	r = parser_parse(p, "graphics:;:G");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "appear:2:20:1");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "visibility:70");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "flags:TRAP | FLOOR | PIT");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "effect:DAMAGE");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "effect-yx:11:22");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "dice:4d$S");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "expr:S:DUNGEON_LEVEL:/ 2");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "effect-xtra:TIMED_INC:CUT");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "effect-yx-xtra:13:25");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "dice-xtra:8d$S");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "expr-xtra:S:DUNGEON_LEVEL:/ 25 + 3");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "save:FEATHER");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "desc:A hole dug to snare the unwary.");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "msg:You fall into a pit!");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "msg-good:You float gently to the bottom of "
+		"the pit.");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "msg-bad:A small dart hits you!");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "msg-xtra:You are impaled!");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	ok;
+}
+
+static int test_name0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "name:test trap:test trap 1");
+	struct trap_kind *t;
+
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->name);
+	require(streq(t->name, "test trap"));
+	null(t->text);
+	notnull(t->desc);
+	require(streq(t->desc, "test trap 1"));
+	null(t->msg);
+	null(t->msg_good);
+	null(t->msg_bad);
+	null(t->msg_xtra);
+	eq(t->d_attr, 0);
+	eq(t->d_char, 0);
+	eq(t->rarity, 0);
+	eq(t->min_depth, 0);
+	eq(t->max_num, 0);
+	eq(t->power.base, 0);
+	eq(t->power.dice, 0);
+	eq(t->power.sides, 0);
+	eq(t->power.m_bonus, 0);
+	require(trf_is_empty(t->flags));
+	require(of_is_empty(t->save_flags));
+	null(t->effect);
+	null(t->effect_xtra);
+	ok;
+}
+
+static int test_graphics0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Try with a full name for the color. */
+	enum parser_error r = parser_parse(p, "graphics:^:Red");
+	struct trap_kind *t;
+
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	eq(t->d_attr, COLOUR_RED);
+	eq(t->d_char, L'^');
+	/* Check that matching the color's full name is case-insensitive. */
+	r = parser_parse(p, "graphics:%:light green");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	eq(t->d_attr, COLOUR_L_GREEN);
+	eq(t->d_char, L'%');
+	/* Try with a single letter code for the color. */
+	r = parser_parse(p, "graphics:_:s");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	eq(t->d_attr, COLOUR_SLATE);
+	eq(t->d_char, L'_');
+	ok;
+}
+
+static int test_appear0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "appear:2:20:1");
+	struct trap_kind *t;
+
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	eq(t->rarity, 2);
+	eq(t->min_depth, 20);
+	eq(t->max_num, 1);
+	ok;
+}
+
+static int test_visibility0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "visibility:5+2d10M50");
+	struct trap_kind *t;
+
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	eq(t->power.base, 5);
+	eq(t->power.dice, 2);
+	eq(t->power.sides, 10);
+	eq(t->power.m_bonus, 50);
+	ok;
+}
+
+static int test_visibility_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "visibility:1d6+1d10");
+
+	eq(r, PARSE_ERROR_NOT_RANDOM);
+	ok;
+}
+
+static int test_flags0(void *state) {
+	struct parser *p = (struct parser*) state;
+	struct trap_kind *t = (struct trap_kind*) parser_priv(p);
+	enum parser_error r;
+	bitflag eflags[TRF_SIZE];
+
+	notnull(t);
+	trf_wipe(t->flags);
+	/* Try with no flags. */
+	r = parser_parse(p, "flags:");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	require(trf_is_empty(t->flags));
+	/* Try with a single flag. */
+	r = parser_parse(p, "flags:TRAP");
+	eq(r, PARSE_ERROR_NONE);
+	/* Try with multiple flags at once. */
+	r = parser_parse(p, "flags:FLOOR | VISIBLE");
+	eq(r, PARSE_ERROR_NONE);
+	trf_wipe(eflags);
+	trf_on(eflags, TRF_TRAP);
+	trf_on(eflags, TRF_FLOOR);
+	trf_on(eflags, TRF_VISIBLE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	require(trf_is_equal(t->flags, eflags));
+	ok;
+}
+
+static int test_flags_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Try with an unrecognized flag. */
+	enum parser_error r = parser_parse(p, "flags:XYZZY");
+
+	eq(r, PARSE_ERROR_INVALID_FLAG);
+	ok;
+}
+
+static int test_missing_effect0(void *state) {
+	struct parser *p = (struct parser*) state;
+	struct trap_kind *t = (struct trap_kind*) parser_priv(p);
+	enum parser_error r;
+
+	notnull(t);
+	null(t->effect);
+	/*
+	 * Specifying effect details without and effect should not signal an
+	 * error and leave the trap unmodified.
+	 */
+	r = parser_parse(p, "effect-yx:11:23");
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "dice:4+5d$S");
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "expr:S:DUNGEON_LEVEL:/ 10 + 2");
+	eq(r, PARSE_ERROR_NONE);
+	ok;
+}
+
+static int test_effect0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Try with an effect that has no subtype, radius or other. */
+	enum parser_error r = parser_parse(p, "effect:DAMAGE");
+	struct trap_kind *t;
+	struct effect *e;
+
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	e = t->effect;
+	notnull(e);
+	while (e->next) e = e->next;
+	eq(e->index, EF_DAMAGE);
+	null(e->dice);
+	eq(e->y, 0);
+	eq(e->x, 0);
+	eq(e->subtype, 0);
+	eq(e->radius, 0);
+	eq(e->other, 0);
+	null(e->msg);
+	/* Try with an effect that has a subtype but no radius or other. */
+	r = parser_parse(p, "effect:TIMED_INC:SLOW");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	e = t->effect;
+	notnull(e);
+	while (e->next) e = e->next;
+	eq(e->index, EF_TIMED_INC);
+	null(e->dice);
+	eq(e->y, 0);
+	eq(e->x, 0);
+	eq(e->subtype, TMD_SLOW);
+	eq(e->radius, 0);
+	eq(e->other, 0);
+	/* Try with an effect that has a subtype and radius but no other. */
+	r = parser_parse(p, "effect:SPOT:FIRE:1");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	e = t->effect;
+	notnull(e);
+	while (e->next) e = e->next;
+	eq(e->index, EF_SPOT);
+	null(e->dice);
+	eq(e->y, 0);
+	eq(e->x, 0);
+	eq(e->subtype, PROJ_FIRE);
+	eq(e->radius, 1);
+	eq(e->other, 0);
+	/* Try with an effect that has a subtype, radius, and other. */
+	r = parser_parse(p, "effect:SPOT:LIGHT_WEAK:2:10");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	e = t->effect;
+	notnull(e);
+	while (e->next) e = e->next;
+	eq(e->index, EF_SPOT);
+	null(e->dice);
+	eq(e->y, 0);
+	eq(e->x, 0);
+	eq(e->subtype, PROJ_LIGHT_WEAK);
+	eq(e->radius, 2);
+	eq(e->other, 10);
+	ok;
+}
+
+static int test_effect_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Try with an unrecognized effect. */
+	enum parser_error r = parser_parse(p, "effect:XYZZY");
+
+	eq(r, PARSE_ERROR_INVALID_EFFECT);
+	/* Try with a recognized effect but an unrecognized subtype. */
+	r = parser_parse(p, "effect:TIMED_INC:XYZZY");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	ok;
+}
+
+static int test_effect_yx0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Set up a new effect. */
+	enum parser_error r = parser_parse(p, "effect:DAMAGE");
+	struct trap_kind *t;
+	struct effect *e;
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "effect-yx:11:23");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	e = t->effect;
+	notnull(e);
+	while (e->next) e = e->next;
+	eq(e->y, 11);
+	eq(e->x, 23);
+	ok;
+}
+
+static int test_dice0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Set up a new effect. */
+	enum parser_error r = parser_parse(p, "effect:DAMAGE");
+	struct trap_kind *t;
+	struct effect *e;
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "dice:5+2d8M30");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	e = t->effect;
+	notnull(e);
+	while (e->next) e = e->next;
+	notnull(e->dice);
+	require(dice_test_values(e->dice, 5, 2, 8, 30));
+	ok;
+}
+
+static int test_dice_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Set up a new effect. */
+	enum parser_error r = parser_parse(p, "effect:DAMAGE");
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "dice:1d8+7");
+	eq(r, PARSE_ERROR_INVALID_DICE);
+	ok;
+}
+
+static int test_missing_dice0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Set up a new effect. */
+	enum parser_error r = parser_parse(p, "effect:DAMAGE");
+	struct trap_kind *t;
+
+	eq(r, PARSE_ERROR_NONE);
+	/*
+	 * Specifying an expression without dice should not flag an error and
+	 * not modify the trap.
+	 */
+	r = parser_parse(p, "expr:S:DUNGEON_LEVEL:/ 5 + 2");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->effect);
+	null(t->effect->dice);
+	ok;
+}
+
+static int test_expr0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Set up a new effect with dice. */
+	enum parser_error r = parser_parse(p, "effect:DAMAGE");
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "dice:$B+5d$S");
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "expr:B:DUNGEON_LEVEL:/ 10 + 8");
+	eq(r, PARSE_ERROR_NONE);
+	ok;
+}
+
+static int test_expr_bad0(void *state) {
+	struct  parser *p = (struct parser*) state;
+	/* Set up a new effect with dice. */
+	enum parser_error r = parser_parse(p, "effect:DAMAGE");
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "dice:$B+10d$S");
+	/* Try an expression with invalid operations. */
+	r = parser_parse(p, "expr:S:DUNGEON_LEVEL:^ 2");
+	eq(r, PARSE_ERROR_BAD_EXPRESSION_STRING);
+	/* Try to bind the expression to a variable that is not in the dice. */
+	r = parser_parse(p, "expr:M:DUNGEON_LEVEL:/ 8 + 1");
+	eq(r, PARSE_ERROR_UNBOUND_EXPRESSION);
+	ok;
+}
+
+static int test_missing_effect_xtra0(void *state) {
+	struct parser *p = (struct parser*) state;
+	struct trap_kind *t = (struct trap_kind*) parser_priv(p);
+	enum parser_error r;
+
+	notnull(t);
+	null(t->effect_xtra);
+	/*
+	 * Specifying effect details without and effect should not signal an
+	 * error and leave the trap unmodified.
+	 */
+	r = parser_parse(p, "effect-yx-xtra:7:15");
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "dice-xtra:$B+5d4");
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "expr-xtra:B:DUNGEON_LEVEL:/ 10 + 8");
+	eq(r, PARSE_ERROR_NONE);
+	ok;
+}
+
+static int test_effect_xtra0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Try with an effect that has no subtype, radius or other. */
+	enum parser_error r = parser_parse(p, "effect-xtra:WAKE");
+	struct trap_kind *t;
+	struct effect *e;
+
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	e = t->effect_xtra;
+	notnull(e);
+	while (e->next) e = e->next;
+	eq(e->index, EF_WAKE);
+	null(e->dice);
+	eq(e->y, 0);
+	eq(e->x, 0);
+	eq(e->subtype, 0);
+	eq(e->radius, 0);
+	eq(e->other, 0);
+	null(e->msg);
+	/* Try with an effect that has a subtype but no radius or other. */
+	r = parser_parse(p, "effect-xtra:DRAIN_STAT:STR");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	e = t->effect_xtra;
+	notnull(e);
+	while (e->next) e = e->next;
+	eq(e->index, EF_DRAIN_STAT);
+	null(e->dice);
+	eq(e->y, 0);
+	eq(e->x, 0);
+	eq(e->subtype, STAT_STR);
+	eq(e->radius, 0);
+	eq(e->other, 0);
+	/* Try with an effect that has a subtype and radius but no other. */
+	r = parser_parse(p, "effect-xtra:SPOT:ACID:1");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	e = t->effect_xtra;
+	notnull(e);
+	while (e->next) e = e->next;
+	eq(e->index, EF_SPOT);
+	null(e->dice);
+	eq(e->y, 0);
+	eq(e->x, 0);
+	eq(e->subtype, PROJ_ACID);
+	eq(e->radius, 1);
+	eq(e->other, 0);
+	/* Try with an effect that has a subtype, radius, and other. */
+	r = parser_parse(p, "effect-xtra:SPHERE:FIRE:4:5");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	e = t->effect_xtra;
+	notnull(e);
+	while (e->next) e = e->next;
+	eq(e->index, EF_SPHERE);
+	null(e->dice);
+	eq(e->y, 0);
+	eq(e->x, 0);
+	eq(e->subtype, PROJ_FIRE);
+	eq(e->radius, 4);
+	eq(e->other, 5);
+	ok;
+}
+
+static int test_effect_xtra_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Try with an unrecognized effect. */
+	enum parser_error r = parser_parse(p, "effect-xtra:XYZZY");
+
+	eq(r, PARSE_ERROR_INVALID_EFFECT);
+	/* Try with a recognized effect but an unrecognized subtype. */
+	r = parser_parse(p, "effect-xtra:BOLT:XYZZY");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	ok;
+}
+
+static int test_effect_yx_xtra0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Set up a new effect. */
+	enum parser_error r = parser_parse(p, "effect-xtra:DAMAGE");
+	struct trap_kind *t;
+	struct effect *e;
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "effect-yx-xtra:13:27");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	e = t->effect_xtra;
+	notnull(e);
+	while (e->next) e = e->next;
+	eq(e->y, 13);
+	eq(e->x, 27);
+	ok;
+}
+
+static int test_dice_xtra0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Set up a new effect. */
+	enum parser_error r = parser_parse(p, "effect-xtra:DAMAGE");
+	struct trap_kind *t;
+	struct effect *e;
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "dice-xtra:10+5d6");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	e = t->effect_xtra;
+	notnull(e);
+	while (e->next) e = e->next;
+	notnull(e->dice);
+	require(dice_test_values(e->dice, 10, 5, 6, 0));
+	ok;
+}
+
+static int test_dice_xtra_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Set up a new effect. */
+	enum parser_error r = parser_parse(p, "effect-xtra:DAMAGE");
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "dice-xtra:1d6+1d8+1d12");
+	eq(r, PARSE_ERROR_INVALID_DICE);
+	ok;
+}
+
+static int test_missing_dice_xtra0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Set up a new effect. */
+	enum parser_error r = parser_parse(p, "effect-xtra:DAMAGE");
+	struct trap_kind *t;
+
+	eq(r, PARSE_ERROR_NONE);
+	/*
+	 * Specifying an expression without dice should not flag an error and
+	 * not modify the trap.
+	 */
+	r = parser_parse(p, "expr-xtra:B:DUNGEON_LEVEL:* 2");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->effect_xtra);
+	null(t->effect_xtra->dice);
+	ok;
+}
+
+static int test_expr_xtra0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Set up a new effect with dice. */
+	enum parser_error r = parser_parse(p, "effect-xtra:DAMAGE");
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "dice-xtra:$B+5d$S");
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "expr-xtra:S:DUNGEON_LEVEL:/ 20 + 4");
+	eq(r, PARSE_ERROR_NONE);
+	ok;
+}
+
+static int test_expr_xtra_bad0(void *state) {
+	struct  parser *p = (struct parser*) state;
+	/* Set up a new effect with dice. */
+	enum parser_error r = parser_parse(p, "effect-xtra:DAMAGE");
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "dice-xtra:$B+4d$S");
+	/* Try an expression with invalid operations. */
+	r = parser_parse(p, "expr-xtra:B:DUNGEON_LEVEL:% 9");
+	eq(r, PARSE_ERROR_BAD_EXPRESSION_STRING);
+	/* Try to bind the expression to a variable that is not in the dice. */
+	r = parser_parse(p, "expr-xtra:T:DUNGEON_LEVEL:+ 1");
+	eq(r, PARSE_ERROR_UNBOUND_EXPRESSION);
+	ok;
+}
+
+static int test_save0(void *state) {
+	struct parser *p = (struct parser*) state;
+	struct trap_kind *t = (struct trap_kind*) parser_priv(p);
+	enum parser_error r;
+	bitflag eflags[OF_SIZE];
+
+	notnull(t);
+	of_wipe(t->save_flags);
+	/* Try with a single flag. */
+	r = parser_parse(p, "save:FEATHER");
+	eq(r, PARSE_ERROR_NONE);
+	/* Try with multiple flags at once. */
+	r = parser_parse(p, "save:FREE_ACT | HOLD_LIFE");
+	eq(r, PARSE_ERROR_NONE);
+	of_wipe(eflags);
+	of_on(eflags, OF_FEATHER);
+	of_on(eflags, OF_FREE_ACT);
+	of_on(eflags, OF_HOLD_LIFE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	require(of_is_equal(t->save_flags, eflags));
+	ok;
+}
+
+static int test_save_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Try with an unrecognized flag. */
+	enum parser_error r = parser_parse(p, "save:XYZZY");
+
+	eq(r, PARSE_ERROR_INVALID_FLAG);
+	ok;
+}
+
+static int test_desc0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "desc:This weakened ceiling "
+		"beam threatens to collapse at any moment.");
+	struct trap_kind *t;
+
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->desc);
+	require(streq(t->text, "This weakened ceiling beam threatens to "
+		"collapse at any moment."));
+	/* Check that a second directive is appended to the first. */
+	r = parser_parse(p, "desc:  You would prefer not to be nearby when "
+		"it does.");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->desc);
+	require(streq(t->text, "This weakened ceiling beam threatens to "
+		"collapse at any moment.  You would prefer not to be nearby "
+		"when it does."));
+	ok;
+}
+
+static int test_msg0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p,
+		"msg:Blades whirl around you, slicing your skin!");
+	struct trap_kind *t;
+
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->msg);
+	require(streq(t->msg, "Blades whirl around you, slicing your skin!"));
+	/* Check that a second directive is appended to the first. */
+	r = parser_parse(p,
+		"msg:  The air is filled with a fine mist of blood.");
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->msg);
+	require(streq(t->msg, "Blades whirl around you, slicing your "
+		"skin!  The air is filled with a fine mist of blood."));
+	ok;
+}
+
+static int test_msg_good0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p,
+		"msg-good:You manage to spring to the side.");
+	struct trap_kind *t;
+
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->msg_good);
+	require(streq(t->msg_good, "You manage to spring to the side."));
+	/* Check that a second directive is appended to the first. */
+	r = parser_parse(p,
+		"msg-good:  The floor is not as lucky and shatters.");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->msg_good);
+	require(streq(t->msg_good, "You manage to spring to the side.  The "
+		"floor is not as lucky and shatters."));
+	ok;
+}
+
+static int test_msg_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "msg-bad:A small dart hits you!");
+	struct trap_kind *t;
+
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->msg_bad);
+	require(streq(t->msg_bad, "A small dart hits you!"));
+	/* Check that a second directive is appended to the first. */
+	r = parser_parse(p,
+		"msg-bad:  Numbness spreads from where it pricked you.");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->msg_bad);
+	require(streq(t->msg_bad, "A small dart hits you!  Numbness spreads "
+		"from where it pricked you."));
+	ok;
+}
+
+static int test_msg_xtra0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "msg-xtra:You are impaled!");
+	struct trap_kind *t;
+
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->msg_xtra);
+	require(streq(t->msg_xtra, "You are impaled!"));
+	/* Check that a second directive is appended to the first. */
+	r = parser_parse(p, "msg-xtra:  And begin to bleed profusely.");
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->msg_xtra);
+	require(streq(t->msg_xtra, "You are impaled!  And begin to bleed "
+		"profusely."));
+	ok;
+}
+
+static int test_complete0(void *state) {
+	const char *lines[] = {
+		"name:dart trap:slow dart",
+		"graphics:^:r",
+		"appear:1:2:0",
+		"visibility:M50",
+		"flags:TRAP | FLOOR | SAVE_ARMOR",
+		"effect:DAMAGE",
+		"dice:1d4",
+		"effect:TIMED_INC_NO_RES:SLOW",
+		"dice:20+1d20",
+		"desc:A trap which shoots slowing darts.",
+		"msg-good:A small dart barely misses you.",
+		"msg-bad:A small dart hits you!"
+	};
+	struct parser *p = (struct parser*) state;
+	bitflag tflags[TRF_SIZE];
+	struct trap_kind *t;
+	struct effect *e;
+	int i;
+
+	for (i = 0; i < (int) N_ELEMENTS(lines); ++i) {
+		enum parser_error r = parser_parse(p, lines[i]);
+
+		eq(r, PARSE_ERROR_NONE);
+	}
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->name);
+	require(streq(t->name, "dart trap"));
+	notnull(t->desc);
+	require(streq(t->desc, "slow dart"));
+	null(t->msg);
+	notnull(t->msg_good);
+	require(streq(t->msg_good, "A small dart barely misses you."));
+	notnull(t->msg_bad);
+	require(streq(t->msg_bad, "A small dart hits you!"));
+	null(t->msg_xtra);
+	eq(t->d_attr, COLOUR_RED);
+	eq(t->d_char, L'^');
+	eq(t->rarity, 1);
+	eq(t->min_depth, 2);
+	eq(t->max_num, 0);
+	eq(t->power.base, 0);
+	eq(t->power.dice, 0);
+	eq(t->power.sides, 0);
+	eq(t->power.m_bonus, 50);
+	trf_wipe(tflags);
+	trf_on(tflags, TRF_TRAP);
+	trf_on(tflags, TRF_FLOOR);
+	trf_on(tflags, TRF_SAVE_ARMOR);
+	require(trf_is_equal(t->flags, tflags));
+	require(of_is_empty(t->save_flags));
+	e = t->effect;
+	notnull(e);
+	eq(e->index, EF_DAMAGE);
+	notnull(e->dice);
+	require(dice_test_values(e->dice, 0, 1, 4, 0));
+	eq(e->y, 0);
+	eq(e->x, 0);
+	eq(e->subtype, 0);
+	eq(e->radius, 0);
+	eq(e->other, 0);
+	null(e->msg);
+	e = e->next;
+	notnull(e);
+	eq(e->index, EF_TIMED_INC_NO_RES);
+	notnull(e->dice);
+	require(dice_test_values(e->dice, 20, 1, 20, 0));
+	eq(e->y, 0);
+	eq(e->x, 0);
+	eq(e->subtype, TMD_SLOW);
+	eq(e->radius, 0);
+	eq(e->other, 0);
+	null(e->msg);
+	e = e->next;
+	null(e);
+	null(t->effect_xtra);
+	ok;
+}
+
+const char *suite_name = "parse/partrap";
+/*
+ * test_missing_header_record0() has to be before test_name0() and
+ * test_complete0().
+ * test_missing_effect0() has to be after test_name0() and before
+ * test_effect0(), test_effect_bad0(), test_effect_yx0(), test_dice0(),
+ * test_dice_bad0(), test_missing_dice0(), test_expr0(), test_expr_bad0(),
+ * and test_complete0().
+ * test_missing_effect_xtra0() has to be after test_name0() and before
+ * test_effect_xtra0(), test_effect_xtra_bad0(), test_effect_yx_xtra0(),
+ * test_dice_xtra0(), test_dice_xtra_bad0(), test_missing_dice_xtra0(),
+ * test_expr_xtra0(), test_expr_xtra_bad0(), and test_complete0().
+ * test_graphics0(), test_appear0(), test_visibility0(),
+ * test_visibility_bad0(), test_flags0(), test_flags_bad0(), test_effect0(),
+ * test_effect_bad0(), test_effect_yx0(), test_dice0(), test_dice_bad0(),
+ * test_missing_dice0(), test_expr0(), test_expr_bad0(), test_effect_xtra0(),
+ * test_effect_xtra_bad0(), test_effect_yx_xtra0(), test_dice_xtra0(),
+ * test_dice_xtra_bad0(), test_expr_xtra0(), test_expr_xtra_bad0(),
+ * test_save0(), and test_save_bad0() have to be after test_name0().
+ */
+struct test tests[] = {
+	{ "missing_header_record0", test_missing_header_record0 },
+	{ "name0", test_name0 },
+	{ "graphics0", test_graphics0 },
+	{ "appear0", test_appear0 },
+	{ "visibility0", test_visibility0 },
+	{ "visibility_bad0", test_visibility_bad0 },
+	{ "flags0", test_flags0 },
+	{ "flags_bad0", test_flags_bad0 },
+	{ "missing_effect0", test_missing_effect0 },
+	{ "effect0", test_effect0 },
+	{ "effect_bad0", test_effect_bad0 },
+	{ "effect_yx0", test_effect_yx0 },
+	{ "dice0", test_dice0 },
+	{ "dice_bad0", test_dice_bad0 },
+	{ "missing_dice0", test_missing_dice0 },
+	{ "expr0", test_expr0 },
+	{ "expr_bad0", test_expr_bad0 },
+	{ "missing_effect_xtra0", test_missing_effect_xtra0 },
+	{ "effect_xtra0", test_effect_xtra0 },
+	{ "effect_xtra_bad0", test_effect_xtra_bad0 },
+	{ "effect_yx_xtra0", test_effect_yx_xtra0 },
+	{ "dice_xtra0", test_dice_xtra0 },
+	{ "dice_xtra_bad0", test_dice_xtra_bad0 },
+	{ "missing_dice_xtra0", test_missing_dice_xtra0 },
+	{ "expr_xtra0", test_expr_xtra0 },
+	{ "expr_xtra_bad0", test_expr_xtra_bad0 },
+	{ "save0", test_save0 },
+	{ "save_bad0", test_save_bad0 },
+	{ "desc0", test_desc0 },
+	{ "msg0", test_msg0 },
+	{ "msg_good0", test_msg_good0 },
+	{ "msg_bad0", test_msg_bad0 },
+	{ "msg_xtra0", test_msg_xtra0 },
+	{ "complete0", test_complete0 },
+	{ NULL, NULL }
+};

--- a/src/tests/parse/pprop.c
+++ b/src/tests/parse/pprop.c
@@ -1,0 +1,350 @@
+/* parse/pprop */
+/* Exercise parsing used for player_property.txt. */
+
+#include "unit-test.h"
+#include "init.h"
+#include "object.h"
+#include "player.h"
+#include "project.h"
+#include "z-form.h"
+#include "z-virt.h"
+#include <ctype.h>
+
+static const char *elem_names[] = {
+	#define ELEM(a) #a,
+	#include "list-elements.h"
+	#undef ELEM
+};
+
+int setup_tests(void **state) {
+	int i;
+
+	*state = player_property_parser.init();
+	/*
+	 * Set up enough of the projections array to satisfy how it is used for
+	 * elemental properties.
+	 */
+	projections = mem_zalloc(ELEM_MAX * sizeof(*projections));
+	for (i = 0; i < ELEM_MAX; ++i) {
+		char *cursor;
+
+		projections[i].name = string_make(elem_names[i]);
+		cursor = projections[i].name;
+		while (*cursor) {
+			*cursor = tolower(*cursor);
+			++cursor;
+		}
+	}
+	return !*state;
+}
+
+int teardown_tests(void *state) {
+	struct {
+		const char *src, *ptype, *name, *desc, *idx_str; int idx, val; bool repeated;
+	} expected[] = {
+		{
+			"test_complete_player0",
+			"player",
+			"Full Spellcaster",
+			"You may obtain a perfect success rate with magic.",
+			"PF_ZERO_FAIL",
+			PF_ZERO_FAIL,
+			0,
+			false
+		},
+		{
+			"test_complete_object0",
+			"object",
+			"Sustain Strength",
+			"Your strength is sustained",
+			"OF_SUST_STR",
+			OF_SUST_STR,
+			0,
+			false,
+		},
+		{
+			"test_complete_element0",
+			"element",
+			"Vulnerability",
+			"You are vulnerable to",
+			"ELEM_",
+			0,
+			-1,
+			true
+		}
+	};
+	struct parser *p = (struct parser*) state;
+	int r = 0;
+	char buffer[320];
+	const struct player_ability *a;
+	int i;
+
+	if (player_property_parser.finish(p)) {
+		r = 1;
+	}
+	a = player_abilities;
+	for (i = 0; i < (int) N_ELEMENTS(expected); ++i) {
+		int jn = (expected[i].repeated) ? ELEM_MAX : 1;
+		int j;
+
+		for (j = 0; j < jn;  ++j) {
+			if (a) {
+				if (a->index != expected[i].idx + j) {
+					r = 1;
+					if (verbose) {
+						printf("    %s:%d: code from %s() did not make it through\n", suite_name, __LINE__ - 3, expected[i].src);
+						printf("      got %d\n", a->index);
+						if (expected[i].repeated) {
+							printf("      expected %d (%s%s)\n", expected[i].idx + j, expected[i].idx_str, elem_names[j]);
+						} else {
+							printf("      expected %d (%s)\n", expected[i].idx + j, expected[i].idx_str);
+						}
+					}
+				}
+				if (!streq(a->type, expected[i].ptype)) {
+					r = 1;
+					if (verbose) {
+						printf("    %s:%d: type from %s() did not make it through\n", suite_name, __LINE__ - 3, expected[i].src);
+						printf("      got \"%s\"\n", a->type);
+						printf("      expected \"%s\"\n", expected[i].ptype);
+					}
+				}
+				if (expected[i].repeated) {
+					char *cap_name = string_make(
+						projections[j].name);
+					size_t nc;
+
+					my_strcap(cap_name);
+					nc = strnfmt(buffer,
+						sizeof(buffer), "%s %s",
+						cap_name, expected[i].name);
+					if (nc >= sizeof(buffer) - 1) {
+						r = 1;
+						if (verbose) {
+							printf("    %s:%d: due to an insufficient buffer, could not check name from %s() for ability (%d of %d)\n", suite_name, __LINE__ - 3, expected[i].src, j + 1, ELEM_MAX);
+						}
+					} else if (!streq(a->name, buffer)) {
+						r = 1;
+						if (verbose) {
+							printf("    %s:%d: name from %s() did not make it through to ability (%d of %d)\n", suite_name, __LINE__ - 3, expected[i].src, j + 1, ELEM_MAX);
+							printf("      got \"%s\"\n", a->name);
+							printf("      expected \"%s\"\n", buffer);
+						}
+					}
+					string_free(cap_name);
+					nc = strnfmt(buffer,
+						sizeof(buffer), "%s %s.",
+						expected[i].desc,
+						projections[j].name);
+					if (nc >= sizeof(buffer) - 1) {
+						r = 1;
+						if (verbose) {
+							printf("    %s:%d: due to an insufficient buffer, could not check desc from %s() for ability (%d of %d)\n", suite_name, __LINE__ - 3, expected[i].src, j + 1, ELEM_MAX);
+						}
+					} else if (!streq(a->desc, buffer)) {
+						r = 1;
+						if (verbose) {
+							printf("    %s:%d: desc from %s() did not make it through to ability (%d of %d)\n", suite_name, __LINE__ - 3, expected[i].src, j + 1, ELEM_MAX);
+							printf("      got \"%s\"\n", a->desc);
+							printf("      expected \"%s\"\n", buffer);
+						}
+					}
+				} else {
+					if (!streq(a->name, expected[i].name)) {
+						r = 1;
+						if (verbose) {
+							printf("    %s:%d: name from %s() did not make it through\n", suite_name, __LINE__ - 3, expected[i].src);
+							printf("      got \"%s\"\n", a->name);
+							printf("      expected \"%s\"\n", expected[i].name);
+						}
+					}
+					if (!streq(a->desc, expected[i].desc)) {
+						r = 1;
+						if (verbose) {
+							printf("    %s:%d: desc from %s() did not make it through\n", suite_name, __LINE__ - 3, expected[i].src);
+							printf("      got \"%s\"\n", a->desc);
+							printf("      expected \"%s\"\n", expected[i].desc);
+						}
+					}
+				}
+				if (a->value != expected[i].val) {
+					r = 1;
+					if (verbose) {
+						printf("    %s:%d: value from %s() did not get through\n", suite_name, __LINE__ - 3, expected[i].src);
+						printf("      got %d\n", a->value);
+						printf("      expected %d\n", expected[i].val);
+					}
+				}
+				a = a->next;
+			} else {
+				r = 1;
+				if (verbose) {
+					if (expected[i].repeated) {
+						printf("    %s:%d: missing ability (%d of %d) generated from %s()\n", suite_name, __LINE__ - 3, j + 1, ELEM_MAX, expected[i].src);
+					} else {
+						printf("    %s:%d: missing ability from %s()\n", suite_name, __LINE__ - 5, expected[i].src);
+					}
+				}
+			}
+		}
+	}
+	player_property_parser.cleanup();
+	for (i = 0; i < ELEM_MAX; ++i) {
+		string_free(projections[i].name);
+	}
+	mem_free(projections);
+	return r;
+}
+
+static int test_missing_record_header0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r;
+
+	null(parser_priv(p));
+	/* Without a preceding type directive, all these should fail. */
+	r = parser_parse(p, "code:ZERO_FAIL");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "desc:You are made of rock.");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "name:Rock");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "value:3");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "bindui:test_ui:0:1");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	ok;
+}
+
+static int test_complete_player0(void *state) {
+	const char *lines[] = {
+		"type:player",
+		"code:ZERO_FAIL",
+		"name:Full Spellcaster",
+		"desc:You may obtain a perfect ",
+		"desc:success rate with magic."
+	};
+	struct parser *p = (struct parser*) state;
+	int i;
+
+	for (i = 0; i < (int) N_ELEMENTS(lines); ++i) {
+		enum parser_error r = parser_parse(p, lines[i]);
+
+		eq(r, PARSE_ERROR_NONE);
+	}
+	ok;
+}
+
+static int test_complete_object0(void *state) {
+	const char *lines[] = {
+		"type:object",
+		"code:SUST_STR",
+		"bindui:test_ui:1:special",
+		"name:Sustain Strength",
+		"desc:Your strength is sustained",
+	};
+	struct parser *p = (struct parser*) state;
+	int i;
+
+	for (i = 0; i < (int) N_ELEMENTS(lines); ++i) {
+		enum parser_error r = parser_parse(p, lines[i]);
+
+		eq(r, PARSE_ERROR_NONE);
+	}
+	ok;
+}
+
+static int test_complete_element0(void *state) {
+	const char *lines[] = {
+		"type:element",
+		"bindui:test_ui:0:-1",
+		"name:Vulnerability",
+		"desc:You are vulnerable to",
+		"value:-1",
+	};
+	struct parser *p = (struct parser*) state;
+	int i;
+
+	for (i = 0; i < (int) N_ELEMENTS(lines); ++i) {
+		enum parser_error r = parser_parse(p, lines[i]);
+
+		eq(r, PARSE_ERROR_NONE);
+	}
+	ok;
+}
+
+static int test_name_memleak0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Set up a property */
+	enum parser_error r = parser_parse(p, "type:player");
+
+	eq(r, PARSE_ERROR_NONE);
+	/* Try setting the name twice to see if memory is leaked. */
+	r = parser_parse(p, "name:First Name");
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "name:Second Name");
+	eq(r, PARSE_ERROR_NONE);
+	ok;
+}
+
+static int test_code_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* First try a property of type player with an invalid code. */
+	enum parser_error r = parser_parse(p, "type:player");
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "code:XYZZY");
+	eq(r, PARSE_ERROR_INVALID_PLAY_PROP_CODE);
+	/* Try a property of type object with an invalid code. */
+	r = parser_parse(p, "type:object");
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "code:XYZZY");
+	eq(r, PARSE_ERROR_INVALID_PLAY_PROP_CODE);
+	/*
+	 * Then try with a property of a type that's not recognized; that'll
+	 * be detected when trying to set the code.
+	 */
+	r = parser_parse(p, "type:xyzzy");
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "code:SUST_STR");
+	eq(r, PARSE_ERROR_INVALID_PLAY_PROP_CODE);
+	ok;
+}
+
+static int test_bindui_bad0(void *state)
+{
+	struct parser *p = (struct parser*) state;
+	/* Set up an empty property. */
+	enum parser_error r = parser_parse(p, "type:player");
+
+	eq(r, PARSE_ERROR_NONE);
+	/*
+	 * Try binding with values that are not "special" nor an integer
+	 * that is in bounds.
+	 */
+	r = parser_parse(p, "bindui:test_ui:0:xyzzy");
+	eq(r, PARSE_ERROR_NOT_NUMBER);
+	r = parser_parse(p, "bindui:test_ui:1:18446744073709551615");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	r = parser_parse(p, "bindui:test_ui:1:-18446744073709551615");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	ok;
+}
+
+const char *suite_name = "parse/pprop";
+/*
+ * test_missing_record_header0() has to be before test_complete_player0(),
+ * test_complete_object0(), and test_complete_element0().  The checks in
+ * teardown_tests() assume test_complete_player0(), test_complete_object0(),
+ * and test_complete_element0() are run in that order and are before
+ * test_name_memleak0(), test_code_bad0(), and test_bindui_bad0().
+ */
+struct test tests[] = {
+	{ "missing_record_header0", test_missing_record_header0 },
+	{ "complete_player0", test_complete_player0 },
+	{ "complete_object0", test_complete_object0 },
+	{ "complete_element0", test_complete_element0 },
+	{ "name_memleak0", test_name_memleak0 },
+	{ "code_bad0", test_code_bad0 },
+	{ "bindui_bad0", test_bindui_bad0 },
+	{ NULL, NULL }
+};

--- a/src/tests/parse/realm.c
+++ b/src/tests/parse/realm.c
@@ -1,0 +1,196 @@
+/* parse/realm */
+/* Exercise parsing used for realm.txt. */
+
+#include "unit-test.h"
+#include "init.h"
+#include "player.h"
+
+int setup_tests(void **state) {
+	*state = realm_parser.init();
+	return !*state;
+}
+
+int teardown_tests(void *state) {
+	struct parser *p = (struct parser*) state;
+	int r = 0;
+
+	if (realm_parser.finish(p)) {
+		r = 1;
+	}
+	realm_parser.cleanup();
+	return r;
+}
+
+static int test_missing_record_header0(void *state)
+{
+	struct parser *p = (struct parser*) state;
+	enum parser_error r;
+
+	null(parser_priv(p));
+	r = parser_parse(p, "stat:STR");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "verb:perform");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "spell-noun:feat of strength");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "book-noun:exercise manual");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	ok;
+}
+
+static int test_name0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "name:calisthenics");
+	struct magic_realm *realm;
+
+	eq(r, PARSE_ERROR_NONE);
+	realm = (struct magic_realm*) parser_priv(p);
+	notnull(realm);
+	notnull(realm->name);
+	require(streq(realm->name, "calisthenics"));
+	eq(realm->stat, 0);
+	null(realm->verb);
+	null(realm->spell_noun);
+	null(realm->book_noun);
+	ok;
+}
+
+static int test_stat0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "stat:STR");
+	struct magic_realm *realm;
+
+	eq(r, PARSE_ERROR_NONE);
+	realm = (struct magic_realm*) parser_priv(p);
+	notnull(realm);
+	eq(realm->stat, STAT_STR);
+	ok;
+}
+
+static int test_stat_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Try an unrecognized stat. */
+	enum parser_error r = parser_parse(p, "stat:XYZZY");
+
+	eq(r, PARSE_ERROR_INVALID_SPELL_STAT);
+	ok;
+}
+
+static int test_verb0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "verb:perform");
+	struct magic_realm *realm;
+
+	eq(r, PARSE_ERROR_NONE);
+	realm = (struct magic_realm*) parser_priv(p);
+	notnull(realm);
+	notnull(realm->verb);
+	require(streq(realm->verb, "perform"));
+	/*
+	 * Try setting again to see that the prior value is replaced without
+	 * a memory leak.
+	 */
+	r = parser_parse(p, "verb:recite");
+	eq(r, PARSE_ERROR_NONE);
+	realm = (struct magic_realm*) parser_priv(p);
+	notnull(realm);
+	notnull(realm->verb);
+	require(streq(realm->verb, "recite"));
+	ok;
+}
+
+static int test_spell_noun0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "spell-noun:feat of strength");
+	struct magic_realm *realm;
+
+	eq(r, PARSE_ERROR_NONE);
+	realm = (struct magic_realm*) parser_priv(p);
+	notnull(realm);
+	notnull(realm->spell_noun);
+	require(streq(realm->spell_noun, "feat of strength"));
+	/*
+	 * Try setting again to see that the prior value is replaced without
+	 * a memory leak.
+	 */
+	r = parser_parse(p, "spell-noun:prayer");
+	eq(r, PARSE_ERROR_NONE);
+	realm = (struct magic_realm*) parser_priv(p);
+	notnull(realm);
+	notnull(realm->spell_noun);
+	require(streq(realm->spell_noun, "prayer"));
+	ok;
+}
+
+static int test_book_noun0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "book-noun:exercise manual");
+	struct magic_realm *realm;
+
+	eq(r, PARSE_ERROR_NONE);
+	realm = (struct magic_realm*) parser_priv(p);
+	notnull(realm);
+	notnull(realm->book_noun);
+	require(streq(realm->book_noun, "exercise manual"));
+	/*
+	 * Try setting again to see that the prior value is replaced without
+	 * a memory leak.
+	 */
+	r = parser_parse(p, "book-noun:hymnal");
+	eq(r, PARSE_ERROR_NONE);
+	realm = (struct magic_realm*) parser_priv(p);
+	notnull(realm);
+	notnull(realm->book_noun);
+	require(streq(realm->book_noun, "hymnal"));
+	ok;
+}
+
+static int test_complete0(void *state) {
+	const char *lines[] = {
+		"name:arcane",
+		"stat:INT",
+		"verb:cast",
+		"spell-noun:spell",
+		"book-noun:magic book"
+	};
+	struct parser *p = (struct parser*) state;
+	int i;
+	struct magic_realm *realm;
+
+	for (i = 0; i < (int) N_ELEMENTS(lines); ++i) {
+		enum parser_error r = parser_parse(p, lines[i]);
+
+		eq(r, PARSE_ERROR_NONE);
+	}
+	realm = (struct magic_realm*) parser_priv(p);
+	notnull(realm);
+	notnull(realm->name);
+	require(streq(realm->name, "arcane"));
+	eq(realm->stat, STAT_INT);
+	notnull(realm->verb);
+	require(streq(realm->verb, "cast"));
+	notnull(realm->spell_noun);
+	require(streq(realm->spell_noun, "spell"));
+	notnull(realm->book_noun);
+	require(streq(realm->book_noun, "magic book"));
+	ok;
+}
+
+const char *suite_name = "parse/realm";
+/*
+ * test_missing_record_header0() has to be before test_name0() and
+ * test_complete0().
+ * test_stat0(), test_stat_bad0(), test_verb0(), test_spell_noun0(), and
+ * test_book_noun0() have to after test_name0().
+ */
+struct test tests[] = {
+	{ "missing_record_header0", test_missing_record_header0 },
+	{ "name0", test_name0 },
+	{ "stat0", test_stat0 },
+	{ "stat_bad0", test_stat_bad0 },
+	{ "verb0", test_verb0 },
+	{ "spell_noun0", test_spell_noun0 },
+	{ "book_noun0", test_book_noun0 },
+	{ "complete0", test_complete0 },
+	{ NULL, NULL }
+};

--- a/src/tests/parse/shape.c
+++ b/src/tests/parse/shape.c
@@ -1,0 +1,674 @@
+/* parse/shape */
+/* Exercise the parsing used for shape.txt. */
+
+#include "unit-test.h"
+#include "effects.h"
+#include "init.h"
+#include "object.h"
+#include "player.h"
+#include "player-timed.h"
+#include "project.h"
+#include "z-virt.h"
+
+int setup_tests(void **state) {
+	/* Parsing needs z_info. */
+	z_info = mem_zalloc(sizeof(*z_info));
+	*state = shape_parser.init();
+	return !*state;
+}
+
+int teardown_tests(void *state) {
+	struct parser *p = (struct parser*) state;
+	int r = 0;
+
+	if (shape_parser.finish(p)) {
+		r = 1;
+	}
+	shape_parser.cleanup();
+	mem_free(z_info);
+	return r;
+}
+
+static int test_missing_record_header0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r;
+
+	null(parser_priv(p));
+	r = parser_parse(p, "combat:-3:-4:2");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "skill-disarm-phys:-5");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "skill-disarm-magic:-10");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "skill-save:20");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "skill-stealth:13");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "skill-search:5");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "skill-melee:10");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "skill-throw:-5");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "skill-dig:25");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "obj-flags:FEATHER | FREE_ACT");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "player-flags:STEAL");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "values:SPEED[3] | STEALTH[3] | INFRA[5]");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "effect:DAMAGE");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "effect-yx:11:23");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "dice:1d$S");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "expr:S:PLAYER_LEVEL:+ 0");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "effect-msg:turning into a bat");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "blow:bite");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	ok;
+}
+
+static int test_name0(void *state) {
+	struct parser *p = (struct parser*) state;
+	int eidx = z_info->shape_max;
+	struct player_shape *s;
+	enum parser_error r;
+	int i;
+
+	r = parser_parse(p, "name:fox");
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_shape*) parser_priv(p);
+	notnull(s);
+	notnull(s->name);
+	require(streq(s->name, "fox"));
+	eq(s->sidx, eidx);
+	eq(s->to_a, 0);
+	eq(s->to_h, 0);
+	eq(s->to_d, 0);
+	for (i = 0; i < SKILL_MAX; ++i) {
+		eq(s->skills[i], 0);
+	}
+	require(of_is_empty(s->flags));
+	require(pf_is_empty(s->pflags));
+	for (i = 0; i < OBJ_MOD_MAX; ++i) {
+		eq(s->modifiers[i], 0);
+	}
+	for (i = 0; i < ELEM_MAX; ++i) {
+		eq(s->el_info[i].res_level, 0);
+		eq(s->el_info[i].flags, 0);
+	}
+	null(s->effect);
+	null(s->blows);
+	eq(s->num_blows, 0);
+	ok;
+}
+
+static int test_combat0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "combat:5:2:-2");
+	struct player_shape *s;
+
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_shape*) parser_priv(p);
+	notnull(s);
+	eq(s->to_a, -2);
+	eq(s->to_h, 5);
+	eq(s->to_d, 2);
+	ok;
+}
+
+static int test_disarm_phys0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "skill-disarm-phys:-5");
+	struct player_shape *s;
+
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_shape*) parser_priv(p);
+	notnull(s);
+	eq(s->skills[SKILL_DISARM_PHYS], -5);
+	ok;
+}
+
+static int test_disarm_magic0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "skill-disarm-magic:-10");
+	struct player_shape *s;
+
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_shape*) parser_priv(p);
+	notnull(s);
+	eq(s->skills[SKILL_DISARM_MAGIC], -10);
+	ok;
+}
+
+static int test_save0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "skill-save:20");
+	struct player_shape *s;
+
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_shape*) parser_priv(p);
+	notnull(s);
+	eq(s->skills[SKILL_SAVE], 20);
+	ok;
+}
+
+static int test_stealth0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "skill-stealth:-7");
+	struct player_shape *s;
+
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_shape*) parser_priv(p);
+	notnull(s);
+	eq(s->skills[SKILL_STEALTH], -7);
+	ok;
+}
+
+static int test_search0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "skill-search:12");
+	struct player_shape *s;
+
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_shape*) parser_priv(p);
+	notnull(s);
+	eq(s->skills[SKILL_SEARCH], 12);
+	ok;
+}
+
+static int test_melee0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "skill-melee:9");
+	struct player_shape *s;
+
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_shape*) parser_priv(p);
+	notnull(s);
+	eq(s->skills[SKILL_TO_HIT_MELEE], 9);
+	ok;
+}
+
+static int test_throw0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "skill-throw:3");
+	struct player_shape *s;
+
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_shape*) parser_priv(p);
+	notnull(s);
+	eq(s->skills[SKILL_TO_HIT_THROW], 3);
+	ok;
+}
+
+static int test_dig0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "skill-dig:8");
+	struct player_shape *s;
+
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_shape*) parser_priv(p);
+	notnull(s);
+	eq(s->skills[SKILL_DIGGING], 8);
+	ok;
+}
+
+static int test_obj_flags0(void *state) {
+	struct parser *p = (struct parser*) state;
+	struct player_shape *s = (struct player_shape*) parser_priv(p);
+	bitflag eflags[OF_SIZE];
+	enum parser_error r;
+
+	notnull(s);
+	of_wipe(s->flags);
+	/* Try with no flags specified. */
+	r = parser_parse(p, "obj-flags:");
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_shape*) parser_priv(p);
+	notnull(s);
+	require(of_is_empty(s->flags));
+	/* Try with one flag. */
+	r = parser_parse(p, "obj-flags:FEATHER");
+	eq(r, PARSE_ERROR_NONE);
+	/* Try with two flags at once. */
+	r = parser_parse(p, "obj-flags:FREE_ACT | REGEN");
+	eq(r, PARSE_ERROR_NONE);
+	of_wipe(eflags);
+	of_on(eflags, OF_FEATHER);
+	of_on(eflags, OF_FREE_ACT);
+	of_on(eflags, OF_REGEN);
+	s = (struct player_shape*) parser_priv(p);
+	notnull(s);
+	require(of_is_equal(s->flags, eflags));
+	ok;
+}
+
+static int test_obj_flags_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Try an unrecognized flag. */
+	enum parser_error r = parser_parse(p, "obj-flags:XYZZY");
+
+	eq(r, PARSE_ERROR_INVALID_FLAG);
+	ok;
+}
+
+static int test_player_flags0(void *state) {
+	struct parser *p = (struct parser*) state;
+	struct player_shape *s = (struct player_shape*) parser_priv(p);
+	bitflag eflags[PF_SIZE];
+	enum parser_error r;
+
+	notnull(s);
+	pf_wipe(s->pflags);
+	/* Try with no flags specified. */
+	r = parser_parse(p, "player-flags:");
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_shape*) parser_priv(p);
+	notnull(s);
+	require(pf_is_empty(s->pflags));
+	/* Try with one flag. */
+	r = parser_parse(p, "player-flags:STEAL");
+	eq(r, PARSE_ERROR_NONE);
+	/* Try with two flags at once. */
+	r = parser_parse(p, "player-flags:SEE_ORE | ROCK");
+	eq(r, PARSE_ERROR_NONE);
+	pf_wipe(eflags);
+	pf_on(eflags, PF_STEAL);
+	pf_on(eflags, PF_SEE_ORE);
+	pf_on(eflags, PF_ROCK);
+	s = (struct player_shape*) parser_priv(p);
+	notnull(s);
+	require(pf_is_equal(s->pflags, eflags));
+	ok;
+}
+
+static int test_player_flags_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Try with an invalid player flag. */;
+	enum parser_error r = parser_parse(p, "player-flags:XYZZY");
+
+	eq(r, PARSE_ERROR_INVALID_FLAG);
+	ok;
+}
+
+static int test_values0(void *state) {
+	struct parser *p = (struct parser*) state;
+	struct player_shape *s = (struct player_shape*) parser_priv(p);
+	enum parser_error r;
+	int i;
+
+	notnull(s);
+	for (i = 0; i < OBJ_MOD_MAX; ++i) {
+		s->modifiers[i] = 0;
+	}
+	for (i = 0; i < ELEM_MAX; ++i) {
+		s->el_info[i].res_level = 0;
+		s->el_info[i].flags = 0;
+	}
+	/* Try with one modifier. */
+	r = parser_parse(p, "values:STR[-2]");
+	eq(r, PARSE_ERROR_NONE);
+	/* Try with a resistand and a modifier at once. */
+	r = parser_parse(p, "values:RES_POIS[3] | STEALTH[4]");
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_shape*) parser_priv(p);
+	notnull(s);
+	for (i = 0; i < OBJ_MOD_MAX; ++i) {
+		if (i == OBJ_MOD_STR) {
+			eq(s->modifiers[i], -2);
+		} else if (i == OBJ_MOD_STEALTH) {
+			eq(s->modifiers[i], 4);
+		} else {
+			eq(s->modifiers[i], 0);
+		}
+	}
+	for (i = 0; i < ELEM_MAX; ++i) {
+		if (i == ELEM_POIS) {
+			eq(s->el_info[i].res_level, 3);
+		} else {
+			eq(s->el_info[i].res_level, 0);
+		}
+		eq(s->el_info[i].flags, 0);
+	}
+	ok;
+}
+
+static int test_values_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Try an unrecognized modifier. */
+	enum parser_error r = parser_parse(p, "values:XYZZY[5]");
+
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	/* Try an unrecognized element. */
+	r = parser_parse(p, "values:RES_XYZZY[1]");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	ok;
+}
+
+static int test_missing_effect0(void *state) {
+	struct parser *p = (struct parser*) state;
+	struct player_shape *s = (struct player_shape*) parser_priv(p);
+	enum parser_error r;
+
+	notnull(s);
+	null(s->effect);
+	/*
+	 * Trying to modify an effect that isn't present shouldn't return
+	 * an error.
+	 */
+	r = parser_parse(p, "effect-yx:7:15");
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_shape*) parser_priv(p);
+	notnull(s);
+	null(s->effect);
+	r = parser_parse(p, "dice:7+2d$S");
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_shape*) parser_priv(p);
+	notnull(s);
+	null(s->effect);
+	r = parser_parse(p, "expr:S:PLAYER_LEVEL:* 2");
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_shape*) parser_priv(p);
+	notnull(s);
+	null(s->effect);
+	r = parser_parse(p, "effect-msg:turning into a vampire");
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_shape*) parser_priv(p);
+	notnull(s);
+	null(s->effect);
+	ok;
+}
+
+static int test_effect0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Try an effect without a subtype, radius or other. */
+	enum parser_error r = parser_parse(p, "effect:DAMAGE");
+	struct player_shape *s;
+	struct effect *e;
+
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_shape*) parser_priv(p);
+	notnull(s);
+	e = s->effect;
+	notnull(e);
+	while (e->next) e = e->next;
+	eq(e->index, EF_DAMAGE);
+	null(e->dice);
+	eq(e->y, 0);
+	eq(e->x, 0);
+	eq(e->subtype, 0);
+	eq(e->radius, 0);
+	eq(e->other, 0);
+	null(e->msg);
+	/* Try an effect with a subtype but no radius or other. */
+	r = parser_parse(p, "effect:CURE:POISONED");
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_shape*) parser_priv(p);
+	notnull(s);
+	e = s->effect;
+	notnull(e);
+	while (e->next) e = e->next;
+	eq(e->index, EF_CURE);
+	null(e->dice);
+	eq(e->y, 0);
+	eq(e->x, 0);
+	eq(e->subtype, TMD_POISONED);
+	eq(e->radius, 0);
+	eq(e->other, 0);
+	null(e->msg);
+	/* Try an effect with a subtype and radius but no other. */
+	r = parser_parse(p, "effect:SPOT:LIGHT_WEAK:2");
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_shape*) parser_priv(p);
+	notnull(s);
+	e = s->effect;
+	notnull(e);
+	while (e->next) e = e->next;
+	eq(e->index, EF_SPOT);
+	eq(e->y, 0);
+	eq(e->x, 0);
+	eq(e->subtype, PROJ_LIGHT_WEAK);
+	eq(e->radius, 2);
+	eq(e->other, 0);
+	null(e->msg);
+	/* Try an effect with a subtype, radius, and other. */
+	r = parser_parse(p, "effect:TIMED_INC:SHERO:0:5");
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_shape*) parser_priv(p);
+	notnull(s);
+	e = s->effect;
+	notnull(e);
+	while (e->next) e = e->next;
+	eq(e->index, EF_TIMED_INC);
+	eq(e->y, 0);
+	eq(e->x, 0);
+	eq(e->subtype, TMD_SHERO);
+	eq(e->radius, 0);
+	eq(e->other, 5);
+	null(e->msg);
+	ok;
+}
+
+static int test_effect_yx0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Set up an effect. */
+	enum parser_error r = parser_parse(p, "effect:DAMAGE");
+	struct player_shape *s;
+	struct effect *e;
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "effect-yx:7:15");
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_shape*) parser_priv(p);
+	notnull(s);
+	e = s->effect;
+	notnull(e);
+	while (e->next) e = e->next;
+	eq(e->y, 7);
+	eq(e->x, 15);
+	ok;
+}
+
+static int test_dice0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Set up an effect. */
+	enum parser_error r = parser_parse(p, "effect:DAMAGE");
+	struct player_shape *s;
+	struct effect *e;
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "dice:5+6d7");
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_shape*) parser_priv(p);
+	notnull(s);
+	e = s->effect;
+	notnull(e);
+	while (e->next) e = e->next;
+	notnull(e->dice);
+	require(dice_test_values(e->dice, 5, 6, 7, 0));
+	ok;
+}
+
+static int test_dice_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Set up an effect. */
+	enum parser_error r = parser_parse(p, "effect:DAMAGE");
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "dice:2d8+2d10-3");
+	eq(r, PARSE_ERROR_INVALID_DICE);
+	ok;
+}
+
+static int test_missing_dice0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Set up an effect. */
+	enum parser_error r = parser_parse(p, "effect:DAMAGE");
+	struct player_shape *s;
+	struct effect *e;
+
+	eq(r, PARSE_ERROR_NONE);
+	/*
+	 * Binding an expression when there is no dice should not return an
+	 * error.
+	 */
+	r = parser_parse(p, "expr:S:PLAYER_LEVEL:/ 5 + 2");
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_shape*) parser_priv(p);
+	notnull(s);
+	e = s->effect;
+	notnull(e);
+	while (e->next) e = e->next;
+	null(e->dice);
+	ok;
+}
+
+static int test_expr0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Set up an effect with dice. */
+	enum parser_error r = parser_parse(p, "effect:DAMAGE");
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "dice:$B+4d$S");
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "expr:B:PLAYER_LEVEL:* 2");
+	eq(r, PARSE_ERROR_NONE);
+	ok;
+}
+
+static int test_expr_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Set up an effect with dice. */
+	enum parser_error r = parser_parse(p, "effect:DAMAGE");
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "dice:$B+4d$S");
+	eq(r, PARSE_ERROR_NONE);
+	/* Try an expression with invalid operations. */
+	r = parser_parse(p, "expr:B:PLAYER_LEVEL:% 5");
+	eq(r, PARSE_ERROR_BAD_EXPRESSION_STRING);
+	/* Try binding to a variable that isn't in the dice. */
+	r = parser_parse(p, "expr:N:PLAYER_LEVEL:/ 5 + 1");
+	eq(r, PARSE_ERROR_UNBOUND_EXPRESSION);
+	ok;
+}
+
+static int test_effect_msg0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Set up an effect. */
+	enum parser_error r = parser_parse(p, "effect:DAMAGE");
+	struct player_shape *s;
+	struct effect *e;
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "effect-msg:turning into");
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_shape*) parser_priv(p);
+	notnull(s);
+	e = s->effect;
+	notnull(e);
+	while (e->next) e = e->next;
+	notnull(e->msg);
+	require(streq(e->msg, "turning into"));
+	/* Check that a second directive appends to the first. */
+	r = parser_parse(p, "effect-msg: a bat");
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_shape*) parser_priv(p);
+	notnull(s);
+	e = s->effect;
+	notnull(e);
+	while (e->next) e = e->next;
+	notnull(e->msg);
+	require(streq(e->msg, "turning into a bat"));
+	ok;
+}
+
+static int test_blow0(void *state) {
+	struct parser *p = (struct parser*) state;
+	struct player_shape *s = (struct player_shape*) parser_priv(p);
+	struct player_blow *b;
+	enum parser_error r;
+	int old_count, i;
+
+	notnull(s);
+	old_count = s->num_blows;
+	require(old_count >= 0);
+	r = parser_parse(p, "blow:bite");
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "blow:bite");
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "blow:sting");
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_shape*) parser_priv(p);
+	notnull(s);
+	eq(s->num_blows, old_count + 3);
+	b = s->blows;
+	notnull(b);
+	notnull(b->name);
+	require(streq(b->name, "sting"));
+	b = b->next;
+	notnull(b);
+	notnull(b->name);
+	require(streq(b->name, "bite"));
+	b = b->next;
+	notnull(b);
+	notnull(b->name);
+	require(streq(b->name, "bite"));
+	b = b->next;
+	for (i = 0; i < old_count; ++i) {
+		notnull(b);
+		b = b->next;
+	}
+	null(b);
+	ok;
+}
+
+const char *suite_name = "parser/shape";
+/*
+ * test_missing_record_header0() has to be before test_name0().
+ * test_missing_effect0() has to be after test_name0() and before
+ * test_effect0(), test_effect_yx0, test_dice0(), test_bad_dice0(),
+ * test_expr0(), test_bad_expr0(), and test_effect_msg0().
+ * test_combat0(), test_disarm_phys0(), test_disarm_magic0(), test_save0(),
+ * test_stealth0(), test_search0(), test_melee0(), test_throw0(), test_dig0(),
+ * test_obj_flags0(), test_obj_flags_bad0(), test_player_flags0(),
+ * test_player_flags_bad0(), test_values0(), test_values_bad0(),
+ * test_effect0(), test_effect_yx0(), test_dice0(), test_dice_bad0(),
+ * test_missing_dice0(), test_expr0(), test_expr_bad0(), test_effect_msg0(),
+ * and test_blow0() have to be after test_name0().
+ */
+struct test tests[] = {
+	{ "missing_record_header0", test_missing_record_header0 },
+	{ "name0", test_name0 },
+	{ "combat0", test_combat0 },
+	{ "disarm_phys0", test_disarm_phys0 },
+	{ "disarm_magic0", test_disarm_magic0 },
+	{ "save0", test_save0 },
+	{ "stealth0", test_stealth0 },
+	{ "search0", test_search0 },
+	{ "melee0", test_melee0 },
+	{ "throw0", test_throw0 },
+	{ "dig0", test_dig0 },
+	{ "obj_flags0", test_obj_flags0 },
+	{ "obj_flags_bad0", test_obj_flags_bad0 },
+	{ "player_flags0", test_player_flags0 },
+	{ "player_flags_bad0", test_player_flags_bad0 },
+	{ "values0", test_values0 },
+	{ "values_bad0", test_values_bad0 },
+	{ "missing_effect0", test_missing_effect0 },
+	{ "effect0", test_effect0 },
+	{ "effect_yx0", test_effect_yx0 },
+	{ "dice0", test_dice0 },
+	{ "dice_bad0", test_dice_bad0 },
+	{ "missing_dice0", test_missing_dice0 },
+	{ "expr0", test_expr0 },
+	{ "expr_bad0", test_expr_bad0 },
+	{ "effect_msg0", test_effect_msg0 },
+	{ "blow0", test_blow0 },
+	{ NULL, NULL }
+};

--- a/src/tests/parse/suite.mk
+++ b/src/tests/parse/suite.mk
@@ -1,6 +1,7 @@
 TESTPROGS += parse/a-info \
 	parse/blowe \
 	parse/blowm \
+	parse/body \
 	parse/brand \
 	parse/curse \
 	parse/c-info \
@@ -9,6 +10,7 @@ TESTPROGS += parse/a-info \
 	parse/flavor \
 	parse/graphics \
 	parse/h-info \
+	parse/hints \
 	parse/k-info \
 	parse/lore \
 	parse/mbase \
@@ -19,11 +21,16 @@ TESTPROGS += parse/a-info \
 	parse/p-info \
 	parse/pain \
 	parse/parse \
+	parse/partrap \
 	parse/pit \
+	parse/pprop \
 	parse/proj \
 	parse/ptimed \
 	parse/r-info \
 	parse/readstore \
+	parse/realm \
+	parse/shape \
 	parse/slay \
 	parse/v-info \
+	parse/world \
 	parse/z-info

--- a/src/tests/parse/world.c
+++ b/src/tests/parse/world.c
@@ -1,0 +1,67 @@
+/* parse/world */
+/* Exercise parsing used for world.txt. */
+
+#include "unit-test.h"
+#include "game-world.h"
+#include "init.h"
+
+NOSETUP
+NOTEARDOWN
+
+static int test_complete0(void *state)
+{
+	const char *lines[] = {
+		"level:0:Town:None:Test 1",
+		"level:1:Test 1:Town:Test 2",
+		"level:2:Test 2:Test 1:None"
+	};
+	struct parser *p = world_parser.init();
+	struct level *lv;
+	int i, rtn;
+
+	notnull(p);
+	for (i = 0; i < (int) N_ELEMENTS(lines); ++i) {
+		enum parser_error r = parser_parse(p, lines[i]);
+
+		eq(r, PARSE_ERROR_NONE);
+	}
+	rtn = world_parser.finish(p);
+	eq(rtn, 0);
+
+	lv = world;
+	notnull(lv);
+	eq(lv->depth, 0);
+	notnull(lv->name);
+	require(streq(lv->name, "Town"));
+	null(lv->up);
+	notnull(lv->down);
+	require(streq(lv->down, "Test 1"));
+	lv = lv->next;
+	notnull(lv);
+	eq(lv->depth, 1);
+	notnull(lv->name);
+	require(streq(lv->name, "Test 1"));
+	notnull(lv->up);
+	require(streq(lv->up, "Town"));
+	notnull(lv->down);
+	require(streq(lv->down, "Test 2"));
+	lv = lv->next;
+	notnull(lv);
+	eq(lv->depth, 2);
+	notnull(lv->name);
+	require(streq(lv->name, "Test 2"));
+	notnull(lv->up);
+	require(streq(lv->up, "Test 1"));
+	null(lv->down);
+	lv = lv->next;
+	null(lv);
+
+	world_parser.cleanup();
+	ok;
+}
+
+const char *suite_name = "parse/world";
+struct test tests[] = {
+	{ "complete0", test_complete0 },
+	{ NULL, NULL }
+};

--- a/src/tests/parse/z-info.c
+++ b/src/tests/parse/z-info.c
@@ -1,4 +1,5 @@
 /* parse/z-info */
+/* Exercise parsing used for constants.txt. */
 
 #include "unit-test.h"
 #include "unit-test-data.h"
@@ -7,7 +8,7 @@
 
 
 int setup_tests(void **state) {
-	*state = init_parse_constants();
+	*state = constants_parser.init();
 	return !*state;
 }
 
@@ -19,58 +20,181 @@ int teardown_tests(void *state) {
 }
 
 static int test_negative(void *state) {
-	errr r = parser_parse(state, "level-max:F:-1");
+	struct parser *p = (struct parser*) state;
+	errr r = parser_parse(p, "level-max:monsters:-1");
+
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	r = parser_parse(p, "mon-gen:chance:-1");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	r = parser_parse(p, "mon-play:mult-rate:-1");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	r = parser_parse(p, "dun-gen:wall-max:-1");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	r = parser_parse(p, "world:dungeon-hgt:-1");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	r = parser_parse(p, "carry-cap:pack-size:-1");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	r = parser_parse(p, "store:shuffle:-1");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	r = parser_parse(p, "obj-make:great-obj:-1");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	r = parser_parse(p, "player:max-sight:-1");
 	eq(r, PARSE_ERROR_INVALID_VALUE);
 	ok;
 }
 
-static int test_badmax(void *state) {
-	errr r = parser_parse(state, "level-max:D:1");
+static int test_baddirective(void *state) {
+	struct parser *p = (struct parser*) state;
+	errr r = parser_parse(p, "level-max:D:1");
+
+	eq(r, PARSE_ERROR_UNDEFINED_DIRECTIVE);
+	r = parser_parse(p, "mon-gen:xyzzy:5");
+	eq(r, PARSE_ERROR_UNDEFINED_DIRECTIVE);
+	r = parser_parse(p, "mon-play:xyzzy:10");
+	eq(r, PARSE_ERROR_UNDEFINED_DIRECTIVE);
+	r = parser_parse(p, "dun-gen:xyzzy:3");
+	eq(r, PARSE_ERROR_UNDEFINED_DIRECTIVE);
+	r = parser_parse(p, "world:xyzzy:170");
+	eq(r, PARSE_ERROR_UNDEFINED_DIRECTIVE);
+	r = parser_parse(p, "carry-cap:xyzzy:40");
+	eq(r, PARSE_ERROR_UNDEFINED_DIRECTIVE);
+	r = parser_parse(p, "store:xyzzy:20");
+	eq(r, PARSE_ERROR_UNDEFINED_DIRECTIVE);
+	r = parser_parse(p, "obj-make:xyzzy:5000");
+	eq(r, PARSE_ERROR_UNDEFINED_DIRECTIVE);
+	r = parser_parse(p, "player:xyzzy:300");
 	eq(r, PARSE_ERROR_UNDEFINED_DIRECTIVE);
 	ok;
 }
 
-#define TEST_MAX(l,u) \
+#define TEST_CONSTANT(l,u,section) \
 	static int test_##l(void *s) { \
 		struct angband_constants *m = parser_priv(s); \
 		char buf[64]; \
 		errr r; \
-		snprintf(buf, sizeof(buf), "level-max:%s:%d", u, __LINE__); \
+		snprintf(buf, sizeof(buf), "%s:%s:%d", section, u, __LINE__); \
 		r = parser_parse(s, buf); \
 		eq(m->l, __LINE__); \
 		eq(r, 0); \
 		ok; \
 	}
 
-TEST_MAX(level_monster_max, "monsters")
+TEST_CONSTANT(level_monster_max, "monsters", "level-max")
 
-#define TEST_MON(l,u) \
-	static int test_##l(void *s) { \
-		struct angband_constants *m = parser_priv(s); \
-		char buf[64]; \
-		errr r; \
-		snprintf(buf, sizeof(buf), "mon-gen:%s:%d", u, __LINE__); \
-		r = parser_parse(s, buf); \
-		eq(m->l, __LINE__); \
-		eq(r, 0); \
-		ok; \
-	}
+TEST_CONSTANT(alloc_monster_chance, "chance", "mon-gen")
+TEST_CONSTANT(level_monster_min, "level-min", "mon-gen")
+TEST_CONSTANT(town_monsters_day, "town-day", "mon-gen")
+TEST_CONSTANT(town_monsters_night, "town-night", "mon-gen")
+TEST_CONSTANT(repro_monster_max, "repro-max", "mon-gen")
+TEST_CONSTANT(ood_monster_chance, "ood-chance", "mon-gen")
+TEST_CONSTANT(ood_monster_amount, "ood-amount", "mon-gen")
+TEST_CONSTANT(monster_group_max, "group-max", "mon-gen")
+TEST_CONSTANT(monster_group_dist, "group-dist", "mon-gen")
 
-TEST_MON(alloc_monster_chance, "chance")
-TEST_MON(level_monster_min, "level-min")
-TEST_MON(town_monsters_day, "town-day")
-TEST_MON(town_monsters_night, "town-night")
-TEST_MON(repro_monster_max, "repro-max")
+TEST_CONSTANT(glyph_hardness, "break-glyph", "mon-play")
+TEST_CONSTANT(repro_monster_rate, "mult-rate", "mon-play")
+TEST_CONSTANT(life_drain_percent, "life-drain", "mon-play")
+TEST_CONSTANT(flee_range, "flee-range", "mon-play")
+TEST_CONSTANT(turn_range, "turn-range", "mon-play")
+
+TEST_CONSTANT(level_room_max, "cent-max", "dun-gen")
+TEST_CONSTANT(level_door_max, "door-max", "dun-gen")
+TEST_CONSTANT(wall_pierce_max, "wall-max", "dun-gen")
+TEST_CONSTANT(tunn_grid_max, "tunn-max", "dun-gen")
+TEST_CONSTANT(room_item_av, "amt-room", "dun-gen")
+TEST_CONSTANT(both_item_av, "amt-item", "dun-gen")
+TEST_CONSTANT(both_gold_av, "amt-gold", "dun-gen")
+TEST_CONSTANT(level_pit_max, "pit-max", "dun-gen")
+
+TEST_CONSTANT(max_depth, "max-depth", "world")
+TEST_CONSTANT(day_length, "day-length", "world")
+TEST_CONSTANT(dungeon_hgt, "dungeon-hgt", "world")
+TEST_CONSTANT(dungeon_wid, "dungeon-wid", "world")
+TEST_CONSTANT(town_hgt, "town-hgt", "world")
+TEST_CONSTANT(town_wid, "town-wid", "world")
+TEST_CONSTANT(feeling_total, "feeling-total", "world")
+TEST_CONSTANT(feeling_need, "feeling-need", "world")
+TEST_CONSTANT(stair_skip, "stair-skip", "world")
+TEST_CONSTANT(move_energy, "move-energy", "world")
+
+TEST_CONSTANT(pack_size, "pack-size", "carry-cap")
+TEST_CONSTANT(quiver_size, "quiver-size", "carry-cap")
+TEST_CONSTANT(quiver_slot_size, "quiver-slot-size", "carry-cap")
+TEST_CONSTANT(thrown_quiver_mult, "thrown-quiver-mult", "carry-cap")
+TEST_CONSTANT(floor_size, "floor-size", "carry-cap")
+
+TEST_CONSTANT(store_inven_max, "inven-max", "store")
+TEST_CONSTANT(store_turns, "turns", "store")
+TEST_CONSTANT(store_shuffle, "shuffle", "store")
+TEST_CONSTANT(store_magic_level, "magic-level", "store")
+
+TEST_CONSTANT(max_obj_depth, "max-depth", "obj-make")
+TEST_CONSTANT(great_obj, "great-obj", "obj-make")
+TEST_CONSTANT(great_ego, "great-ego", "obj-make")
+TEST_CONSTANT(fuel_torch, "fuel-torch", "obj-make")
+TEST_CONSTANT(fuel_lamp, "fuel-lamp", "obj-make")
+TEST_CONSTANT(default_lamp, "default-lamp", "obj-make")
+
+TEST_CONSTANT(max_sight, "max-sight", "player")
+TEST_CONSTANT(max_range, "max-range", "player")
+TEST_CONSTANT(start_gold, "start-gold", "player")
+TEST_CONSTANT(food_value, "food-value", "player")
 
 const char *suite_name = "parse/z-info";
 struct test tests[] = {
 	{ "negative", test_negative },
-	{ "badmax", test_badmax },
+	{ "baddirective", test_baddirective },
 	{ "monsters_max", test_level_monster_max },
 	{ "mon_chance", test_alloc_monster_chance },
 	{ "monsters_min", test_level_monster_min },
 	{ "town_day", test_town_monsters_day },
 	{ "town_night", test_town_monsters_night },
 	{ "repro_max", test_repro_monster_max },
+	{ "ood_chance", test_ood_monster_chance },
+	{ "ood_amount", test_ood_monster_amount },
+	{ "group_max", test_monster_group_max },
+	{ "group_dist", test_monster_group_dist },
+	{ "break_glyph", test_glyph_hardness },
+	{ "mult_rate", test_repro_monster_rate },
+	{ "life_drain", test_life_drain_percent },
+	{ "flee_range", test_flee_range },
+	{ "turn_range", test_turn_range },
+	{ "cent_max", test_level_room_max },
+	{ "door_max", test_level_door_max },
+	{ "wall_max", test_wall_pierce_max },
+	{ "tunn_max", test_tunn_grid_max },
+	{ "amt_room", test_room_item_av },
+	{ "amt_item", test_both_item_av },
+	{ "amt_gold", test_both_gold_av },
+	{ "pit_max", test_level_pit_max },
+	{ "max_depth", test_max_depth },
+	{ "day_length", test_day_length },
+	{ "dungeon_hgt", test_dungeon_hgt },
+	{ "dungeon_wid", test_dungeon_wid },
+	{ "town_hgt", test_town_hgt },
+	{ "town_wid", test_town_wid },
+	{ "feeling_total", test_feeling_total },
+	{ "feeling_need", test_feeling_need },
+	{ "stair_skip", test_stair_skip },
+	{ "move_energy", test_move_energy },
+	{ "pack_size", test_pack_size },
+	{ "quiver_size", test_quiver_size },
+	{ "quiver_slot_size", test_quiver_slot_size },
+	{ "thrown_quiver_mult", test_thrown_quiver_mult },
+	{ "floor_size", test_floor_size },
+	{ "inven_max", test_store_inven_max },
+	{ "turns", test_store_turns },
+	{ "shuffle", test_store_shuffle },
+	{ "magic-level", test_store_magic_level },
+	{ "max_obj_depth", test_max_obj_depth },
+	{ "great_obj", test_great_obj },
+	{ "great_ego", test_great_ego },
+	{ "fuel_torch", test_fuel_torch },
+	{ "fuel_lamp", test_fuel_lamp },
+	{ "default_lamp", test_default_lamp },
+	{ "max_sight", test_max_sight },
+	{ "max_range", test_max_range },
+	{ "start_gold", test_start_gold },
+	{ "food_value", test_food_value },
 	{ NULL, NULL }
 };


### PR DESCRIPTION
… test cases.  Make the init_parse_* functions in init.c private since they can be accessed through the file_parser structures.  Add more tests for better coverage of init.c.