### PR TITLE
Generation failures: protect against artifact loss and better messages

### DIFF
--- a/src/gen-util.c
+++ b/src/gen-util.c
@@ -917,6 +917,27 @@ void vault_monsters(struct chunk *c, struct loc grid, int depth, int num)
 	}
 }
 
+/**
+ * Mark artifacts in a failed chunk as not created
+ */
+void uncreate_artifacts(struct chunk *c)
+{
+	int y, x;
+
+	/* Also mark created artifacts as not created ... */
+	for (y = 0; y < c->height; y++) {
+		for (x = 0; x < c->width; x++) {
+			struct loc grid = loc(x, y);
+			struct object *obj = square_object(c, grid);
+			while (obj) {
+				if (obj->artifact) {
+					mark_artifact_created(obj->artifact, false);
+				}
+				obj = obj->next;
+			}
+		}
+	}
+}
 
 /**
  * Dump the given level for post-mortem analysis; handle all I/O.

--- a/src/generate.c
+++ b/src/generate.c
@@ -1131,9 +1131,14 @@ static struct chunk *cave_generate(struct player *p, int height, int width)
 		/* Choose a profile and build the level */
 		dun->profile = choose_profile(p);
 		event_signal_string(EVENT_GEN_LEVEL_START, dun->profile->name);
-		chunk = dun->profile->builder(p, height, width);
+		chunk = dun->profile->builder(p, height, width, &error);
 		if (!chunk) {
-			error = "Failed to find builder";
+			if (!error) {
+				error = "unspecified level builder failure";
+			}
+			if (OPT(p, cheat_room)) {
+				msg("Generation restarted: %s.", error);
+			}
 			cleanup_dun_data(dun);
 			event_signal_flag(EVENT_GEN_LEVEL_END, false);
 			continue;
@@ -1192,6 +1197,7 @@ static struct chunk *cave_generate(struct player *p, int height, int width)
 			if (OPT(p, cheat_room)) {
 				msg("Generation restarted: %s.", error);
 			}
+			uncreate_artifacts(chunk);
 			cave_clear(chunk, p);
 			event_signal_flag(EVENT_GEN_LEVEL_END, false);
 		}

--- a/src/generate.h
+++ b/src/generate.h
@@ -211,7 +211,8 @@ struct streamer_profile {
 /*
  * cave_builder is a function pointer which builds a level.
  */
-typedef struct chunk * (*cave_builder) (struct player *p, int h, int w);
+typedef struct chunk * (*cave_builder) (struct player *p, int h, int w,
+		const char **p_error);
 
 
 struct cave_profile {
@@ -324,16 +325,25 @@ int get_level_profile_index_from_name(const char *name);
 const char *get_level_profile_name_from_index(int i);
 
 /* gen-cave.c */
-struct chunk *town_gen(struct player *p, int min_height, int min_width);
-struct chunk *classic_gen(struct player *p, int min_height, int min_width);
-struct chunk *labyrinth_gen(struct player *p, int min_height, int min_width);
+struct chunk *town_gen(struct player *p, int min_height, int min_width,
+	const char **p_error);
+struct chunk *classic_gen(struct player *p, int min_height, int min_width,
+	const char **p_error);
+struct chunk *labyrinth_gen(struct player *p, int min_height, int min_width,
+	const char **p_error);
 void ensure_connectedness(struct chunk *c, bool allow_vault_disconnect);
-struct chunk *cavern_gen(struct player *p, int min_height, int min_width);
-struct chunk *modified_gen(struct player *p, int min_height, int min_width);
-struct chunk *moria_gen(struct player *p, int min_height, int min_width);
-struct chunk *hard_centre_gen(struct player *p, int min_height, int min_width);
-struct chunk *lair_gen(struct player *p, int min_height, int min_width);
-struct chunk *gauntlet_gen(struct player *p, int min_height, int min_width);
+struct chunk *cavern_gen(struct player *p, int min_height, int min_width,
+	const char **p_error);
+struct chunk *modified_gen(struct player *p, int min_height, int min_width,
+	const char **p_error);
+struct chunk *moria_gen(struct player *p, int min_height, int min_width,
+	const char **p_error);
+struct chunk *hard_centre_gen(struct player *p, int min_height, int min_width,
+	const char **p_error);
+struct chunk *lair_gen(struct player *p, int min_height, int min_width,
+	const char **p_error);
+struct chunk *gauntlet_gen(struct player *p, int min_height, int min_width,
+	const char **p_error);
 struct chunk *arena_gen(struct player *p, int min_height, int min_width);
 
 /* gen-chunk.c */
@@ -430,6 +440,7 @@ void vault_monsters(struct chunk *c, struct loc grid, int depth, int num);
 void alloc_objects(struct chunk *c, int set, int typ, int num, int depth,
 	uint8_t origin);
 bool alloc_object(struct chunk *c, int set, int typ, int depth, uint8_t origin);
+void uncreate_artifacts(struct chunk *c);
 void dump_level_simple(const char *basefilename, const char *title,
 	struct chunk *c);
 void dump_level(ang_file *fo, const char *title, struct chunk *c, int **dist);

--- a/src/wiz-stats.c
+++ b/src/wiz-stats.c
@@ -1461,7 +1461,7 @@ static void stats_collect_level(void)
  * This code will go through the artifact list and make each artifact
  * uncreated so that our sim player can find them again!
  */
-static void uncreate_artifacts(void)
+static void uncreate_all_artifacts(void)
 {
 	int i;
 
@@ -1524,7 +1524,7 @@ static void clearing_stats(void)
 	/* Do many iterations of the game */
 	for (iter = 0; iter < tries; iter++) {
 		/* Move all artifacts to uncreated */
-		uncreate_artifacts();
+		uncreate_all_artifacts();
 
 		/* Move all uniques to alive */
 		revive_uniques();


### PR DESCRIPTION
Resolves https://github.com/angband/angband/issues/5490.  Uses uncreate_artifacts() from Narsil.  Adds an argument to all the level builders to specify a string describing a failure.  For the scale of the artifact loss issue, generated many levels at level 50 and level 95:  the change protected against zero lost artifacts in the 10000 successful generations at level 50 and eight lost artifacs in the 10000 successful generations at level 95.