### PR TITLE
Replace the effect chain for an ego with an activation.  …

### DIFF
--- a/lib/gamedata/ego_item.txt
+++ b/lib/gamedata/ego_item.txt
@@ -22,6 +22,8 @@
 # flags-off: flag | flag | etc
 # values: label[value] | label[value] | etc.
 # min-values: label[value] | label[value] | etc.
+# act: name
+# time: timeout random value
 # brand: code
 # slay: code
 # curse: name : power
@@ -68,15 +70,6 @@
 # One or more 'item' lines are used when we don't want all object kinds of
 # this tval to be possible for this ego-item.
 
-# 'effect' is for the effect when an item is activated.  Fields are the
-# name of the effect (as found in src/list-effects.h) and possibly one or
-# two parameters to the effect.
-
-# 'dice' provides a random value to be used by an activation effect
-
-# 'time' gives a random value to be used as the time to recharge for an
-# activatable item.
-
 # 'flags' is for flags, which can be either object flags (as found in
 # src/list-object-flags.h) or kind flags (src/list-kind-flags.h).  As many
 # flags: lines may be used as are needed to specify all the flags, and
@@ -101,6 +94,12 @@
 # While resistances can be specified on a 'values' line, they can not appear
 # in a 'min-values' line.  Also, unlike the 'values' line, all the values must
 # be plain integers:  full random expressions are not allowed.
+
+# 'act' is any activation that the ego might have - most have none.  The
+# activation is specified by its name, as found in activation.txt.
+
+# 'time' gives a random value to be used as the time to recharge for the
+# activation.
 
 # 'brand' adds a brand to the ego.  It should be omitted for egos without
 # brands and may appear more than once for egos with multiple brands.  Specify

--- a/src/load.c
+++ b/src/load.c
@@ -245,10 +245,7 @@ static struct object *rd_item(void)
 	}
 
 	/* Set effect */
-	if (effect && obj->ego)
-		obj->effect = obj->ego->effect;
-
-	if (effect && !obj->effect)
+	if (effect)
 		obj->effect = obj->kind->effect;
 
 	/* Success */

--- a/src/obj-make.c
+++ b/src/obj-make.c
@@ -448,9 +448,9 @@ void ego_apply_magic(struct object *obj, int level)
 		obj->el_info[i].flags |= obj->ego->el_info[i].flags;
 	}
 
-	/* Add effect (ego effect will trump object effect, when there are any) */
-	if (obj->ego->effect) {
-		obj->effect = obj->ego->effect;
+	/* Add activation (ego's activation will trump object's, if any). */
+	if (obj->ego->activation) {
+		obj->activation = obj->ego->activation;
 		obj->time = obj->ego->time;
 	}
 

--- a/src/object.h
+++ b/src/object.h
@@ -366,9 +366,8 @@ struct ego_item {
 	int min_to_d;			/* Minimum to-dam value */
 	int min_to_a;			/* Minimum to-ac value */
 
-	struct effect *effect;	/**< Effect this item produces (effects.c) */
-	char *effect_msg;
-	random_value time;		/**< Recharge time (rods/activation) */
+	struct activation *activation;	/**< Activation */
+	random_value time;		/**< Recharge time for activation */
 
 	bool everseen;			/* Do not spoil ignore menus */
 };


### PR DESCRIPTION
… Resolves https://github.com/angband/angband/issues/5451 .  Since Vanilla has no egos with effect chains, there's no impact on savefile compatibility; modded games with such egos do have savefile compatibility issues (loss of the effect for the ego item when loading an old save into a version with this change).