### PR TITLE
Avoid use after free when an error is reported from a parser's finish method

### DIFF
--- a/src/datafile.c
+++ b/src/datafile.c
@@ -63,8 +63,13 @@ errr run_parser(struct file_parser *fp) {
 		return r;
 	}
 	r = fp->finish(p);
-	if (r)
-		print_error(fp, p);
+	if (r) {
+		msg("Parser finish error in %s: %s", fp->name,
+			(r > 0 && r < PARSE_ERROR_MAX) ?
+			parser_error_str[r] : "unspecified error");
+		event_signal(EVENT_MESSAGE_FLUSH);
+		quit_fmt("Parser finish error in %s.", fp->name);
+	}
 	return r;
 }
 

--- a/src/ui-entry.c
+++ b/src/ui-entry.c
@@ -2275,7 +2275,7 @@ static errr finish_parse_ui_entry(struct parser *p)
 	int i;
 
 	if (hatch_last_embryo(p)) {
-		result = 1;
+		result = -1;
 	}
 	for (i = 0; i < n_entry; ++i) {
 		int j;
@@ -2296,10 +2296,10 @@ static errr finish_parse_ui_entry(struct parser *p)
 				if (n2 != (size_t)-1) {
 					entries[i]->nlabel = n;
 				} else {
-					result = 1;
+					result = -1;
 				}
 			} else {
-				result = 1;
+				result = -1;
 			}
 		}
 		fill_out_shortened(entries[i]);


### PR DESCRIPTION
Resolves PowerWyrm's report here, http://angband.oook.cz/forum/showthread.php?t=11459 .