### PR TITLE
nds: Enable the Borg on the Nintendo 3DS

### DIFF
--- a/src/Makefile.3ds
+++ b/src/Makefile.3ds
@@ -41,7 +41,7 @@ TARGET		:=	$(PROGNAME)
 BUILD		:=	3ds-build
 SOURCES		:=	nds
 DATA		:=
-INCLUDES	:=
+INCLUDES	:=	.
 GRAPHICS	:=
 GFXBUILD	:=	$(BUILD)
 #ROMFS		:=	romfs
@@ -58,9 +58,6 @@ ICON		:=	nds/att-48.png
 #---------------------------------------------------------------------------------
 ARCH	:=	-march=armv6k -mtune=mpcore -mfloat-abi=hard -mtp=soft
 
-#---------------------------------------------------------------------------------
-# add -DALLOW_BORG to allow the borg to run
-#---------------------------------------------------------------------------------
 CFLAGS	:=	-g -Wall -mword-relocations -ffunction-sections \
 			$(ARCH)
 
@@ -72,7 +69,7 @@ endif
 CFLAGS	+=	$(INCLUDE) -D__3DS__
 
 # Angband flags
-CFLAGS	+=	-DNDS -DHAVE_DIRENT_H
+CFLAGS	+=	-DNDS -DHAVE_DIRENT_H -DALLOW_BORG
 
 CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
 

--- a/src/Makefile.nds.arm9
+++ b/src/Makefile.nds.arm9
@@ -16,7 +16,7 @@ include $(DEVKITARM)/ds_rules
 #---------------------------------------------------------------------------------
 BUILD		:=	nds-build
 SOURCES		:=	nds
-INCLUDES	:=	nds
+INCLUDES	:=	. nds
 DATA		:=
 
 
@@ -25,9 +25,6 @@ DATA		:=
 #---------------------------------------------------------------------------------
 ARCH	:=	-mthumb -mthumb-interwork
 
-#---------------------------------------------------------------------------------
-# add -DALLOW_BORG to allow the borg to run
-#---------------------------------------------------------------------------------
 CFLAGS	:=	-g -Wall -march=armv5te -mtune=arm946e-s $(ARCH)
 
 # Omit some flags for easier debugging
@@ -38,6 +35,8 @@ endif
 CFLAGS	+=	$(INCLUDE) -DARM9
 
 # Angband flags
+# NDS hardware is too weak to handle the additional 400KB of RAM for the Borg.
+# If you really want to enable it, you'd add -DALLOW_BORG here.
 CFLAGS	+=	-DNDS -DHAVE_DIRENT_H
 
 CXXFLAGS	:=	$(CFLAGS) -fno-rtti -fno-exceptions


### PR DESCRIPTION
NDS hardware is too limited to support the additional 400KB of memory usage, so discourage enabling the Borg there.