### PR TITLE
Destroyed grid: remove any orphaned objects with a known counterpart there

### DIFF
--- a/src/cave.h
+++ b/src/cave.h
@@ -370,6 +370,8 @@ struct trap *square_trap(struct chunk *c, struct loc grid);
 bool square_holds_object(struct chunk *c, struct loc grid, struct object *obj);
 void square_excise_object(struct chunk *c, struct loc grid, struct object *obj);
 void square_excise_pile(struct chunk *c, struct loc grid);
+void square_excise_all_imagined(struct chunk *p_c, struct chunk *c,
+		struct loc grid);
 void square_delete_object(struct chunk *c, struct loc grid, struct object *obj, bool do_note, bool do_light);
 void square_sense_pile(struct chunk *c, struct loc grid);
 void square_know_pile(struct chunk *c, struct loc grid);

--- a/src/effect-handler-attack.c
+++ b/src/effect-handler-attack.c
@@ -1233,6 +1233,8 @@ bool effect_handler_DESTRUCTION(effect_handler_context_t *context)
 				}
 
 				/* Delete objects */
+				square_excise_all_imagined(player->cave, cave,
+					grid);
 				square_excise_pile(player->cave, grid);
 				square_excise_pile(cave, grid);
 				square_destroy(cave, grid);

--- a/src/effect-handler-general.c
+++ b/src/effect-handler-general.c
@@ -1554,6 +1554,12 @@ bool effect_handler_DETECT_GOLD(effect_handler_context_t *context)
  * This is a helper for effect_handler_SENSE_OBJECTS and
  * effect_handler_DETECT_OBJECTS to remove remembered objects at locations
  * sensed or detected as empty.
+ *
+ * When compatibility with old savefiles is no longer needed (those which
+ * have objects in the known cave which need to be relocated; 4.3 can drop
+ * support for them) calls to this function can be replaced by:
+ *     square_excise_all_imagined(player->cave, cave, grid);
+ *     square_excise_pile(player->cave, grid);
  */
 static void forget_remembered_objects(struct chunk *c, struct chunk *knownc, struct loc grid)
 {

--- a/src/tests/effects/destruction.c
+++ b/src/tests/effects/destruction.c
@@ -144,6 +144,17 @@ static int test_obj_pile_simple(void *state) {
 	generate_piles(cave, player);
 	effect_simple(EF_DESTRUCTION, source_player(), "0", 0,
 		MAX(cave->width / 2, cave->height / 2), 0, 0, 0, NULL);
+	/*
+	 * This is a way to trigger use after free notices from the address
+	 * sanitizer if there is dangling references to the known versions of
+	 * objects (for instance, before
+	 * https://github.com/angband/angband/issues/5723 was resolved).
+	 */
+	update_player_object_knowledge(player);
+	/*
+	 * This is a convenient way to trigger pile integrity checks on every
+	 * grid.
+	 */
 	wiz_light(cave, player, true);
 	cave_free(player->cave);
 	player->cave = NULL;
@@ -165,6 +176,17 @@ static int test_obj_pile_orphan(void *state) {
 	orphan_piles(cave);
 	effect_simple(EF_DESTRUCTION, source_player(), "0", 0,
 		MAX(cave->width / 2, cave->height / 2), 0, 0, 0, NULL);
+	/*
+	 * This is a way to trigger use after free notices from the address
+	 * sanitizer if there is dangling references to the known versions of
+	 * objects (for instance, before
+	 * https://github.com/angband/angband/issues/5723 was resolved).
+	 */
+	update_player_object_knowledge(player);
+	/*
+	 * This is a convenient way to trigger pile integrity checks on every
+	 * grid.
+	 */
 	wiz_light(cave, player, true);
 	cave_free(player->cave);
 	player->cave = NULL;

--- a/src/tests/effects/earthquake.c
+++ b/src/tests/effects/earthquake.c
@@ -144,6 +144,17 @@ static int test_obj_pile_simple(void *state) {
 	generate_piles(cave, player);
 	effect_simple(EF_EARTHQUAKE, source_player(), "0", 0,
 		MAX(cave->width / 2, cave->height / 2), 0, 0, 0, NULL);
+	/*
+	 * This is a way to trigger use after free notices from the address
+	 * sanitizer if there is dangling references to the known versions of
+	 * objects (for instance, before
+	 * https://github.com/angband/angband/issues/5723 was resolved).
+	 */
+	update_player_object_knowledge(player);
+	/*
+	 * This is a convenient way to trigger pile integrity checks on every
+	 * grid.
+	 */
 	wiz_light(cave, player, true);
 	cave_free(player->cave);
 	player->cave = NULL;
@@ -165,6 +176,17 @@ static int test_obj_pile_orphan(void *state) {
 	orphan_piles(cave);
 	effect_simple(EF_EARTHQUAKE, source_player(), "0", 0,
 		MAX(cave->width / 2, cave->height / 2), 0, 0, 0, NULL);
+	/*
+	 * This is a way to trigger use after free notices from the address
+	 * sanitizer if there is dangling references to the known versions of
+	 * objects (for instance, before
+	 * https://github.com/angband/angband/issues/5723 was resolved).
+	 */
+	update_player_object_knowledge(player);
+	/*
+	 * This is a convenient way to trigger pile integrity checks on every
+	 * grid.
+	 */
 	wiz_light(cave, player, true);
 	cave_free(player->cave);
 	player->cave = NULL;


### PR DESCRIPTION
Resolves https://github.com/angband/angband/issues/5723 .  Likely resolves https://github.com/NickMcConnell/FAangband/issues/331 .  May impact https://github.com/NickMcConnell/FAangband/issues/332 .  Extend test cases for destruction and earthquake effects so they can detect, if compiled with the address sanitizer, the buggy behavior causing https://github.com/angband/angband/issues/5723 .