### PR TITLE
Fix command annotation:  wielding takes energy

### DIFF
--- a/src/cmd-core.c
+++ b/src/cmd-core.c
@@ -88,7 +88,7 @@ static const struct command_info game_cmds[] =
 	{ CMD_PATHFIND, "walk", do_cmd_pathfind, false, true, 0 },
 	{ CMD_PICKUP, "pickup", do_cmd_pickup, false, true, 0 },
 	{ CMD_AUTOPICKUP, "autopickup", do_cmd_autopickup, false, true, 0 },
-	{ CMD_WIELD, "wear or wield", do_cmd_wield, false, false, 0 },
+	{ CMD_WIELD, "wear or wield", do_cmd_wield, false, true, 0 },
 	{ CMD_TAKEOFF, "take off", do_cmd_takeoff, false, true, 0 },
 	{ CMD_DROP, "drop", do_cmd_drop, false, true, 0 },
 	{ CMD_UNINSCRIBE, "un-inscribe", do_cmd_uninscribe, false, false, 0 },


### PR DESCRIPTION
That's a correction for handling bloodlust from https://github.com/angband/angband/commit/d88b41a03f7fcd6a0d040fc2797447d543d8e845 .