### PR TITLE
Have "make clean" remove all optional intermediates

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -20,7 +20,8 @@ CFLAGS += -I. -fPIC -std=c99 -O0
 GCOBJS = $(OBJECTS:.o=.gcno) $(OBJECTS:.o=.gcda)
 GCOVS = $(OBJECTS:.o=.c.gcov)
 
-CLEAN = angband.o $(OBJECTS) win/angband.res version.h
+# buildsys's default clean will take care of any .o from SRCS.
+CLEAN = $(PROGNAME).o $(ALLMAINFILES) ${ALLMAINFILES:.o=.dep} version.h
 DISTCLEAN = autoconf.h tests/.deps
 
 $(PROG): $(PROGNAME).o $(MAINFILES)

--- a/src/Makefile.src
+++ b/src/Makefile.src
@@ -87,6 +87,25 @@ WINMAINFILES = \
 
 X11MAINFILES = main-x11.o
 
+STATSMAINFILES = main-stats.o \
+        stats/db.o
+
+SPOILMAINFILES = main-spoil.o
+
+# Remember all optional intermediates so "make clean" will get all of them
+# even if the configuration has changed since a build was done.
+ALLMAINFILES = \
+	$(BASEMAINFILES) \
+	$(GCUMAINFILES) \
+	$(SDL2MAINFILES) \
+	$(SDLMAINFILES) \
+	$(SNDSDLFILES) \
+	$(TESTMAINFILES) \
+	$(WINMAINFILES) \
+	$(X11MAINFILES) \
+	$(STATSMAINFILES) \
+	$(SPOILMAINFILES)
+
 ANGFILES0 = \
 	cave.o \
 	cave-map.o \
@@ -232,11 +251,6 @@ ANGFILES0 = \
 	borg/borg7.o \
 	borg/borg8.o \
 	borg/borg9.o
-
-STATSMAINFILES = main-stats.o \
-        stats/db.o
-
-SPOILMAINFILES = main-spoil.o
 
 buildid.o: $(ANGFILES0)
 ANGFILES = $(ANGFILES0) buildid.o


### PR DESCRIPTION
That's to address part two of Magnate's request here, http://angband.oook.cz/forum/showpost.php?p=161423&postcount=1 .  Also use $(PROGNAME).o rather than angband.o in the clean rule so forks have one less thing to change.