### PR TITLE
Tidy some monster-related parsing

### DIFF
--- a/src/mon-init.c
+++ b/src/mon-init.c
@@ -1600,7 +1600,7 @@ static enum parser_error parse_monster_friends_base(struct parser *p) {
 	f->base = lookup_monster_base(parser_getsym(p, "name"));
 	if (!f->base) {
 		mem_free(f);
-		return PARSE_ERROR_UNRECOGNISED_TVAL;
+		return PARSE_ERROR_INVALID_MONSTER_BASE;
 	}
 	if (parser_hasval(p, "role")) {
 		const char *role_name = parser_getsym(p, "role");


### PR DESCRIPTION
- Plug some memory leaks on error returns.
- Use a more appropriate parser error for an invalid monster base in monster.txt's friends-base directive.