### PR TITLE
Version 1.3.0 of libwebp (msys2 packages updated to that from 1.2.4 …

### DIFF
--- a/src/Makefile.msys2.sdl2
+++ b/src/Makefile.msys2.sdl2
@@ -48,6 +48,7 @@ VIDEO_sdl2_ldflags := \
 	-ljxl \
 	-lhwy \
 	-lwebp \
+	-lsharpyuv \
 	-lfreetype \
 	-lharfbuzz \
 	-lDwrite \


### PR DESCRIPTION
…on 2023/1/13) has libsharpyuv as a dependency.

Should resolve workflow failures for SDL2 under msys2.