### PR TITLE
Nintendo BlocksDS: update to BlocksDS 0.11.0

### DIFF
--- a/src/Makefile.blocksds.arm7
+++ b/src/Makefile.blocksds.arm7
@@ -61,7 +61,7 @@ SOURCES_C	:= main-nds-arm7.c
 # Compiler and linker flags
 # -------------------------
 
-DEFINES		+= -DNDS -D__NDS__ -DARM7
+DEFINES		+= -DNDS -D__NDS__ -DBLOCKSDS -DARM7
 
 ARCH		:= -mcpu=arm7tdmi -mtune=arm7tdmi
 

--- a/src/Makefile.blocksds.arm9
+++ b/src/Makefile.blocksds.arm9
@@ -82,7 +82,7 @@ SOURCES_CPP	:= $(shell find -L $(SOURCEDIRS) -name "*.cpp")
 # Compiler and linker flags
 # -------------------------
 
-DEFINES		+= -DNDS -D__NDS__ -DARM9 -DHAVE_DIRENT_H
+DEFINES		+= -DNDS -D__NDS__ -DBLOCKSDS -DARM9 -DHAVE_DIRENT_H
 
 ARCH		:= -march=armv5te -mtune=arm946e-s
 
@@ -125,8 +125,8 @@ ifeq (,$(NDS_DEBUG))
 CFLAGS		+= -Os -fomit-frame-pointer -ffast-math -DNDEBUG
 CXXFLAGS	+= -Os -fomit-frame-pointer -ffast-math -DNDEBUG
 else
-CFLAGS		+= -Og
-CXXFLAGS	+= -Og
+CFLAGS		+= -Og -g
+CXXFLAGS	+= -Og -g
 endif
 
 # Intermediate build files

--- a/src/nds/nds-slot2-ram.c
+++ b/src/nds/nds-slot2-ram.c
@@ -1,4 +1,5 @@
 #ifndef __3DS__
+#ifndef BLOCKSDS
 
 /**********************************
   Copyright (C) Rick Wong (Lick)
@@ -439,4 +440,5 @@ void  ram_turbo (bool enable)
         REG_EXMEMCNT &= ~0x001A;
 }
 
+#endif
 #endif

--- a/src/nds/nds-slot2-ram.h
+++ b/src/nds/nds-slot2-ram.h
@@ -11,6 +11,7 @@ and GPLv2 (http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt) licenses.
 #define _NDS_SLOT2_RAM
 
 #ifndef __3DS__
+#ifndef BLOCKSDS
 
 #include <nds/ndstypes.h>
 
@@ -38,6 +39,7 @@ void  ram_lock (void);
 //  enable = set lowest waitstates, disable = set default waitstates
 void  ram_turbo (bool enable);
 
+#endif
 #endif
 
 #endif

--- a/src/nds/nds-slot2-virt.c
+++ b/src/nds/nds-slot2-virt.c
@@ -14,17 +14,27 @@ static uint32_t mem_alt_ptr_mask, mem_alt_ptr_value;
 static mspace mem_alt_mspace;
 
 void mem_init_alt(void) {
+#ifdef BLOCKSDS
+	if (peripheralSlot2Init(SLOT2_PERIPHERAL_EXTRAM) && peripheralSlot2RamStart()) {
+		peripheralSlot2Open(SLOT2_PERIPHERAL_EXTRAM);
+		peripheralSlot2EnableCache(true);
+		mem_alt_ptr_mask = 0xF8000000;
+		mem_alt_ptr_value = 0x08000000;
+
+		mem_alt_mspace = create_mspace_with_base(peripheralSlot2RamStart(), peripheralSlot2RamSize(), 0);
+#else
 	if (ram_init(DETECT_RAM)) {
 		mem_alt_ptr_mask = 0xFE000000;
 		mem_alt_ptr_value = 0x08000000;
 
 		mem_alt_mspace = create_mspace_with_base(ram_unlock(), ram_size(), 0);
+#endif
 	} else {
 		mem_alt_ptr_mask = 0xFF000000;
 		mem_alt_ptr_value = 0x06000000;
 
 		/* Update if VRAM allocation in nds-draw.c is changed! */
-		mem_alt_mspace = create_mspace_with_base(0x06860000, 0x068A4000 - 0x06860000, 0);
+		mem_alt_mspace = create_mspace_with_base((void *)0x06860000, 0x068A4000 - 0x06860000, 0);
 	}
 }
 


### PR DESCRIPTION
The big change here is that BlocksDS is providing its own Slot-2 RAM API - providing faster I/O on supported cartridges, as well as support for more cartridges than the dated `ram.c` library.
