### PR TITLE
Workflows: drop USE_PRINTF_STYLE_CHECKS for builds with CMake

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          env CFLAGS=-Wall cmake -DUSE_PRINTF_STYLE_CHECKS=ON ..
+          env CFLAGS=-Wall cmake ..
           make
 
   ncurses:
@@ -61,7 +61,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          env CFLAGS=-Wall cmake -DSUPPORT_GCU_FRONTEND=ON -DUSE_PRINTF_STYLE_CHECKS=ON ..
+          env CFLAGS=-Wall cmake -DSUPPORT_GCU_FRONTEND=ON ..
           make
 
   sdl:
@@ -80,7 +80,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          env CFLAGS=-Wall cmake -DSUPPORT_SDL_FRONTEND=ON -DSUPPORT_SDL_SOUND=ON -DUSE_PRINTF_STYLE_CHECKS=ON ..
+          env CFLAGS=-Wall cmake -DSUPPORT_SDL_FRONTEND=ON -DSUPPORT_SDL_SOUND=ON ..
           make
 
   sdl2:


### PR DESCRIPTION
CMakeLists.txt dropped that option in https://github.com/angband/angband/commit/6d447386ba10f3836468a2e36d62730fe7d52a81 .  Format argument checking for gcc and clang was made the default in https://github.com/angband/angband/commit/838f0f3030c3dcc1dbcbdb5daa565743a454490a .