### PR TITLE
wrap up another pass at random artifact activations

### DIFF
--- a/src/borg/borg1.c
+++ b/src/borg/borg1.c
@@ -30,6 +30,7 @@ power_item** borg_power_item;
 int*    n_pwr;
 int*    borg_has;
 int*    borg_skill;
+int*    borg_activation;
 int     size_depth;
 int     size_obj;
 int*    formula[1000];
@@ -265,6 +266,12 @@ const char* prefix_pref[] =
     "_ACCW",     /* CCW potions (just because we use it so often) */
     "_ACSW",     /* CSW potions (+ CLW if cut) */
     "_ACLW",
+    "_AENCH_TOH", /* enchant weapons and armor (+spells) */
+    "_AENCH_TOD",
+    "_AENCH_SWEP",
+    "_AENCH_ARM",
+    "_AENCH_SARM",
+    "_ABRAND",
     "_ARESHEAT", /* potions of res heat */
     "_ARESCOLD", /* pot of res cold */
     "_ARESPOIS", /* Potions of Res Poison */
@@ -274,6 +281,8 @@ const char* prefix_pref[] =
     "_ASHROOM",		/* Number of cool mushrooms */
     "_AROD1",		/* Attack rods */
     "_AROD2",		/* Attack rods */
+    "_ANEED_ID",    /* a wielded item that needs ID */
+    "_MULTI_BONUSES", /* Items with multiple useful bonuses */
     "_DINV",        /* See Inv Spell is Legal */
     "_WEIGHT",      /* weight of all inventory and equipment */
     "_EMPTY",       /* number of empty slots */
@@ -634,12 +643,6 @@ int16_t amt_fix_exp;
 
 int16_t amt_cool_staff;   /* holiness - power staff */
 int16_t amt_cool_wand;	/* # of charges on Wands which can be useful for attacks */
-int16_t amt_enchant_to_a;
-int16_t amt_enchant_to_d;
-int16_t amt_enchant_to_h;
-int16_t amt_brand_weapon;  /*  brand bolts */
-int16_t amt_enchant_weapon;
-int16_t amt_enchant_armor;
 int16_t amt_digger;
 int16_t amt_ego;
 

--- a/src/borg/borg1.h
+++ b/src/borg/borg1.h
@@ -932,6 +932,7 @@ typedef struct power_item
 extern power_item** borg_power_item;
 extern int*     n_pwr;
 extern int*     borg_has;
+extern int*     borg_activation;
 extern int*     borg_skill;
 extern int      size_depth;
 extern int      size_obj;
@@ -1162,6 +1163,12 @@ enum
     BI_ACCW,
     BI_ACSW,
     BI_ACLW,
+    BI_AENCH_TOH,
+    BI_AENCH_TOD,
+    BI_AENCH_SWEP,
+    BI_AENCH_ARM,
+    BI_AENCH_SARM,
+    BI_ABRAND,
     BI_ARESHEAT,
     BI_ARESCOLD,
     BI_ARESPOIS,
@@ -1171,6 +1178,8 @@ enum
     BI_ASHROOM,
     BI_AROD1,		/* Attack rods */
     BI_AROD2,		/* Attack rods */
+    BI_ANEED_ID,
+    BI_MULTIPLE_BONUSES,
     BI_DINV,	/* See Inv Spell Legal */
     BI_WEIGHT,  /* weight of all inventory and equipment */
     BI_EMPTY,   /* number of empty slots */
@@ -1506,6 +1515,7 @@ extern int32_t  my_power;
 
 /*
  * Various "amounts" (for the player)
+ * !FIX should probably be BORG_SKILL values 
  */
 
 extern int16_t  amt_food_lowcal;
@@ -1524,12 +1534,6 @@ extern int16_t  amt_inc_stat[6];
 
 extern int16_t  amt_fix_exp;
 
-extern int16_t  amt_enchant_to_a;
-extern int16_t  amt_enchant_to_d;
-extern int16_t  amt_enchant_to_h;
-extern int16_t  amt_brand_weapon;  /* cubragol and bolts */
-extern int16_t  amt_enchant_weapon;
-extern int16_t  amt_enchant_armor;
 extern int16_t  amt_digger;
 extern int16_t  amt_ego;
 

--- a/src/borg/borg4.c
+++ b/src/borg/borg4.c
@@ -920,7 +920,10 @@ static void borg_notice_aux1(void)
         /* total up the weight of the items */
         borg_skill[BI_WEIGHT] += item->weight * item->iqty;
 
-        if (borg_item_note_needs_id(item)) my_need_id++;
+        if (borg_item_note_needs_id(item)) {
+            my_need_id++;
+            borg_skill[BI_ANEED_ID] += 1;
+        }
 
         /* track first cursed item */
         if (!borg_skill[BI_FIRST_CURSED] && item->uncursable)
@@ -1142,6 +1145,32 @@ static void borg_notice_aux1(void)
         if (of_has(item->flags, OF_SUST_DEX)) borg_skill[BI_SDEX] = true;
         if (of_has(item->flags, OF_SUST_CON)) borg_skill[BI_SCON] = true;
 
+        /* Good to have one item with multiple high resists */
+        int bonuses = ((item->el_info[ELEM_POIS].res_level > 0) +
+            (item->el_info[ELEM_SOUND].res_level > 0) +
+            (item->el_info[ELEM_SHARD].res_level > 0) +
+            (item->el_info[ELEM_NEXUS].res_level > 0) +
+            (item->el_info[ELEM_NETHER].res_level > 0) +
+            (item->el_info[ELEM_CHAOS].res_level > 0) +
+            (item->el_info[ELEM_DISEN].res_level > 0) +
+            /* resist base 4 */
+            ((item->el_info[ELEM_FIRE].res_level > 0) &&
+                (item->el_info[ELEM_COLD].res_level > 0) &&
+                (item->el_info[ELEM_ELEC].res_level > 0) &&
+                (item->el_info[ELEM_ACID].res_level > 0)) +
+            /* sustains all stats  */
+            (of_has(item->flags, OF_SUST_STR) &&
+                of_has(item->flags, OF_SUST_INT) &&
+                of_has(item->flags, OF_SUST_WIS) &&
+                of_has(item->flags, OF_SUST_DEX) &&
+                of_has(item->flags, OF_SUST_CON)));
+
+        if (bonuses > 2)
+            borg_skill[BI_MULTIPLE_BONUSES] += bonuses;
+
+        /* track activations */
+        if (item->activ_idx)
+            borg_activation[item->activ_idx] += 1;
 
         /* Hack -- Net-zero The borg will miss read acid damaged items such as
          * Leather Gloves [2,-2] and falsely assume they help his power.
@@ -1481,7 +1510,7 @@ static void borg_notice_aux1(void)
 
         /* Enchant all weapons (to hit) */
         if ((borg_spell_legal_fail(ENCHANT_WEAPON, 65) ||
-            amt_enchant_weapon >= 1))
+            borg_skill[BI_AENCH_SWEP] >= 1))
         {
             if (item->to_h < borg_cfg[BORG_ENCHANT_LIMIT])
             {
@@ -1522,7 +1551,7 @@ static void borg_notice_aux1(void)
 
         /* Note need for enchantment */
         if (borg_spell_legal_fail(ENCHANT_ARMOUR, 65) ||
-            amt_enchant_armor >= 1)
+            borg_skill[BI_AENCH_SARM] >= 1)
         {
             if (item->to_a < borg_cfg[BORG_ENCHANT_LIMIT])
             {
@@ -1630,15 +1659,6 @@ static void borg_notice_aux2(void)
     amt_cool_staff = 0;
     amt_cool_wand = 0;
     amt_digger = 0;
-
-    /* Reset enchantment */
-    amt_enchant_to_a = 0;
-    amt_enchant_to_d = 0;
-    amt_enchant_to_h = 0;
-
-    amt_brand_weapon = 0;
-    amt_enchant_weapon = 0;
-    amt_enchant_armor = 0;
 
     /* Reset number of Ego items needing *ID* */
     amt_ego = 0;
@@ -1838,17 +1858,17 @@ static void borg_notice_aux2(void)
         else if (item->sval == sv_scroll_word_of_recall)
             borg_skill[BI_RECALL] += item->iqty;
         else if (item->sval == sv_scroll_enchant_armor)
-            amt_enchant_to_a += item->iqty;
+            borg_skill[BI_AENCH_ARM] += item->iqty;
+        else if (item->sval == sv_scroll_star_enchant_armor)
+            borg_skill[BI_AENCH_SARM] += item->iqty;
         else if (item->sval == sv_scroll_enchant_weapon_to_hit)
-            amt_enchant_to_h += item->iqty;
+            borg_skill[BI_AENCH_TOH] += item->iqty;
         else if (item->sval == sv_scroll_enchant_weapon_to_dam)
-            amt_enchant_to_d += item->iqty;
+            borg_skill[BI_AENCH_TOD] += item->iqty;
         else if (item->sval == sv_scroll_star_enchant_weapon)
-            amt_enchant_weapon += item->iqty;
+            borg_skill[BI_AENCH_SWEP] += item->iqty;
         else if (item->sval == sv_scroll_protection_from_evil)
             borg_skill[BI_APFE] += item->iqty;
-        else if (item->sval == sv_scroll_star_enchant_armor)
-            amt_enchant_armor += item->iqty;
         else if (item->sval == sv_scroll_rune_of_protection)
             borg_skill[BI_AGLYPH] += item->iqty;
         else if (item->sval == sv_scroll_teleport_level)
@@ -2161,23 +2181,23 @@ static void borg_notice_aux2(void)
     /* Handle ENCHANT_WEAPON */
     if (borg_spell_legal_fail(ENCHANT_WEAPON, 65))
     {
-        amt_enchant_to_h += 1000;
-        amt_enchant_to_d += 1000;
-        amt_enchant_weapon += 1000;
+        borg_skill[BI_AENCH_TOH] += 1000;
+        borg_skill[BI_AENCH_TOD] += 1000;
+        borg_skill[BI_AENCH_SWEP] += 1000;
     }
 
     /* Handle "Brand Weapon (bolts)" */
     if (borg_equips_item(act_firebrand, false) ||
         borg_spell_legal_fail(BRAND_AMMUNITION, 65))
     {
-        amt_brand_weapon += 1000;
+        borg_skill[BI_ABRAND] += 1000;
     }
 
     /* Handle "enchant armor" */
     if (borg_spell_legal_fail(ENCHANT_ARMOUR, 65))
     {
-        amt_enchant_to_a += 1000;
-        amt_enchant_armor += 1000;
+        borg_skill[BI_AENCH_ARM] += 1000;
+        borg_skill[BI_AENCH_SARM] += 1000;
     }
 
     /* Handle Diggers (stone to mud) */
@@ -2778,7 +2798,7 @@ static void borg_notice_weapon_swap(void)
 
     /* Enchant swap weapons (to hit) */
     if ((borg_spell_legal_fail(ENCHANT_WEAPON, 65) ||
-        amt_enchant_weapon >= 1) && item->tval != TV_DIGGING)
+        borg_skill[BI_AENCH_SWEP] >= 1) && item->tval != TV_DIGGING)
     {
         if (item->to_h < 10)
         {
@@ -3291,7 +3311,7 @@ static void borg_notice_armour_swap(void)
     /* Hack -- enchant the swap equipment (armor) */
     /* Note need for enchantment */
     if (borg_spell_legal_fail(ENCHANT_ARMOUR, 65) ||
-        amt_enchant_armor >= 1)
+        borg_skill[BI_AENCH_SARM] >= 1)
     {
         if (item->to_a < 10)
         {
@@ -3318,6 +3338,7 @@ void borg_notice(bool notice_swap)
 
     /* Clear out 'has' array */
     memset(borg_has, 0, size_obj * sizeof(int));
+    memset(borg_activation, 0, z_info->act_max * sizeof(int));
 
     /* Many of our variables are tied to borg_skill[], which is erased at the
      * the start of borg_notice().  So we must update the frame the cheat in
@@ -4921,400 +4942,362 @@ static int32_t borg_power_aux1(void)
     }
 #endif
 
-    /* Reward for activatable items in inventory */
-    for (i = INVEN_WIELD; i < INVEN_TOTAL; i++)
-    {
-        int multibonus = 0;
+    /* bonus for something with multiple useful bonuses */
+    value += 3000L * borg_skill[BI_MULTIPLE_BONUSES];
 
-        item = &borg_items[i];
+    /* bonus for wearing something that needs an ID */
+    value += 10000L * borg_skill[BI_ANEED_ID];
 
-        /* Skip empty items */
-        if (!item->iqty) continue;
+    int activation_bonus = 0;
+    int act;
+    for (act = 1; act < z_info->act_max; act++) {
+        if (!borg_activation[act])
+            continue;
+        /* an extra bonus for activations */
+        if (act_illumination == act)
+            activation_bonus += 500;
+        else if (act_mapping == act)
+            activation_bonus += 550;
+        else if (act_clairvoyance == act)
+            activation_bonus += 600;
+        else if (act_fire_bolt == act)
+            activation_bonus += (500 + (9 * (8 + 1) / 2));
+        else if (act_cold_bolt == act)
+            activation_bonus += (500 + (6 * (8 + 1) / 2));
+        else if (act_elec_bolt == act)
+            activation_bonus += (500 + (4 * (8 + 1) / 2));
+        else if (act_acid_bolt == act)
+            activation_bonus += (500 + (5 * (8 + 1) / 2));
+        else if (act_mana_bolt == act)
+            activation_bonus += (500 + (12 * (8 + 1) / 2));
+        else if (act_stinking_cloud == act)
+            activation_bonus += (500 + (24));
+        else if (act_cold_ball50 == act)
+            activation_bonus += (500 + (96));
+        else if (act_cold_ball100 == act)
+            activation_bonus += (500 + (200));
+        else if (act_fire_bolt72 == act)
+            activation_bonus += (500 + (72));
+        else if (act_cold_bolt2 == act)
+            activation_bonus += (500 + (12 * (8 + 1) / 2));
+        else if (act_fire_ball == act)
+            activation_bonus += (500 + (144));
+        else if (act_dispel_evil == act)
+            activation_bonus += (500 + (10 + (borg_skill[BI_CLEVEL] * 5) / 2));
+        else if (act_confuse2 == act)
+            activation_bonus += 0; /* no code to handle this activation */
+        else if (act_haste == act)
+            activation_bonus += 0; /* handled by adding to speed available */
+        else if (act_haste1 == act)
+            activation_bonus += 0; /* handled by adding to speed available */
+        else if (act_haste2 == act)
+            activation_bonus += 0; /* handled by adding to speed available */
+        else if (act_detect_objects == act)
+            activation_bonus += 10;
+        else if (act_probing == act)
+            activation_bonus += 0; /* no code to handle this activation */
+        else if (act_stone_to_mud == act)
+            activation_bonus += 0; /* handled by adding to digger available */
+        else if (act_tele_other == act) {
+            if (borg_class == CLASS_MAGE)
+                activation_bonus += 500;
+            else
+                activation_bonus += (500 + (500));
+        } else if (act_drain_life1 == act)
+            activation_bonus += (500 + 90);
+        else if (act_drain_life2 == act)
+            activation_bonus += (500 + 120);
+        else if (act_berserker == act)
+            activation_bonus += (500);
+        else if (act_cure_light == act)
+            activation_bonus += 0; /* handled by adding to healing available */
+        else if (act_cure_serious == act)
+            activation_bonus += 0; /* handled by adding to healing available */
+        else if (act_cure_critical == act)
+            activation_bonus += 0; /* handled by adding to healing available */
+        else if (act_cure_full2 == act)
+            activation_bonus += 0; /* handled by adding to healing available */
+        else if (act_loskill == act)
+            activation_bonus += (500 + 200);
+        else if (act_recall == act)
+            activation_bonus += 0; /* handled by adding to recall available */
+        else if (act_arrow == act)
+            activation_bonus += (500 + (150));
+        else if (act_rem_fear_pois == act) {
+            if (borg_class == CLASS_MAGE || borg_class == CLASS_PRIEST || borg_class == CLASS_DRUID)
+                activation_bonus += 500;
+            else
+                activation_bonus += (500 + (200));
+        } else if (act_tele_phase == act)
+            activation_bonus += 500;
+        else if (act_detect_all == act)
+            activation_bonus += 0; /* handled by adding to detects available */
+        else if (act_cure_full == act)
+            activation_bonus += 0; /* handled by adding to healing available */
+        else if (act_heal1 == act)
+            activation_bonus += 0; /* handled by adding to healing available */
+        else if (act_heal2 == act)
+            activation_bonus += 0; /* handled by adding to healing available */
+        else if (act_heal3 == act)
+            activation_bonus += 0; /* handled by adding to healing available */
+        else if (act_cure_nonorlybig == act)
+            activation_bonus += 0; /* handled by adding to healing available */
+        else if (act_protevil == act)
+            activation_bonus += 0; /* handled by adding to PFE available */
+        else if (act_destroy_doors == act)
+            activation_bonus += 50;
+        else if (act_banishment == act)
+            activation_bonus += 1000;
+        else if (act_resist_all == act) {
+            activation_bonus += (500 + (150));
+            /* extra bonus if you can't cast RESISTANCE */
+            if (borg_class != CLASS_MAGE)
+                activation_bonus += 25000;
+        } else if (act_sleepii == act) {
+            activation_bonus += 500;
+            /* extra bonus if you can't cast a sleep type spell */
+            if ((borg_class != CLASS_DRUID) && (borg_class != CLASS_NECROMANCER))
+                activation_bonus += 200;
+        } else if (act_recharge == act) {
+            activation_bonus += 500;
+            /* extra bonus if you can't cast a charge type spell */
+            if ((borg_class != CLASS_MAGE) && (borg_class != CLASS_ROGUE))
+                activation_bonus += 100;
+        } else if (act_tele_long == act)
+            activation_bonus += 300;
+        else if (act_missile == act)
+            activation_bonus += (500 + (2 * (6 + 1) / 2));
+        else if (act_cure_temp == act)
+            activation_bonus += 500;
+        else if (act_starlight2 == act)
+            activation_bonus += 100 + (10 * (8 + 1)) / 2;
+        else if (act_bizarre == act)
+            activation_bonus += (999999); /* HACK this is the one ring */
+        else if (act_star_ball == act)
+            activation_bonus += (500 + (300));
+        else if (act_rage_bless_resist == act) {
+            activation_bonus += (500 + (150));
+            /* extra bonus if you can't cast RESISTANCE */
+            if (borg_class != CLASS_MAGE)
+                activation_bonus += 25000;
+        } else if (act_polymorph == act) {
+            activation_bonus += 0; /* no activation_bonus, borg doesn't use polymorph */
+        } else if (act_starlight == act)
+            activation_bonus += 100 + (6 * (8 + 1)) / 2;
+        else if (act_light == act)
+            activation_bonus += 0; /* handled by adding to ALITE */
+        else if (act_firebrand == act)
+            activation_bonus += 500;
+        else if (act_restore_life == act)
+            activation_bonus += 0; /* handled by adding to the rll available */
+        else if (act_restore_exp == act)
+            activation_bonus += 0; /* handled by adding to the rll available */
+        else if (act_restore_st_lev == act)
+            activation_bonus += 0; /* handled by adding to the rll available */
+        else if (act_enlightenment == act)
+            activation_bonus += 500;
+        else if (act_hero == act)
+            activation_bonus += 500;
+        else if (act_shero == act)
+            activation_bonus += 500;
+        else if (act_cure_paranoia == act)
+            activation_bonus += 100;
+        else if (act_cure_mind == act)
+            activation_bonus += 1000;
+        else if (act_cure_body == act)
+            activation_bonus += 1000;
+        else if (act_mon_slow == act)
+            activation_bonus += 500;
+        else if (act_mon_confuse == act)
+            activation_bonus += 500;
+        else if (act_sleep_all == act)
+            activation_bonus += 500;
+        else if (act_mon_scare == act)
+            activation_bonus += 500;
+        else if (act_light_line == act)
+            activation_bonus += 50;
+        else if (act_disable_traps == act)
+            activation_bonus += 50;
+        else if (act_drain_life3 == act)
+            activation_bonus += (500 + 150);
+        else if (act_drain_life4 == act)
+            activation_bonus += (500 + 250);
+        else if (act_elec_ball == act)
+            activation_bonus += 500 + 64;
+        else if (act_elec_ball2 == act)
+            activation_bonus += 500 + 250;
+        else if (act_acid_bolt2 == act)
+            activation_bonus += (500 + (10 * (8 + 1) / 2));
+        else if (act_acid_bolt3 == act)
+            activation_bonus += (500 + (12 * (8 + 1) / 2));
+        else if (act_acid_ball == act)
+            activation_bonus += 500 + 120;
+        else if (act_cold_ball160 == act)
+            activation_bonus += 500 + 160;
+        else if (act_cold_ball2 == act)
+            activation_bonus += 500 + 200;
+        else if (act_fire_ball2 == act)
+            activation_bonus += 500 + 120;
+        else if (act_fire_ball200 == act)
+            activation_bonus += 500 + 200;
+        else if (act_fire_bolt2 == act)
+            activation_bonus += (500 + (12 * (8 + 1) / 2));
+        else if (act_fire_bolt3 == act)
+            activation_bonus += (500 + (16 * (8 + 1) / 2));
+        else if (act_dispel_evil60 == act)
+            activation_bonus += 500 + 60;
+        else if (act_dispel_undead == act)
+            activation_bonus += 500 + 60;
+        else if (act_dispel_all == act)
+            activation_bonus += 500 + 60 * 2;
+        else if (act_deep_descent == act)
+            activation_bonus += 0; // !FIX no code to handle
+        else if (act_earthquakes == act)
+            activation_bonus += 500;
+        else if (act_destruction2 == act)
+            activation_bonus += 500;
+        else if (act_losslow == act)
+            activation_bonus += 50;
+        else if (act_lossleep == act)
+            activation_bonus += 100;
+        else if (act_losconf == act)
+            activation_bonus += 100;
+        else if (act_satisfy == act)
+            activation_bonus += 50;
+        else if (act_blessing == act)
+            activation_bonus += 50;
+        else if (act_blessing2 == act)
+            activation_bonus += 50;
+        else if (act_blessing3 == act)
+            activation_bonus += 50;
+        else if (act_glyph == act)
+            activation_bonus += 0; /* handled by adding to skill */
+        else if (act_tele_level == act)
+            activation_bonus += 5000L;
+        else if (act_confusing == act)
+            activation_bonus += 0; /* scroll only ever read to get rid of it */
+        else if (act_enchant_tohit == act)
+            activation_bonus += 0; // !FIX no code to handle
+        else if (act_enchant_todam == act)
+            activation_bonus += 0; // !FIX no code to handle
+        else if (act_enchant_weapon == act)
+            activation_bonus += 0; // !FIX no code to handle
+        else if (act_enchant_armor == act)
+            activation_bonus += 0; // !FIX no code to handle
+        else if (act_enchant_armor2 == act)
+            activation_bonus += 0; // !FIX no code to handle
+        else if (act_remove_curse == act)
+            activation_bonus += 9000;
+        else if (act_remove_curse2 == act)
+            activation_bonus += 10000;
+        else if (act_detect_treasure == act)
+            activation_bonus += 0; /* borg never uses this */
+        else if (act_detect_invis == act)
+            activation_bonus += 50;
+        else if (act_detect_evil == act)
+            activation_bonus += 50;
+        else if (act_restore_mana == act)
+            activation_bonus += 5000;
+        /* the potion equivilant of increase stat with dec */
+        /*  are only consumed to get rid of them */
+        else if (act_brawn == act)
+            activation_bonus += 0;
+        else if (act_intellect == act)
+            activation_bonus += 0;
+        else if (act_contemplation == act)
+            activation_bonus += 0;
+        else if (act_toughness == act)
+            activation_bonus += 0;
+        else if (act_nimbleness == act)
+            activation_bonus += 0;
+        else if (act_restore_str == act)
+            activation_bonus += 50;
+        else if (act_restore_int == act)
+            activation_bonus += 50;
+        else if (act_restore_wis == act)
+            activation_bonus += 50;
+        else if (act_restore_dex == act)
+            activation_bonus += 50;
+        else if (act_restore_con == act)
+            activation_bonus += 50;
+        else if (act_restore_all == act)
+            activation_bonus += 150;
+        else if (act_tmd_free_act == act)
+            activation_bonus += 0; /* !FIX no code to handle */
+        else if (act_tmd_infra == act)
+            activation_bonus += 0; /* potion only consumed to get rid of it */
+        else if (act_tmd_sinvis == act)
+            activation_bonus += 50;
+        else if (act_tmd_esp == act)
+            activation_bonus += 50;
+        else if (act_resist_acid == act)
+            activation_bonus += 100;
+        else if (act_resist_elec == act)
+            activation_bonus += 100;
+        else if (act_resist_fire == act)
+            activation_bonus += 100;
+        else if (act_resist_cold == act)
+            activation_bonus += 100;
+        else if (act_resist_pois == act)
+            activation_bonus += 150;
+        else if (act_cure_confusion == act)
+            activation_bonus += 50;
+        else if (act_wonder == act)
+            activation_bonus += 300;
+        else if (act_wand_breath == act)
+            activation_bonus += 0; /* !FIX no code to handle (currently no code for wands of drag breath) */
+        else if (act_staff_magi == act)
+            borg_skill[BI_ASTFMAGI] += 10;
+        else if (act_staff_holy == act)
+            activation_bonus += 1000;
+        else if (act_drink_breath == act)
+            activation_bonus += 0; /* !FIX no code to handle (nor for the potion) */
+        else if (act_food_waybread == act)
+            activation_bonus += 50;
+        else if (act_shroom_emergency == act)
+            activation_bonus += 0; /* mushroom only consumed to get rid of it */
+        else if (act_shroom_terror == act)
+            activation_bonus += 0;
+        else if (act_shroom_stone == act)
+            activation_bonus += 50;
+        else if (act_shroom_debility == act)
+            activation_bonus += 0;
+        else if (act_shroom_sprinting == act)
+            activation_bonus += 0; /* mushroom only consumed to get rid of it */
+        else if (act_shroom_purging == act)
+            activation_bonus += 50;
+        else if (act_ring_acid == act)
+            activation_bonus += 10000;
+        else if (act_ring_flames == act)
+            activation_bonus += 25000;
+        else if (act_ring_ice == act)
+            activation_bonus += 15000;
+        else if (act_ring_lightning == act)
+            activation_bonus += 10000;
+        else if (act_dragon_blue == act)
+            activation_bonus += 1100;
+        else if (act_dragon_green == act)
+            activation_bonus += 2750;
+        else if (act_dragon_red == act)
+            activation_bonus += 1100;
+        else if (act_dragon_multihued == act)
+            activation_bonus += 3250;
+        else if (act_dragon_gold == act)
+            activation_bonus += 5150;
+        else if (act_dragon_chaos == act)
+            activation_bonus += 5150;
+        else if (act_dragon_law == act)
+            activation_bonus += 5150;
+        else if (act_dragon_balance == act)
+            activation_bonus += 5150;
+        else if (act_dragon_shining == act)
+            activation_bonus += 5150;
+        else if (act_dragon_power == act)
+            activation_bonus += 5150;
 
-        /* a small bonus for wearing things that are not IDd*/
-        /* unless you know the ID spell*/
-        if (!item->ident && !borg_spell_legal(IDENTIFY_RUNE))
-            value += 10000L;
-
-        /* Good to have one item with multiple high resists */
-        multibonus = ((item->el_info[ELEM_POIS].res_level > 0) +
-            (item->el_info[ELEM_SOUND].res_level > 0) +
-            (item->el_info[ELEM_SHARD].res_level > 0) +
-            (item->el_info[ELEM_NEXUS].res_level > 0) +
-            (item->el_info[ELEM_NETHER].res_level > 0) +
-            (item->el_info[ELEM_CHAOS].res_level > 0) +
-            (item->el_info[ELEM_DISEN].res_level > 0) +
-            ((item->el_info[ELEM_FIRE].res_level > 0) &&
-                (item->el_info[ELEM_COLD].res_level > 0) &&
-                (item->el_info[ELEM_ELEC].res_level > 0) &&
-                (item->el_info[ELEM_ACID].res_level > 0)) +
-            (of_has(item->flags, OF_SUST_STR) &&
-                of_has(item->flags, OF_SUST_INT) &&
-                of_has(item->flags, OF_SUST_WIS) &&
-                of_has(item->flags, OF_SUST_DEX) &&
-                of_has(item->flags, OF_SUST_CON)));
-
-        if (multibonus >= 2) value += 3000 * multibonus;
-
-        int activation = item->activ_idx;
-
-            /* an extra bonus for activations */
-        if (activation)
-        {
-            if (act_illumination == activation)
-                value += 500;
-            else if (act_mapping == activation)
-                value += 550;
-            else if (act_clairvoyance == activation)
-                value += 600;
-            else if (act_fire_bolt == activation)
-                value += (500 + (9 * (8 + 1) / 2));
-            else if (act_cold_bolt == activation)
-                value += (500 + (6 * (8 + 1) / 2));
-            else if (act_elec_bolt == activation)
-                value += (500 + (4 * (8 + 1) / 2));
-            else if (act_acid_bolt == activation)
-                value += (500 + (5 * (8 + 1) / 2));
-            else if (act_mana_bolt == activation)
-                value += (500 + (12 * (8 + 1) / 2));
-            else if (act_stinking_cloud == activation)
-                value += (500 + (24));
-            else if (act_cold_ball50 == activation)
-                value += (500 + (96));
-            else if (act_cold_ball100 == activation)
-                value += (500 + (200));
-            else if (act_fire_bolt72 == activation)
-                value += (500 + (72));
-            else if (act_cold_bolt2 == activation)
-                value += (500 + (12 * (8 + 1) / 2));
-            else if (act_fire_ball == activation)
-                value += (500 + (144));
-            else if (act_dispel_evil == activation)
-                value += (500 + (10 + (borg_skill[BI_CLEVEL] * 5) / 2));
-            else if (act_confuse2 == activation)
-                value += 0; /* no code to handle this activation */
-            else if (act_haste == activation)
-                value += 0;  /* handled by adding to speed available */
-            else if (act_haste1 == activation)
-                value += 0; /* handled by adding to speed available */
-            else if (act_haste2 == activation)
-                value += 0; /* handled by adding to speed available */
-            else if (act_detect_objects ==activation)
-                value += 10;
-            else if (act_probing == activation)
-                value += 0; /* no code to handle this activation */
-            else if (act_stone_to_mud == activation)
-                value += 0; /* handled by adding to digger available */
-            else if (act_tele_other == activation)
-            {
-                if (borg_class == CLASS_MAGE)
-                    value += 500;
-                else
-                    value += (500 + (500));
-            }
-            else if (act_drain_life1 == activation)
-                value += (500 + 90);
-            else if (act_drain_life2 == activation)
-                value += (500 + 120);
-            else if (act_berserker == activation)
-                value += (500);
-            else if (act_cure_light == activation)
-                value += 0; /* handled by adding to healing available */
-            else if (act_cure_serious == activation)
-                value += 0; /* handled by adding to healing available */
-            else if (act_cure_critical == activation)
-                value += 0; /* handled by adding to healing available */
-            else if (act_cure_full2 == activation)
-                value += 0; /* handled by adding to healing available */
-            else if (act_loskill == activation)
-                value += (500 + 200);
-            else if (act_recall == activation)
-                value += 0; /* handled by adding to recall available */
-            else if (act_arrow == activation)
-                value += (500 + (150));
-            else if (act_rem_fear_pois == activation)
-            {
-                if (borg_class == CLASS_MAGE || borg_class == CLASS_PRIEST || borg_class == CLASS_DRUID)
-                    value += 500;
-                else
-                    value += (500 + (200));
-            }
-            else if (act_tele_phase == activation)
-                value += 500;
-            else if (act_detect_all == activation)
-                value += 0; /* handled by adding to detects available */
-            else if (act_cure_full == activation)
-                value += 0; /* handled by adding to healing available */
-            else if (act_heal1 == activation)
-                value += 0; /* handled by adding to healing available */
-            else if (act_heal2 == activation)
-                value += 0; /* handled by adding to healing available */
-            else if (act_heal3 == activation)
-                value += 0;  /* handled by adding to healing available */
-            else if (act_cure_nonorlybig == activation)
-                value += 0;  /* handled by adding to healing available */
-            else if (act_protevil == activation)
-                value += 0; /* handled by adding to PFE available */
-            else if (act_destroy_doors == activation)
-                value += 0; /* no code to handle this activation */
-            else if (act_banishment == activation)
-                value += 1000;
-            else if (act_resist_all == activation)
-            {
-                value += (500 + (150));
-                /* extra bonus if you can't cast RESISTANCE */
-                if (borg_class != CLASS_MAGE) value += 25000;
-            }
-            else if (act_sleepii == activation)
-            {
-                value += 500;
-                /* extra bonus if you can't cast a sleep type spell */
-                if ((borg_class != CLASS_DRUID) && (borg_class != CLASS_NECROMANCER))
-                    value += 200;
-            }
-            else if (act_recharge == activation)
-            {
-                value += 500;
-                /* extra bonus if you can't cast a charge type spell */
-                if ((borg_class != CLASS_MAGE) && (borg_class != CLASS_ROGUE))
-                    value += 100;
-            }
-            else if (act_tele_long == activation)
-                value += 300;
-            else if (act_missile == activation)
-                value += (500 + (2 * (6 + 1) / 2));
-            else if (act_cure_temp == activation)
-                value += 500;
-            else if (act_starlight2 == activation)
-                value += 100 + (10 * (8 + 1)) / 2;
-            else if (act_bizarre == activation)
-                value += (999999); /* HACK this is the one ring */
-            else if (act_star_ball == activation)
-                value += (500 + (300));
-            else if (act_rage_bless_resist == activation)
-            {
-                value += (500 + (150));
-                /* extra bonus if you can't cast RESISTANCE */
-                if (borg_class != CLASS_MAGE) value += 25000;
-            }
-            else if (act_polymorph == activation)
-            {
-                value += 0;  /* no value, borg doesn't use polymorph */
-            }
-            else if (act_starlight == activation)
-                value += 100 + (6 * (8 + 1)) / 2;
-            else if (act_light == activation)
-                value += 0;  /* handled by adding to ALITE */
-            else if (act_firebrand == activation)
-                value += 500;
-            else if (act_restore_life == activation)
-                value += 0;  /* handled by adding to the rll available */
-            else if (act_restore_exp == activation)
-                value += 0;  /* handled by adding to the rll available */
-            else if (act_restore_st_lev == activation)
-                value += 0;  /* handled by adding to the rll available */
-            else if (act_enlightenment == activation)
-                value += 500;
-            else if (act_hero == activation)
-                value += 500;  
-            else if (act_shero == activation)
-                value += 500;
-            else if (act_cure_paranoia == activation)
-                value += 100;
-            else if (act_cure_mind == activation)
-                value += 1000;
-            else if (act_cure_body == activation)
-                value += 1000;
-            else if (act_mon_slow == activation)
-                value += 500; //!FIX recalc  
-            else if (act_mon_confuse == activation)
-                value += 500; //!FIX recalc  
-            else if (act_sleep_all == activation)
-                value += 500; //!FIX recalc  
-            else if (act_mon_scare == activation)
-                value += 500; //!FIX recalc 
-            else if (act_light_line == activation)
-                value += 50;  //!FIX recalc 
-            else if (act_disable_traps == activation)
-                value += 0;  // !FIX no code to handle
-            else if (act_drain_life3 == activation)
-                value += (500 + 150);
-            else if (act_drain_life4 == activation)
-                value += (500 + 250);
-            else if (act_elec_ball == activation)
-                value += 500 + 64;  
-            else if (act_elec_ball2 == activation)
-                value += 500 + 250;  
-            else if (act_acid_bolt2 == activation)
-                value += (500 + (10 * (8 + 1) / 2));
-            else if (act_acid_bolt3 == activation)
-                value += (500 + (12 * (8 + 1) / 2));
-            else if (act_acid_ball == activation)
-                value += 500 + 120; 
-            else if (act_cold_ball160 == activation)
-                value += 500 + 160; 
-            else if (act_cold_ball2 == activation)
-                value += 500 + 200;
-            else if (act_fire_ball2 == activation)
-                value += 500 + 120;
-            else if (act_fire_ball200 == activation)
-                value += 500 + 200;
-            else if (act_fire_bolt2 == activation)
-                value += (500 + (12 * (8 + 1) / 2));
-            else if (act_fire_bolt3 == activation)
-                value += (500 + (16 * (8 + 1) / 2));
-            else if (act_dispel_evil60 == activation)
-                value += 500 + 60;
-            else if (act_dispel_undead == activation)
-                value += 500 + 60;
-            else if (act_dispel_all == activation)
-                value += 500 + 60 * 2;
-            else if (act_deep_descent == activation)
-                value += 0;  // !FIX no code to handle
-            else if (act_earthquakes == activation)
-                value += 0;  // !FIX no code to handle
-            else if (act_destruction2 == activation)
-                value += 500;  
-            else if (act_losslow == activation)
-                value += 50;
-            else if (act_lossleep == activation)
-                value += 100;
-            else if (act_losconf == activation)
-                value += 100;
-            else if (act_satisfy == activation)
-                value += 0;  // !FIX no code to handle
-            else if (act_blessing == activation)
-                value += 50;
-            else if (act_blessing2 == activation)
-                value += 50;
-            else if (act_blessing3 == activation)
-                value += 50;
-            else if (act_glyph == activation)
-                value += 0;  /* handled by adding to skill */
-            else if (act_tele_level == activation)
-                value += 5000L;
-            else if (act_confusing == activation)
-                value += 0;  // !FIX no code to handle
-            else if (act_enchant_tohit == activation)
-                value += 0;  // !FIX no code to handle
-            else if (act_enchant_todam == activation)
-                value += 0;  // !FIX no code to handle
-            else if (act_enchant_weapon == activation)
-                value += 0;  // !FIX no code to handle
-            else if (act_enchant_armor == activation)
-                value += 0;  // !FIX no code to handle
-            else if (act_enchant_armor2 == activation)
-                value += 0;  // !FIX no code to handle
-            else if (act_remove_curse == activation)
-                value += 9000;  
-            else if (act_remove_curse2 == activation)
-                value += 10000;
-            else if (act_detect_treasure == activation)
-                value += 0;  // !FIX no code to handle
-            else if (act_detect_invis == activation)
-                value += 0;  // !FIX no code to handle
-            else if (act_detect_evil == activation)
-                value += 0;  // !FIX no code to handle
-            else if (act_restore_mana == activation)
-                value += 5000;
-            else if (act_brawn == activation)
-                value += 0;  // !FIX no code to handle
-            else if (act_intellect == activation)
-                value += 0;  // !FIX no code to handle
-            else if (act_contemplation == activation)
-                value += 0;  // !FIX no code to handle
-            else if (act_toughness == activation)
-                value += 0;  // !FIX no code to handle
-            else if (act_nimbleness == activation)
-                value += 0;  // !FIX no code to handle
-            else if (act_restore_str == activation)
-                value += 50;  
-            else if (act_restore_int == activation)
-                value += 50;  
-            else if (act_restore_wis == activation)
-                value += 50;  
-            else if (act_restore_dex == activation)
-                value += 50;  
-            else if (act_restore_con == activation)
-                value += 50;  
-            else if (act_restore_all == activation)
-                value += 150;
-            else if (act_tmd_free_act == activation)
-                value += 0;  // !FIX no code to handle
-            else if (act_tmd_infra == activation)
-                value += 0;  // !FIX no code to handle
-            else if (act_tmd_sinvis == activation)
-                value += 0;  // !FIX no code to handle
-            else if (act_tmd_esp == activation)
-                value += 0;  // !FIX no code to handle
-            else if (act_resist_acid == activation)
-                value += 100;
-            else if (act_resist_elec == activation)
-                value += 100;
-            else if (act_resist_fire == activation)
-                value += 100;  
-            else if (act_resist_cold == activation)
-                value += 100;
-            else if (act_resist_pois == activation)
-                value += 150;
-            else if (act_cure_confusion == activation)
-                value += 0;  // !FIX no code to handle
-            else if (act_wonder == activation)
-                value += 300;
-            else if (act_wand_breath == activation)
-                value += 0;  // !FIX no code to handle (currently no code for wands of drag breath)
-            else if (act_staff_magi == activation)
-                borg_skill[BI_ASTFMAGI] += 10;
-            else if (act_staff_holy == activation)
-                value += 1000;
-            else if (act_drink_breath == activation)
-                value += 0;  // !FIX no code to handle (nor for the potion)
-            else if (act_food_waybread == activation)
-                value += 50;  
-            else if (act_shroom_emergency == activation)
-                value += 0;  // !FIX no code to handle
-            else if (act_shroom_terror == activation)
-                value += 0;  // !FIX no code to handle
-            else if (act_shroom_stone == activation)
-                value += 0;  // !FIX no code to handle
-            else if (act_shroom_debility == activation)
-                value += 0;  // !FIX no code to handle
-            else if (act_shroom_sprinting == activation)
-                value += 0;  // !FIX no code to handle
-            else if (act_shroom_purging == activation)
-                value += 50;
-            else if (act_ring_acid == activation)
-                value += 10000;
-            else if (act_ring_flames == activation)
-                value += 25000;
-            else if (act_ring_ice == activation)
-                value += 15000;
-            else if (act_ring_lightning == activation)
-                value += 10000;
-            else if (act_dragon_blue == activation)
-                value += 1100;
-            else if (act_dragon_green == activation)
-                value += 2750;
-            else if (act_dragon_red == activation)
-                value += 1100;
-            else if (act_dragon_multihued == activation)
-                value += 3250;
-            else if (act_dragon_gold == activation)
-                value += 5150;
-            else if (act_dragon_chaos == activation)
-                value += 5150;
-            else if (act_dragon_law == activation)
-                value += 5150;
-            else if (act_dragon_balance == activation)
-                value += 5150;
-            else if (act_dragon_shining == activation)
-                value += 5150;
-            else if (act_dragon_power == activation)
-                value += 5150;
-
-        }
+        /* bonus is per item that has this activation */
+        value += activation_bonus * borg_activation[act];
     }
-
 
     /* Result */
     return (value);
@@ -5948,19 +5931,19 @@ static int32_t borg_power_aux2(void)
     /*** Enchantment ***/
 
     /* Reward enchant armor */
-    if (amt_enchant_to_a < 1000 && my_need_enchant_to_a) value += 540L;
+    if (borg_skill[BI_AENCH_ARM] < 1000 && my_need_enchant_to_a) value += 540L;
 
     /* Reward enchant weapon to hit */
-    if (amt_enchant_to_h < 1000 && my_need_enchant_to_h) value += 540L;
+    if (borg_skill[BI_AENCH_TOH] < 1000 && my_need_enchant_to_h) value += 540L;
 
     /* Reward enchant weapon to damage */
-    if (amt_enchant_to_d < 1000 && my_need_enchant_to_d) value += 500L;
+    if (borg_skill[BI_AENCH_TOD] < 1000 && my_need_enchant_to_d) value += 500L;
 
     /* Reward *enchant weapon* to damage */
-    if (amt_enchant_weapon) value += 5000L;
+    if (borg_skill[BI_AENCH_SWEP]) value += 5000L;
 
     /* Reward *enchant armour*  */
-    if (amt_enchant_armor) value += 5000L;
+    if (borg_skill[BI_AENCH_SARM]) value += 5000L;
 
     /* Reward carrying a shovel if low level */
     if (borg_skill[BI_MAXDEPTH] <= 40 && borg_skill[BI_MAXDEPTH] >= 25 && borg_gold < 100000 && borg_items[INVEN_WIELD].tval != TV_DIGGING &&
@@ -6050,9 +6033,9 @@ static int32_t borg_power_aux2(void)
         /* Some items will be used immediately and should not contribute to encumbrance */
         if (item && item->iqty &&
             ((item->tval == TV_SCROLL &&
-                ((item->sval == sv_scroll_enchant_armor && amt_enchant_to_a < 1000 && my_need_enchant_to_a) ||
-                    (item->sval == sv_scroll_enchant_weapon_to_hit && amt_enchant_to_h < 1000 && my_need_enchant_to_h) ||
-                    (item->sval == sv_scroll_enchant_weapon_to_dam && amt_enchant_to_d < 1000 && my_need_enchant_to_d) ||
+                ((item->sval == sv_scroll_enchant_armor && borg_skill[BI_AENCH_ARM] < 1000 && my_need_enchant_to_a) ||
+                    (item->sval == sv_scroll_enchant_weapon_to_hit && borg_skill[BI_AENCH_TOH] < 1000 && my_need_enchant_to_h) ||
+                    (item->sval == sv_scroll_enchant_weapon_to_dam && borg_skill[BI_AENCH_TOD] < 1000 && my_need_enchant_to_d) ||
                     item->sval == sv_scroll_star_enchant_weapon ||
                     item->sval == sv_scroll_star_enchant_armor)) ||
                 (item->tval == TV_POTION &&

--- a/src/borg/borg6.c
+++ b/src/borg/borg6.c
@@ -2700,7 +2700,8 @@ static bool borg_heal(int danger)
                 borg_quaff_potion(sv_potion_cure_serious) ||
                 borg_quaff_crit(false) ||
                 borg_quaff_potion(sv_potion_healing) ||
-                borg_use_staff_fail(sv_staff_healing) ||
+                borg_use_staff_fail(sv_staff_healing) || 
+                borg_activate_item(act_cure_confusion) ||
                 borg_use_staff_fail(sv_staff_curing)))
         {
             borg_note("# Fixing Confusion. Level 2");
@@ -4538,7 +4539,8 @@ bool borg_caution(void)
         if (borg_eat_food(TV_MUSHROOM, sv_mush_cure_mind) ||
             borg_quaff_potion(sv_potion_cure_serious) ||
             borg_quaff_crit(false) ||
-            borg_quaff_potion(sv_potion_healing) ||
+            borg_quaff_potion(sv_potion_healing) || 
+            borg_activate_item(act_cure_confusion) ||
             borg_use_staff_fail(sv_staff_healing))
         {
             borg_note("# Healing.  Confusion.");
@@ -11062,7 +11064,8 @@ static int borg_defend_aux_shield(int p1)
     /* Cant when screwed */
     if (borg_skill[BI_ISBLIND] || borg_skill[BI_ISCONFUSED] || borg_skill[BI_ISFORGET]) return (0);
 
-    if (borg_has[kv_mush_stoneskin] <= 0)
+    if (borg_has[kv_mush_stoneskin] <= 0 && 
+        !borg_equips_item(act_shroom_stone, true))
         return (0);
 
     /* pretend we are protected and look again */
@@ -11086,7 +11089,8 @@ static int borg_defend_aux_shield(int p1)
         borg_note("# Attempting to eat a stone skin");
 
         /* do it! */
-        if (borg_eat_food(TV_MUSHROOM, sv_mush_stoneskin))
+        if (borg_eat_food(TV_MUSHROOM, sv_mush_stoneskin) ||
+            borg_activate_item(act_shroom_stone))
         {
             /* No resting to recoop mana */
             borg_no_rest_prep = 2000;
@@ -12115,8 +12119,9 @@ static int borg_defend_aux_earthquake(int p1)
     /* Cast the spell */
     if (!borg_simulate &&
         (borg_spell(TREMOR) ||
-            borg_spell(QUAKE) ||
-            borg_spell(GRONDS_BLOW)))
+         borg_spell(QUAKE) ||
+         borg_spell(GRONDS_BLOW) || 
+         borg_activate_item(act_earthquakes)))
     {
         /* Must make a new Sea too */
         borg_needs_new_sea = true;
@@ -12129,7 +12134,8 @@ static int borg_defend_aux_earthquake(int p1)
     /* Can I cast the spell? */
     if (!borg_spell_okay_fail(TREMOR, 35) &&
         !borg_spell_okay_fail(QUAKE, 35) &&
-        !borg_spell_okay_fail(GRONDS_BLOW, 35))
+        !borg_spell_okay_fail(GRONDS_BLOW, 35) &&
+        !borg_equips_item(act_earthquakes, true))
         return (0);
 
     /* See if he is in real danger or fighting summoner*/
@@ -12521,7 +12527,11 @@ static int borg_defend_aux_inviso(int p1)
         !borg_equips_staff_fail(sv_staff_detect_invis) &&
         !borg_equips_staff_fail(sv_staff_detect_evil) &&
         !borg_spell_okay_fail(SENSE_INVISIBLE, fail_allowed) &&
-        !borg_spell_okay_fail(DETECTION, fail_allowed))
+        !borg_spell_okay_fail(DETECTION, fail_allowed) &&
+        !borg_equips_item(act_detect_invis, true) && 
+        !borg_equips_item(act_tmd_sinvis, true) && 
+        !borg_equips_item(act_tmd_esp, true) && 
+        !borg_equips_item(act_detect_evil, true))
         return (0);
 
     /* Darkness */
@@ -12537,7 +12547,11 @@ static int borg_defend_aux_inviso(int p1)
     if (borg_spell_fail(REVEAL_MONSTERS, fail_allowed) ||
         borg_read_scroll(sv_scroll_detect_invis) ||
         borg_use_staff(sv_staff_detect_invis) ||
-        borg_use_staff(sv_staff_detect_evil))
+        borg_use_staff(sv_staff_detect_evil) ||
+        borg_activate_item(act_detect_invis) || 
+        borg_activate_item(act_tmd_sinvis) || 
+        borg_activate_item(act_tmd_esp) ||
+        borg_activate_item(act_detect_evil))
     {
         borg_see_inv = 3000; /* hack, actually a snap shot, no ignition message */
         return (10);
@@ -14670,7 +14684,8 @@ bool borg_recover(void)
         if (borg_eat_food(TV_MUSHROOM, sv_mush_cure_mind) ||
             borg_quaff_potion(sv_potion_cure_serious) ||
             borg_quaff_crit(false) ||
-            borg_use_staff_fail(sv_staff_curing) ||
+            borg_use_staff_fail(sv_staff_curing) || 
+            borg_activate_item(act_cure_confusion) || 
             borg_zap_rod(sv_rod_curing))
         {
             return (true);
@@ -14693,7 +14708,8 @@ bool borg_recover(void)
     /* Hack -- satisfy hunger */
     if ((borg_skill[BI_ISHUNGRY] || borg_skill[BI_ISWEAK]) && (q < 25))
     {
-        if (borg_read_scroll(sv_scroll_satisfy_hunger))
+        if (borg_read_scroll(sv_scroll_satisfy_hunger) || 
+            borg_activate_item(act_satisfy))
         {
             return (true);
         }
@@ -15215,7 +15231,8 @@ static bool borg_play_step(int y2, int x2)
         /* don't bother unless we are near full mana */
         if (borg_skill[BI_CURSP] > ((borg_skill[BI_MAXSP] * 4) / 5))
         {
-            if (borg_spell(DISABLE_TRAPS_DESTROY_DOORS))
+            if (borg_spell(DISABLE_TRAPS_DESTROY_DOORS) ||
+                borg_activate_item(act_disable_traps))
             {
                 borg_note("# Disable Traps, Destroy Doors");
                 ag->trap = 0;
@@ -15267,7 +15284,8 @@ static bool borg_play_step(int y2, int x2)
         if (!randint0(100) || time_this_panel >= 500)
         {
             /* Mega-Hack -- allow "destroy doors" */
-            if (borg_spell(DISABLE_TRAPS_DESTROY_DOORS))
+            if (borg_spell(DISABLE_TRAPS_DESTROY_DOORS) ||
+                borg_activate_item(act_destroy_doors))
             {
                 borg_note("# Disable Traps, Destroy Doors");
                 return (true);

--- a/src/borg/borg7.c
+++ b/src/borg/borg7.c
@@ -784,8 +784,8 @@ static bool borg_enchant_to_a(void)
     if (!my_need_enchant_to_a) return (false);
 
     /* Need "enchantment" ability */
-    if ((!amt_enchant_to_a) &&
-        (!amt_enchant_armor)) return (false);
+    if ((!borg_skill[BI_AENCH_ARM]) &&
+        (!borg_skill[BI_AENCH_SARM])) return (false);
 
 
     /* Look for armor that needs enchanting */
@@ -804,7 +804,7 @@ static bool borg_enchant_to_a(void)
 
         /* Skip "boring" items */
         if (borg_spell_okay_fail(ENCHANT_ARMOUR, 65) ||
-           amt_enchant_armor >=1)
+           borg_skill[BI_AENCH_SARM] >=1)
         {
             if (a >= borg_cfg[BORG_ENCHANT_LIMIT]) continue;
         }
@@ -854,8 +854,8 @@ static bool borg_enchant_to_h(void)
         !enchant_weapon_swap_to_h) return (false);
 
     /* Need "enchantment" ability */
-    if ( (!amt_enchant_to_h) &&
-         (!amt_enchant_weapon) ) return (false);
+    if ( (!borg_skill[BI_AENCH_TOH]) &&
+         (!borg_skill[BI_AENCH_SWEP]) ) return (false);
 
 
     /* Look for a weapon that needs enchanting */
@@ -877,7 +877,7 @@ static bool borg_enchant_to_h(void)
 
         /* Skip "boring" items */
         if (borg_spell_okay_fail(ENCHANT_WEAPON, 65) ||
-            amt_enchant_weapon >= 1 )
+            borg_skill[BI_AENCH_SWEP] >= 1 )
         {
             if (a >= borg_cfg[BORG_ENCHANT_LIMIT]) continue;
         }
@@ -923,7 +923,7 @@ static bool borg_enchant_to_h(void)
 
             /* Skip items that are already enchanted */
             if (borg_spell_okay_fail(ENCHANT_WEAPON, 65) ||
-                amt_enchant_weapon >= 1)
+                borg_skill[BI_AENCH_SWEP] >= 1)
             {
                 if (s_a >= borg_cfg[BORG_ENCHANT_LIMIT]) skip = true;
             }
@@ -967,7 +967,7 @@ static bool borg_enchant_to_h(void)
 
             /* Skip items that are already enchanted */
             if (borg_spell_okay_fail(ENCHANT_WEAPON, 65) ||
-                amt_enchant_weapon >= 1 )
+                borg_skill[BI_AENCH_SWEP] >= 1 )
             {
                 if (a >= 10) continue;
             }
@@ -1018,8 +1018,8 @@ static bool borg_enchant_to_d(void)
         !enchant_weapon_swap_to_d) return (false);
 
     /* Need "enchantment" ability */
-    if ( (!amt_enchant_to_d) &&
-         (!amt_enchant_weapon) ) return (false);
+    if ( (!borg_skill[BI_AENCH_TOD]) &&
+         (!borg_skill[BI_AENCH_SWEP]) ) return (false);
 
 
     /* Look for a weapon that needs enchanting */
@@ -1041,7 +1041,7 @@ static bool borg_enchant_to_d(void)
 
         /* Skip "boring" items */
         if (borg_spell_okay_fail(ENCHANT_WEAPON, 65) ||
-            amt_enchant_weapon >= 1 )
+            borg_skill[BI_AENCH_SWEP] >= 1 )
         {
             if (a >= borg_cfg[BORG_ENCHANT_LIMIT]) continue;
         }
@@ -1086,7 +1086,7 @@ static bool borg_enchant_to_d(void)
 
             /* Skip "boring" items */
             if (borg_spell_okay_fail(ENCHANT_WEAPON, 65) ||
-                amt_enchant_weapon >= 1)
+                borg_skill[BI_AENCH_SWEP] >= 1)
             {
                 if (s_a >= borg_cfg[BORG_ENCHANT_LIMIT]) skip = true;
             }
@@ -1135,7 +1135,7 @@ static bool borg_enchant_to_d(void)
 
             /* Skip items that are already enchanted */
             if (borg_spell_okay_fail(ENCHANT_WEAPON, 65) ||
-                amt_enchant_weapon >= 1 )
+                borg_skill[BI_AENCH_SWEP] >= 1 )
             {
                 if (a >= 10) continue;
             }
@@ -1183,7 +1183,7 @@ static bool borg_brand_weapon(void)
     if (!my_need_brand_weapon) return (false);
 
     /* Need "brand" ability */
-    if (!amt_brand_weapon) return (false);
+    if (!borg_skill[BI_ABRAND]) return (false);
 
     /* look through inventory for ammo */
         for (i = QUIVER_START; i < QUIVER_END; i++)

--- a/src/borg/borg9.c
+++ b/src/borg/borg9.c
@@ -3994,6 +3994,7 @@ static void init_borg_txt_file(void)
     }
     borg_has = mem_zalloc(size_obj * sizeof(int));
     borg_skill = borg_has + z_info->k_max;
+    borg_activation = mem_zalloc(z_info->act_max * sizeof(int));
 
     /* a couple of spot checks on settings definitiosn */
     if (!streq(borg_settings[BORG_MUNCHKIN_LEVEL].setting_string, "borg_munchkin_level") ||
@@ -4156,6 +4157,8 @@ static void clean_borg_txt_file(void)
     borg_cfg = NULL;
     mem_free(borg_has);
     borg_has = NULL;
+    mem_free(borg_activation);
+    borg_activation = NULL;
     borg_skill = NULL;
     for (i = 0; i < MAX_CLASSES; ++i) {
         mem_free(borg_power_item[i]);
@@ -5968,6 +5971,7 @@ void do_cmd_borg(void)
         mem_free(borg_required_item); /* externalize the 400 later */
         mem_free(borg_power_item); /* externalize the 400 later */
         mem_free(borg_has);
+        mem_free(borg_activation);
         for (j = 0; j < 1000; j++)
         {
             if (formula[j])


### PR DESCRIPTION
This includes 
1) the rest of the "easy to handle" activations.  There are still a few that the borg either doesn't do or hasn't had code for the base object added.  For example, wand of dragon breath and its corresponding activation don't have code yet
2) moved some globals into the borg_skill array.  Basically the code should have "borg_notice fills in borg_skill and similar arrays, borg_power only looks at the borg_skill and similar arrays to know what the borgs power level is" and over time other globals have migrated in and code has been added to borg_power that looks directly at items.  It works but will make it hard to reimplement the dynamic calculations.