### PR TITLE
In the equippable comparison, don't display the equipment characters …

### DIFF
--- a/src/ui-equip-cmp.c
+++ b/src/ui-equip-cmp.c
@@ -2793,8 +2793,14 @@ static int display_page(struct equippable_summary *s, const struct player *p,
 		assert(isort >= 0 && isort < s->nitems);
 		e = s->items + isort;
 
-		Term_putch(s->icol_name - 4, rdetails.value_position.y,
-			e->at, e->ch);
+		if (tile_width == 1 && tile_height == 1) {
+			Term_putch(s->icol_name - 4, rdetails.value_position.y,
+				e->at, e->ch);
+		} else {
+			/* No equippy chars with big tiles. */
+			Term_putch(s->icol_name - 4, rdetails.value_position.y,
+				COLOUR_WHITE, L' ');
+		}
 		Term_putch(s->icol_name - 2, rdetails.value_position.y, color,
 			source_to_char(e->src));
 		if (isort == s->isel0 || isort == s->isel1 ||


### PR DESCRIPTION
…when using tiles and the tile multipliers are different than 1 x 1.  Avoids displaying truncated tiles in that situation.  Found while researching https://github.com/angband/angband/issues/5552 .