### PR TITLE
Don't deduct charge/item when using an unidentified item and effect is canceled

### DIFF
--- a/src/cmd-obj.c
+++ b/src/cmd-obj.c
@@ -646,7 +646,7 @@ static void use_aux(struct command *cmd, struct object *obj, enum use use,
 		 * items, ODESC_ALTNUM means that the work_obj's number doesn't
 		 * need to be adjusted).
 		 */
-		if (!deduct_before) {
+		if (used && !deduct_before) {
 			assert(!from_floor);
 			if (use == USE_CHARGE) {
 				obj->pval--;


### PR DESCRIPTION
Resolves PowerDiver's report here, http://angband.oook.cz/forum/showpost.php?p=161575&postcount=21 .