### PR TITLE
Avoid format overflow warnings (compiler detects that a NULL could be…

### DIFF
--- a/src/ui-prefs.c
+++ b/src/ui-prefs.c
@@ -255,7 +255,7 @@ void dump_features(ang_file *fff)
 			uint8_t attr = feat_x_attr[j][i];
 			wint_t chr = feat_x_char[j][i];
 
-			const char *light = NULL;
+			const char *light = "";
 			if (j == LIGHTING_TORCH)
 				light = "torch";
 			if (j == LIGHTING_LOS)
@@ -265,7 +265,7 @@ void dump_features(ang_file *fff)
 			else if (j == LIGHTING_DARK)
 				light = "dark";
 
-			assert(light);
+			assert(light[0]);
 
 			file_putf(fff, "feat:%s:%s:%d:%d\n", feat->name, light, attr, chr);
 		}

--- a/src/ui-spell.c
+++ b/src/ui-spell.c
@@ -73,7 +73,7 @@ static void spell_menu_display(struct menu *m, int oid, bool cursor,
 
 	int attr;
 	const char *illegible = NULL;
-	const char *comment = NULL;
+	const char *comment = "";
 
 	if (!spell) return;
 


### PR DESCRIPTION
… passed to a %s format specifier) with the msys2, Nintendo 3DS, and DOS compilers.