### PR TITLE
Fix crash when using wizard commands to re-roll a previously IDed ego…

### DIFF
--- a/src/cmd-wizard.c
+++ b/src/cmd-wizard.c
@@ -2362,6 +2362,7 @@ void do_cmd_wiz_reroll_item(struct command *cmd)
 		obj->prev = prev;
 		obj->next = next;
 		obj->known = known_obj;
+		obj->known->ego = obj->ego;
 		obj->oidx = oidx;
 		obj->grid = grid;
 		obj->notice = notice;


### PR DESCRIPTION
If you have a previously IDed ego item, and use the wizard command ^A-o to reroll it (as an ego), occasionally a normal item (non-ego) is generated, which causes a crash in obj_desc_name because obj->known->ego is non-null, but obj->ego is null:

```
else if ((obj->known->ego && !(mode & ODESC_NOEGO)) || (obj->ego && store))
		strnfcat(buf, max, &end, " %s", obj->ego->name);
```

```
Program received signal SIGSEGV, Segmentation fault.
obj_desc_name (buf=0x7fffb61f98c0 "a Pair of Leather Sandals", max=256, end=25, obj=0x55c5bddafd68, prefix=true, mode=99, terse=false, 
    p=0x55c5bdc3ba08) at obj-desc.c:330
330			strnfcat(buf, max, &end, " %s", obj->ego->name);
(gdb) bt
#0  obj_desc_name (buf=0x7fffb61f98c0 "a Pair of Leather Sandals", max=256, end=25, obj=0x55c5bddafd68, prefix=true, mode=99, terse=false, 
    p=0x55c5bdc3ba08) at obj-desc.c:330
#1  0x000055c5bbe9e85b in object_desc (buf=0x7fffb61f98c0 "a Pair of Leather Sandals", max=256, obj=0x55c5bddafd68, mode=99, p=0x55c5bdc3ba08)
    at obj-desc.c:634
#2  0x000055c5bbe336d2 in wiz_display_item (obj=0x55c5bddafd68, all=true, p=0x55c5bdc3ba08) at cmd-wizard.c:215
#3  0x000055c5bbe37271 in do_cmd_wiz_play_item (cmd=0x55c5bbfde540 <cmd_queue+1056>) at cmd-wizard.c:1703
#4  0x000055c5bbe2ecd1 in process_command (ctx=CTX_GAME, cmd=0x55c5bbfde540 <cmd_queue+1056>) at cmd-core.c:289
#5  0x000055c5bbe2eddc in cmdq_pop (c=CTX_GAME) at cmd-core.c:318
#6  0x000055c5bbe4eed4 in process_player () at game-world.c:970
#7  0x000055c5bbe4f228 in run_game_loop () at game-world.c:1080
#8  0x000055c5bbf1cfaa in play_game (mode=GAME_SELECT) at ui-game.c:912
#9  0x000055c5bbf5e14f in main (argc=1, argv=0x7fffb61f9c68) at main.c:547
```
