### PR TITLE
Drop "light" from the descriptions of some quylthulg varieties

### DIFF
--- a/lib/gamedata/monster.txt
+++ b/lib/gamedata/monster.txt
@@ -10530,8 +10530,8 @@ spell-freq:2
 spells:BLINK | TPORT
 spells:S_DEMON
 message-invis:BLINK:Something slurps.
-desc:A pile of pulsing flesh that glows with an inner hellish fire.  The world
-desc: itself seems to cry out against it.
+desc:A pile of pulsing flesh that reeks of sulfur.  The world itself seems to
+desc: cry out against it.
 
 name:draconic quylthulg
 base:quylthulg
@@ -13095,7 +13095,7 @@ spell-freq:2
 spells:BLINK | TELE_TO
 spells:S_HI_DEMON
 message-invis:BLINK:Something slurps.
-desc:A massive pulsating mound of flesh, glowing with a hellish light.
+desc:A massive pulsating mound of flesh, strongly reeking of sulfur.
 
 name:greater draconic quylthulg
 base:quylthulg
@@ -13113,8 +13113,7 @@ spell-freq:2
 spells:BLINK | TELE_TO
 spells:S_HI_DRAGON
 message-invis:BLINK:Something slurps.
-desc:A massive mound of scaled flesh, throbbing and pulsating with multi-hued
-desc: light.
+desc:A massive mound of multi-hued scaled flesh, throbbing and pulsating.
 
 name:greater rotting quylthulg
 base:quylthulg


### PR DESCRIPTION
See the discussion here, http://angband.oook.cz/forum/showthread.php?t=11492 , including Nick's suggestion, adopted here, for the demonic quylthulgs.