### PR TITLE
Fix segfault after player death and starting a new game

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -4207,6 +4207,7 @@ void cleanup_angband(void)
 	if (cave) {
 		cave_free(cave);
 		cave = NULL;
+		character_dungeon = false;
 	}
 
 	monster_list_finalize();


### PR DESCRIPTION
This bug can be triggered by starting angband with: ./src/angband -c

Enabling the animate_flicker option, killing your character, and choosing to start a new game.

The crash occurs because ui-display.c idle_update() calls functions expecting `cave` pointer to be valid.