### PR TITLE
nds: Set an alpha value for translated colors

### DIFF
--- a/src/main-nds.c
+++ b/src/main-nds.c
@@ -232,7 +232,8 @@ static void init_color_data(void)
 #ifdef __3DS__
 		color_data[i] = angband_color_table[i][1] << 24 |
 		                angband_color_table[i][2] << 16 |
-		                angband_color_table[i][3] << 8;
+		                angband_color_table[i][3] << 8 |
+		                0xFF;
 #else
 		color_data[i] = RGB15(angband_color_table[i][1] >> 3,
 		                      angband_color_table[i][2] >> 3,


### PR DESCRIPTION
Not sure why this isn't an issue anywhere else (thinking about it, what does an alpha value even do when writing to a framebuffer?), but Citra on Wayland actually draws with an alpha value, causing the game to be completely transparent (as in "you can actually see the Desktop, and pretty much only that).