### PR TITLE
Trap: skip extra effect or other side effects if the player is dead

### DIFF
--- a/src/trap.c
+++ b/src/trap.c
@@ -548,8 +548,8 @@ extern void hit_trap(struct loc grid, int delayed)
 			effect = trap->kind->effect;
 			effect_do(effect, source_trap(trap), NULL, &ident, false, 0, 0, 0, NULL);
 
-			/* Trap may have gone */
-			if (!square_trap(cave, grid)) break;
+			/* Trap may have gone or the player may be dead */
+			if (!square_trap(cave, grid) || player->is_dead) break;
 
 			/* Do any extra effects */
 			if (trap->kind->effect_xtra && one_in_(2)) {
@@ -559,8 +559,8 @@ extern void hit_trap(struct loc grid, int delayed)
 				effect_do(effect, source_trap(trap), NULL, &ident, false,
 						  0, 0, 0, NULL);
 
-				/* Trap may have gone */
-				if (!square_trap(cave, grid)) break;
+				/* Trap may have gone or the player may be dead */
+				if (!square_trap(cave, grid) || player->is_dead) break;
 			}
 		}
 


### PR DESCRIPTION
Fixes an instance of bad messaging reported for https://github.com/angband/angband/issues/2798 .