### PR TITLE
SDL2: return early in pict hook if tiles aren't enabled rather than …

### DIFF
--- a/src/main-sdl2.c
+++ b/src/main-sdl2.c
@@ -4020,6 +4020,14 @@ static errr term_pict_hook(int col, int row, int n,
 	struct subwindow *subwindow = Term->data;
 	assert(subwindow != NULL);
 
+	if (!current_graphics_mode || current_graphics_mode->grafID == GRAPHICS_NONE) {
+		/*
+		 * Do nothing unsuccessfully if asked to draw a tile while
+		 * they're not enabled.  Could proceed in this function
+		 * with no apparent ill effects, but that just wastes time.
+		 */
+		return -1;
+	}
 	assert(subwindow->window->graphics.texture != NULL);
 
 	if (subwindow->window->graphics.overdraw_row) {


### PR DESCRIPTION
…trigger an assertion; avoids the crashes reported in https://github.com/angband/angband/issues/5597 and https://github.com/angband/angband/issues/5592 .