### PR TITLE
"Drop All" command key in rogue keymap mode

### DIFF
--- a/src/ui-context.c
+++ b/src/ui-context.c
@@ -729,7 +729,7 @@ int context_menu_object(struct object *obj)
 
 			if (obj->number > 1) {
 				/* 'D' is used for ignore in rogue keymap, so swap letters. */
-				cmdkey = (mode == KEYMAP_MODE_ORIG) ? 'D' : 'k';
+				cmdkey = (mode == KEYMAP_MODE_ORIG) ? 'D' : 'A';
 				menu_dynamic_add_label(m, "Drop All", cmdkey,
 									   MENU_VALUE_DROP_ALL, labels);
 			}
@@ -738,7 +738,7 @@ int context_menu_object(struct object *obj)
 
 			if (obj->number > 1) {
 				/* 'D' is used for ignore in rogue keymap, so swap letters. */
-				cmdkey = (mode == KEYMAP_MODE_ORIG) ? 'D' : 'k';
+				cmdkey = (mode == KEYMAP_MODE_ORIG) ? 'D' : 'A';
 				menu_dynamic_add_label(m, "Drop All", cmdkey,
 									   MENU_VALUE_DROP_ALL, labels);
 			}


### PR DESCRIPTION
The "Drop All" command key is currently 'k' in rogue keymap mode in the item context submenu of the inventory menu.  In all other menus 'j' and 'k' can be used to navigate up and down to select a menu item.  I propose this be changed to 'A'.