### PR TITLE
Avoid using sscanf()

### DIFF
--- a/src/datafile.c
+++ b/src/datafile.c
@@ -156,29 +156,53 @@ int code_index_in_array(const char *code_name[], const char *code)
  * Gets a name and argument for a value expression of the form NAME[arg]
  * \param name_and_value is the expression
  * \param string is the random value string to return (NULL if not required)
+ * \param nstring is the maximum number of bytes to write to string; not used
+ * if string is NULL
  * \param num is the integer to return (NULL if not required)
  */
-static bool find_value_arg(char *value_name, char *string, int *num)
+static bool find_value_arg(char *value_name, char *string, size_t nstring,
+		int *num)
 {
-	char *t;
-
 	/* Find the first bracket */
-	for (t = value_name; *t && (*t != '['); ++t)
-		;
+	char *to = strchr(value_name, '[');
+
+	if (!to) {
+		return false;
+	}
 
 	/* Choose random_value value or int or fail */
 	if (string) {
-		/* Get the dice */
-		if (1 != sscanf(t + 1, "%s", string))
+		/* Find the closing bracket. */
+		char *tc = strchr(to + 1, ']');
+
+		if (!tc || (size_t)(tc - to) > nstring) {
 			return false;
+		}
+		/* Get the dice */
+		memcpy(string, to + 1, tc - (to + 1));
+		string[tc - (to + 1)] = '\0';
 	} else if (num) {
 		/* Get the value */
-		if (1 != sscanf(t + 1, "%d", num))
-			return false;
-	} else return false;
+		char *tc;
+		long lv = strtol(to + 1, &tc, 10);
 
-	/* Terminate the string */
-	*t = '\0';
+		/*
+		 * Also reject INT_MIN and INT_MAX so don't have to check errno
+		 * to detect overflow when sizeof(long) == sizeof(int).
+		 */
+		if (*tc != ']' || lv <= INT_MIN || lv >= INT_MAX) {
+			return false;
+		}
+		*num = (int)lv;
+	} else {
+		return false;
+	}
+
+	/*
+	 * Put a null where the opening bracket is; make it easier for the
+	 * caller to handle the name.
+	 */
+	*to = '\0';
 
 	/* Success */
 	return true;
@@ -196,22 +220,23 @@ errr grab_rand_value(random_value *value, const char **value_type,
 					 const char *name_and_value)
 {
 	int i = 0;
-	char value_name[80];
+	/* Get a rewritable string */
+	char *value_name = string_make(name_and_value);
 	char dice_string[40];
 	dice_t *dice;
 
-	/* Get a rewritable string */
-	my_strcpy(value_name, name_and_value, strlen(name_and_value));
-
 	/* Parse the value expression */
-	if (!find_value_arg(value_name, dice_string, NULL))
+	if (!find_value_arg(value_name, dice_string, sizeof(dice_string), NULL)) {
+		string_free(value_name);
 		return PARSE_ERROR_INVALID_VALUE;
+	}
 
 	dice = dice_new();
 
 	while (value_type[i] && !streq(value_type[i], value_name))
 		i++;
 
+	string_free(value_name);
 	if (value_type[i]) {
 		if (!dice_parse_string(dice, dice_string)) {
 			dice_free(dice);
@@ -237,22 +262,75 @@ errr grab_int_value(int *value, const char **value_type,
 					const char *name_and_value)
 {
 	int val, i = 0;
-	char value_name[80];
-
 	/* Get a rewritable string */
-	my_strcpy(value_name, name_and_value, strlen(name_and_value));
+	char *value_name = string_make(name_and_value);
 
 	/* Parse the value expression */
-	if (!find_value_arg(value_name, NULL, &val))
+	if (!find_value_arg(value_name, NULL, 0, &val)) {
+		string_free(value_name);
 		return PARSE_ERROR_INVALID_VALUE;
+	}
 
 	while (value_type[i] && !streq(value_type[i], value_name))
 		i++;
 
+	string_free(value_name);
 	if (value_type[i])
 		value[i] = val;
 
 	return value_type[i] ? PARSE_ERROR_NONE : PARSE_ERROR_INTERNAL;
+}
+
+/**
+ * Parse a string expected to be of the form "<int><whitespace>
+ * <optional fixed string><whitespace><int>".
+ *
+ * \param lo will be dereferenced and set to the first integer in the string
+ * if the return value is PARSE_ERROR_NONE.
+ * \param hi will be dereferenced and set to the second integer in the string
+ * if the return value is PARSE_ERROR_NONE.
+ * \param range is the string to parse.
+ * \param sep is the optional string separating the two integers.  It may be
+ * NULL.  If not NULL, it must neither start nor end with whitespace.
+ * \return PARSE_ERROR_NONE if successful, otherwise an error value.
+ */
+errr grab_int_range(int *lo, int *hi, const char *range, const char *sep)
+{
+	char *pe;
+	long lv1 = strtol(range, &pe, 10), lv2;
+
+	/*
+	 * Reject INT_MIN and INT_MAX as well so don't have to check errno in
+	 * order to recognize overflow when sizeof(int) == sizeof(long).
+	 */
+	if (pe == range || !isspace(*pe) || lv1 <= INT_MIN || lv1 >= INT_MAX) {
+		return PARSE_ERROR_INVALID_VALUE;
+	}
+	range = pe;
+	if (sep) {
+		size_t nonwhite_offset;
+
+		pe = strstr(range, sep);
+		if (!pe) {
+			return PARSE_ERROR_INVALID_VALUE;
+		}
+		nonwhite_offset = strspn(range, " \t");
+		if (range + nonwhite_offset != pe) {
+			return PARSE_ERROR_INVALID_VALUE;
+		}
+		range = pe + strlen(sep);
+		if (!isspace(*range)) {
+			return PARSE_ERROR_INVALID_VALUE;
+		}
+	}
+	lv2 = strtol(range, &pe, 10);
+	if (pe == range || !contains_only_spaces(pe) || lv2 <= INT_MIN
+			|| lv2 >= INT_MAX) {
+		return PARSE_ERROR_INVALID_VALUE;
+	}
+	*lo = (int)lv1;
+	*hi = (int)lv2;
+	return PARSE_ERROR_NONE;
 }
 
 /**
@@ -269,24 +347,26 @@ errr grab_index_and_int(int *value, int *index, const char **value_type,
 						const char *prefix, const char *name_and_value)
 {
 	int i;
-	char value_name[80];
-	char value_string[80];
-
 	/* Get a rewritable string */
-	my_strcpy(value_name, name_and_value, strlen(name_and_value));
+	char *value_name = string_make(name_and_value);
+	char *value_string = string_make(prefix);
 
 	/* Parse the value expression */
-	if (!find_value_arg(value_name, NULL, value))
+	if (!find_value_arg(value_name, NULL, 0, value)) {
+		string_free(value_string);
+		string_free(value_name);
 		return PARSE_ERROR_INVALID_VALUE;
+	}
 
 	/* Compose the value string and look for it */
 	for (i = 0; value_type[i]; i++) {
-		my_strcpy(value_string, prefix, sizeof(value_string));
-		my_strcat(value_string, value_type[i],
-				  sizeof(value_string) - strlen(value_string));
+		value_string = string_append(value_string, value_type[i]);
 		if (streq(value_string, value_name)) break;
+		my_strcpy(value_string, prefix, strlen(prefix) + 1);
 	}
 
+	free(value_string);
+	free(value_name);
 	if (value_type[i])
 		*index = i;
 
@@ -303,20 +383,22 @@ errr grab_index_and_int(int *value, int *index, const char **value_type,
  */
 errr grab_base_and_int(int *value, char **base, const char *name_and_value)
 {
-	char value_name[80];
-
 	/* Get a rewritable string */
-	my_strcpy(value_name, name_and_value, strlen(name_and_value));
+	char *value_name = string_make(name_and_value);
 
 	/* Parse the value expression */
-	if (!find_value_arg(value_name, NULL, value))
+	if (!find_value_arg(value_name, NULL, 0, value)) {
+		string_free(value_name);
 		return PARSE_ERROR_INVALID_VALUE;
+	}
 
 	/* Must be a slay */
-	if (strncmp(value_name, "SLAY_", 5))
+	if (strncmp(value_name, "SLAY_", 5)) {
+		string_free(value_name);
 		return PARSE_ERROR_INVALID_VALUE;
-	else
-		*base = string_make(value_name + 5);
+	}
+	*base = string_make(value_name + 5);
+	string_free(value_name);
 
 	/* If we've got this far, assume it's a valid monster base name */
 	return PARSE_ERROR_NONE;

--- a/src/datafile.h
+++ b/src/datafile.h
@@ -42,6 +42,7 @@ errr grab_rand_value(random_value *value, const char **value_type,
 					 const char *name_and_value);
 errr grab_int_value(int *value, const char **value_type,
 					const char *name_and_value);
+errr grab_int_range(int *lo, int *hi, const char *range, const char *sep);
 errr grab_index_and_int(int *value, int *index, const char **value_type,
 						const char *prefix, const char *name_and_value);
 errr grab_base_and_int(int *value, char **base, const char *name_and_value);

--- a/src/effects.c
+++ b/src/effects.c
@@ -136,145 +136,144 @@ effect_index effect_lookup(const char *name)
  */
 int effect_subtype(int index, const char *type)
 {
-	int val = -1;
+	char *pe;
+	long lv;
 
+	lv = strtol(type, &pe, 10);
+	if (pe != type) {
+		/*
+		 * Got a plain numeric value.  Verify that there isn't garbage
+		 * after it and that it doesn't overflow.  Also reject INT_MIN
+		 * and INT_MAX so don't have to check errno to detect overflow
+		 * when sizeof(long) == sizeof(int).
+		 */
+		return (contains_only_spaces(pe) && lv < INT_MAX
+			&& lv > INT_MIN) ? (int)lv : -1;
+	}
 	/* If not a numerical value, assign according to effect index */
-	if (sscanf(type, "%d", &val) != 1) {
-		switch (index) {
-				/* Projection name */
-			case EF_PROJECT_LOS:
-			case EF_PROJECT_LOS_AWARE:
-			case EF_DESTRUCTION:
-			case EF_SPOT:
-			case EF_SPHERE:
-			case EF_BALL:
-			case EF_BREATH:
-			case EF_ARC:
-			case EF_SHORT_BEAM:
-			case EF_LASH:
-			case EF_SWARM:
-			case EF_STRIKE:
-			case EF_STAR:
-			case EF_STAR_BALL:
-			case EF_BOLT:
-			case EF_BEAM:
-			case EF_BOLT_OR_BEAM:
-			case EF_LINE:
-			case EF_ALTER:
-			case EF_BOLT_STATUS:
-			case EF_BOLT_STATUS_DAM:
-			case EF_BOLT_AWARE:
-			case EF_MELEE_BLOWS:
-			case EF_TOUCH:
-			case EF_TOUCH_AWARE: {
-				val = proj_name_to_idx(type);
-				break;
-			}
+	switch (index) {
+		/* Projection name */
+		case EF_PROJECT_LOS:
+		case EF_PROJECT_LOS_AWARE:
+		case EF_DESTRUCTION:
+		case EF_SPOT:
+		case EF_SPHERE:
+		case EF_BALL:
+		case EF_BREATH:
+		case EF_ARC:
+		case EF_SHORT_BEAM:
+		case EF_LASH:
+		case EF_SWARM:
+		case EF_STRIKE:
+		case EF_STAR:
+		case EF_STAR_BALL:
+		case EF_BOLT:
+		case EF_BEAM:
+		case EF_BOLT_OR_BEAM:
+		case EF_LINE:
+		case EF_ALTER:
+		case EF_BOLT_STATUS:
+		case EF_BOLT_STATUS_DAM:
+		case EF_BOLT_AWARE:
+		case EF_MELEE_BLOWS:
+		case EF_TOUCH:
+		case EF_TOUCH_AWARE:
+			return proj_name_to_idx(type);
 
-				/* Timed effect name */
-			case EF_CURE:
-			case EF_TIMED_SET:
-			case EF_TIMED_INC:
-			case EF_TIMED_INC_NO_RES:
-			case EF_TIMED_DEC: {
-				val = timed_name_to_idx(type);
-				break;
-			}
+		/* Timed effect name */
+		case EF_CURE:
+		case EF_TIMED_SET:
+		case EF_TIMED_INC:
+		case EF_TIMED_INC_NO_RES:
+		case EF_TIMED_DEC:
+			return timed_name_to_idx(type);
 
-				/* Nourishment types */
-			case EF_NOURISH: {
-				if (streq(type, "INC_BY"))
-					val = 0;
-				else if (streq(type, "DEC_BY"))
-					val = 1;
-				else if (streq(type, "SET_TO"))
-					val = 2;
-				else if (streq(type, "INC_TO"))
-					val = 3;
-				break;
+		/* Nourishment types */
+		case EF_NOURISH:
+			if (streq(type, "INC_BY")) {
+				return 0;
+			} else if (streq(type, "DEC_BY")) {
+				return 1;
+			} else if (streq(type, "SET_TO")) {
+				return 2;
+			} else if (streq(type, "INC_TO")) {
+				return 3;
 			}
+			break;
 
-				/* Monster timed effect name */
-			case EF_MON_TIMED_INC: {
-				val = mon_timed_name_to_idx(type);
-				break;
-			}
+		/* Monster timed effect name */
+		case EF_MON_TIMED_INC:
+			return mon_timed_name_to_idx(type);
 
-				/* Summon name */
-			case EF_SUMMON: {
-				val = summon_name_to_idx(type);
-				break;
-			}
+		/* Summon name */
+		case EF_SUMMON:
+			return summon_name_to_idx(type);
 
-				/* Stat name */
-			case EF_RESTORE_STAT:
-			case EF_DRAIN_STAT:
-			case EF_LOSE_RANDOM_STAT:
-			case EF_GAIN_STAT: {
-				val = stat_name_to_idx(type);
-				break;
-			}
+		/* Stat name */
+		case EF_RESTORE_STAT:
+		case EF_DRAIN_STAT:
+		case EF_LOSE_RANDOM_STAT:
+		case EF_GAIN_STAT:
+			return stat_name_to_idx(type);
 
-				/* Enchant type name - not worth a separate function */
-			case EF_ENCHANT: {
-				if (streq(type, "TOBOTH"))
-					val = ENCH_TOBOTH;
-				else if (streq(type, "TOHIT"))
-					val = ENCH_TOHIT;
-				else if (streq(type, "TODAM"))
-					val = ENCH_TODAM;
-				else if (streq(type, "TOAC"))
-					val = ENCH_TOAC;
-				break;
+		/* Enchant type name - not worth a separate function */
+		case EF_ENCHANT:
+			if (streq(type, "TOBOTH")) {
+				return ENCH_TOBOTH;
+			} else if (streq(type, "TOHIT")) {
+				return ENCH_TOHIT;
+			} else if (streq(type, "TODAM")) {
+				return ENCH_TODAM;
+			} else if (streq(type, "TOAC")) {
+				return ENCH_TOAC;
 			}
+			break;
 
-				/* Player shape name */
-			case EF_SHAPECHANGE: {
-				val = shape_name_to_idx(type);
-				break;
-			}
+		/* Player shape name */
+		case EF_SHAPECHANGE:
+			return shape_name_to_idx(type);
 
-				/* Targeted earthquake */
-			case EF_EARTHQUAKE: {
-				if (streq(type, "TARGETED"))
-					val = 1;
-				else if (streq(type, "NONE"))
-					val = 0;
-				break;
+		/* Targeted earthquake */
+		case EF_EARTHQUAKE:
+			if (streq(type, "TARGETED")) {
+				return 1;
+			} else if (streq(type, "NONE")) {
+				return 0;
 			}
+			break;
 
-				/* Inscribe a glyph */
-			case EF_GLYPH: {
-				if (streq(type, "WARDING"))
-					val = GLYPH_WARDING;
-				else if (streq(type, "DECOY"))
-					val = GLYPH_DECOY;
-				break;
+		/* Inscribe a glyph */
+		case EF_GLYPH:
+			if (streq(type, "WARDING")) {
+				return GLYPH_WARDING;
+			} else if (streq(type, "DECOY")) {
+				return GLYPH_DECOY;
 			}
+			break;
 
-				/* Allow teleport away */
-			case EF_TELEPORT: {
-				if (streq(type, "AWAY"))
-					val = 1;
-				break;
+		/* Allow teleport away */
+		case EF_TELEPORT:
+			if (streq(type, "AWAY")) {
+				return 1;
 			}
+			break;
 
-				/* Allow monster teleport toward */
-			case EF_TELEPORT_TO: {
-				if (streq(type, "SELF"))
-					val = 1;
-				break;
+		/* Allow monster teleport toward */
+		case EF_TELEPORT_TO:
+			if (streq(type, "SELF")) {
+				return 1;
 			}
+			break;
 
-				/* Some effects only want a radius, so this is a dummy */
-			default: {
-				if (streq(type, "NONE"))
-					val = 0;
+		/* Some effects only want a radius, so this is a dummy */
+		default:
+			if (streq(type, "NONE")) {
+				return 0;
 			}
-		}
+			break;
 	}
 
-	return val;
+	return -1;
 }
 
 static int32_t effect_value_base_spell_power(void)

--- a/src/init.c
+++ b/src/init.c
@@ -3459,8 +3459,9 @@ static enum parser_error parse_class_book_properties(struct parser *p) {
 	k->alloc_prob = parser_getint(p, "common");
 
 	tmp = parser_getstr(p, "minmax");
-	if (sscanf(tmp, "%d to %d", &amin, &amax) != 2)
+	if (grab_int_range(&amin, &amax, tmp, "to")) {
 		return PARSE_ERROR_INVALID_ALLOCATION;
+	}
 	k->level = amin;
 	k->alloc_min = amin;
 	k->alloc_max = amax;

--- a/src/main-gcu.c
+++ b/src/main-gcu.c
@@ -1500,10 +1500,32 @@ errr init_gcu(int argc, char **argv) {
         {
             if (streq(argv[i], "-spacer"))
             {
+                char *pe, *ystr;
+                long lv;
+
                 i++;
                 if (i >= argc)
                     quit("Missing size specifier for -spacer");
-                sscanf(argv[i], "%dx%d", &spacer_cx, &spacer_cy);
+                lv = strtol(argv[i], &pe, 10);
+                /*
+                 * Also reject INT_MIN and INT_MAX so do not have to check
+                 * errno to detect overflow on platforms where sizeof(int) ==
+                 * sizeof(long).
+                 */
+                if (pe == argv[i] || *pe != 'x' || lv <= INT_MIN ||
+                        lv >= INT_MAX) {
+                    quit_fmt("Invalid specification for -spacer; got %s",
+                        argv[i]);
+                }
+                spacer_cx = (int)lv;
+                ystr = pe + 1;
+                lv = strtol(ystr, &pe, 10);
+                if (pe == ystr || !contains_only_spaces(pe) ||
+                        lv <= INT_MIN || lv >= INT_MAX) {
+                    quit_fmt("Invalid specification for -spacer; got %s",
+                        argv[i]);
+                }
+                spacer_cy = (int)lv;
             }
             else if (streq(argv[i], "-right") || streq(argv[i], "-left"))
             {

--- a/src/main-sdl.c
+++ b/src/main-sdl.c
@@ -5612,29 +5612,49 @@ static int cmp_font(const void *f1, const void *f2)
 {
 	const char *font1 = *(const char **)f1;
 	const char *font2 = *(const char **)f2;
-	int height1, height2;
-	int width1, width2;
-	int nsc1, nsc2;
-	char face1[5], face2[5];
+	int height1 = 0, height2 = 0;
+	int width1 = 0, width2 = 0;
+	char *ew, *face1 = NULL, *ext1 = NULL, *face2 = NULL, *ext2 = NULL;
+	long lv;
 
-	nsc1 = sscanf(font1, "%dx%d%4s.", &width1, &height1, face1);
-	nsc2 = sscanf(font2, "%dx%d%4s.", &width2, &height2, face2);
+	lv = strtol(font1, &ew, 10);
+	if (ew != font1 && *ew == 'x' && lv > INT_MIN && lv < INT_MAX) {
+		width1 = (int)lv;
+		lv = strtol(ew + 1, &face1, 10);
+		if (face1 != ew + 1 && lv > INT_MIN && lv < INT_MAX) {
+			height1 = (int)lv;
+			ext1 = strchr(face1, '.');
+			if (ext1 == face1) {
+				ext1 = NULL;
+			}
+		}
+	}
+	lv = strtol(font2, &ew, 10);
+	if (ew != font2 && *ew == 'x' && lv > INT_MIN && lv < INT_MAX) {
+		width2 = (int)lv;
+		lv = strtol(ew + 1, &face2, 10);
+		if (face2 != ew + 1 && lv > INT_MIN && lv < INT_MAX) {
+			height2 = (int)lv;
+			ext2 = strchr(face2, '.');
+			if (ext2 == face2) {
+				ext2 = NULL;
+			}
+		}
+	}
 
-	if (nsc1 != 3) {
-		if (nsc2 != 3) {
+	if (!ext1) {
+		if (!ext2) {
 			/*
 			 * Neither match the expected pattern.  Sort
 			 * alphabetically.
 			 */
 			return strcmp(font1, font2);
 		}
-		/*
-		 * Put f2 first, since it matches the expected pattern.
-		 */
+		/* Put f2 first since it matches the expected pattern. */
 		return 1;
 	}
-	if (nsc2 != 3) {
-		/* Put f1 first, since it matches the expected pattern. */
+	if (!ext2) {
+		/* Put f1 first since it matches the expected pattern. */
 		return -1;
 	}
 	if (width1 < width2) {
@@ -5649,7 +5669,7 @@ static int cmp_font(const void *f1, const void *f2)
 	if (height1 > height2) {
 		return 1;
 	}
-	return strcmp(face1, face2);
+	return strncmp(face1, face2, MAX(ext1 - face1, ext2 - face2));
 }
 
 /**

--- a/src/main-sdl2.c
+++ b/src/main-sdl2.c
@@ -5758,28 +5758,64 @@ static int sort_cb_font_info(const void *infoa, const void *infob)
 		return strcmp(namea, nameb);
 	} else {
 		/* otherwise, we'll sort them numbers-wise (6x12x.fon before 6x13x.fon) */
-		int wa = 0;
-		int ha = 0;
-		char facea[4 + 1] = {0};
+		int wa = 0, ha = 0, wb = 0, hb = 0;
+		char *facea = NULL, *exta = NULL, *faceb = NULL, *extb = NULL;
+		char *ew;
+		long lv;
 
-		int wb = 0;
-		int hb = 0;
-		char faceb[4 + 1] = {0};
+		lv = strtol(namea, &ew, 10);
+		if (ew != namea && *ew == 'x' && lv > INT_MIN && lv < INT_MAX) {
+			wa = (int)lv;
+			lv = strtol(ew + 1, &facea, 10);
+			if (facea != ew + 1 && lv > INT_MIN && lv < INT_MAX) {
+				ha = (int)lv;
+				exta = strchr(namea, '.');
+				if (exta == namea) {
+					exta = NULL;
+				}
+			}
+		}
+		lv = strtol(nameb, &ew, 10);
+		if (ew != nameb && *ew == 'x' && lv > INT_MIN && lv < INT_MAX) {
+			wb = (int)lv;
+			lv = strtol(ew + 1, &faceb, 10);
+			if (faceb != ew + 1 && lv > INT_MIN && lv < INT_MAX) {
+				hb = (int)lv;
+				extb = strchr(faceb, '.');
+				if (extb == faceb) {
+					extb = NULL;
+				}
+			}
+		}
 
-		sscanf(namea, "%dx%d%4[^.]", &wa, &ha, facea);
-		sscanf(nameb, "%dx%d%4[^.]", &wb, &hb, faceb);
-
+		if (!exta) {
+			if (!extb) {
+				/*
+				 * Neither match the expected pattern.  Sort
+				 * alphabetically.
+				 */
+				return strcmp(namea, nameb);
+			}
+			/* Put b last since it matches the expected pattern. */
+			return -1;
+		}
+		if (!extb) {
+			/* Put a last since it matches the expected pattern. */
+			return 1;
+		}
 		if (wa < wb) {
 			return -1;
-		} else if (wa > wb) {
-			return 1;
-		} else if (ha < hb) {
-			return -1;
-		} else if (ha > hb) {
-			return 1;
-		} else {
-			return strcmp(facea, faceb);
 		}
+		if (wa > wb) {
+			return 1;
+		}
+		if (ha < hb) {
+			return -1;
+		}
+		if (ha > hb) {
+			return 1;
+		}
+		return strncmp(facea, faceb, MAX(exta - facea, extb - faceb));
 	}
 }
 

--- a/src/main-spoil.c
+++ b/src/main-spoil.c
@@ -116,10 +116,14 @@ static uint32_t parse_seed(const char *src)
 		char *s;
 
 		if (file_getl(fin, buf, sizeof(buf)) &&
-				(s = my_stristr(buf, "seed"))) {
+				(s = my_stristr(buf, "seed "))) {
+			char *pe;
 			unsigned long ulv;
 
-			if (sscanf(s, "seed %lx", &ulv) == 1) {
+			errno = 0;
+			ulv = strtoul(s + 5, &pe, 16);
+			if (pe != s + 5 && (ulv < ULONG_MAX || errno == 0)
+					&& ulv <= 4294967295) {
 				result = (uint32_t)ulv;
 			}
 		}

--- a/src/message.c
+++ b/src/message.c
@@ -290,10 +290,13 @@ int message_lookup_by_name(const char *name)
 		#undef MSG
 	};
 	size_t i;
-	unsigned int number;
+	char *pe;
+	unsigned long number = strtoul(name, &pe, 10);
 
-	if (sscanf(name, "%u", &number) == 1)
-		return (number < MSG_MAX) ? (int)number : -1;
+	if (pe != name) {
+		return (contains_only_spaces(pe) && number < MSG_MAX) ?
+			(int)number : -1;
+	}
 
 	for (i = 0; i < N_ELEMENTS(message_names); i++) {
 		if (my_stricmp(name, message_names[i]) == 0)

--- a/src/obj-init.c
+++ b/src/obj-init.c
@@ -87,22 +87,21 @@ static const char *element_names[] = {
 
 static bool grab_element_flag(struct element_info *info, const char *flag_name)
 {
-	char prefix[20];
-	char suffix[20];
+	char *under = strchr(flag_name, '_');
 	size_t i;
 
-	if (2 != sscanf(flag_name, "%[^_]_%s", prefix, suffix)) {
+	if (!under) {
 		return false;
 	}
 
 	/* Ignore or hate */
 	for (i = 0; i < ELEM_MAX; i++) {
-		if (streq(suffix, element_names[i])) {
-			if (streq(prefix, "IGNORE")) {
+		if (streq(under + 1, element_names[i])) {
+			if (!strncmp(flag_name, "IGNORE", under - flag_name)) {
 				info[i].flags |= EL_INFO_IGNORE;
 				return true;
 			}
-			if (streq(prefix, "HATES")) {
+			if (!strncmp(flag_name, "HATES", under - flag_name)) {
 				info[i].flags |= EL_INFO_HATES;
 				return true;
 			}
@@ -1735,7 +1734,7 @@ static enum parser_error parse_object_alloc(struct parser *p) {
 		return PARSE_ERROR_MISSING_RECORD_HEADER;
 	}
 	k->alloc_prob = parser_getint(p, "common");
-	if (sscanf(tmp, "%d to %d", &amin, &amax) != 2) {
+	if (grab_int_range(&amin, &amax, tmp, "to")) {
 		return PARSE_ERROR_INVALID_ALLOCATION;
 	}
 	k->alloc_min = amin;
@@ -2233,7 +2232,7 @@ static enum parser_error parse_ego_alloc(struct parser *p) {
 		return PARSE_ERROR_MISSING_RECORD_HEADER;
 	}
 	e->alloc_prob = parser_getint(p, "common");
-	if (sscanf(tmp, "%d to %d", &amin, &amax) != 2) {
+	if (grab_int_range(&amin, &amax, tmp, "to")) {
 		return PARSE_ERROR_INVALID_ALLOCATION;
 	}
 	if (amin > 255 || amax > 255 || amin < 0 || amax < 0) {
@@ -2760,7 +2759,7 @@ static enum parser_error parse_artifact_alloc(struct parser *p) {
 		return PARSE_ERROR_MISSING_RECORD_HEADER;
 	}
 	a->alloc_prob = parser_getint(p, "common");
-	if (sscanf(tmp, "%d to %d", &amin, &amax) != 2) {
+	if (grab_int_range(&amin, &amax, tmp, "to")) {
 		return PARSE_ERROR_INVALID_ALLOCATION;
 	}
 	if (amin > 255 || amax > 255 || amin < 0 || amax < 0) {

--- a/src/obj-tval.c
+++ b/src/obj-tval.c
@@ -386,12 +386,13 @@ static char *de_armour(const char *name)
  */
 int tval_find_idx(const char *name)
 {
-	size_t i = 0;
-	unsigned int r;
-	char *mod_name;
+	size_t i;
+	char *mod_name, *pe;
+	unsigned long r = strtoul(name, &pe, 10);
 
-	if (sscanf(name, "%u", &r) == 1)
-		return r;
+	if (pe != name) {
+		return (contains_only_spaces(pe) && r < TV_MAX) ? (int)r : -1;
+	}
 
 	mod_name = de_armour(name);
 

--- a/src/obj-util.c
+++ b/src/obj-util.c
@@ -495,10 +495,12 @@ struct ego_item *lookup_ego_item(const char *name, int tval, int sval)
 int lookup_sval(int tval, const char *name)
 {
 	int k;
-	unsigned int r;
+	char *pe;
+	unsigned long r = strtoul(name, &pe, 10);
 
-	if (sscanf(name, "%u", &r) == 1)
-		return r;
+	if (pe != name) {
+		return (contains_only_spaces(pe) && r < INT_MAX) ? (int)r : -1;
+	}
 
 	/* Look for it */
 	for (k = 0; k < z_info->k_max; k++) {

--- a/src/tests/parse/e-info.c
+++ b/src/tests/parse/e-info.c
@@ -565,6 +565,16 @@ static int test_values_bad0(void *state) {
 	/* Try an unrecognized element. */
 	r = parser_parse(p, "values:RES_XYZZY[3]");
 	eq(r, PARSE_ERROR_INVALID_VALUE);
+	/* Check handling of a missing opening bracket. */
+	r = parser_parse(p, "values:STEALTH1]");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	r = parser_parse(p, "values:RES_POIS1]");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	/* CHeck handling of a missing closing bracket. */
+	r = parser_parse(p, "values:STEALTH[1");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	r = parser_parse(p, "values:RES_POIS[1");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
 	ok;
 }
 
@@ -604,6 +614,12 @@ static int test_min_values_bad0(void *state) {
 	/* Try an unrecognized object modifier. */
 	enum parser_error r = parser_parse(p, "min-values:XYZZY[3]");
 
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	/* Check handling of a missing opening bracket. */
+	r = parser_parse(p, "min-values:STEALTH1]");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	/* Check handling of a missing closing bracket. */
+	r = parser_parse(p, "min-values:STEALTH[1");
 	eq(r, PARSE_ERROR_INVALID_VALUE);
 	ok;
 }

--- a/src/tests/parse/k-info.c
+++ b/src/tests/parse/k-info.c
@@ -238,6 +238,29 @@ static int test_alloc_bad0(void *state) {
 	enum parser_error r = parser_parse(p, "alloc:2:7");
 
 	eq(r, PARSE_ERROR_INVALID_ALLOCATION);
+	/* Check missing whitespace. */
+	r = parser_parse(p, "alloc:1:2to 7");
+	eq(r, PARSE_ERROR_INVALID_ALLOCATION);
+	r = parser_parse(p, "alloc:1:2 to7");
+	eq(r, PARSE_ERROR_INVALID_ALLOCATION);
+	/* Check when either integer is invalid or out of range. */
+	r = parser_parse(p, "alloc:1:a to 7");
+	eq(r, PARSE_ERROR_INVALID_ALLOCATION);
+	r = parser_parse(p, "alloc:1:2 to b");
+	eq(r, PARSE_ERROR_INVALID_ALLOCATION);
+	r = parser_parse(p, "alloc:1:-8989999988989898889389 to 1");
+	eq(r, PARSE_ERROR_INVALID_ALLOCATION);
+	r = parser_parse(p, "alloc:1:1 to 3892867393957396729696739023");
+	eq(r, PARSE_ERROR_INVALID_ALLOCATION);
+	r = parser_parse(p, "alloc:1:1119392572692029396720296 to 3399268202846826927928487928482968283293");
+	eq(r, PARSE_ERROR_INVALID_ALLOCATION);
+	/* Check an invalid separating string. */
+	r = parser_parse(p, "alloc:1:2 x 7");
+	eq(r, PARSE_ERROR_INVALID_ALLOCATION);
+	r = parser_parse(p, "alloc:1:2 sto 7");
+	eq(r, PARSE_ERROR_INVALID_ALLOCATION);
+	r = parser_parse(p, "alloc:1:2 top 7");
+	eq(r, PARSE_ERROR_INVALID_ALLOCATION);
 	ok;
 }
 
@@ -667,6 +690,19 @@ static int test_values_bad0(void *state) {
 	eq(r, PARSE_ERROR_INVALID_VALUE);
 	/* Check for invalid resistance. */
 	r = parser_parse(p, "values:RES_XYZZY[-1]");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	/* Check handling of missing opening bracket. */
+	r = parser_parse(p, "values:STEALTH1]");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	r = parser_parse(p, "values:RES_ELEC1]");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	/* Check handling of missing closing bracket. */
+	r = parser_parse(p, "values:STEALTH[1");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	r = parser_parse(p, "values:RES_ELEC[1");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	/* Check handling of a long dice string. */
+	r = parser_parse(p, "values:STEALTH[-1+0000000000000000000000000001d000000000000000000000001M0000000000000000000001]");
 	eq(r, PARSE_ERROR_INVALID_VALUE);
 	ok;
 }

--- a/src/ui-death.c
+++ b/src/ui-death.c
@@ -116,8 +116,6 @@ static void display_winner(void)
 
 	int wid, hgt;
 	int i = 2;
-	int width = 0;
-
 
 	path_build(buf, sizeof(buf), ANGBAND_DIR_SCREENS, "crown.txt");
 	fp = file_open(buf, MODE_READ, FTYPE_TEXT);
@@ -126,15 +124,20 @@ static void display_winner(void)
 	Term_get_size(&wid, &hgt);
 
 	if (fp) {
+		char *pe;
+		long lw;
+		int width;
+
 		/* Get us the first line of file, which tells us how long the */
 		/* longest line is */
 		file_getl(fp, buf, sizeof(buf));
-		sscanf(buf, "%d", &width);
-		if (!width) width = 25;
+		lw = strtol(buf, &pe, 10);
+		width = (pe != buf && lw > 0 && lw < INT_MAX) ? (int)lw : 25;
 
 		/* Dump the file to the screen */
-		while (file_getl(fp, buf, sizeof(buf)))
-			put_str(buf, i++, (wid/2) - (width/2));
+		while (file_getl(fp, buf, sizeof(buf))) {
+			put_str(buf, i++, (wid / 2) - (width / 2));
+		}
 
 		file_close(fp);
 	}


### PR DESCRIPTION
For integer conversions, strtol() and strtoul() define what happens when the input would overflow what can be represented internally.  Apparently, sscanf() does not define what happens in that case.  The use of sscanf() for extracting a string in grab_element_flag() could cause a buffer overflow with an appropriately crafted data file.  Avoiding sscanf() also avoids compiler warnings from Visual Studio when _CRT_SECURE_NO_WARNINGS is not set.