### PR TITLE
Use player's view for square_isinteresting() calls

### DIFF
--- a/src/player-path.c
+++ b/src/player-path.c
@@ -617,7 +617,7 @@ static bool run_test(const struct player *p)
 
 		/* Check memorized grids */
 		if (square_isknown(cave, grid)) {
-			bool notice = square_isinteresting(cave, grid);
+			bool notice = square_isinteresting(p->cave, grid);
 
 			/* Interesting feature */
 			if (notice) return true;

--- a/src/target.c
+++ b/src/target.c
@@ -354,7 +354,8 @@ bool target_accept(int y, int x)
 	}
 
 	/* Interesting memorized features */
-	if (square_isknown(cave, grid) && square_isinteresting(cave, grid)) {
+	if (square_isknown(cave, grid)
+			&& square_isinteresting(player->cave, grid)) {
 		return true;
 	}
 

--- a/src/ui-target.c
+++ b/src/ui-target.c
@@ -807,7 +807,7 @@ static bool aux_terrain(struct chunk *c, struct player *p,
 	const char *name, *lphrase2, *lphrase3;
 	char out_val[TARGET_OUT_VAL_SIZE];
 
-	if (!auxst->boring && !square_isinteresting(c, auxst->grid))
+	if (!auxst->boring && !square_isinteresting(p->cave, auxst->grid))
 		return false;
 
 	/* Terrain feature if needed */


### PR DESCRIPTION
Closes a possible cause for https://github.com/angband/angband/issues/5295 : magic mapping includes a grid with a secret door, monster opens or breaks that door, now that grid is "interesting" even if the player hasn't seen or mapped the grid since the door was opened or broken.