### PR TITLE
Give hafted weapons bonuses if the character has the BLESS_WEAPON property

### DIFF
--- a/src/player-calcs.c
+++ b/src/player-calcs.c
@@ -2293,7 +2293,9 @@ void calc_bonuses(struct player *p, struct player_state *state, bool known_only,
 		}
 
 		/* Divine weapon bonus for blessed weapons */
-		if (player_has(p, PF_BLESS_WEAPON) && of_has(state->flags, OF_BLESSED)){
+		if (player_has(p, PF_BLESS_WEAPON)
+				&& (weapon->tval == TV_HAFTED
+				|| of_has(state->flags, OF_BLESSED))) {
 			state->to_h += 2;
 			state->to_d += 2;
 			state->bless_wield = true;


### PR DESCRIPTION
That's to match the description of the property.  Resolves https://github.com/angband/angband/issues/5664 .