### PR TITLE
When appending spells to monster lore, set ref_race for expressions

### DIFF
--- a/src/mon-lore.c
+++ b/src/mon-lore.c
@@ -1498,8 +1498,13 @@ void lore_append_spells(textblock *tb, const struct monster_race *race,
 	const char *initial_pronoun;
 	bool know_hp;
 	bitflag current_flags[RSF_SIZE], test_flags[RSF_SIZE];
+	const struct monster_race *old_ref;
 
 	assert(tb && race && lore);
+
+	/* Set the race for expressions in the spells. */
+	old_ref = ref_race;
+	ref_race = race;
 
 	know_hp = lore->armour_known;
 
@@ -1597,6 +1602,9 @@ void lore_append_spells(textblock *tb, const struct monster_race *race,
 
 		textblock_append(tb, ".  ");
 	}
+
+	/* Restore the previous reference. */
+	ref_race = old_ref;
 }
 
 /**


### PR DESCRIPTION
Ported from NarSil, where it prevents crashes during lore updates after a monster dies on its own turn.