### PR TITLE
Fix crash if there is a multi-realm caster class

### DIFF
--- a/src/player-spell.c
+++ b/src/player-spell.c
@@ -200,6 +200,7 @@ struct magic_realm *class_magic_realms(const struct player_class *c, int *count)
 
 		/* Add it */
 		r_test = mem_zalloc(sizeof(struct magic_realm));
+		memcpy(r_test, book->realm, sizeof(struct magic_realm));
 		r_test->next = r;
 		r = r_test;
 		(*count)++;


### PR DESCRIPTION
Items after the first one in magic_realm linked list are not initialized, leading to a crash if you define a multi-realm caster class.