### PR TITLE
Check unshifted shape rather than current shape when testing for Banish

### DIFF
--- a/src/effect-handler-general.c
+++ b/src/effect-handler-general.c
@@ -2297,8 +2297,16 @@ bool effect_handler_BANISH(effect_handler_context_t *context)
 		/* Hack -- Skip Unique Monsters */
 		if (monster_is_unique(mon)) continue;
 
-		/* Skip "wrong" monsters (see warning above) */
-		if ((char) mon->race->d_char != typ) continue;
+		/*
+		 * Skip "wrong" monsters (see warning above); for shape shifters
+		 * it is the original race that matters not whatever shape the
+		 * the monster has now.
+		 */
+		if (mon->original_race) {
+			if ((char) mon->original_race->d_char != typ) continue;
+		} else {
+			if ((char) mon->race->d_char != typ) continue;
+		}
 
 		/* Delete the monster */
 		delete_monster_idx(i);

--- a/src/main-stats.c
+++ b/src/main-stats.c
@@ -26,6 +26,7 @@
 #include "init.h"
 #include "main.h"
 #include "mon-make.h"
+#include "mon-predicate.h"
 #include "mon-util.h"
 #include "monster.h"
 #include "obj-gear.h"
@@ -276,7 +277,7 @@ static void kill_all_monsters(int level)
 
 		monster_death(mon, player, true);
 
-		if (rf_has(mon->race->flags, RF_UNIQUE))
+		if (monster_is_unique(mon))
 			mon->race->max_num = 0;
 	}
 }

--- a/src/mon-desc.c
+++ b/src/mon-desc.c
@@ -179,7 +179,7 @@ void monster_desc(char *desc, size_t max, const struct monster *mon, int mode)
 		const char *comma_pos;
 
 		/* Unique, indefinite or definite */
-		if (rf_has(mon->race->flags, RF_UNIQUE)) {
+		if (monster_is_shape_unique(mon)) {
 			/* Start with the name (thus nominative and objective) */
 			/*
 			 * Strip off descriptive phrase if a possessive will be

--- a/src/mon-group.c
+++ b/src/mon-group.c
@@ -115,7 +115,7 @@ static void monster_group_remove_leader(struct chunk *c, struct monster *leader,
 		}
 
 		/* Uniques always take over */
-		if (rf_has(mon->race->flags, RF_UNIQUE)) {
+		if (monster_is_unique(mon)) {
 			poss_leader = mon->midx;
 		}
 		list_entry = list_entry->next;

--- a/src/mon-move.c
+++ b/src/mon-move.c
@@ -151,9 +151,7 @@ static bool monster_can_kill(struct monster *mon, struct loc grid)
 	if (!mon1) return true;
 
 	/* No trampling uniques */
-	if (rf_has(mon1->race->flags, RF_UNIQUE) ||
-			(mon1->original_race &&
-			rf_has(mon1->original_race->flags, RF_UNIQUE))) {
+	if (monster_is_unique(mon1)) {
 		return false;
 	}
 
@@ -994,7 +992,7 @@ bool multiply_monster(const struct monster *mon)
 	 * since it may have zero for cur_num in the race structure for the
 	 * shape).
 	 */
-	if (!rf_has(mon->race->flags, RF_UNIQUE) && scatter_ext(cave, &grid,
+	if (!monster_is_shape_unique(mon) && scatter_ext(cave, &grid,
 			1, mon->grid, 1, true, square_isempty) > 0) {
 		/* Create a new monster (awake, no groups) */
 		result = place_new_monster(cave, grid, mon->race, false, false,

--- a/src/mon-predicate.c
+++ b/src/mon-predicate.c
@@ -86,9 +86,18 @@ bool monster_is_not_invisible(const struct monster *mon)
 }
 
 /**
- * Monster is unique
+ * Monster's unshifted form is unique
  */
 bool monster_is_unique(const struct monster *mon)
+{
+	return rf_has((mon->original_race) ?
+		mon->original_race->flags : mon->race->flags, RF_UNIQUE);
+}
+
+/**
+ * Monster's current form is unique
+ */
+bool monster_is_shape_unique(const struct monster *mon)
 {
 	return rf_has(mon->race->flags, RF_UNIQUE);
 }

--- a/src/mon-predicate.h
+++ b/src/mon-predicate.h
@@ -34,6 +34,7 @@ bool monster_passes_walls(const struct monster *mon);
 bool monster_is_invisible(const struct monster *mon);
 bool monster_is_not_invisible(const struct monster *mon);
 bool monster_is_unique(const struct monster *mon);
+bool monster_is_shape_unique(const struct monster *mon);
 bool monster_is_stupid(const struct monster *mon);
 bool monster_is_smart(const struct monster *mon);
 bool monster_is_esp_detectable(const struct monster *mon);

--- a/src/mon-timed.c
+++ b/src/mon-timed.c
@@ -79,8 +79,7 @@ static bool saving_throw(const struct monster *mon, int effect_type, int timer, 
 						   );
 
 	/* Give unique monsters a double check */
-	if (rf_has(mon->race->flags, RF_UNIQUE) &&
-			(randint0(100) < resist_chance)) {
+	if (monster_is_unique(mon) && (randint0(100) < resist_chance)) {
 		return true;
 	}
 

--- a/src/mon-util.c
+++ b/src/mon-util.c
@@ -1031,7 +1031,7 @@ static void player_kill_monster(struct monster *mon, struct player *p,
 	}
 
 	/* Play a special sound if the monster was unique */
-	if (rf_has(mon->race->flags, RF_UNIQUE)) {
+	if (monster_is_unique(mon)) {
 		if (mon->race->base == lookup_monster_base("Morgoth"))
 			soundfx = MSG_KILL_KING;
 		else
@@ -1084,7 +1084,7 @@ static void player_kill_monster(struct monster *mon, struct player *p,
 	}
 
 	/* When the player kills a Unique, it stays dead */
-	if (rf_has(mon->race->flags, RF_UNIQUE)) {
+	if (monster_is_unique(mon)) {
 		char unique_name[80];
 		assert(mon->original_race == NULL);
 		mon->race->max_num = 0;
@@ -1195,8 +1195,7 @@ bool mon_take_nonplayer_hit(int dam, struct monster *t_mon,
 	assert(t_mon);
 
 	/* "Unique" or arena monsters can only be "killed" by the player */
-	if (rf_has(t_mon->race->flags, RF_UNIQUE)
-			|| player->upkeep->arena_level) {
+	if (monster_is_unique(t_mon) || player->upkeep->arena_level) {
 		/* Reduce monster hp to zero, but don't kill it. */
 		if (dam > t_mon->hp) dam = t_mon->hp;
 	}
@@ -1433,7 +1432,7 @@ void steal_monster_item(struct monster *mon, int midx)
 
 	if (midx < 0) {
 		/* Base monster protection and player stealing skill */
-		bool unique = rf_has(mon->race->flags, RF_UNIQUE);
+		bool unique = monster_is_unique(mon);
 		int guard = (mon->race->level * (unique ? 4 : 3)) / 4 +
 			mon->mspeed - player->state.speed;
 		int steal_skill = player->state.skills[SKILL_STEALTH] +

--- a/src/object.h
+++ b/src/object.h
@@ -466,7 +466,7 @@ struct object {
 
 	uint8_t origin;			/**< How this item was found */
 	uint8_t origin_depth;		/**< What depth the item was found at */
-	struct monster_race *origin_race;	/**< Monster race that dropped it */
+	const struct monster_race *origin_race;	/**< Monster race that dropped it */
 
 	quark_t note; 			/**< Inscription index */
 };

--- a/src/project-mon.c
+++ b/src/project-mon.c
@@ -1041,7 +1041,7 @@ static bool project_m_monster_attack(project_monster_handler_context_t *context,
 	struct monster *mon = context->mon;
 
 	/* "Unique" monsters can only be "killed" by the player */
-	if (rf_has(mon->race->flags, RF_UNIQUE)) {
+	if (monster_is_unique(mon)) {
 		/* Reduce monster hp to zero, but don't kill it. */
 		if (dam > mon->hp) dam = mon->hp;
 	}
@@ -1167,8 +1167,7 @@ static void project_m_apply_side_effects(project_monster_handler_context_t *cont
 		struct monster_race *new;
 
 		/* Uniques cannot be polymorphed; nor can an arena monster */
-		if (rf_has(mon->race->flags, RF_UNIQUE)
-				|| player->upkeep->arena_level) {
+		if (monster_is_unique(mon) || player->upkeep->arena_level) {
 			if (context->seen) add_monster_message(mon, hurt_msg, false);
 			return;
 		}
@@ -1186,7 +1185,7 @@ static void project_m_apply_side_effects(project_monster_handler_context_t *cont
 			return;
 		}
 
-		old = mon->race;
+		old = (mon->original_race) ? mon->original_race : mon->race;
 		new = poly_race(old, player->depth);
 
 		/* Handle polymorph */

--- a/src/ui-map.c
+++ b/src/ui-map.c
@@ -246,7 +246,7 @@ void grid_data_as_text(struct grid_data *g, int *ap, wchar_t *cp, int *tap,
 				a = da;
 				c = dc;
 			} else if (OPT(player, purple_uniques) && 
-					   rf_has(mon->race->flags, RF_UNIQUE)) {
+					monster_is_shape_unique(mon)) {
 				/* Turn uniques purple if desired (violet, actually) */
 				a = COLOUR_VIOLET;
 				c = dc;

--- a/src/wiz-stats.c
+++ b/src/wiz-stats.c
@@ -31,6 +31,7 @@
 #include "generate.h"
 #include "init.h"
 #include "mon-make.h"
+#include "mon-predicate.h"
 #include "monster.h"
 #include "obj-init.h"
 #include "obj-pile.h"
@@ -1102,8 +1103,7 @@ static void monster_death_stats(int m_idx)
 	assert(m_idx > 0);
 	mon = cave_monster(cave, m_idx);
 
-	/* Check if monster is UNIQUE */
-	uniq = rf_has(mon->race->flags,RF_UNIQUE);
+	uniq = monster_is_unique(mon);
 
 	/* Mimicked objects will have already been counted as floor objects */
 	mon->mimicked_obj = NULL;
@@ -1149,7 +1149,7 @@ static bool stats_monster(struct monster *mon, int i)
 	mon_total[lvl] += addval;
 
 	/* Increment unique count if appropriate */
-	if (rf_has(mon->race->flags, RF_UNIQUE)){
+	if (monster_is_unique(mon)) {
 
 		/* add to total */
 		uniq_total[lvl] += addval;
@@ -1167,8 +1167,7 @@ static bool stats_monster(struct monster *mon, int i)
 
 			mon_ood[lvl] += addval;
 
-			/* Is it a unique */
-			if (rf_has(mon->race->flags, RF_UNIQUE))
+			if (monster_is_unique(mon))
 				uniq_ood[lvl] += addval;
 	}
 
@@ -1178,8 +1177,7 @@ static bool stats_monster(struct monster *mon, int i)
 
 		mon_deadly[lvl] += addval;
 
-		/* Is it a unique? */
-		if (rf_has(mon->race->flags, RF_UNIQUE))
+		if (monster_is_unique(mon))
 			uniq_deadly[lvl] += addval;
 	}
 


### PR DESCRIPTION
See http://angband.oook.cz/forum/showthread.php?t=11589 .  Refactor monster_is_unique() so it tests the unshifted shape and add monster_is_shape_unique() to test the current shape.  The results of those can only differ if the monster is currently shape shifted.  Use those functions instead of direct tests of a monster's race->flags or original_race->flags.  Where that intentionally changes the prior behavior is in nominating a new group leader, compacting monsters, protecting a unique from trampling, computing saving throw against timed effects, calculating the difficulty of player thefts, protecting a unique from death to non-player hits or projections, protecting a unique from polymorph, and handling of uniques in the statistics code.  In all cases except for trampling, the prior code tested the current shape, and now the code tests the unshifted shape.  For trampling, the prior code tested if either the current or unshifted shape is unique, and now the code tests only the unshifted shape.  Since place_monster() checks for shape shifting, also handle shape shifting in its helper function, mon_create_drop().  There, always use the unshifted shape when computing the drop.