### PR TITLE
SDL: fix cmp_font() for when neither font name matches the expected …

### DIFF
--- a/src/main-sdl.c
+++ b/src/main-sdl.c
@@ -5626,7 +5626,7 @@ static int cmp_font(const void *f1, const void *f2)
 			 * Neither match the expected pattern.  Sort
 			 * alphabetically.
 			 */
-			return strcmp(f1, f2);
+			return strcmp(font1, font2);
 		}
 		/*
 		 * Put f2 first, since it matches the expected pattern.


### PR DESCRIPTION
…pattern; from s88100's commit to PWMAngband here, https://github.com/draconisPW/PWMAngband/commit/a6032f71bd27543ac83aeeaf8c43ddd640172556