### PR TITLE
Fix build warning in borg code

### DIFF
--- a/src/borg/borg-trait.c
+++ b/src/borg/borg-trait.c
@@ -2879,8 +2879,6 @@ void borg_notice_player(void)
 {
     int i;
 
-    struct player_state *state = &player->known_state;
-
     /*** Hack -- Extract class ***/
     borg.trait[BI_CLASS] = player->class->cidx;
 


### PR DESCRIPTION
borg/borg-trait.c: In function ‘borg_notice_player’: borg/borg-trait.c:2882:26: warning: unused variable ‘state’ [-Wunused-variable]
 2882 |     struct player_state *state = &player->known_state;
      |                          ^~~~~