### PR TITLE
Rename DETECT_GOLD to DETECT_ORE; split SENSE_OBJECTS and DETECT_OBJECTS

### DIFF
--- a/lib/gamedata/class.txt
+++ b/lib/gamedata/class.txt
@@ -278,7 +278,9 @@ effect:IDENTIFY
 desc:Reveals an unknown rune on an object.
 
 spell:Treasure Detection:10:3:60:5
-effect:DETECT_GOLD
+effect:DETECT_ORE
+effect-yx:22:40
+effect:SENSE_GOLD
 effect-yx:22:40
 effect:SENSE_OBJECTS
 effect-yx:22:40
@@ -378,7 +380,9 @@ effect:DETECT_DOORS
 effect-yx:22:40
 effect:DETECT_STAIRS
 effect-yx:22:40
-effect:DETECT_GOLD
+effect:DETECT_ORE
+effect-yx:22:40
+effect:SENSE_GOLD
 effect-yx:22:40
 effect:SENSE_OBJECTS
 effect-yx:22:40
@@ -1418,6 +1422,8 @@ dice:10
 desc:Teleports you randomly up to 10 squares away.
 
 spell:Object Detection:10:3:60:5
+effect:DETECT_ORE
+effect-yx:22:40
 effect:DETECT_GOLD
 effect-yx:22:40
 effect:DETECT_OBJECTS

--- a/lib/gamedata/object.txt
+++ b/lib/gamedata/object.txt
@@ -2587,7 +2587,9 @@ cost:70
 alloc:50:0 to 70
 pile:40:1d5
 power:6
-effect:DETECT_GOLD
+effect:DETECT_ORE
+effect-yx:22:40
+effect:SENSE_GOLD
 effect-yx:22:40
 effect:SENSE_OBJECTS
 effect-yx:22:40
@@ -3370,6 +3372,8 @@ effect:RESTORE_STAT:INT
 effect:GAIN_STAT:INT
 effect:RESTORE_STAT:WIS
 effect:GAIN_STAT:WIS
+effect:DETECT_ORE
+effect-yx:22:40
 effect:DETECT_GOLD
 effect-yx:22:40
 effect:DETECT_OBJECTS
@@ -4511,7 +4515,9 @@ weight:15
 cost:1000
 alloc:30:8 to 75
 power:6
-effect:DETECT_GOLD
+effect:DETECT_ORE
+effect-yx:22:40
+effect:SENSE_GOLD
 effect-yx:22:40
 effect:SENSE_OBJECTS
 effect-yx:22:40
@@ -4528,7 +4534,9 @@ attack:1d1:0:0
 armor:0:0
 flags:IGNORE_ELEC
 power:10
-effect:DETECT_GOLD
+effect:DETECT_ORE
+effect-yx:22:40
+effect:SENSE_GOLD
 effect-yx:22:40
 effect:SENSE_OBJECTS
 effect-yx:22:40

--- a/lib/gamedata/old_class.txt
+++ b/lib/gamedata/old_class.txt
@@ -251,7 +251,9 @@ expr:B:PLAYER_LEVEL:+ 55
 desc:Shoots a radius-2 fire ball.
 
 spell:Treasure Detection:30:10:70:10
-effect:DETECT_GOLD
+effect:DETECT_ORE
+effect-yx:22:40
+effect:SENSE_GOLD
 effect-yx:22:40
 effect:SENSE_OBJECTS
 effect-yx:22:40
@@ -814,7 +816,9 @@ effect:DETECT_DOORS
 effect-yx:22:40
 effect:DETECT_STAIRS
 effect-yx:22:40
-effect:DETECT_GOLD
+effect:DETECT_ORE
+effect-yx:22:40
+effect:SENSE_GOLD
 effect-yx:22:40
 effect:SENSE_OBJECTS
 effect-yx:22:40
@@ -1024,6 +1028,8 @@ desc: all light-sensitive monsters in the area of effect.
 desc:  If you are in a room, the entire room will be lit up as well.
 
 spell:Object Detection:10:3:60:1
+effect:DETECT_ORE
+effect-yx:22:40
 effect:DETECT_GOLD
 effect-yx:22:40
 effect:DETECT_OBJECTS
@@ -1532,7 +1538,9 @@ expr:B:PLAYER_LEVEL:+ 55
 desc:Shoots a radius-2 fire ball.
 
 spell:Treasure Detection:35:20:70:10
-effect:DETECT_GOLD
+effect:DETECT_ORE
+effect-yx:22:40
+effect:SENSE_GOLD
 effect-yx:22:40
 effect:SENSE_OBJECTS
 effect-yx:22:40
@@ -2007,7 +2015,9 @@ desc:Detects all non-invisible monsters in the immediate area,
 desc: for one turn only.
 
 spell:Detection:15:15:80:12
-effect:DETECT_GOLD
+effect:DETECT_ORE
+effect-yx:22:40
+effect:SENSE_GOLD
 effect-yx:22:40
 effect:SENSE_OBJECTS
 effect-yx:22:40

--- a/src/cave-map.c
+++ b/src/cave-map.c
@@ -230,7 +230,7 @@ void square_note_spot(struct chunk *c, struct loc grid)
 	if (!square_isseen(c, grid) && !square_isplayer(c, grid)) return;
 
 	/* Make the player know precisely what is on this grid */
-	square_know_pile(c, grid);
+	square_know_pile(c, grid, NULL);
 
 	/* Notice traps, memorize those we can see */
 	if (square_issecrettrap(c, grid)) {
@@ -445,9 +445,9 @@ void wiz_light(struct chunk *c, struct player *p, bool full)
 
 			/* Memorize objects */
 			if (full) {
-				square_know_pile(c, grid);
+				square_know_pile(c, grid, NULL);
 			} else {
-				square_sense_pile(c, grid);
+				square_sense_pile(c, grid, NULL);
 			}
 
 			/* Forget unprocessed, unknown grids in the mapping area */
@@ -511,9 +511,9 @@ void wiz_dark(struct chunk *c, struct player *p, bool full)
 
 			/* Memorize objects */
 			if (full) {
-				square_know_pile(c, grid);
+				square_know_pile(c, grid, NULL);
 			} else {
-				square_sense_pile(c, grid);
+				square_sense_pile(c, grid, NULL);
 			}
 
 			/* Forget unprocessed, unknown grids in the mapping area */

--- a/src/cave.h
+++ b/src/cave.h
@@ -373,8 +373,10 @@ void square_excise_pile(struct chunk *c, struct loc grid);
 void square_excise_all_imagined(struct chunk *p_c, struct chunk *c,
 		struct loc grid);
 void square_delete_object(struct chunk *c, struct loc grid, struct object *obj, bool do_note, bool do_light);
-void square_sense_pile(struct chunk *c, struct loc grid);
-void square_know_pile(struct chunk *c, struct loc grid);
+void square_sense_pile(struct chunk *c, struct loc grid,
+		bool (*pred)(const struct object*));
+void square_know_pile(struct chunk *c, struct loc grid,
+		bool (*pred)(const struct object*));
 int square_num_walls_adjacent(struct chunk *c, struct loc grid);
 int square_num_walls_diagonal(struct chunk *c, struct loc grid);
 

--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -1401,8 +1401,8 @@ void do_cmd_hold(struct command *cmd)
 		/* Turn will be taken exiting the shop */
 		player->upkeep->energy_use = 0;
 	} else {
-	    event_signal(EVENT_SEEFLOOR);
-		square_know_pile(cave, player->grid);
+		event_signal(EVENT_SEEFLOOR);
+		square_know_pile(cave, player->grid, NULL);
 	}
 }
 

--- a/src/cmd-pickup.c
+++ b/src/cmd-pickup.c
@@ -318,7 +318,7 @@ static uint8_t player_pickup_item(struct player *p, struct object *obj, bool men
 	uint8_t objs_picked_up = 0;
 
 	/* Always know what's on the floor */
-	square_know_pile(cave, p->grid);
+	square_know_pile(cave, p->grid, NULL);
 
 	/* Always pickup gold, effortlessly */
 	player_pickup_gold(p);

--- a/src/game-world.c
+++ b/src/game-world.c
@@ -950,7 +950,7 @@ void process_player(void)
 				!player->timed[TMD_PARALYZED] &&
 				!player->timed[TMD_TERROR] &&
 				!player->timed[TMD_AFRAID])
-				effect_simple(EF_DETECT_GOLD, source_none(), "0", 0, 0, 0, 3, 3, NULL);
+				effect_simple(EF_DETECT_ORE, source_none(), "0", 0, 0, 0, 3, 3, NULL);
 		}
 
 		/* Paralyzed or Knocked Out player gets no turn */

--- a/src/list-effects.h
+++ b/src/list-effects.h
@@ -45,6 +45,8 @@ EFFECT(READ_MINDS,					false,	NULL,		0,		EFINFO_NONE,	"maps the area around rece
 EFFECT(DETECT_TRAPS,				false,	NULL,		0,		EFINFO_NONE,	"detects traps nearby",	"detect traps")
 EFFECT(DETECT_DOORS,				false,	NULL,		0,		EFINFO_NONE,	"detects doors nearby",	"detect doors")
 EFFECT(DETECT_STAIRS,				false,	NULL,		0,		EFINFO_NONE,	"detects stairs nearby",	"detect stairs")
+EFFECT(DETECT_ORE,					false,	NULL,		0,		EFINFO_NONE,	"detects veins nearby",	"detect veins")
+EFFECT(SENSE_GOLD,					false,	NULL,		0,		EFINFO_NONE,	"senses gold nearby",	"sense gold")
 EFFECT(DETECT_GOLD,					false,	NULL,		0,		EFINFO_NONE,	"detects gold nearby",	"detect gold")
 EFFECT(SENSE_OBJECTS,				false,	NULL,		0,		EFINFO_NONE,	"senses objects nearby",	"sense objects")
 EFFECT(DETECT_OBJECTS,				false,	NULL,		0,		EFINFO_NONE,	"detects objects nearby",	"detect objects")

--- a/src/player-util.c
+++ b/src/player-util.c
@@ -1562,7 +1562,7 @@ void player_handle_post_move(struct player *p, bool eval_trap,
 		if (is_involuntary) {
 			cmdq_flush();
 		}
-		square_know_pile(cave, p->grid);
+		square_know_pile(cave, p->grid, NULL);
 	}
 
 	/* Discover invisible traps, set off visible ones */


### PR DESCRIPTION
In the split, one part handles money (SENSE_GOLD and DETECT_GOLD) and the other (SENSE_OBJECTS and DETECT_OBJECTS) handles all other objects.  That's to match how gold gets different treatment in other parts of the game and to resolve PowerDiver's report here, https://forum.angband.live/forum/showpost.php?p=162031&postcount=14 , of inconsistent messaging.  Give square_sense_pile() and square_know_pile() an additional argument to select which objects in the pile are processed.  Add forgetting remembered objects that are no longer there to square_sense_pile():  square_know_pile() already has it and the sense effect was implementing it separately for remembered piles that had completely gone away.  All objects and spells with SENSE_OBJECTS or DETECT_OBJECTS also get the _GOLD effect:  they'll sense/detect the same things as before this change but with some messaging changes and differences in forgetting for the sensing case.