### PR TITLE
Put constants for criticals in constants.txt

### DIFF
--- a/lib/gamedata/constants.txt
+++ b/lib/gamedata/constants.txt
@@ -202,3 +202,216 @@ player:start-gold:600
 
 # Number of turns that 1% of player food capacity feeds them for
 player:food-value:100
+
+#---------------------------------------------------------------------
+# Constants for non-O critical calculations
+# In general, those calculations compute the chance for a critical
+# from a linear combination of the to-hit bonuses, the player's
+# to-hit skill, the player's level, and the weapon or missile's
+# weight.  If a critical happens, they then compute the power (i.e.
+# severity of the critical) from a random term and the weapon or
+# missile's weight.  For more details see critical_melee() and
+# critical_shot() in player-attack.c.
+#---------------------------------------------------------------------
+
+# Amount added to the to-hit value for calculating the chance of a melee
+# critical when the target is debuffed
+melee-critical:debuff-toh:10
+
+# Scale factor for the weapon's weight in the chance for a melee critical
+melee-critical:chance-weight-scale:1
+
+# Scale factor for the overall to-hit value when calculating the chance
+# for a melee critical
+melee-critical:chance-toh-scale:5
+
+# Scale factor for player level when calculating the chance for a melee critical
+melee-critical:chance-level-scale:0
+
+# Scale factor for the to-hit skill when calculating the chance for a melee
+# critical
+melee-critical:chance-toh-skill-scale:1
+
+# Value added to the chance for a melee critical
+melee-critical:chance-offset:-60
+
+# Maximum range for melee critical chance; if the chance is N and the maximum
+# range is M, then the probability a critical will happen is
+# min(max(0, N), M) / M; to avoid extra inaccuracies for the damage shown
+# within object descriptions, this should be a multiple of 100
+melee-critical:chance-range:5000
+
+# Scale factor for the weapon weight in the power of a melee critical
+melee-critical:power-weight-scale:1
+
+# The maximum of the random part of the power for a melee critical
+melee-critical:power-random:650
+
+# Define each of the levels for melee criticals.  If no critical levels are
+# defined, then there's no extra damage due to critical hits.
+# The first value is the cutoff for the power.  Any critical which has a power
+# less than that cutoff and is not covered by a lower power level will fall
+# in that level.  The cutoff for the last level is not used and that level
+# will catch any criticals not caught by the previous levels.  To be valid,
+# the cutoffs for all levels but the last must be in scrictly ascending order.
+# The second value is the damage multiplier for that power level.
+# The third value is the amount added to the damage for that power level.
+# The fourth value is the name of the message, from list-messages.h, to use when
+# a critical happens for that power level.
+melee-critical-level:400:2:5:HIT_GOOD
+melee-critical-level:700:2:10:HIT_GREAT
+melee-critical-level:900:3:15:HIT_SUPERB
+melee-critical-level:1300:3:20:HIT_HI_GREAT
+melee-critical-level:-1:4:20:HIT_HI_SUPERB
+
+# Amount added to the to-hit value for calculating the chance of a ranged
+# critical when the target is debuffed
+ranged-critical:debuff-toh:10
+
+# Scale factor for the missile's weight in the chance for a ranged critical
+ranged-critical:chance-weight-scale:1
+
+# Scale factor for the overall to-hit value when calculating the chance
+# for a ranged critical
+ranged-critical:chance-toh-scale:4
+
+# Scale factor for player level when calculating the chance for a ranged
+# critical
+ranged-critical:chance-level-scale:2
+
+# Scale factor for the launched to-hit skill when calculating the chance for
+# a ranged critical when using a launcher
+ranged-critical:chance-launched-toh-skill-scale:0
+
+# Scale factor for the thrown to-hit skill when calculating the chance for
+# a ranged critical for a thrown object
+ranged-critical:chance-thrown-toh-skill-scale:0
+
+# Value added to the chance for a ranged critical
+ranged-critical:chance-offset:0
+
+# Maximum range for ranged critical chance; if the chance is N and the maximum
+# range is M, then the probability a critical will happen is
+# min(max(0, N), M) / M; to avoid extra inaccuracies for the damage shown
+# within object descriptions, this should be a multiple of 100
+ranged-critical:chance-range:5000
+
+# Scale factor for the missle weight in the power of a ranged critical
+ranged-critical:power-weight-scale:1
+
+# The maximum of the random part of the power for a ranged critical
+ranged-critical:power-random:500
+
+# Define each of the levels for ranged criticals.  If no critical levels are
+# defined, then there's no extra damage due to critical hits.
+# The first value is the cutoff for the power.  Any critical which has a power
+# less than that cutoff and is not covered by a lower power level will fall
+# in that level.  The cutoff for the last level is not used and that level
+# will catch any criticals not caught by the previous levels.  To be valid,
+# the cutoffs for all levels but the last must be in scrictly ascending order.
+# The second value is the damage multiplier for that power level.
+# The third value is the amount added to the damage for that power level.
+# The fourth value is the name of the message, from list-messages.h, to use
+# when a critical happens for that power level.
+ranged-critical-level:500:2:5:HIT_GOOD
+ranged-critical-level:1000:2:10:HIT_GREAT
+ranged-critical-level:-1:3:15:HIT_SUPERB
+
+#---------------------------------------------------------------------
+# Constants for O critical calculations
+# In general, those calculations compute a "power" of the critical
+# by scaling the chance of a hit.  The "power" is then converted to
+# a chance of a critical using (a * power) / (b + power + c) as the
+# chance where a, b, and c are constants specified here.  For more
+# details, see o_critical_melee() and o_critical_shot() in
+# player-attack.c.
+#---------------------------------------------------------------------
+
+# Amount added to the to-hit value for calculating the power of a melee critical
+# when the target is debuffed
+o-melee-critical:debuff-toh:10
+
+# The numerator for the scale factor applied to the combined to-hit value to
+# get the power of the critical
+o-melee-critical:power-toh-scale-numerator:1
+
+# The denominator for the scale factor applied to the combined to-hit value to
+# get the power of the critical
+o-melee-critical:power-toh-scale-denominator:3
+
+# The scale factor for the critical's power in the numerator for the chance
+# of the critical
+o-melee-critical:chance-power-scale-numerator:1
+
+# The scale factor for the critical's power in the denominator for the chance
+# of the critical
+o-melee-critical:chance-power-scale-denominator:1
+
+# Value of an added term in the denominator for the chance of a critical
+o-melee-critical:chance-add-denominator:240
+
+# Define each of the levels for melee criticals.  They are considered in the
+# order appear so it's convenient to put the least likely first.  If not
+# critical levels are defined, then there's no extra damage due to critical
+# hits.
+# Except for the last level, one over the first value is the probability that
+# this level occurs when none of the prior levels have been selected; the last
+# level will always be used if none of the prior levels have been selected.
+# The first value must be positive.
+# The second value is the number of dice to add for the critical.  It must be
+# non-negative.
+# The third value is the name of the message, from list-messages.h, to use
+# when a critical happens for that power level.
+o-melee-critical-level:40:5:HIT_HI_SUPERB
+o-melee-critical-level:12:4:HIT_HI_GREAT
+o-melee-critical-level:3:3:HIT_SUPERB
+o-melee-critical-level:2:2:HIT_GREAT
+o-melee-critical-level:1:1:HIT_GOOD
+
+# Amount added to the to-hit value for calculating the power of a ranged
+# critical when the target is debuffed
+o-ranged-critical:debuff-toh:10
+
+# The numerator for the scale factor applied to the combined to-hit value to
+# get the power of the critical with a launched missile
+o-ranged-critical:power-launched-toh-scale-numerator:1
+
+# The denominator for the scale factor applied to the combined to-hit value to
+# get the power of the critical with a launched missile
+o-ranged-critical:power-launched-toh-scale-denominator:1
+
+# The numerator for the scale factor applied to the combined to-hit value to
+# get the power of the critical with a thrown missile; this and the
+# denominator are currently set so thrown missiles get more criticals
+o-ranged-critical:power-thrown-toh-scale-numerator:3
+
+# The denominator for the scale factor applied to the combined to-hit value to
+# get the power of the critical with a thrown missile
+o-ranged-critical:power-thrown-toh-scale-denominator:2
+
+# The scale factor for the critical's power in the numerator for the chance
+# of the critical
+o-ranged-critical:chance-power-scale-numerator:1
+
+# The scale factor for the critical's power in the denominator for the chance
+# of the critical
+o-ranged-critical:chance-power-scale-denominator:1
+
+# Value of an added term in the denominator for the chance of a critical
+o-ranged-critical:chance-add-denominator:360
+
+# Define each of the levels for ranged criticals.  They are considered in the
+# order appear so it's convenient to put the least likely first.  If not
+# critical levels are defined, then there's no extra damage due to critical
+# hits.
+# Except for the last level, one over the first value is the probability that
+# this level occurs when none of the prior levels have been selected; the last
+# level will always be used if none of the prior levels have been selected.
+# The first value must be positive.
+# The second value is the number of dice to add for the critical.  It must be
+# non-negative.
+# The third value is the name of the message, from list-messages.h, to use
+# when a critical happens for that power level.
+o-ranged-critical-level:50:3:HIT_SUPERB
+o-ranged-critical-level:10:2:HIT_GREAT
+o-ranged-critical-level:1:1:HIT_GOOD

--- a/src/init.c
+++ b/src/init.c
@@ -35,6 +35,7 @@
 #include "generate.h"
 #include "hint.h"
 #include "init.h"
+#include "message.h"
 #include "mon-init.h"
 #include "mon-list.h"
 #include "mon-lore.h"
@@ -698,6 +699,253 @@ static enum parser_error parse_constants_player(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
+static enum parser_error parse_constants_melee_critical(struct parser *p)
+{
+	struct angband_constants *z = parser_priv(p);
+	const char *label = parser_getsym(p, "label");
+	int value = parser_getint(p, "value");
+
+	if (streq(label, "debuff-toh")) {
+		z->m_crit_debuff_toh = value;
+	} else if (streq(label, "chance-weight-scale")) {
+		z->m_crit_chance_weight_scl = value;
+	} else if (streq(label, "chance-toh-scale")) {
+		z->m_crit_chance_toh_scl = value;
+	} else if (streq(label, "chance-level-scale")) {
+		z->m_crit_chance_level_scl = value;
+	} else if (streq(label, "chance-toh-skill-scale")) {
+		z->m_crit_chance_toh_skill_scl = value;
+	} else if (streq(label, "chance-offset")) {
+		z->m_crit_chance_offset = value;
+	} else if (streq(label, "chance-range")) {
+		z->m_crit_chance_range = value;
+	} else if (streq(label, "power-weight-scale")) {
+		z->m_crit_power_weight_scl = value;
+	} else if (streq(label, "power-random")) {
+		z->m_crit_power_random = value;
+	} else {
+		return PARSE_ERROR_UNDEFINED_DIRECTIVE;
+	}
+
+	return PARSE_ERROR_NONE;
+}
+
+static enum parser_error parse_constants_melee_critical_level(struct parser *p)
+{
+	struct angband_constants *z = parser_priv(p);
+	struct critical_level *new_level;
+	const char *msgt_str = parser_getstr(p, "msg");
+	int msgt = message_lookup_by_name(msgt_str);
+
+	if (msgt < 0) {
+		return PARSE_ERROR_INVALID_MESSAGE;
+	}
+	new_level = mem_alloc(sizeof(*new_level));
+	new_level->next = NULL;
+	new_level->cutoff = parser_getint(p, "cutoff");
+	new_level->mult = parser_getint(p, "mult");
+	new_level->add = parser_getint(p, "add");
+	new_level->msgt = msgt;
+	/* Add it to the end of the linked list. */
+	if (z->m_crit_level_head) {
+		struct critical_level *cursor = z->m_crit_level_head;
+
+		while (cursor->next) {
+			cursor = cursor->next;
+		}
+		cursor->next = new_level;
+	} else {
+		z->m_crit_level_head = new_level;
+	}
+
+	return PARSE_ERROR_NONE;
+}
+
+static enum parser_error parse_constants_ranged_critical(struct parser *p)
+{
+	struct angband_constants *z = parser_priv(p);
+	const char *label = parser_getsym(p, "label");
+	int value = parser_getint(p, "value");
+
+	if (streq(label, "debuff-toh")) {
+		z->r_crit_debuff_toh = value;
+	} else if (streq(label, "chance-weight-scale")) {
+		z->r_crit_chance_weight_scl = value;
+	} else if (streq(label, "chance-toh-scale")) {
+		z->r_crit_chance_toh_scl = value;
+	} else if (streq(label, "chance-level-scale")) {
+		z->r_crit_chance_level_scl = value;
+	} else if (streq(label, "chance-launched-toh-skill-scale")) {
+		z->r_crit_chance_launched_toh_skill_scl = value;
+	} else if (streq(label, "chance-thrown-toh-skill-scale")) {
+		z->r_crit_chance_thrown_toh_skill_scl = value;
+	} else if (streq(label, "chance-offset")) {
+		z->r_crit_chance_offset = value;
+	} else if (streq(label, "chance-range")) {
+		z->r_crit_chance_range = value;
+	} else if (streq(label, "power-weight-scale")) {
+		z->r_crit_power_weight_scl = value;
+	} else if (streq(label, "power-random")) {
+		z->r_crit_power_random = value;
+	} else {
+		return PARSE_ERROR_UNDEFINED_DIRECTIVE;
+	}
+	return PARSE_ERROR_NONE;
+}
+
+static enum parser_error parse_constants_ranged_critical_level(struct parser *p)
+{
+	struct angband_constants *z = parser_priv(p);
+	struct critical_level *new_level;
+	const char *msgt_str = parser_getstr(p, "msg");
+	int msgt = message_lookup_by_name(msgt_str);
+
+	if (msgt < 0) {
+		return PARSE_ERROR_INVALID_MESSAGE;
+	}
+	new_level = mem_alloc(sizeof(*new_level));
+	new_level->next = NULL;
+	new_level->cutoff = parser_getint(p, "cutoff");
+	new_level->mult = parser_getint(p, "mult");
+	new_level->add = parser_getint(p, "add");
+	new_level->msgt = msgt;
+	/* Add it to the end of the linked list. */
+	if (z->r_crit_level_head) {
+		struct critical_level *cursor = z->r_crit_level_head;
+
+		while (cursor->next) {
+			cursor = cursor->next;
+		}
+		cursor->next = new_level;
+	} else {
+		z->r_crit_level_head = new_level;
+	}
+
+	return PARSE_ERROR_NONE;
+}
+
+static enum parser_error parse_constants_o_melee_critical(struct parser *p)
+{
+	struct angband_constants *z = parser_priv(p);
+	const char *label = parser_getsym(p, "label");
+	int value = parser_getint(p, "value");
+
+	if (streq(label, "debuff-toh")) {
+		z->o_m_crit_debuff_toh = value;
+	} else if (streq(label, "power-toh-scale-numerator")) {
+		z->o_m_crit_power_toh_scl_num = value;
+	} else if (streq(label, "power-toh-scale-denominator")) {
+		z->o_m_crit_power_toh_scl_den = value;
+	} else if (streq(label, "chance-power-scale-numerator")) {
+		z->o_m_crit_chance_power_scl_num = value;
+	} else if (streq(label, "chance-power-scale-denominator")) {
+		z->o_m_crit_chance_power_scl_den = value;
+	} else if (streq(label, "chance-add-denominator")) {
+		z->o_m_crit_chance_add_den = value;
+	} else {
+		return PARSE_ERROR_UNDEFINED_DIRECTIVE;
+	}
+
+	return PARSE_ERROR_NONE;
+}
+
+static enum parser_error parse_constants_o_melee_critical_level(struct parser *p)
+{
+	struct angband_constants *z = parser_priv(p);
+	struct o_critical_level *new_level;
+	unsigned int chance = parser_getuint(p, "chance");
+	const char *msgt_str = parser_getstr(p, "msg");
+	int msgt = message_lookup_by_name(msgt_str);
+
+	if (chance == 0) {
+		return PARSE_ERROR_INVALID_VALUE;
+	}
+	if (msgt < 0) {
+		return PARSE_ERROR_INVALID_MESSAGE;
+	}
+	new_level = mem_alloc(sizeof(*new_level));
+	new_level->next = NULL;
+	new_level->chance = chance;
+	new_level->added_dice = parser_getuint(p, "dice");
+	new_level->msgt = msgt;
+	/* Add it to the end of the linked list. */
+	if (z->o_m_crit_level_head) {
+		struct o_critical_level *cursor = z->o_m_crit_level_head;
+
+		while (cursor->next) {
+			cursor = cursor->next;
+		}
+		cursor->next = new_level;
+	} else {
+		z->o_m_crit_level_head = new_level;
+	}
+
+	return PARSE_ERROR_NONE;
+}
+
+static enum parser_error parse_constants_o_ranged_critical(struct parser *p)
+{
+	struct angband_constants *z = parser_priv(p);
+	const char *label = parser_getsym(p, "label");
+	int value = parser_getint(p, "value");
+
+	if (streq(label, "debuff-toh")) {
+		z->o_r_crit_debuff_toh = value;
+	} else if (streq(label, "power-launched-toh-scale-numerator")) {
+		z->o_r_crit_power_launched_toh_scl_num = value;
+	} else if (streq(label, "power-launched-toh-scale-denominator")) {
+		z->o_r_crit_power_launched_toh_scl_den = value;
+	} else if (streq(label, "power-thrown-toh-scale-numerator")) {
+		z->o_r_crit_power_thrown_toh_scl_num = value;
+	} else if (streq(label, "power-thrown-toh-scale-denominator")) {
+		z->o_r_crit_power_thrown_toh_scl_den = value;
+	} else if (streq(label, "chance-power-scale-numerator")) {
+		z->o_r_crit_chance_power_scl_num = value;
+	} else if (streq(label, "chance-power-scale-denominator")) {
+		z->o_r_crit_chance_power_scl_den = value;
+	} else if (streq(label, "chance-add-denominator")) {
+		z->o_r_crit_chance_add_den = value;
+	} else {
+		return PARSE_ERROR_UNDEFINED_DIRECTIVE;
+	}
+
+	return PARSE_ERROR_NONE;
+}
+
+static enum parser_error parse_constants_o_ranged_critical_level(struct parser *p)
+{
+	struct angband_constants *z = parser_priv(p);
+	struct o_critical_level *new_level;
+	unsigned int chance = parser_getuint(p, "chance");
+	const char *msgt_str = parser_getstr(p, "msg");
+	int msgt = message_lookup_by_name(msgt_str);
+
+	if (chance == 0) {
+		return PARSE_ERROR_INVALID_VALUE;
+	}
+	if (msgt < 0) {
+		return PARSE_ERROR_INVALID_MESSAGE;
+	}
+	new_level = mem_alloc(sizeof(*new_level));
+	new_level->next = NULL;
+	new_level->chance = chance;
+	new_level->added_dice = parser_getuint(p, "dice");
+	new_level->msgt = msgt;
+	/* Add it to the end of the linked list. */
+	if (z->o_r_crit_level_head) {
+		struct o_critical_level *cursor = z->o_r_crit_level_head;
+
+		while (cursor->next) {
+			cursor = cursor->next;
+		}
+		cursor->next = new_level;
+	} else {
+		z->o_r_crit_level_head = new_level;
+	}
+
+	return PARSE_ERROR_NONE;
+}
+
 static struct parser *init_parse_constants(void) {
 	struct angband_constants *z = mem_zalloc(sizeof *z);
 	struct parser *p = parser_new();
@@ -712,6 +960,22 @@ static struct parser *init_parse_constants(void) {
 	parser_reg(p, "store sym label int value", parse_constants_store);
 	parser_reg(p, "obj-make sym label int value", parse_constants_obj_make);
 	parser_reg(p, "player sym label int value", parse_constants_player);
+	parser_reg(p, "melee-critical sym label int value",
+		parse_constants_melee_critical);
+	parser_reg(p, "melee-critical-level int cutoff int mult int add "
+		"str msg", parse_constants_melee_critical_level);
+	parser_reg(p, "ranged-critical sym label int value",
+		parse_constants_ranged_critical);
+	parser_reg(p, "ranged-critical-level int cutoff int mult int add "
+		"str msg", parse_constants_ranged_critical_level);
+	parser_reg(p, "o-melee-critical sym label int value",
+		parse_constants_o_melee_critical);
+	parser_reg(p, "o-melee-critical-level uint chance uint dice str msg",
+		parse_constants_o_melee_critical_level);
+	parser_reg(p, "o-ranged-critical sym label int value",
+		parse_constants_o_ranged_critical);
+	parser_reg(p, "o-ranged-critical-level uint chance uint dice str msg",
+		parse_constants_o_ranged_critical_level);
 	return p;
 }
 
@@ -719,14 +983,68 @@ static errr run_parse_constants(struct parser *p) {
 	return parse_file_quit_not_found(p, "constants");
 }
 
+static int check_critical_levels(const struct critical_level *head)
+{
+	/*
+	 * Reject if the cutoffs, except for the last one which is unused, do
+	 * not strictly increase.
+	 */
+	if (!head) {
+		return 0;
+	}
+	while (head->next) {
+		int prev_cutoff = head->cutoff;
+
+		head = head->next;
+		if (head->next && head->cutoff <= prev_cutoff) {
+			return 1;
+		}
+	}
+	return 0;
+}
+
 static errr finish_parse_constants(struct parser *p) {
 	z_info = parser_priv(p);
 	parser_destroy(p);
+	if (check_critical_levels(z_info->m_crit_level_head)) {
+		plog("The cutoffs for melee criticals in constants.txt are "
+			"not strictly increasing.");
+		return PARSE_ERROR_NON_SEQUENTIAL_RECORDS;
+	}
+	if (check_critical_levels(z_info->r_crit_level_head)) {
+		plog("The cutoffs for ranged criticals in constants.txt are "
+			"not strictly increasing.");
+		return PARSE_ERROR_NON_SEQUENTIAL_RECORDS;
+	}
 	return 0;
+}
+
+static void cleanup_critical_levels(struct critical_level *head)
+{
+	while (head) {
+		struct critical_level *target = head;
+
+		head = head->next;
+		mem_free(target);
+	}
+}
+
+static void cleanup_o_critical_levels(struct o_critical_level *head)
+{
+	while (head) {
+		struct o_critical_level *target = head;
+
+		head = head->next;
+		mem_free(target);
+	}
 }
 
 static void cleanup_constants(void)
 {
+	cleanup_critical_levels(z_info->m_crit_level_head);
+	cleanup_critical_levels(z_info->r_crit_level_head);
+	cleanup_o_critical_levels(z_info->o_m_crit_level_head);
+	cleanup_o_critical_levels(z_info->o_r_crit_level_head);
 	mem_free(z_info);
 }
 

--- a/src/init.h
+++ b/src/init.h
@@ -16,8 +16,30 @@
 #include "z-bitflag.h"
 #include "z-file.h"
 #include "z-rand.h"
+#include "z-util.h"
 #include "datafile.h"
 #include "object.h"
+
+/* Define a level of severity for a non-O critical */
+struct critical_level {
+	struct critical_level *next;
+	int cutoff;		/* powers less than this are included;
+					ignored for last level */
+	int mult;		/* damage multiplier for this level */
+	int add;		/* additive damage for this level */
+	int msgt;		/* message type to use for this level */
+};
+
+/* Define a level of severity for an O critical */
+struct o_critical_level {
+	struct o_critical_level *next;
+	unsigned int chance;		/* one in chance of this level unless
+						this is the last level; the rest
+						go to the next level */
+	unsigned int added_dice;	/* number of dice added for this
+						level */
+	int msgt;			/* message type to use for this level */
+};
 
 /**
  * Information about maximal indices of certain arrays.
@@ -121,6 +143,72 @@ struct angband_constants
 	uint16_t max_range;	/* Maximum missile and spell range */
 	uint16_t start_gold;	/* Amount of gold the player starts with */
 	uint16_t food_value;	/* Number of turns 1% of food lasts */
+
+	/*
+	 * Constants for non-O melee critical calculations; read from
+	 * constants.txt
+	 */
+	int m_crit_debuff_toh;
+	int m_crit_chance_weight_scl;
+	int m_crit_chance_toh_scl;
+	int m_crit_chance_level_scl;
+	int m_crit_chance_toh_skill_scl;
+	int m_crit_chance_offset;
+	int m_crit_chance_range;
+	int m_crit_power_weight_scl;
+	int m_crit_power_random;
+	struct critical_level *m_crit_level_head;
+
+	/*
+	 * Constants for non-O ranged critical calculations; read from
+	 * constants.txt
+	 */
+	int r_crit_debuff_toh;
+	int r_crit_chance_weight_scl;
+	int r_crit_chance_toh_scl;
+	int r_crit_chance_level_scl;
+	int r_crit_chance_launched_toh_skill_scl;
+	int r_crit_chance_thrown_toh_skill_scl;
+	int r_crit_chance_offset;
+	int r_crit_chance_range;
+	int r_crit_power_weight_scl;
+	int r_crit_power_random;
+	struct critical_level *r_crit_level_head;
+
+	/*
+	 * Constants for O melee critical calculations; read from
+	 * constants.txt
+	 */
+	int o_m_crit_debuff_toh;
+	int o_m_crit_power_toh_scl_num;
+	int o_m_crit_power_toh_scl_den;
+	int o_m_crit_chance_power_scl_num;
+	int o_m_crit_chance_power_scl_den;
+	int o_m_crit_chance_add_den;
+	struct o_critical_level *o_m_crit_level_head;
+	/*
+	 * For object information, O critical levels do not depend on the
+	 * properties of the player or weapon so they can be summed over once
+	 * after loading the constants file and stored here.
+	 * The sums are done in obj-info.c.
+	 */
+	struct my_rational o_m_max_added;
+
+	/*
+	 * Constants for O ranged critical calculations; read from
+	 * constants.txt
+	 */
+	int o_r_crit_debuff_toh;
+	int o_r_crit_power_launched_toh_scl_num;
+	int o_r_crit_power_launched_toh_scl_den;
+	int o_r_crit_power_thrown_toh_scl_num;
+	int o_r_crit_power_thrown_toh_scl_den;
+	int o_r_crit_chance_power_scl_num;
+	int o_r_crit_chance_power_scl_den;
+	int o_r_crit_chance_add_den;
+	struct o_critical_level *o_r_crit_level_head;
+	/* See comment for o_m_max_added above. */
+	struct my_rational o_r_max_added;
 };
 
 struct init_module {

--- a/src/mon-timed.h
+++ b/src/mon-timed.h
@@ -30,8 +30,6 @@
 #define CONF_HIT_REDUCTION		20  /* Percentage reduction in accuracy for spells */
 #define CONF_RANDOM_CHANCE		40  /* Percentage chance of an aimed spell going in random direction */
 
-#define DEBUFF_CRITICAL_HIT		10  /* Effective increase in to-hit for critical hit calcs */
-
 /**
  * Monster Timed Effects
  */

--- a/src/player-attack.h
+++ b/src/player-attack.h
@@ -55,6 +55,8 @@ extern void do_cmd_throw(struct command *cmd);
 
 
 extern int breakage_chance(const struct object *obj, bool hit_target);
+int chance_of_missile_hit_base(const struct player *p,
+	const struct object *missile, const struct object *launcher);
 int chance_of_melee_hit_base(const struct player *p,
 	const struct object *weapon);
 extern bool test_hit(int to_hit, int ac);

--- a/src/tests/z-util/rational.c
+++ b/src/tests/z-util/rational.c
@@ -1,0 +1,217 @@
+/* z-util/rational.c */
+
+#include "unit-test.h"
+#include "z-util.h"
+
+NOSETUP
+NOTEARDOWN
+
+static int test_rational_construct(void *state) {
+	struct my_rational result = my_rational_construct(0, 1);
+
+	eq(result.n, 0);
+	eq(result.d, 1);
+	result = my_rational_construct(1, 1);
+	eq(result.n, 1);
+	eq(result.d, 1);
+	result = my_rational_construct(105, 441);
+	eq(result.n, 5);
+	eq(result.d, 21);
+	ok;
+}
+
+static int test_rational_to_uint(void *state) {
+	struct my_rational arg;
+	unsigned int result, remainder;
+
+	arg = my_rational_construct(0, 1);
+	result = my_rational_to_uint(&arg, 0, NULL);
+	eq(result, 0);
+	result = my_rational_to_uint(&arg, 0, &remainder);
+	eq(result, 0);
+	eq(remainder, 0);
+	result = my_rational_to_uint(&arg, 1, NULL);
+	eq(result, 0);
+	result = my_rational_to_uint(&arg, 1, &remainder);
+	eq(result, 0);
+	eq(remainder, 0);
+	result = my_rational_to_uint(&arg, 100, NULL);
+	eq(result, 0);
+	result = my_rational_to_uint(&arg, 100, &remainder);
+	eq(result, 0);
+	eq(remainder, 0);
+
+	arg = my_rational_construct(9, 5);
+	result = my_rational_to_uint(&arg, 1, NULL);
+	eq(result, 1);
+	result = my_rational_to_uint(&arg, 1, &remainder);
+	eq(result, 1);
+	eq(remainder, 4);
+	result = my_rational_to_uint(&arg, 4, NULL);
+	eq(result, 7);
+	result = my_rational_to_uint(&arg, 4, &remainder);
+	eq(result, 7);
+	eq(remainder, 1);
+	result = my_rational_to_uint(&arg, 17, NULL);
+	eq(result, 30);
+	result = my_rational_to_uint(&arg, 17, &remainder);
+	eq(result, 30);
+	eq(remainder, 3);
+
+	arg = my_rational_construct(UINT_MAX - 5, 8);
+	result = my_rational_to_uint(&arg, 15, NULL);
+	eq(result, UINT_MAX);
+	result = my_rational_to_uint(&arg, 15, &remainder);
+	eq(result, UINT_MAX);
+	eq(remainder, 0);
+	arg = my_rational_construct(UINT_MAX - 7, UINT_MAX - 6);
+	result = my_rational_to_uint(&arg, 24, NULL);
+	eq(result, 23);
+	result = my_rational_to_uint(&arg, 24, &remainder);
+	eq(result, 23);
+	eq(remainder, UINT_MAX - 30);
+	arg = my_rational_construct(UINT_MAX, UINT_MAX - 1);
+	result = my_rational_to_uint(&arg, UINT_MAX, NULL);
+	eq(result, UINT_MAX);
+	result = my_rational_to_uint(&arg, UINT_MAX, &remainder);
+	eq(result, UINT_MAX);
+	eq(remainder, 0);
+	arg = my_rational_construct(3, 8);
+	result = my_rational_to_uint(&arg, UINT_MAX, NULL);
+	eq(result, (3U * (1U << (CHAR_BIT * sizeof(unsigned int) - 3)) - 1U));
+	result = my_rational_to_uint(&arg, UINT_MAX, &remainder);
+	eq(result, (3U * (1U << (CHAR_BIT * sizeof(unsigned int) - 3)) - 1U));
+	eq(remainder, 5);
+
+	ok;
+}
+
+static int test_rational_product(void *state) {
+	struct my_rational arg1, arg2, result;
+
+	arg1 = my_rational_construct(0, 5);
+	arg2 = my_rational_construct(1, 1);
+	result = my_rational_product(&arg1, &arg2);
+	eq(result.n, 0);
+	result = my_rational_product(&arg2, &arg1);
+	eq(result.n, 0);
+
+	arg1 = my_rational_construct(1, 9);
+	arg2 = my_rational_construct(2, 7);
+	result = my_rational_product(&arg1, &arg2);
+	eq(result.n, 2);
+	eq(result.d, 63);
+	result = my_rational_product(&arg2, &arg1);
+	eq(result.n, 2);
+	eq(result.d, 63);
+
+	arg1 = my_rational_construct(39, 64);
+	arg2 = my_rational_construct(7, 13);
+	result = my_rational_product(&arg1, &arg2);
+	eq(result.n, 21);
+	eq(result.d, 64);
+	result = my_rational_product(&arg2, &arg1);
+	eq(result.n, 21);
+	eq(result.d, 64);
+
+	arg1 = my_rational_construct(5, 4);
+	arg2 = my_rational_construct(6, 35);
+	result = my_rational_product(&arg1, &arg2);
+	eq(result.n, 3);
+	eq(result.d, 14);
+	result = my_rational_product(&arg2, &arg1);
+	eq(result.n, 3);
+	eq(result.d, 14);
+
+	arg1 = my_rational_construct(UINT_MAX - 1, UINT_MAX);
+	arg2 = my_rational_construct(UINT_MAX - 1, UINT_MAX - 2);
+	result = my_rational_product(&arg1, &arg2);
+	eq(result.n, 1);
+	eq(result.d, 1);
+	result = my_rational_product(&arg2, &arg1);
+	eq(result.n, 1);
+	eq(result.d, 1);
+
+	arg1 = my_rational_construct(1, UINT_MAX);
+	arg2 = my_rational_construct(1, UINT_MAX - 1);
+	result = my_rational_product(&arg1, &arg2);
+	eq(result.n, 0);
+	eq(result.d, 1);
+
+	arg1 = my_rational_construct(UINT_MAX, 3);
+	arg2 = my_rational_construct(UINT_MAX - 1, 7);
+	result = my_rational_product(&arg1, &arg2);
+	eq(result.n, UINT_MAX);
+	eq(result.d, 1);
+
+	ok;
+}
+
+static int test_rational_sum(void *state) {
+	struct my_rational arg1, arg2, result;
+
+	arg1 = my_rational_construct(0, 7);
+	arg2 = my_rational_construct(1, 1);
+	result = my_rational_sum(&arg1, &arg2);
+	eq(result.n, 1);
+	eq(result.d, 1);
+	result = my_rational_sum(&arg2, &arg1);
+	eq(result.n, 1);
+	eq(result.d, 1);
+
+	arg1 = my_rational_construct(9, 17);
+	arg2 = my_rational_construct(3, 5);
+	result = my_rational_sum(&arg1, &arg2);
+	eq(result.n, 96);
+	eq(result.d, 85);
+	result = my_rational_sum(&arg2, &arg1);
+	eq(result.n, 96);
+	eq(result.d, 85);
+
+	arg1 = my_rational_construct(3, 8);
+	arg2 = my_rational_construct(5, 4);
+	result = my_rational_sum(&arg1, &arg2);
+	eq(result.n, 13);
+	eq(result.d, 8);
+	result = my_rational_sum(&arg2, &arg1);
+	eq(result.n, 13);
+	eq(result.d, 8);
+
+	arg1 = my_rational_construct(3, 14);
+	arg2 = my_rational_construct(7, 30);
+	result = my_rational_sum(&arg1, &arg2);
+	eq(result.n, 47);
+	eq(result.d, 105);
+	result = my_rational_sum(&arg2, &arg1);
+	eq(result.n, 47);
+	eq(result.d, 105);
+
+	arg1 = my_rational_construct(UINT_MAX - 1, UINT_MAX);
+	arg2 = my_rational_construct(UINT_MAX - 2, UINT_MAX);
+	result = my_rational_sum(&arg1, &arg2);
+	eq(result.n, UINT_MAX - 2);
+	eq(result.d, UINT_MAX / 2);
+
+	arg1 = my_rational_construct(1, UINT_MAX);
+	arg2 = my_rational_construct(1, UINT_MAX - 1);
+	result = my_rational_sum(&arg1, &arg2);
+	eq(result.n, 2);
+	eq(result.d, UINT_MAX);
+
+	arg1 = my_rational_construct(UINT_MAX - 1, 1);
+	arg2 = my_rational_construct(17, 8);
+	result = my_rational_sum(&arg1, &arg2);
+	eq(result.n, UINT_MAX);
+	eq(result.d, 1);
+
+	ok;
+}
+
+const char *suite_name = "z-util/rational";
+struct test tests[] = {
+	{ "rational_construct", test_rational_construct },
+	{ "rational_to_uint", test_rational_to_uint },
+	{ "rational_product", test_rational_product },
+	{ "rational_sum", test_rational_sum },
+	{ NULL, NULL }
+};

--- a/src/tests/z-util/suite.mk
+++ b/src/tests/z-util/suite.mk
@@ -1,1 +1,3 @@
-TESTPROGS += z-util/util
+TESTPROGS += \
+	z-util/rational \
+	z-util/util

--- a/src/z-util.h
+++ b/src/z-util.h
@@ -22,6 +22,9 @@
 #include "h-basic.h"
 
 
+struct my_rational { unsigned int n, d; }; /* numerator and denominator */
+
+
 /**
  * ------------------------------------------------------------------------
  * Available variables
@@ -239,5 +242,14 @@ uint32_t djb2_hash(const char *str);
  */
 int mean(const int *nums, int size);
 int variance(const int *nums, int size);
+unsigned int gcd(unsigned int a, unsigned int b);
+struct my_rational my_rational_construct(unsigned int numerator,
+		unsigned int denominator);
+unsigned int my_rational_to_uint(const struct my_rational *a,
+		unsigned int scale, unsigned int *remainder);
+struct my_rational my_rational_product(const struct my_rational *a,
+		const struct my_rational *b);
+struct my_rational my_rational_sum(const struct my_rational *a,
+		const struct my_rational *b);
 
 #endif /* INCLUDED_Z_UTIL_H */


### PR DESCRIPTION
Resolves part of https://github.com/angband/angband/issues/4803 . Fixes some mismatches between the critical calculations used for displayed object information and those used for combat.  In all instances the object information calculations were changed to match those for combat:
    1) For non-O melee criticals, the normalization of the sums for the
       additive term was wrong (500 instead of 1300).
    2) For non-O melee criticals the to-hit value was scaled by 3 for
       object information while the scale factor for combat was 1.
    3) Non-O criticals summed over a range of powers that was w, the weight
       of the missile or weapon, to w + a where a is 649 for melee criticals
       and 499 for ranged criticals.  The range of powers in the combat
       calculations is 1 + weight to 1 + weight + a.
    4) For O criticals with melee weapons, the to-hit value was not
       scaled down by a factor of three as it is in the combat calculations.
    5) For O criticals with thrown weapons, the power of the critical
       wasn't boosted by a factor of 1.5 for the object information
       calculations.
For the object information calculations, calculate_melee_crits(), o_calculate_melee_crits(), calculate_missile_crits(), and o_calculate_missile_crits() now report values rounded to the nearest integer.  However, since there is further scaling for those results, the final values reported to the player still aren't guaranteed to be rounded to the nearest tenth.
Because of the corrections and the change to rounding, the reported damage for a level 1 warrior with 18/30 strength and 18/40 dexterity wielding a +0,+0 dagger and a +0,+0 x2 short bow with +0,+0 arrows changed as follows (that warrior had 3.84 blows/round with the dagger and 1 shot per round with the bow):
                                old non-O     new non-O     old 0     new O
                                 ---------        ---------     -----     -----
dagger, wielded          24.5                21.8         17.7       13.7
dagger, thrown            7.5                    7.6         10.5       11.3
arrow, launched           5.0                   5.0           7.0        7.0