### PR TITLE
Fix incorrect scaling of monster hearing and smell

### DIFF
--- a/src/mon-init.c
+++ b/src/mon-init.c
@@ -1200,7 +1200,7 @@ static enum parser_error parse_monster_hearing(struct parser *p) {
 	if (!r)
 		return PARSE_ERROR_MISSING_RECORD_HEADER;
 	/* Assumes max_sight is 20, so we adjust in case it isn't */
-	r->hearing = parser_getint(p, "hearing") * 20 / z_info->max_sight;
+	r->hearing = parser_getint(p, "hearing") * z_info->max_sight / 20;
 	return PARSE_ERROR_NONE;
 }
 
@@ -1210,7 +1210,7 @@ static enum parser_error parse_monster_smell(struct parser *p) {
 	if (!r)
 		return PARSE_ERROR_MISSING_RECORD_HEADER;
 	/* Assumes max_sight is 20, so we adjust in case it isn't */
-	r->smell = parser_getint(p, "smell") * 20 / z_info->max_sight;
+	r->smell = parser_getint(p, "smell") * z_info->max_sight / 20;
 	return PARSE_ERROR_NONE;
 }
 


### PR DESCRIPTION
With this fix, the monster hearing and smell distances scale with LoS size