### PR TITLE
Loosen coupling between MAX_COLORS and the BG_* constants.  Cut color…

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -3959,7 +3959,7 @@ static int get_background_color_index(int idx)
 {
     int ibkg = COLOUR_DARK;
 
-    switch (idx / MAX_COLORS) {
+    switch (idx / MULT_BG) {
     case BG_BLACK:
 	/* There's nothing to do. */
 	break;

--- a/src/main-gcu.c
+++ b/src/main-gcu.c
@@ -1146,7 +1146,7 @@ static errr Term_text_gcu(int x, int y, int n, int a, const wchar_t *s) {
 		int color;
 
 		/* Set bg and fg to the same color when drawing solid walls */
-		if (a / MAX_COLORS == BG_SAME) {
+		if (a / MULT_BG == BG_SAME) {
 			color = same_colortable[attr];
 		} else {
 			color = colortable[attr];

--- a/src/main-sdl.c
+++ b/src/main-sdl.c
@@ -4905,7 +4905,7 @@ static errr Term_text_sdl(int col, int row, int n, int a, const wchar_t *s)
 	mbstr[len] = '\0';
 
 	/* Handle background */
-	switch (a / MAX_COLORS)
+	switch (a / MULT_BG)
 	{
 		case BG_BLACK:
 			/* Default Background */

--- a/src/main-sdl2.c
+++ b/src/main-sdl2.c
@@ -988,7 +988,7 @@ static void render_grid_cell_text(const struct subwindow *subwindow,
 	SDL_Color fg = g_colors[a % MAX_COLORS];
 	SDL_Color bg;
 
-	switch (ta / MAX_COLORS) {
+	switch (ta / MULT_BG) {
 		case BG_BLACK:
 			bg = subwindow->color;
 			break;
@@ -3973,7 +3973,7 @@ static errr term_text_hook(int col, int row, int n, int a, const wchar_t *s)
 	SDL_Color fg = g_colors[a % MAX_COLORS];
 	SDL_Color bg;
 
-	switch (a / MAX_COLORS) {
+	switch (a / MULT_BG) {
 		case BG_BLACK:
 			bg = subwindow->color;
 			break;

--- a/src/main-win.c
+++ b/src/main-win.c
@@ -2112,7 +2112,7 @@ static errr Term_text_win(int x, int y, int n, int a, const wchar_t *s)
 			SetTextColor(hdc, win_clr[a % MAX_COLORS]);
 
 		/* Determine the background colour - from Sil */
-		switch (a / MAX_COLORS)
+		switch (a / MULT_BG)
 		{
 			case BG_SAME:
 				/* Background same as foreground*/

--- a/src/main-x11.c
+++ b/src/main-x11.c
@@ -2020,7 +2020,32 @@ static errr Term_xtra_x11_react(void)
 					}
 				} else if (i == COLOUR_WHITE) {
 					Metadpy->fg = pixel;
+				} else if (i == COLOUR_SHADE) {
+					int j;
+
+					/*
+					 * For all colors, modify the variant
+					 * that uses COLOUR_SHADE as the
+					 * background.
+					 */
+					for (j = BG_DARK * MAX_COLORS;
+							j < (BG_DARK + 1)
+							* MAX_COLORS; ++j) {
+						Infoclr_set(clr[j]);
+						Infoclr_change_bg(pixel);
+					}
 				}
+
+				/*
+				 * Also modify the variants of this color
+				 * which uses the color itself as the
+				 * background or COLOUR_SHADE as the background.
+				 */
+				Infoclr_set(clr[i + BG_SAME * MAX_COLORS]);
+				Infoclr_change_fg(pixel);
+				Infoclr_change_bg(pixel);
+				Infoclr_set(clr[i + BG_DARK * MAX_COLORS]);
+				Infoclr_change_fg(pixel);
 			}
 		}
 
@@ -2140,7 +2165,7 @@ static errr Term_wipe_x11(int x, int y, int n)
 static errr Term_text_x11(int x, int y, int n, int a, const wchar_t *s)
 {
 	/* Draw the text */
-	Infoclr_set(clr[a]);
+	Infoclr_set(clr[(a / MULT_BG) * MAX_COLORS + (a % MAX_COLORS)]);
 
 	/* Draw the text */
 	Infofnt_text_std(x, y, s, n);

--- a/src/ui-command.c
+++ b/src/ui-command.c
@@ -393,7 +393,7 @@ void html_screenshot(const char *path, int mode, term *other_term)
 
 			/* Set the foreground and background */
 			fg_colour = a % MAX_COLORS;
-			switch (a / MAX_COLORS)
+			switch (a / MULT_BG)
 			{
 				case BG_BLACK:
 					bg_colour = COLOUR_DARK;
@@ -405,7 +405,8 @@ void html_screenshot(const char *path, int mode, term *other_term)
 					bg_colour = COLOUR_SHADE;
 					break;
 				default:
-				assert((a >= BG_BLACK) && (a < BG_MAX * MAX_COLORS));
+					assert((a >= 0)
+						&& (a < BG_MAX * MULT_BG));
 			}
 
 			/*

--- a/src/ui-map.c
+++ b/src/ui-map.c
@@ -131,9 +131,9 @@ static void grid_get_attr(struct grid_data *g, int *a)
 	/* Hybrid or block walls */
 	if (use_graphics == GRAPHICS_NONE && feat_is_wall(g->f_idx)) {
 		if (OPT(player, hybrid_walls))
-			*a = *a + (MAX_COLORS * BG_DARK);
+			*a = *a + (MULT_BG * BG_DARK);
 		else if (OPT(player, solid_walls))
-			*a = *a + (MAX_COLORS * BG_SAME);
+			*a = *a + (MULT_BG * BG_SAME);
 	}
 }
 

--- a/src/ui-options.c
+++ b/src/ui-options.c
@@ -919,10 +919,18 @@ static void colors_modify(const char *title, int row)
 		if (cx.code == ESCAPE) break;
 
 		/* Analyze */
-		if (cx.code == 'n')
+		if (cx.code == 'n') {
 			a = (uint8_t)(a + 1);
-		if (cx.code == 'N')
+			if (a >= MAX_COLORS) {
+				a = 0;
+			}
+		}
+		if (cx.code == 'N') {
 			a = (uint8_t)(a - 1);
+			if (a >= MAX_COLORS) {
+				a = MAX_COLORS - 1;
+			}
+		}
 		if (cx.code == 'k')
 			angband_color_table[a][0] =
 				(uint8_t)(angband_color_table[a][0] + 1);

--- a/src/ui-prefs.c
+++ b/src/ui-prefs.c
@@ -1018,8 +1018,17 @@ static enum parser_error parse_prefs_color(struct parser *p)
 	if (d->bypass) return PARSE_ERROR_NONE;
 
 	idx = parser_getuint(p, "idx");
-	if (idx > MAX_COLORS)
-		return PARSE_ERROR_OUT_OF_BOUNDS;
+	if (idx >= MAX_COLORS) {
+		/*
+		 * Silently ignore indices that would have been in bounds for
+		 * Angband 4.2.4 or earlier (color table was 256 then) for
+		 * backwards compatibility with existing preference files.
+		 * Flag indices that would be out of bounds even with 4.2.4's
+		 * bigger color table.
+		 */
+		return (idx < 256) ?
+			PARSE_ERROR_NONE : PARSE_ERROR_OUT_OF_BOUNDS;
+	}
 
 	angband_color_table[idx][0] = parser_getint(p, "k");
 	angband_color_table[idx][1] = parser_getint(p, "r");

--- a/src/z-color.h
+++ b/src/z-color.h
@@ -70,9 +70,20 @@
 
 /**
  * Maximum number of colours, and number of "basic" Angband colours
+ * Limit the maximum to be less than or equal to 128 since the 7th bit (i.e.
+ * 128 or 0x80) in color indices is used to trigger tile rendering with the
+ * front ends that set higher_pict to true in struct term.
  */ 
-#define MAX_COLORS        256
+#define MAX_COLORS      32
 #define BASIC_COLORS    29
+/**
+ * This is the multiplier for the BG_* constants.  Must be a multiple of
+ * MAX_COLORS (so (c + MULT_BG * BG_x) % MAX_COLORS is equal to c for 0 <= c
+ * < MAX_COLORS) and (MULT_BG * BG_x) & 0x80 must be zero to avoid triggering
+ * tile rendering with the front ends that set higher_pict to true in
+ * struct term.
+ */
+#define MULT_BG 256
 #define BG_BLACK 0	/* The set number for the black-background glyphs */
 #define BG_SAME  1	/* The set number for the same-background glyphs */
 #define BG_DARK  2	/* The set number for the dark-background glyphs */


### PR DESCRIPTION
… table size from 256 to 32.  Resolves https://github.com/angband/angband/issues/5597 (no more color table indices >= 128 that can trigger tile rendering).  In the X11 front end, update the colors used for BG_SAME and BG_SHADE when customized colors are loaded.