### PR TITLE
Fix a possible NULL dereference

### DIFF
--- a/src/effect-handler-general.c
+++ b/src/effect-handler-general.c
@@ -1344,7 +1344,7 @@ bool effect_handler_DETECT_TRAPS(effect_handler_context_t *context)
 				}
 
 				/* Identify once */
-				if (!obj->known || obj->known->pval != obj->pval) {
+				if (obj->known && obj->known->pval != obj->pval) {
 					/* Hack - know the pile */
 					square_know_pile(cave, grid);
 


### PR DESCRIPTION
Fix the following MSVC/clang-tidy code analysis warning:
>src\effect-handler-general.c(1286,23): warning G5C0E2821: Access to field 'pval' results in a dereference of a null pointer (loaded from field 'known') [clang-analyzer-core.NullDereference]
>                                        obj->known->pval = obj->pval;
>
>src\effect-handler-general.c:1281:9: note: Assuming field 'known' is null
>                                if (!obj->known || obj->known->pval != obj->pval) {
>                                    ^~~~~~~~~~~
>src\effect-handler-general.c:1281:21: note: Left side of '||' is true
>                                if (!obj->known || obj->known->pval != obj->pval) {
>                                                ^
>src\effect-handler-general.c:1286:23: note: Access to field 'pval' results in a dereference of a null pointer (loaded from field 'known')
>                                        obj->known->pval = obj->pval;

Note: the check is done against an old code so the line number does not match.
