### PR TITLE
Avoid drawing artifacts with the enter menu and big tiles

### DIFF
--- a/src/ui-context.c
+++ b/src/ui-context.c
@@ -1214,8 +1214,17 @@ static bool cmd_menu(struct command_list *list, void *selection_p)
 		}
 	}
 
-	/* Load the screen */
-	screen_load();
+	/*
+	 * Load the screen.  Do a more expensive update if not breaking out
+	 * all the way from the menus and there may be partially overwritten
+	 * big tiles.
+	 */
+	if (result && screen_save_depth > 1
+			&& (tile_width > 1 || tile_height > 1)) {
+		screen_load_all();
+	} else {
+		screen_load();
+	}
 
 	return result;
 }

--- a/src/ui-output.c
+++ b/src/ui-output.c
@@ -407,11 +407,12 @@ void prt(const char *str, int row, int col) {
 /**
  * Screen loading and saving can be done to an arbitrary depth but it's
  * important that every call to screen_save() is balanced by a call to
- * screen_load() later on.  'screen_save_depth' is used by the game to keep
- * track of whether it should try to update the map and sidebar or not,
- * so if you miss out a screen_load you will not get proper game updates.
+ * screen_load() or screen_load_all() later on.  'screen_save_depth' is used
+ * by the game to keep track of whether it should try to update the map and
+ * sidebar or not, so if you miss out a screen_load or screen_load_all you will
+ * not get proper game updates.
  *
- * Term_save() / Term_load() do all the heavy lifting here.
+ * Term_save() / Term_load() / Term_load_all() do all the heavy lifting here.
  */
 
 /**
@@ -438,6 +439,17 @@ void screen_load(void)
 {
 	event_signal(EVENT_MESSAGE_FLUSH);
 	Term_load();
+	screen_save_depth--;
+}
+
+/**
+ * Load the screen by replaying all the saves in reverse order with a redraw
+ * for each and decrease the "icky" depth.
+ */
+void screen_load_all(void)
+{
+	event_signal(EVENT_MESSAGE_FLUSH);
+	Term_load_all();
 	screen_save_depth--;
 }
 

--- a/src/ui-output.h
+++ b/src/ui-output.h
@@ -96,6 +96,7 @@ void prt(const char *str, int row, int col);
 extern int16_t screen_save_depth;
 void screen_save(void);
 void screen_load(void);
+void screen_load_all(void);
 bool textui_map_is_visible(void);
 
 

--- a/src/ui-term.h
+++ b/src/ui-term.h
@@ -397,6 +397,7 @@ extern errr Term_inkey(ui_event *ch, bool wait, bool take);
 
 extern errr Term_save(void);
 extern errr Term_load(void);
+extern errr Term_load_all(void);
 
 extern errr Term_resize(int w, int h);
 


### PR DESCRIPTION
The artifacts seen were failures to clear or redraw when scrolling through the entries or if backing out one level of the menu and not at the top level of the menu.