### PR TITLE
Makefile.std: use suffix rules rather than pattern rules

### DIFF
--- a/src/Makefile.std
+++ b/src/Makefile.std
@@ -170,7 +170,7 @@ depend:
 
 
 # Some file dependencies
-%.o: %.c
+.c.o:
 	@printf "%10s %-20s\n" CC $<
 	@$(CC) $(CFLAGS) -o $@ -c $<
 


### PR DESCRIPTION
The former works with both GNU make and BSD make.  Fixes a regression introduced by 4.2.5:  on OpenBSD would have to use gmake rather than make to use Makefile.std (still have to change gcc to cc or clang, but that was also true with 4.2.4).