### PR TITLE
Configure categories for the monster knowledge menu from a data file,…

### DIFF
--- a/docs/hacking/modifying.rst
+++ b/docs/hacking/modifying.rst
@@ -225,6 +225,10 @@ ui_entry_renderer.txt
   one of the current renderers, the basic rendering techniques are hard-coded
   in list-ui-entry-renderers.h.
 
+ui_knowledge.txt
+  Handles some configuration of the knowledge menus, namely the layout of
+  the monster categories.
+
 Making Graphical Tilesets
 =========================
 

--- a/lib/gamedata/ui_knowledge.txt
+++ b/lib/gamedata/ui_knowledge.txt
@@ -1,0 +1,189 @@
+# File: ui_knowledge.txt
+
+# Configure some behavior of the knowledge menus.
+
+# === Understanding ui_knowledge.txt ===
+
+# monster-category:name
+# mcat-include-base:name
+# mcat-include-flag:flag | ...
+
+# 'monster-category' introduces a set of directives to define a category of
+# monsters in the monster knowledge menu.  It takes one parameter:  the name
+# that will be shown in the menu for the category.  One name,
+# "***Unclassified***" is reserved for internal use to catch any types of
+# monsters that do not fall into any of the categories specified in this file.
+# In the menu, the categories will appear in the same order that they are
+# defined in this file.
+
+# 'mcat-include-base' adds a monster base to be included in the most recent
+# category specified by a 'monster-category' directive.  It takes one
+# parameter:  the name of the monster base from monster_base.txt.  If that
+# base does not exist or there is no prior 'monster-category' directive,
+# that will trigger a parser error.  This directive may be used more than
+# once for the same category.  If a category includes multiple monster bases,
+# the knowledge menu will display those from a base specified earlier in this
+# file before those from a base that appear later in this file.  Within the
+# same monster base, the knowledge menu will sort the monster types by level
+# and then by name.
+
+# 'mcat-include-flag' adds one or more monster flags to be included in the most
+# recent category specified by a 'monster-category' directive.  It takes
+# one parameter:  a list of zero or more monster flags, separated by spaces
+# or '|'.  Each flag must match one of the first arguments (except 'NONE') to
+# a RF() macro in list-mon-race-flags.h.  All types of monsters that have a
+# flag specified by 'mcat-include-flag' will be included in the category.
+# This directive may be used more than once for the same category.  Monster
+# types which only appear in a category because they possess a flag will
+# appear, when displayed in the monster knowledge menu, after those that are
+# included  because of a monster base and will be sorted by level and then
+# by name.
+
+monster-category:Uniques
+mcat-include-flag:UNIQUE
+
+monster-category:Ainur
+mcat-include-base:ainu
+
+monster-category:Ants
+mcat-include-base:ant
+
+monster-category:Bats
+mcat-include-base:bat
+
+monster-category:Birds
+mcat-include-base:bird
+
+monster-category:Canines
+mcat-include-base:canine
+
+monster-category:Centipede
+mcat-include-base:centipede
+
+monster-category:Demons
+mcat-include-base:minor demon
+mcat-include-base:major demon
+
+monster-category:Dragons
+mcat-include-base:dragon
+mcat-include-base:ancient dragon
+
+monster-category:Elementals/Vortices
+mcat-include-base:vortex
+mcat-include-base:elemental
+
+monster-category:Eyes/Beholders
+mcat-include-base:eye
+
+monster-category:Felines
+mcat-include-base:feline
+
+monster-category:Ghosts
+mcat-include-base:ghost
+
+monster-category:Giants/Ogres
+mcat-include-base:ogre
+mcat-include-base:giant
+
+monster-category:Golems
+mcat-include-base:golem
+
+monster-category:Harpies/Hybrids
+mcat-include-base:hybrid
+
+monster-category:Hominids (Elves, Dwarves)
+mcat-include-base:humanoid
+
+monster-category:Hydras
+mcat-include-base:hydra
+
+monster-category:Icky Things
+mcat-include-base:icky thing
+
+monster-category:Insects
+mcat-include-base:dragon fly
+mcat-include-base:insect
+
+monster-category:Jellies
+mcat-include-base:jelly
+
+monster-category:Killer Beetles
+mcat-include-base:killer beetle
+
+monster-category:Kobolds
+mcat-include-base:kobold
+
+monster-category:Lichs
+mcat-include-base:lich
+
+monster-category:Men
+mcat-include-base:townsfolk
+mcat-include-base:person
+
+monster-category:Mimics
+mcat-include-base:lurker
+mcat-include-base:creeping coins
+mcat-include-base:mimic
+
+monster-category:Molds
+mcat-include-base:mold
+
+monster-category:Mushroom Patches
+mcat-include-base:mushroom
+
+monster-category:Nagas
+mcat-include-base:naga
+
+monster-category:Orcs
+mcat-include-base:orc
+
+monster-category:Quadrupeds
+mcat-include-base:quadruped
+
+monster-category:Quylthulgs
+mcat-include-base:quylthulg
+
+monster-category:Reptiles/Amphibians
+mcat-include-base:reptile
+
+monster-category:Rodents
+mcat-include-base:rodent
+
+monster-category:Scorpions/Spiders
+mcat-include-base:spider
+
+monster-category:Skeletons/Drujs
+mcat-include-base:skeleton
+
+monster-category:Snakes
+mcat-include-base:snake
+
+monster-category:Trees/Ents
+mcat-include-base:tree
+
+monster-category:Trolls
+mcat-include-base:troll
+
+monster-category:Vampires
+mcat-include-base:vampire
+
+monster-category:Wights/Wraiths
+mcat-include-base:wraith
+
+monster-category:Worms/Worm Masses
+mcat-include-base:worm
+
+monster-category:Xorns/Xarens
+mcat-include-base:xorn
+
+monster-category:Yeeks
+mcat-include-base:yeek
+
+monster-category:Yeti
+mcat-include-base:yeti
+
+monster-category:Zephyr Hounds
+mcat-include-base:zephyr hound
+
+monster-category:Zombies
+mcat-include-base:zombie

--- a/src/tests/parse/suite.mk
+++ b/src/tests/parse/suite.mk
@@ -31,6 +31,7 @@ TESTPROGS += parse/a-info \
 	parse/realm \
 	parse/shape \
 	parse/slay \
+	parse/ui_knowledge \
 	parse/v-info \
 	parse/world \
 	parse/z-info

--- a/src/tests/parse/ui_knowledge.c
+++ b/src/tests/parse/ui_knowledge.c
@@ -1,0 +1,164 @@
+/* parse/ui_knowledge.c */
+/* Exercise parsing used for ui_knowledge.txt. */
+
+#include "unit-test.h"
+#include "ui-knowledge.h"
+
+static struct monster_base dummy_mon_bases[] = {
+	{ .name = "bat", .next = NULL },
+	{ .name = "lizard", .next = NULL },
+	{ .name = "winged horror", .next = NULL },
+};
+
+int setup_tests(void **state) {
+	int i;
+
+	*state = ui_knowledge_parser.init();
+	/* Supply a minimal set of monster bases so the tests can function. */
+	for (i = 0; i < (int) N_ELEMENTS(dummy_mon_bases) - 1; ++i) {
+		dummy_mon_bases[i].next = dummy_mon_bases + i + 1;
+	}
+	rb_info = dummy_mon_bases;
+	return !*state;
+}
+
+int teardown_tests(void *state) {
+	struct parser *p = (struct parser*) state;
+	int r = 0;
+
+	if (ui_knowledge_parser.finish(p)) {
+		r = 1;
+	}
+	ui_knowledge_parser.cleanup();
+	return r;
+}
+
+static int test_missing_record_header0(void *state) {
+	struct parser *p = (struct parser*) state;
+	struct ui_knowledge_parse_state *s =
+		(struct ui_knowledge_parse_state*) parser_priv(p);
+	enum parser_error r;
+
+	notnull(s);
+	null(s->categories);
+	r = parser_parse(p, "mcat-include-base:bat");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "mcat-include-flag:UNIQUE");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	ok;
+}
+
+static int test_category0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "monster-category:Flying Things");
+	struct ui_knowledge_parse_state *s;
+
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct ui_knowledge_parse_state*) parser_priv(p);
+	notnull(s);
+	notnull(s->categories);
+	notnull(s->categories->name);
+	require(streq(s->categories->name, "Flying Things"));
+	require(rf_is_empty(s->categories->inc_flags));
+	eq(s->categories->n_inc_bases, 0);
+	ok;
+}
+
+static int test_include_base0(void *state) {
+	struct parser *p = (struct parser*) state;
+	struct ui_knowledge_parse_state *s =
+		(struct ui_knowledge_parse_state*) parser_priv(p);
+	enum parser_error r;
+	int n_old;
+
+	notnull(s);
+	notnull(s->categories);
+	n_old = s->categories->n_inc_bases;
+	r = parser_parse(p, "mcat-include-base:bat");
+	eq(r, PARSE_ERROR_NONE);
+	/* Try adding another base. */
+	r = parser_parse(p, "mcat-include-base:winged horror");
+	eq(r, PARSE_ERROR_NONE);
+	eq(s->categories->n_inc_bases, n_old + 2);
+	notnull(s->categories->inc_bases);
+	notnull(s->categories->inc_bases[s->categories->n_inc_bases - 2]);
+	notnull(s->categories->inc_bases[s->categories->n_inc_bases - 2]->name);
+	require(streq(
+            s->categories->inc_bases[s->categories->n_inc_bases - 2]->name,
+            "bat"));
+	notnull(s->categories->inc_bases[s->categories->n_inc_bases - 1]);
+	notnull(s->categories->inc_bases[s->categories->n_inc_bases - 1]->name);
+	require(streq(
+            s->categories->inc_bases[s->categories->n_inc_bases - 1]->name,
+            "winged horror"));
+	ok;
+}
+
+static int test_include_base_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "mcat-include-base:XYZZY");
+
+	eq(r, PARSE_ERROR_INVALID_MONSTER_BASE);
+	ok;
+}
+
+static int test_include_flag0(void *state) {
+	struct parser *p = (struct parser*) state;
+	struct ui_knowledge_parse_state *s =
+		(struct ui_knowledge_parse_state*) parser_priv(p);
+	bitflag eflags[RF_SIZE];
+	enum parser_error r;
+
+	notnull(s);
+	notnull(s->categories);
+	rf_wipe(s->categories->inc_flags);
+	/* Check that specifying an empty set of flags works. */
+	r = parser_parse(p, "mcat-include-flag:");
+	eq(r, PARSE_ERROR_NONE);
+	require(rf_is_empty(s->categories->inc_flags));
+	/* Check that specifying one flag works. */
+	r = parser_parse(p, "mcat-include-flag:UNIQUE");
+	eq(r, PARSE_ERROR_NONE);
+	/* Check that specifying two flags at once works. */
+	r = parser_parse(p, "mcat-include-flag:MALE | NEVER_MOVE");
+	eq(r, PARSE_ERROR_NONE);
+	rf_wipe(eflags);
+	rf_on(eflags, RF_UNIQUE);
+	rf_on(eflags, RF_MALE);
+	rf_on(eflags, RF_NEVER_MOVE);
+	require(rf_is_equal(s->categories->inc_flags, eflags));
+	ok;
+}
+
+static int test_include_flag_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	struct ui_knowledge_parse_state *s =
+		(struct ui_knowledge_parse_state*) parser_priv(p);
+	bitflag eflags[RF_SIZE];
+	enum parser_error r;
+
+	notnull(s);
+	notnull(s->categories);
+	rf_copy(eflags, s->categories->inc_flags);
+	/* Try an invalid flag. */
+	r = parser_parse(p, "mcat-include-flag:XYZZY");
+	eq(r, PARSE_ERROR_INVALID_FLAG);
+	require(rf_is_equal(s->categories->inc_flags, eflags));
+	ok;
+}
+
+/*
+ * test_missing_record_header0() has to be before test_category0().
+ * test_include_base0(), test_include_base_bad0(), test_include_flag0(),
+ * and test_include_flag_bad0() have to be after test_category0().
+ */
+const char *suite_name = "parse/ui_knowledge";
+struct test tests[] = {
+	{ "missing_record_header0", test_missing_record_header0 },
+	{ "category0", test_category0 },
+	{ "include_base0", test_include_base0 },
+	{ "include_base_bad0", test_include_base_bad0 },
+	{ "include_flag0", test_include_flag0 },
+	{ "include_flag_bad0", test_include_flag_bad0 },
+	{ NULL, NULL }
+};

--- a/src/ui-knowledge.c
+++ b/src/ui-knowledge.c
@@ -26,6 +26,7 @@
 #include "game-world.h"
 #include "grafmode.h"
 #include "init.h"
+#include "mon-init.h"
 #include "mon-lore.h"
 #include "mon-util.h"
 #include "monster.h"
@@ -131,6 +132,19 @@ typedef struct join {
 		int oid;
 		int gid;
 } join_t;
+
+static struct parser *init_ui_knowledge_parser(void);
+static errr run_ui_knowledge_parser(struct parser *p);
+static errr finish_ui_knowledge_parser(struct parser *p);
+static void cleanup_ui_knowledge_parsed_data(void);
+
+struct file_parser ui_knowledge_parser = {
+	"ui_knowledge",
+	init_ui_knowledge_parser,
+	run_ui_knowledge_parser,
+	finish_ui_knowledge_parser,
+	cleanup_ui_knowledge_parsed_data
+};
 
 /**
  * A default group-by
@@ -1075,62 +1089,18 @@ static void display_knowledge(const char *title, int *obj_list, int o_count,
  * ------------------------------------------------------------------------ */
 
 /**
- * Description of each monster group.
+ * Is a flat array describing each monster group.  Configured by
+ * ui_knowledge.txt.  The last element receives special treatment and is
+ * used to catch any type of monster not caught by the other categories.
+ * That's intended as a debugging tool while modding the game.
  */
-static struct
-{
-	const wchar_t *chars;
-	const char *name;
-} monster_group[] = {
-	{ (const wchar_t *)-1,   "Uniques" },
-	{ L"A",        "Ainur" },
-	{ L"a",        "Ants" },
-	{ L"b",        "Bats" },
-	{ L"B",        "Birds" },
-	{ L"C",        "Canines" },
-	{ L"c",        "Centipedes" },
-	{ L"uU",       "Demons" },
-	{ L"dD",       "Dragons" },
-	{ L"vE",       "Elementals/Vortices" },
-	{ L"e",        "Eyes/Beholders" },
-	{ L"f",        "Felines" },
-	{ L"G",        "Ghosts" },
-	{ L"OP",       "Giants/Ogres" },
-	{ L"g",        "Golems" },
-	{ L"H",        "Harpies/Hybrids" },
-	{ L"h",        "Hominids (Elves, Dwarves)" },
-	{ L"M",        "Hydras" },
-	{ L"i",        "Icky Things" },
-	{ L"FI",       "Insects" },
-	{ L"j",        "Jellies" },
-	{ L"K",        "Killer Beetles" },
-	{ L"k",        "Kobolds" },
-	{ L"L",        "Lichs" },
-	{ L"tp",       "Men" },
-	{ L"x$!?=~_",  "Mimics" },
-	{ L"m",        "Molds" },
-	{ L",",        "Mushroom Patches" },
-	{ L"n",        "Nagas" },
-	{ L"o",        "Orcs" },
-	{ L"q",        "Quadrupeds" },
-	{ L"Q",        "Quylthulgs" },
-	{ L"R",        "Reptiles/Amphibians" },
-	{ L"r",        "Rodents" },
-	{ L"S",        "Scorpions/Spiders" },
-	{ L"s",        "Skeletons/Drujs" },
-	{ L"J",        "Snakes" },
-	{ L"l",        "Trees/Ents" },
-	{ L"T",        "Trolls" },
-	{ L"V",        "Vampires" },
-	{ L"W",        "Wights/Wraiths" },
-	{ L"w",        "Worms/Worm Masses" },
-	{ L"X",        "Xorns/Xarens" },
-	{ L"y",        "Yeeks" },
-	{ L"Y",        "Yeti" },
-	{ L"Z",        "Zephyr Hounds" },
-	{ L"z",        "Zombies" },
-	{ NULL,       NULL }
-};
+static struct ui_monster_category *monster_group = NULL;
+
+/**
+ * Is the number of entries, including the last one receiving special
+ * treatment, in monster_group.
+ */
+static int n_monster_group = 0;
 
 /**
  * Display a monster
@@ -1191,14 +1161,35 @@ static int m_cmp_race(const void *a, const void *b)
 	if (c)
 		return c;
 
-	/* Order results */
-	c = r_a->d_char - r_b->d_char;
-	if (c && gid != 0) {
-		/* UNIQUE group is ordered by level & name only */
-		/* Others by order they appear in the group symbols */
-		return text_wcschr(monster_group[gid].chars, r_a->d_char)
-			- text_wcschr(monster_group[gid].chars, r_b->d_char);
+	/*
+	 * If the group specifies monster bases, order those that are included
+	 * by the base by those bases.  Those that aren't in any of the bases
+	 * appear last.
+	 */
+	assert(gid >= 0 && gid < n_monster_group);
+	if (monster_group[gid].n_inc_bases) {
+		int base_a = monster_group[gid].n_inc_bases;
+		int base_b = monster_group[gid].n_inc_bases;
+		int i;
+
+		for (i = 0; i < monster_group[gid].n_inc_bases; ++i) {
+			if (r_a->base == monster_group[gid].inc_bases[i]) {
+				base_a = i;
+			}
+			if (r_b->base == monster_group[gid].inc_bases[i]) {
+				base_b = i;
+			}
+		}
+		c = base_a - base_b;
+		if (c) {
+			return c;
+		}
 	}
+
+	/*
+	 * Within the same base or outside of a specified base, order by level
+	 * and then by name.
+	 */
 	c = r_a->level - r_b->level;
 	if (c)
 		return c;
@@ -1273,23 +1264,43 @@ static void mon_summary(int gid, const int *item_list, int n, int top,
 
 static int count_known_monsters(void)
 {
-	int m_count = 0;
-	int i;
-	size_t j;
+	int m_count = 0, i;
 
-	for (i = 0; i < z_info->r_max; i++) {
+	for (i = 0; i < z_info->r_max; ++i) {
 		struct monster_race *race = &r_info[i];
+		bool classified = false;
+		int j;
+
 		if (!l_list[i].all_known && !l_list[i].sights) {
 			continue;
 		}
-
 		if (!race->name) continue;
 
-		if (rf_has(race->flags, RF_UNIQUE)) m_count++;
+		for (j = 0; j < n_monster_group - 1; ++j) {
+			bool has_base = false;
 
-		for (j = 1; j < N_ELEMENTS(monster_group) - 1; j++) {
-			const wchar_t *pat = monster_group[j].chars;
-			if (text_wcschr(pat, race->d_char)) m_count++;
+			if (monster_group[j].n_inc_bases) {
+				int k;
+
+				for (k = 0; k < monster_group[j].n_inc_bases;
+						++k) {
+					if (race->base == monster_group[j].inc_bases[k]) {
+						++m_count;
+						has_base = true;
+						classified = true;
+						break;
+					}
+				}
+			}
+			if (!has_base && rf_is_inter(race->flags,
+					monster_group[j].inc_flags)) {
+				++m_count;
+				classified = true;
+			}
+		}
+
+		if (!classified) {
+			++m_count;
 		}
 	}
 
@@ -1301,53 +1312,66 @@ static int count_known_monsters(void)
  */
 static void do_cmd_knowledge_monsters(const char *name, int row)
 {
-	group_funcs r_funcs = {race_name, m_cmp_race, default_group_id, mon_summary,
-						   N_ELEMENTS(monster_group), false};
+	group_funcs r_funcs = {race_name, m_cmp_race, default_group_id,
+		mon_summary, n_monster_group, false };
 
 	member_funcs m_funcs = {display_monster, mon_lore, m_xchar, m_xattr,
-							recall_prompt, 0, 0};
+		recall_prompt, 0, 0};
 
 	int *monsters;
-	int m_count = 0;
-	int i;
-	size_t j;
-
-	for (i = 0; i < z_info->r_max; i++) {
-		struct monster_race *race = &r_info[i];
-		if (!l_list[i].all_known && !l_list[i].sights) {
-			continue;
-		}
-
-		if (!race->name) continue;
-
-		if (rf_has(race->flags, RF_UNIQUE)) m_count++;
-
-		for (j = 1; j < N_ELEMENTS(monster_group) - 1; j++) {
-			const wchar_t *pat = monster_group[j].chars;
-			if (text_wcschr(pat, race->d_char)) m_count++;
-		}
-	}
+	int m_count = count_known_monsters(), i, ind;
 
 	default_join = mem_zalloc(m_count * sizeof(join_t));
 	monsters = mem_zalloc(m_count * sizeof(int));
 
-	m_count = 0;
-	for (i = 0; i < z_info->r_max; i++) {
+	ind = 0;
+	for (i = 0; i < z_info->r_max; ++i) {
 		struct monster_race *race = &r_info[i];
+		bool classified = false;
+		int j;
+
 		if (!l_list[i].all_known && !l_list[i].sights) {
 			continue;
 		}
-
 		if (!race->name) continue;
 
-		for (j = 0; j < N_ELEMENTS(monster_group) - 1; j++) {
-			const wchar_t *pat = monster_group[j].chars;
-			if (j == 0 && !rf_has(race->flags, RF_UNIQUE)) continue;
-			if (j > 0 && !text_wcschr(pat, race->d_char)) continue;
+		for (j = 0; j < n_monster_group - 1; ++j) {
+			bool has_base = false;
 
-			monsters[m_count] = m_count;
-			default_join[m_count].oid = i;
-			default_join[m_count++].gid = j;
+			if (monster_group[j].n_inc_bases) {
+				int k;
+
+				for (k = 0; k < monster_group[j].n_inc_bases;
+						++k) {
+					if (race->base == monster_group[j].inc_bases[k]) {
+						assert(ind < m_count);
+						monsters[ind] = ind;
+						default_join[ind].oid = i;
+						default_join[ind].gid = j;
+						++ind;
+						has_base = true;
+						classified = true;
+						break;
+					}
+				}
+			}
+			if (!has_base && rf_is_inter(race->flags,
+					monster_group[j].inc_flags)) {
+				assert(ind < m_count);
+				monsters[ind] = ind;
+				default_join[ind].oid = i;
+				default_join[ind].gid = j;
+				++ind;
+				classified = true;
+			}
+		}
+
+		if (!classified) {
+			assert(ind < m_count);
+			monsters[ind] = ind;
+			default_join[ind].oid = i;
+			default_join[ind].gid = n_monster_group - 1;
+			++ind;
 		}
 	}
 
@@ -3170,6 +3194,190 @@ static void do_cmd_knowledge_shapechange(const char *name, int row)
 
 /**
  * ------------------------------------------------------------------------
+ * ui_knowledge.txt parsing
+ * ------------------------------------------------------------------------
+ */
+static enum parser_error parse_monster_category(struct parser *p)
+{
+	struct ui_knowledge_parse_state *s =
+		(struct ui_knowledge_parse_state*) parser_priv(p);
+	struct ui_monster_category *c;
+
+	assert(s);
+	c = mem_zalloc(sizeof(*c));
+	c->next = s->categories;
+	c->name = string_make(parser_getstr(p, "name"));
+	s->categories = c;
+	return PARSE_ERROR_NONE;
+}
+
+static enum parser_error parse_mcat_include_base(struct parser *p)
+{
+	struct ui_knowledge_parse_state *s =
+		(struct ui_knowledge_parse_state*) parser_priv(p);
+	struct monster_base *b;
+
+	assert(s);
+	if (!s->categories) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	b = lookup_monster_base(parser_getstr(p, "name"));
+	if (!b) {
+		return PARSE_ERROR_INVALID_MONSTER_BASE;
+	}
+	assert(s->categories->n_inc_bases >= 0
+		&& s->categories->n_inc_bases <= s->categories->max_inc_bases);
+	if (s->categories->n_inc_bases == s->categories->max_inc_bases) {
+		if (s->categories->max_inc_bases > INT_MAX
+				/ (2 * (int) sizeof(struct monster_base*))) {
+			return PARSE_ERROR_TOO_MANY_ENTRIES;
+		}
+		s->categories->max_inc_bases = (s->categories->max_inc_bases)
+			? 2 * s->categories->max_inc_bases : 2;
+		s->categories->inc_bases = mem_realloc(
+			s->categories->inc_bases,
+			s->categories->max_inc_bases
+			* sizeof(struct monster_base*));
+	}
+	s->categories->inc_bases[s->categories->n_inc_bases] = b;
+	++s->categories->n_inc_bases;
+
+	return PARSE_ERROR_NONE;
+}
+
+static enum parser_error parse_mcat_include_flag(struct parser *p)
+{
+	struct ui_knowledge_parse_state *s =
+		(struct ui_knowledge_parse_state*) parser_priv(p);
+	char *flags, *next_flag;
+
+	assert(s);
+	if (!s->categories) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+
+	if (!parser_hasval(p, "flags")) {
+		return PARSE_ERROR_NONE;
+	}
+	flags = string_make(parser_getstr(p, "flags"));
+	next_flag = strtok(flags, " |");
+	while (next_flag) {
+		if (grab_flag(s->categories->inc_flags, RF_SIZE, r_info_flags,
+				next_flag)) {
+			string_free(flags);
+			return PARSE_ERROR_INVALID_FLAG;
+		}
+		next_flag = strtok(NULL, " |");
+	}
+	string_free(flags);
+
+	return PARSE_ERROR_NONE;
+}
+
+static struct parser *init_ui_knowledge_parser(void)
+{
+	struct ui_knowledge_parse_state *s = mem_zalloc(sizeof(*s));
+	struct parser *p = parser_new();
+
+	parser_setpriv(p, s);
+	parser_reg(p, "monster-category str name", parse_monster_category);
+	parser_reg(p, "mcat-include-base str name", parse_mcat_include_base);
+	parser_reg(p, "mcat-include-flag ?str flags", parse_mcat_include_flag);
+
+	return p;
+}
+
+static errr run_ui_knowledge_parser(struct parser *p)
+{
+	return parse_file_quit_not_found(p, "ui_knowledge");
+}
+
+static errr finish_ui_knowledge_parser(struct parser *p)
+{
+	struct ui_knowledge_parse_state *s =
+		(struct ui_knowledge_parse_state*) parser_priv(p);
+	struct ui_monster_category *cursor;
+	size_t count;
+
+	assert(s);
+
+	/* Count the number of categories and allocate a flat array for them. */
+	count = 0;
+	for (cursor = s->categories; cursor; cursor = cursor->next) {
+		++count;
+	}
+	if (count > INT_MAX - 1) {
+		/*
+		 * The sorting and display logic for monster groups assumes
+		 * the number of categories fits in an int.
+		 */
+		cursor = s->categories;
+		while (cursor) {
+			struct ui_monster_category *tgt = cursor;
+
+			cursor = cursor->next;
+			string_free((char*) tgt->name);
+			mem_free(tgt->inc_bases);
+			mem_free(tgt);
+		}
+		mem_free(s);
+		parser_destroy(p);
+		return PARSE_ERROR_TOO_MANY_ENTRIES;
+	}
+	if (monster_group) {
+		cleanup_ui_knowledge_parsed_data();
+	}
+	monster_group = mem_alloc((count + 1) * sizeof(*monster_group));
+	n_monster_group = (int) (count + 1);
+
+	/* Set the element at the end which receives special treatment. */
+	monster_group[count].next = NULL;
+	monster_group[count].name = string_make("***Unclassified***");
+	monster_group[count].inc_bases = NULL;
+	rf_wipe(monster_group[count].inc_flags);
+	monster_group[count].n_inc_bases = 0;
+	monster_group[count].max_inc_bases = 0;
+
+	/*
+	 * Set the others, restoring the order they had in the data file.
+	 * Release the memory for the linked list (but not pointed to data
+	 * as ownership for that is transferred to the flat array).
+	 */
+	cursor = s->categories;
+	while (cursor) {
+		struct ui_monster_category *src = cursor;
+
+		cursor = cursor->next;
+		--count;
+		monster_group[count].next = monster_group + count + 1;
+		monster_group[count].name = src->name;
+		monster_group[count].inc_bases = src->inc_bases;
+		rf_copy(monster_group[count].inc_flags, src->inc_flags);
+		monster_group[count].n_inc_bases = src->n_inc_bases;
+		monster_group[count].max_inc_bases = src->max_inc_bases;
+		mem_free(src);
+	}
+
+	mem_free(s);
+	parser_destroy(p);
+	return 0;
+}
+
+static void cleanup_ui_knowledge_parsed_data(void)
+{
+	int i;
+
+	for (i = 0; i < n_monster_group; ++i) {
+		string_free((char*) monster_group[i].name);
+		mem_free(monster_group[i].inc_bases);
+	}
+	mem_free(monster_group);
+	monster_group = NULL;
+	n_monster_group = 0;
+}
+
+/**
+ * ------------------------------------------------------------------------
  * Main knowledge menus
  * ------------------------------------------------------------------------ */
 
@@ -3260,6 +3468,10 @@ void textui_knowledge_init(void)
 	menu->keys_hook = handle_store_shortcuts;
 
 	/* initialize other static variables */
+	if (run_parser(&ui_knowledge_parser) != PARSE_ERROR_NONE) {
+		quit_fmt("Encountered error parsing ui_knowledge.txt");
+	}
+
 	if (!obj_group_order) {
 		int i;
 		int gid = -1;
@@ -3283,6 +3495,7 @@ void textui_knowledge_cleanup(void)
 {
 	mem_free(obj_group_order);
 	obj_group_order = NULL;
+	cleanup_parser(&ui_knowledge_parser);
 }
 
 

--- a/src/ui-knowledge.h
+++ b/src/ui-knowledge.h
@@ -19,6 +19,9 @@
 #ifndef UI_KNOWLEDGE_H
 #define UI_KNOWLEDGE_H
 
+#include "datafile.h"
+#include "monster.h"
+
 void textui_browse_object_knowledge(const char *name, int row);
 void textui_knowledge_init(void);
 void textui_knowledge_cleanup(void);
@@ -35,5 +38,18 @@ void do_cmd_query_symbol(void);
 void do_cmd_center_map(void);
 void do_cmd_monlist(void);
 void do_cmd_itemlist(void);
+
+/* Exposed for use by test cases. */
+struct ui_monster_category {
+	struct ui_monster_category *next;
+	const char *name;
+	const struct monster_base **inc_bases;
+	bitflag inc_flags[RF_SIZE];
+	int n_inc_bases, max_inc_bases;
+};
+struct ui_knowledge_parse_state {
+	struct ui_monster_category *categories;
+};
+extern struct file_parser ui_knowledge_parser;
 
 #endif /* UI_KNOWLEDGE_H */

--- a/src/win/vs2019/Angband.vcxproj
+++ b/src/win/vs2019/Angband.vcxproj
@@ -606,6 +606,7 @@ xcopy $(MSBuildProjectDirectory)\lib\* $(OutDir)lib\ /DESY /exclude:$(MSBuildPro
     <Text Include="lib\gamedata\ui_entry.txt" />
     <Text Include="lib\gamedata\ui_entry_base.txt" />
     <Text Include="lib\gamedata\ui_entry_renderer.txt" />
+    <Text Include="lib\gamedata\ui_knowledge.txt" />
     <Text Include="lib\gamedata\vault.txt" />
     <Text Include="lib\gamedata\visuals.txt" />
     <Text Include="lib\gamedata\world.txt" />

--- a/src/win/vs2019/Angband.vcxproj.filters
+++ b/src/win/vs2019/Angband.vcxproj.filters
@@ -1360,6 +1360,9 @@
     <Text Include="lib\gamedata\ui_entry_renderer.txt">
       <Filter>Resource Files\gamedata</Filter>
     </Text>
+    <Text Include="lib\gamedata\ui_knowledge.txt">
+      <Filter>Resource Files\gamedata</Filter>
+    </Text>
     <Text Include="lib\gamedata\vault.txt">
       <Filter>Resource Files\gamedata</Filter>
     </Text>


### PR DESCRIPTION
… ui_knowledge.txt.  Will change the displayed order within the "Mimics" category (was lurker/trapper, creeping coins, potion mimic, scroll mimic, ring mimic, and chest mimic; now will be lurker/trapper, creeping coins, and then all other mimics sorted by level and then by name).

One reason to do that is to avoid hardcoding the list of categories (and monster base symbols) into ui-knowledge.c.  The ulterior motive for this is to avoid the checking of monster base symbols in ui-knowledge.c which will simplify implementing #5499 .