### PR TITLE
For baseline store sale price, use max(player's perceived price, real price)

### DIFF
--- a/src/store.c
+++ b/src/store.c
@@ -591,14 +591,26 @@ int price_item(struct store *store, const struct object *obj,
 
 	/* Get the value of the stack of wands, or a single item */
 	if (tval_can_have_charges(obj)) {
-		price = MIN(object_value_real(obj, qty), object_value(obj, qty));
+		if (store_buying) {
+			price = MIN(object_value_real(obj, qty),
+				object_value(obj, qty));
+		} else {
+			price = MAX(object_value_real(obj, qty),
+				object_value(obj, qty));
+		}
 	} else {
-		price = MIN(object_value_real(obj, 1), object_value(obj, 1));
+		if (store_buying) {
+			price = MIN(object_value_real(obj, 1),
+				object_value(obj, 1));
+		} else {
+			price = MAX(object_value_real(obj, 1),
+				object_value(obj, 1));
+		}
 	}
 
 	/* Worthless items */
 	if (price <= 0) {
-		return 0;
+		return (store_buying) ? 0 : qty;
 	}
 
 	/* The black market is always a worse deal */


### PR DESCRIPTION
Resolves https://github.com/NickMcConnell/FAangband/issues/383 (the real price of a stocked item generated by store_create_random() is positive, but the player perception of that can be negative leading to a zero priced item with the former pricing scheme).  Also, always constrain the price per item to be at least one when the store is selling.