### PR TITLE
Rearrange UI's handling of a new level to avoid monster list leaking info

### DIFF
--- a/src/ui-display.c
+++ b/src/ui-display.c
@@ -2496,20 +2496,14 @@ static void new_level_display_update(game_event_type type,
 	Term->offset_y = z_info->dungeon_hgt;
 	Term->offset_x = z_info->dungeon_wid;
 
-	/* If autosave is pending, do it now. */
-	if (player->upkeep->autosave) {
-		save_game();
-		player->upkeep->autosave = false;
-	}
-
 	/* Choose panel */
 	verify_panel();
 
-	/* Hack -- Invoke partial update mode */
-	player->upkeep->only_partial = true;
-
 	/* Clear */
 	Term_clear();
+
+	/* Hack -- Invoke partial update mode */
+	player->upkeep->only_partial = true;
 
 	/* Update stuff */
 	player->upkeep->update |= (PU_BONUS | PU_HP | PU_SPELLS);
@@ -2519,9 +2513,6 @@ static void new_level_display_update(game_event_type type,
 
 	/* Fully update the visuals (and monster distances) */
 	player->upkeep->update |= (PU_UPDATE_VIEW | PU_DISTANCE);
-
-	/* Update stuff */
-	update_stuff(player);
 
 	/* Redraw dungeon */
 	player->upkeep->redraw |= (PR_BASIC | PR_EXTRA | PR_MAP);
@@ -2533,11 +2524,18 @@ static void new_level_display_update(game_event_type type,
 	 * set for a few game turns, manually force an update on level change. */
 	monster_list_force_subwindow_update();
 
-	/* Update stuff */
-	update_stuff(player);
+	/* If autosave is pending, do it now. */
+	if (player->upkeep->autosave) {
+		save_game();
+		player->upkeep->autosave = false;
+	}
 
-	/* Redraw stuff */
-	redraw_stuff(player);
+	/*
+	 * Saving has side effect of calling handle_stuff(), but if we did
+	 * not save or saving no longer calls handle_stuff(), call
+	 * handle_stuff() now to process the pending updates and redraws.
+	 */
+	handle_stuff(player);
 
 	/* Hack -- Kill partial update mode */
 	player->upkeep->only_partial = false;


### PR DESCRIPTION
Resolves https://github.com/angband/angband/issues/5713 .