### PR TITLE
Have allocation for throwing_list use its type

### DIFF
--- a/src/ui-object.c
+++ b/src/ui-object.c
@@ -1251,7 +1251,7 @@ bool textui_get_item(struct object **choice, const char *pmt, const char *str,
 		z_info->floor_size;
 
 	floor_list = mem_zalloc(floor_max * sizeof(*floor_list));
-	throwing_list = mem_zalloc(throwing_max * sizeof(*floor_list));
+	throwing_list = mem_zalloc(throwing_max * sizeof(*throwing_list));
 	olist_mode = 0;
 	item_mode = mode;
 	item_cmd = cmd;


### PR DESCRIPTION
Was using floor_list's type, which is the same and will likely remain the same as floor_list's type.