### PR TITLE
SDL2: refactor event handling and change drawing for menu items

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -385,6 +385,9 @@ ADD_EXECUTABLE(OurExecutable
         $<$<BOOL:${SUPPORT_GCU_FRONTEND}>:src/main-gcu.c>
         $<$<BOOL:${SUPPORT_SDL_FRONTEND}>:src/main-sdl.c>
         $<$<BOOL:${SUPPORT_SDL2_FRONTEND}>:src/main-sdl2.c>
+        $<$<BOOL:${SUPPORT_SDL2_FRONTEND}>:src/sdl2/pui-ctrl.c>
+        $<$<BOOL:${SUPPORT_SDL2_FRONTEND}>:src/sdl2/pui-dlg.c>
+        $<$<BOOL:${SUPPORT_SDL2_FRONTEND}>:src/sdl2/pui-misc.c>
         $<$<BOOL:${SUPPORT_WINDOWS_FRONTEND}>:${OUR_WINDOWS_RC}>
         $<$<BOOL:${SUPPORT_WINDOWS_FRONTEND}>:src/main-win.c>
         $<$<BOOL:${SUPPORT_WINDOWS_FRONTEND}>:src/win/readdib.c>

--- a/docs/customize.rst
+++ b/docs/customize.rst
@@ -391,7 +391,7 @@ and drags within the displayed subwindows to change the positions for those
 subwindows.  Disable both "Move" and "Size", by clicking on one if it is
 enabled, to restore passing input to the game's core.
 
-Within "Menu", the first entries control properties each of the displayed
+Within "Menu", the first entries control properties for each of the displayed
 terminal windows within that application window.  For the main window, you
 can set the font, graphical tile set, whether the window is shown with borders
 or not, and whether or not the window will be shown on top of the other windows.
@@ -403,7 +403,8 @@ will be shown on top of the other windows.
 
 Below the entries for the contained terminal windows, is an entry,
 "Fullscreen" for toggling fullscreen mode for that application window.  That
-entry will be gray when fullscreen mode is off and white when it is on.
+entry will display a rectangle at the end of the entry when fullscreen mode
+is on.  That rectangle will be absent when fullscreen mode is off.
 
 In the primary application window which contains the main window, there is an
 entry, "Send Keypad Modifier", after that for whether key strokes from the
@@ -417,7 +418,16 @@ keypad.  https://github.com/angband/angband/issues/4522 has an example of the
 problems that can be avoided by not sending the keypad modifier.
 
 Below "Send Keypad Modifier" in the primary application window's "Menu" is
-"Windows", use that to bring up one of the additional application windows.
+"Menu Shortcuts...".  That allows you to set a keystroke to transfer control
+to a window's menu.  By default, no such keystrokes are defined.  That avoids
+potential conflicts with any keymaps you may have.  While in the menus,
+keystrokes can be used for navigation.  The in-game horizontal and vertical
+movement keys will work to move between controls as will Tab (to go to the
+"next" control) and Shift-Tab (to go to the previous control).  Enter will
+activate a menu item if it can be activated.  Trying to descend further into
+the menus with the in-game movement keys will also activate if a menu item if
+it is as deep as you can go.  Below "Menu Shortcuts..." is "Windows":  use
+that to bring up one of the additional application windows.
 
 The final two entries in "Menu" are "About" for displaying an information
 dialog about the game and "Quit" to save the game and exit.
@@ -425,7 +435,7 @@ dialog about the game and "Quit" to save the game and exit.
 When you leave the game, the current settings for the SDL interface are saved
 as ``sdl2init.txt`` in the same directory as is used for preference files, see
 `User Pref Files`_ for details.  Those settings will be automatically reloaded
-the next time you start the SDL interface.
+the next time you start the SDL2 interface.
 
 Mac
 ~~~

--- a/src/Makefile.msys2.sdl2
+++ b/src/Makefile.msys2.sdl2
@@ -92,8 +92,8 @@ include Makefile.inc
 # Program name (PROGNAME comes from Makefile.src via Makefile.inc)
 EXE := $(PROGNAME)
 
-# Object definitions (BASEOBJS come from Makefile.inc)
-OBJS := main.o main-sdl2.o $(BASEOBJS)
+# Object definitions (SDL2MAINFILES and BASEOBJS come from Makefile.inc)
+OBJS := main.o $(SDL2MAINFILES) $(BASEOBJS)
 
 ifdef SOUND
 OBJS += snd-sdl.o

--- a/src/Makefile.src
+++ b/src/Makefile.src
@@ -116,7 +116,11 @@ BASEMAINFILES = main.o
 
 GCUMAINFILES = main-gcu.o
 
-SDL2MAINFILES = main-sdl2.o
+SDL2MAINFILES = \
+	main-sdl2.o \
+	sdl2/pui-ctrl.o \
+	sdl2/pui-dlg.o \
+	sdl2/pui-misc.o
 
 SDLMAINFILES = main-sdl.o
 

--- a/src/sdl2/pui-ctrl.c
+++ b/src/sdl2/pui-ctrl.c
@@ -1,0 +1,2539 @@
+/**
+ * \file sdl2/pui-ctrl.c
+ * \brief Define handlers for simple controls used by the primitive UI toolkit
+ * for SDL2.
+ *
+ * Copyright (c) 2023 Eric Branlund
+ *
+ * This work is free software; you can redistribute it and/or modify it
+ * under the terms of either:
+ *
+ * a) the GNU General Public License as published by the Free Software
+ *    Foundation, version 2, or
+ *
+ * b) the "Angband licence":
+ *    This software may be copied and distributed for educational, research,
+ *    and not for profit purposes provided that this copyright and statement
+ *    are included in all such copies.  Other copyrights may also apply.
+ */
+
+#include "pui-ctrl.h"
+#include "pui-dlg.h"
+#include "pui-misc.h"
+
+
+static void render_image(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, SDL_Renderer *r);
+static void resize_image(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, int width, int height);
+static void query_image_natural_size(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		int *width, int *height);
+static void cleanup_image(struct sdlpui_control *c);
+
+static void change_label_caption(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		const char *new_caption);
+static void render_label(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, SDL_Renderer *r);
+static void resize_label(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, int width, int height);
+static void query_label_natural_size(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		int *width, int *height);
+static void cleanup_label(struct sdlpui_control *c);
+
+static void change_pb_caption(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		const char *new_caption);
+static void render_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, SDL_Renderer *r);
+static void respond_default_pb(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		enum sdlpui_action_hint hint);
+static void gain_key_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, int comp_ind);
+static void lose_key_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, bool following_mouse);
+static void gain_mouse_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, int comp_ind);
+static void lose_mouse_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e);
+static void arm_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, enum sdlpui_action_hint hint);
+static void disarm_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, enum sdlpui_action_hint hint);
+static int get_pb_interactable_component(struct sdlpui_control *c, bool first);
+static void resize_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, int width, int height);
+static void query_pb_natural_size(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		int *width, int *height);
+static bool is_pb_disabled(const struct sdlpui_control *c);
+static bool set_pb_disabled(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, bool disabled);
+static int get_pb_tag(const struct sdlpui_control *c);
+static int set_pb_tag(struct sdlpui_control *c, int new_tag);
+static void cleanup_pb(struct sdlpui_control *c);
+
+static bool handle_mb_mousemove(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		const struct SDL_MouseMotionEvent *e);
+static bool handle_mb_mousewheel(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		const struct SDL_MouseWheelEvent *e);
+static void change_mb_caption(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		const char *new_caption);
+static void render_mb(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		SDL_Renderer *r);
+static void respond_default_mb(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		enum sdlpui_action_hint hint);
+static void gain_key_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, int comp_ind);
+static void lose_key_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, bool following_mouse);
+static void gain_mouse_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, int comp_ind);
+static void lose_mouse_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e);
+static void lose_child_mb(struct sdlpui_control *c,
+		struct sdlpui_dialog *child);
+static void arm_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, enum sdlpui_action_hint hint);
+static void disarm_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, enum sdlpui_action_hint hint);
+static int get_mb_interactable_component(struct sdlpui_control *c, bool first);
+static bool step_within_mb(struct sdlpui_control *c, bool forward);
+static int get_mb_interactable_component_at(struct sdlpui_control *c, Sint32 x,
+		Sint32 y);
+static void resize_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, int width, int height);
+static void query_mb_natural_size(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		int *width, int *height);
+static bool is_mb_disabled(const struct sdlpui_control *c);
+static bool set_mb_disabled(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, bool disabled);
+static int get_mb_tag(const struct sdlpui_control *c);
+static int set_mb_tag(struct sdlpui_control *c, int new_tag);
+static void cleanup_mb(struct sdlpui_control *c);
+
+Uint32 SDLPUI_CTRL_IMAGE = 0;
+Uint32 SDLPUI_CTRL_LABEL = 0;
+Uint32 SDLPUI_CTRL_MENU_BUTTON = 0;
+Uint32 SDLPUI_CTRL_PUSH_BUTTON = 0;
+
+/* Function table for sdlpui_image */
+static const struct sdlpui_control_funcs image_funcs = {
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	render_image,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	resize_image,
+	query_image_natural_size,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	cleanup_image
+};
+
+/* Function table for sdlpui_label */
+static const struct sdlpui_control_funcs label_funcs = {
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	change_label_caption,
+	render_label,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	resize_label,
+	query_label_natural_size,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	cleanup_label
+};
+
+/* Function table for sdlpui_push_button */
+const struct sdlpui_control_funcs push_button_funcs = {
+	sdlpui_control_handle_key,
+	NULL,
+	NULL,
+	sdlpui_control_handle_mouseclick,
+	sdlpui_control_handle_mousemove,
+	NULL,
+	change_pb_caption,
+	render_pb,
+	respond_default_pb,
+	gain_key_pb,
+	lose_key_pb,
+	gain_mouse_pb,
+	lose_mouse_pb,
+	NULL,
+	arm_pb,
+	disarm_pb,
+	get_pb_interactable_component,
+	NULL,
+	NULL,
+	resize_pb,
+	query_pb_natural_size,
+	is_pb_disabled,
+	set_pb_disabled,
+	get_pb_tag,
+	set_pb_tag,
+	cleanup_pb
+};
+
+/* Function table for sdlpui_menu_button */
+static const struct sdlpui_control_funcs menu_button_funcs = {
+	sdlpui_control_handle_key,
+	NULL,
+	NULL,
+	sdlpui_control_handle_mouseclick,
+	handle_mb_mousemove,
+	handle_mb_mousewheel,
+	change_mb_caption,
+	render_mb,
+	respond_default_mb,
+	gain_key_mb,
+	lose_key_mb,
+	gain_mouse_mb,
+	lose_mouse_mb,
+	lose_child_mb,
+	arm_mb,
+	disarm_mb,
+	get_mb_interactable_component,
+	step_within_mb,
+	get_mb_interactable_component_at,
+	resize_mb,
+	query_mb_natural_size,
+	is_mb_disabled,
+	set_mb_disabled,
+	get_mb_tag,
+	set_mb_tag,
+	cleanup_mb
+};
+
+
+static void render_image(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, SDL_Renderer *r)
+{
+	struct sdlpui_image *ip;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_IMAGE && c->priv);
+	ip = c->priv;
+	SDLPUI_RENDER_TRACER("image", c, "(none)", c->rect, ip->image_rect,
+		d->texture);
+
+	if (ip->image_rect.w > 0 && ip->image_rect.h > 0) {
+		SDL_Rect dst_r = ip->image_rect;
+
+		/* Get the coordinates relative to the dialog. */
+		dst_r.x += c->rect.x;
+		dst_r.y += c->rect.y;
+		if (!d->texture) {
+			/*
+			 * Rendering directly to the window's buffer, so use
+			 * its coordinates.
+			 */
+			dst_r.x += d->rect.x;
+			dst_r.y += d->rect.y;
+		}
+		SDL_RenderCopy(r, ip->image, NULL, &dst_r);
+	}
+}
+
+
+static void resize_image(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, int width, int height)
+{
+	struct sdlpui_image *ip;
+	int tw, th, mhor, mver, nw, nh;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_IMAGE && c->priv);
+	ip = c->priv;
+
+	if (SDL_QueryTexture(ip->image, NULL, NULL, &tw, &th)) {
+		SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION,
+			"SDL_QueryTexture() failed: %s", SDL_GetError());
+		sdlpui_force_quit();
+	}
+	mhor = ip->left_margin + ip->right_margin;
+	mver = ip->top_margin + ip->bottom_margin;
+	nw = tw + mhor;
+	nh = th + mver;
+
+	if (width <= mhor || height <= mver) {
+		/* No room to display anything at all. */
+		ip->image_rect.x = 0;
+		ip->image_rect.y = 0;
+		ip->image_rect.w = 0;
+		ip->image_rect.h = 0;
+		return;
+	}
+	if (width >= nw && height >= nh) {
+		/*
+		 * Can display at the native size.  The internal rectangle
+		 * has the same dimensions as the image.
+		 */
+		ip->image_rect.w = tw;
+		ip->image_rect.h = th;
+	} else {
+		/*
+		 * Set the internal rectangle dimensions to keep close to the
+		 * original aspect ratio.
+		 */
+		long shor = (width >= nw) ?
+			100L :
+			(100L * tw + (width - mhor) / 2) / (width - mhor);
+		long sver = (height >= nh) ?
+			100L :
+			(100L * th + (height - mver) / 2) / (height - mver);
+		long scale = (shor <= sver) ? shor : sver;
+
+		ip->image_rect.w = (int)((tw * scale + 50L) / 100L);
+		ip->image_rect.h = (int)((th * scale + 50L) / 100L);
+		if (ip->image_rect.w < 1) {
+			ip->image_rect.w = 1;
+		}
+		if (ip->image_rect.h < 1) {
+			ip->image_rect.h = 1;
+		}
+	}
+
+	/*
+	 * In x, honor the alignment specified when created.  In y, center if
+	 * the full size of the control exceeds the inner rectangle's height
+	 * plus the vertical margins.
+	 */
+	SDL_assert(width >= ip->image_rect.w + mhor);
+	switch (ip->halign) {
+	case SDLPUI_HOR_LEFT:
+		ip->image_rect.x = ip->left_margin;
+		break;
+
+	case SDLPUI_HOR_RIGHT:
+		ip->image_rect.x = width - ip->image_rect.w - ip->right_margin;
+		break;
+
+	default:
+		ip->image_rect.x = (width - ip->image_rect.w - mhor) / 2
+			+ ip->left_margin;
+		break;
+	}
+	SDL_assert(height >= ip->image_rect.h + mver);
+	ip->image_rect.y = (height - ip->image_rect.h - mver) / 2
+		+ ip->top_margin;
+	c->rect.w = width;
+	c->rect.h = height;
+}
+
+
+static void query_image_natural_size(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		int *width, int *height)
+{
+	struct sdlpui_image *ip;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_IMAGE && c->priv);
+	ip = c->priv;
+	if (SDL_QueryTexture(ip->image, NULL, NULL, width, height)) {
+		SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION,
+			"SDL_QueryTexture() failed: %s", SDL_GetError());
+		sdlpui_force_quit();
+	}
+	*width += ip->left_margin + ip->right_margin;
+	*height += ip->top_margin + ip->bottom_margin;
+}
+
+
+static void cleanup_image(struct sdlpui_control *c)
+{
+	struct sdlpui_image *ip;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_IMAGE && c->priv);
+	ip = c->priv;
+	SDL_DestroyTexture(ip->image);
+	SDL_free(ip);
+}
+
+
+static void change_label_caption(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		const char *new_caption)
+{
+	struct sdlpui_label *lp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_LABEL && c->priv);
+	lp = c->priv;
+	SDL_free(lp->caption);
+	lp->caption = SDL_strdup(new_caption);
+	resize_label(c, d, w, c->rect.w, c->rect.h);
+	d->dirty = true;
+	sdlpui_signal_redraw(w);
+}
+
+
+static void render_label(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, SDL_Renderer *r)
+{
+	const SDL_Color *fg = sdlpui_get_color(w, SDLPUI_COLOR_DIALOG_FG);
+	TTF_Font *font = sdlpui_get_ttf(w);
+	struct sdlpui_label *lp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_LABEL && c->priv);
+	lp = c->priv;
+	SDLPUI_RENDER_TRACER("label", c, lp->caption, c->rect,
+		lp->caption_rect, d->texture);
+
+	if (lp->caption_rect.w > 0 && lp->caption_rect.h > 0) {
+		SDL_Rect dst_r = lp->caption_rect;
+
+		dst_r.x += c->rect.x;
+		dst_r.y += c->rect.y;
+		if (!d->texture) {
+			/*
+			 * Rendering directly to the window's buffer, so use
+			 * its coordinates.
+			 */
+			dst_r.x += d->rect.x;
+			dst_r.y += d->rect.y;
+		}
+		sdlpui_render_utf8_line(r, font, fg, &dst_r, lp->caption);
+	}
+}
+
+
+static void resize_label(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, int width, int height)
+{
+	TTF_Font *font = sdlpui_get_ttf(w);
+	struct sdlpui_label *lp;
+	int sw, sh, border, nw, nh;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_LABEL && c->priv);
+	lp = c->priv;
+
+	sdlpui_get_utf8_metrics(font, lp->caption, &sw, &sh);
+	border = 2 * SDLPUI_DEFAULT_CTRL_BORDER;
+	nw = sw + border;
+	nh = sh + border;
+
+	if (width <= border || height <= border) {
+		/* No room to display anything at all. */
+		lp->caption_rect.x = 0;
+		lp->caption_rect.y = 0;
+		lp->caption_rect.w = 0;
+		lp->caption_rect.h = 0;
+		return;
+	}
+
+	/* If necessary, truncate what will be displaced to the given size. */
+	lp->caption_rect.w = (width >= nw) ? sw : width - border;
+	lp->caption_rect.h = (height >= nh) ? sh : height - border;
+
+	/*
+	 * In x, honor the alignment specified when created.  In y, center if
+	 * the full size of the control exceeds the inner rectangle's height
+	 * plus the vertical borders.
+	 */
+	SDL_assert(width >= lp->caption_rect.w + border);
+	switch (lp->halign) {
+	case SDLPUI_HOR_LEFT:
+		lp->caption_rect.x = SDLPUI_DEFAULT_CTRL_BORDER;
+		break;
+
+	case SDLPUI_HOR_RIGHT:
+		lp->caption_rect.x = width - lp->caption_rect.w
+			- SDLPUI_DEFAULT_CTRL_BORDER;
+		break;
+
+	default:
+		lp->caption_rect.x = (width - lp->caption_rect.w - border) / 2
+			+ SDLPUI_DEFAULT_CTRL_BORDER;
+		break;
+	}
+	SDL_assert(height >= lp->caption_rect.h + border);
+	lp->caption_rect.y = (height - lp->caption_rect.h - border) / 2
+			+ SDLPUI_DEFAULT_CTRL_BORDER;
+	c->rect.w = width;
+	c->rect.h = height;
+}
+
+
+static void query_label_natural_size(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		int *width, int *height)
+{
+	TTF_Font *font = sdlpui_get_ttf(w);
+	struct sdlpui_label *lp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_LABEL && c->priv);
+	lp = c->priv;
+
+	sdlpui_get_utf8_metrics(font, lp->caption, width, height);
+	*width += SDLPUI_DEFAULT_CTRL_BORDER * 2;
+	*height += SDLPUI_DEFAULT_CTRL_BORDER * 2;
+}
+
+
+static void cleanup_label(struct sdlpui_control *c)
+{
+	struct sdlpui_label *lp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_LABEL && c->priv);
+	lp = c->priv;
+	SDL_free(lp->caption);
+	SDL_free(lp);
+}
+
+
+static void change_pb_caption(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		const char *new_caption)
+{
+	struct sdlpui_label *pbp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+	pbp = c->priv;
+	SDL_free(pbp->caption);
+	pbp->caption = SDL_strdup(new_caption);
+	resize_pb(c, d, w, c->rect.w, c->rect.h);
+	d->dirty = true;
+	sdlpui_signal_redraw(w);
+}
+
+
+static void render_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, SDL_Renderer *r)
+{
+	const SDL_Color *fg = sdlpui_get_color(w, SDLPUI_COLOR_DIALOG_FG);
+	const SDL_Color *countersink_color = sdlpui_get_color(w,
+		SDLPUI_COLOR_COUNTERSINK);
+	TTF_Font *font = sdlpui_get_ttf(w);
+	struct sdlpui_push_button *pbp;
+	SDL_Rect dst_r;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+	pbp = c->priv;
+	SDLPUI_RENDER_TRACER("push button", c, pbp->caption, c->rect,
+		pbp->caption_rect, d->texture);
+
+	/*
+	 * Always draw a border.  There's one pixel between these to leave
+	 * space for indicating whether it's armed or not.
+	 */
+	SDL_SetRenderDrawColor(r, countersink_color->r, countersink_color->g,
+		countersink_color->b, countersink_color->a);
+	dst_r = c->rect;
+	if (!d->texture) {
+		/*
+		 * Drawing directly to the window's buffer, use its coordinates.
+		 */
+		dst_r.x += d->rect.x;
+		dst_r.y += d->rect.y;
+	}
+	SDL_RenderDrawRect(r, &dst_r);
+	dst_r.x += 2;
+	dst_r.y += 2;
+	dst_r.w -= 4;
+	dst_r.h -= 4;
+	SDL_SetRenderDrawColor(r, fg->r, fg->g, fg->b, fg->a);
+	SDL_RenderDrawRect(r, &dst_r);
+
+	if (pbp->has_key || pbp->has_mouse) {
+		/* Strengthen the inner border to signal that it has focus. */
+		++dst_r.x;
+		++dst_r.y;
+		dst_r.w -= 2;
+		dst_r.h -= 2;
+		SDL_RenderDrawRect(r, &dst_r);
+	}
+
+	if (!pbp->armed) {
+		/*
+		 * Button is not depressed.  Highlight left and top edges
+		 * as if there's lighting from the upper left since it
+		 * protrudes above the surface.
+		 */
+		SDL_Point points[3];
+
+		points[0].x = c->rect.x + 1;
+		points[0].y = c->rect.y + c->rect.h - 2;
+		if (!d->texture) {
+			points[0].x += d->rect.x;
+			points[0].y += d->rect.y;
+		}
+		points[1].x = points[0].x;
+		points[1].y = points[0].y - c->rect.h + 3;
+		points[2].x = points[0].x + c->rect.w - 3;
+		points[2].y = points[1].y;
+		SDL_RenderDrawLines(r, points, 3);
+	}
+
+	if (pbp->caption_rect.h > 0 && pbp->caption_rect.w > 0) {
+		dst_r = pbp->caption_rect;
+		dst_r.x += c->rect.x;
+		dst_r.y += c->rect.y;
+		if (!d->texture) {
+			dst_r.x += d->rect.x;
+			dst_r.y += d->rect.y;
+		}
+		sdlpui_render_utf8_line(r, font, fg, &dst_r, pbp->caption);
+	}
+
+	if (pbp->disabled) {
+		struct sdlpui_stipple *stipple = sdlpui_get_stipple(w);
+
+		dst_r = c->rect;
+		if (!d->texture) {
+			dst_r.x += d->rect.x;
+			dst_r.y += d->rect.y;
+		}
+		dst_r.x += 2;
+		dst_r.y += 2;
+		dst_r.w -= 4;
+		dst_r.h -= 4;
+		sdlpui_stipple_rect(r, stipple, &dst_r);
+	}
+}
+
+
+static void respond_default_pb(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		enum sdlpui_action_hint hint)
+{
+	struct sdlpui_push_button *pbp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+	pbp = c->priv;
+	if (!pbp->disabled && pbp->callback) {
+		SDLPUI_EVENT_TRACER("push button", c, pbp->caption,
+			"default action invoked");
+		(pbp->callback)(c, d, w);
+	} else {
+		SDLPUI_EVENT_TRACER("push button", c, pbp->caption,
+			(pbp->disabled) ?
+				((pbp->callback) ? "default action suppressed; disable yes, callback available" : "default action suppressed; disable yes, callback unavailable") :
+				((pbp->callback) ? "default action suppressed; disable no, callback available" : "default action suppressed; disable no, callback unavailable"));
+	}
+}
+
+
+static void gain_key_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, int comp_ind)
+{
+	struct sdlpui_push_button *pbp;
+
+	SDL_assert(comp_ind == 0 || comp_ind == -1);
+	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+	pbp = c->priv;
+	if (!pbp->has_key) {
+		SDLPUI_EVENT_TRACER("push button", c, pbp->caption,
+			"gained key focus");
+		pbp->has_key = true;
+		d->dirty = true;
+		sdlpui_signal_redraw(w);
+	}
+}
+
+
+static void lose_key_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, bool following_mouse)
+{
+	struct sdlpui_push_button *pbp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+	pbp = c->priv;
+	if (pbp->has_key) {
+		SDLPUI_EVENT_TRACER("push button", c, pbp->caption,
+			"lost key focus");
+		pbp->has_key = false;
+		d->dirty = true;
+		sdlpui_signal_redraw(w);
+	}
+}
+
+
+static void gain_mouse_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, int comp_ind)
+{
+	struct sdlpui_push_button *pbp;
+
+	SDL_assert(comp_ind == 0 || comp_ind == -1);
+	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+	pbp = c->priv;
+	if (!pbp->has_mouse) {
+		SDLPUI_EVENT_TRACER("push button", c, pbp->caption,
+			"gained mouse focus");
+		pbp->has_mouse = true;
+		d->dirty = true;
+		sdlpui_signal_redraw(w);
+	}
+}
+
+
+static void lose_mouse_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e)
+{
+	struct sdlpui_push_button *pbp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+	pbp = c->priv;
+	if (pbp->has_mouse) {
+		SDLPUI_EVENT_TRACER("push button", c, pbp->caption,
+			"lost mouse focus");
+		pbp->has_mouse = false;
+		d->dirty = true;
+		sdlpui_signal_redraw(w);
+	}
+}
+
+
+static void arm_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, enum sdlpui_action_hint hint)
+{
+	struct sdlpui_push_button *pbp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+	pbp = c->priv;
+	if (!pbp->armed) {
+		pbp->armed = true;
+		d->dirty = true;
+		sdlpui_signal_redraw(w);
+	}
+}
+
+
+static void disarm_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, enum sdlpui_action_hint hint)
+{
+	struct sdlpui_push_button *pbp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+	pbp = c->priv;
+	if (pbp->armed) {
+		pbp->armed = false;
+		d->dirty = true;
+		sdlpui_signal_redraw(w);
+	}
+}
+
+
+static int get_pb_interactable_component(struct sdlpui_control *c, bool first)
+{
+	struct sdlpui_push_button *pbp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+	pbp = c->priv;
+	return (pbp->disabled) ? 0 : 1;
+}
+
+
+static void resize_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, int width, int height)
+{
+	TTF_Font *font = sdlpui_get_ttf(w);
+	struct sdlpui_push_button *pbp;
+	int sw, sh, border, nw, nh;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+	pbp = c->priv;
+
+	sdlpui_get_utf8_metrics(font, pbp->caption, &sw, &sh);
+	border = 2 * (SDLPUI_DEFAULT_CTRL_BORDER + 2);
+	nw = sw + border;
+	nh = sh + border;
+
+	if (width <= border || height <= border) {
+		/* No room to display anything at all. */
+		pbp->caption_rect.x = 0;
+		pbp->caption_rect.y = 0;
+		pbp->caption_rect.w = 0;
+		pbp->caption_rect.h = 0;
+		return;
+	}
+
+	/* If necessary, truncate what will be displaced to the given size. */
+	pbp->caption_rect.w = (width >= nw) ? sw : width - border;
+	pbp->caption_rect.h = (height >= nh) ? sh : height - border;
+
+	/*
+	 * In x, honor the alignment specified when created.  In y, center if
+	 * the full size of the control exceeds the inner rectangle's height
+	 * plus the vertical borders.
+	 */
+	SDL_assert(width >= pbp->caption_rect.w + border);
+	switch (pbp->halign) {
+	case SDLPUI_HOR_LEFT:
+		pbp->caption_rect.x = SDLPUI_DEFAULT_CTRL_BORDER + 2;
+		break;
+
+	case SDLPUI_HOR_RIGHT:
+		pbp->caption_rect.x = width - pbp->caption_rect.w
+			- SDLPUI_DEFAULT_CTRL_BORDER - 2;
+		break;
+
+	default:
+		pbp->caption_rect.x = (width - pbp->caption_rect.w - border) / 2
+			+ SDLPUI_DEFAULT_CTRL_BORDER + 2;
+		break;
+	}
+	SDL_assert(height >= pbp->caption_rect.h + border);
+	pbp->caption_rect.y = (height - pbp->caption_rect.h - border) / 2
+		+ SDLPUI_DEFAULT_CTRL_BORDER + 2;
+	c->rect.w = width;
+	c->rect.h = height;
+}
+
+
+static void query_pb_natural_size(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w, int *width,
+		int *height)
+{
+	TTF_Font *font = sdlpui_get_ttf(w);
+	struct sdlpui_push_button *pbp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+	pbp = c->priv;
+
+	sdlpui_get_utf8_metrics(font, pbp->caption, width, height);
+	*width += (SDLPUI_DEFAULT_CTRL_BORDER + 2) * 2;
+	*height += (SDLPUI_DEFAULT_CTRL_BORDER + 2) * 2;
+}
+
+
+static bool is_pb_disabled(const struct sdlpui_control *c)
+{
+	const struct sdlpui_push_button *pbp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+	pbp = c->priv;
+	return pbp->disabled;
+}
+
+
+static bool set_pb_disabled(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, bool disabled)
+{
+	struct sdlpui_push_button *pbp;
+	bool old_value;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+	pbp = c->priv;
+	old_value = pbp->disabled;
+	if (old_value != disabled) {
+		pbp->disabled = disabled;
+		d->dirty = true;
+		sdlpui_signal_redraw(w);
+	}
+	return old_value;
+}
+
+
+static int get_pb_tag(const struct sdlpui_control *c)
+{
+	const struct sdlpui_push_button *pbp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+	pbp = c->priv;
+	return pbp->tag;
+}
+
+
+static int set_pb_tag(struct sdlpui_control *c, int new_tag)
+{
+	struct sdlpui_push_button *pbp;
+	int old_tag;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+	pbp = c->priv;
+	old_tag = pbp->tag;
+	pbp->tag = new_tag;
+	return old_tag;
+}
+
+
+static void cleanup_pb(struct sdlpui_control *c)
+{
+	struct sdlpui_push_button *pbp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+	pbp = c->priv;
+	SDL_free(pbp->caption);
+	SDL_free(pbp);
+}
+
+
+static void help_mb_popup_submenu(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w)
+{
+	struct sdlpui_menu_button *mbp;
+	int ul_x_win, ul_y_win;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+	mbp = c->priv;
+	SDL_assert(mbp->subtype_code == SDLPUI_MB_SUBMENU);
+
+	SDLPUI_EVENT_TRACER("menu submenu button", c, mbp->caption,
+		"popping up child menu");
+
+	ul_x_win = d->rect.x + c->rect.x;
+	ul_y_win = d->rect.y + c->rect.y;
+	switch (mbp->v.submenu.placement) {
+	case SDLPUI_CHILD_MENU_ABOVE:
+		ul_y_win -= mbp->v.submenu.child->rect.h;
+		break;
+
+	case SDLPUI_CHILD_MENU_BELOW:
+		ul_y_win += c->rect.h;
+		break;
+
+	case SDLPUI_CHILD_MENU_LEFT:
+		ul_x_win -= mbp->v.submenu.child->rect.w;
+		break;
+
+	case SDLPUI_CHILD_MENU_RIGHT:
+		ul_x_win += c->rect.w;
+		break;
+
+	default:
+		SDL_assert(0);
+	}
+	mbp->v.submenu.child = (*mbp->v.submenu.creator)(c, d, w, ul_x_win,
+		ul_y_win);
+
+	SDL_assert(d->ftb->set_child);
+	(*d->ftb->set_child)(d, mbp->v.submenu.child);
+	if (mbp->v.submenu.child->pop_callback) {
+		(*mbp->v.submenu.child->pop_callback)(mbp->v.submenu.child,
+			w, true);
+	}
+	sdlpui_dialog_push_to_top(w, mbp->v.submenu.child);
+}
+
+
+static bool handle_mb_mousemove(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		const struct SDL_MouseMotionEvent *e)
+{
+	/*
+	 * Ignore moution events while a mouse button is pressed (at least up
+	 * to the point that the mouse leaves the window).
+	 */
+	if (e->state != 0) {
+		return true;
+	}
+	if (sdlpui_is_in_control(c, d, e->x, e->y)) {
+		/*
+		 * ranged_int buttons care whether the mouse is in the left or
+		 * right side of the button.  Otherwise, motion within the
+		 * button doesn't matter.
+		 */
+		struct sdlpui_menu_button *mbp;
+
+		SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+		mbp = c->priv;
+		if (mbp->subtype_code == SDLPUI_MB_RANGED_INT) {
+			int old = mbp->has_mouse;
+
+			if (e->x <= d->rect.x + c->rect.x + c->rect.w / 2) {
+				mbp->has_mouse = (mbp->v.ranged_int.curr
+					> mbp->v.ranged_int.min) ? 1 : 0;
+			} else {
+				mbp->has_mouse = (mbp->v.ranged_int.curr
+					< mbp->v.ranged_int.max) ? 2 : 0;
+			}
+			if (old != mbp->has_mouse) {
+				if (!mbp->has_mouse) {
+#ifndef NDEBUG
+					size_t ecap_sz =
+						SDL_strlen(mbp->caption) + 16;
+					char *ecap = SDL_malloc(ecap_sz);
+
+					(void)SDL_snprintf(ecap, ecap_sz,
+						mbp->caption,
+						mbp->v.ranged_int.curr);
+					SDLPUI_EVENT_TRACER("menu ranged int",
+						c, ecap, "lost mouse focus");
+					SDL_free(ecap);
+#endif
+					d->c_mouse = NULL;
+				} else if (!old) {
+#ifndef NDEBUG
+					size_t ecap_sz =
+						SDL_strlen(mbp->caption) + 16;
+					char *ecap = SDL_malloc(ecap_sz);
+
+					(void)SDL_snprintf(ecap, ecap_sz,
+						mbp->caption,
+						mbp->v.ranged_int.curr);
+					SDLPUI_EVENT_TRACER("menu ranged int",
+						c, ecap, "gained mouse focus");
+					SDL_free(ecap);
+#endif
+					d->c_mouse = c;
+				}
+				/* Have keyboard focus follow the mouse. */
+				if (mbp->has_key != mbp->has_mouse) {
+					if (!mbp->has_mouse) {
+#ifndef NDEBUG
+						size_t ecap_sz =
+							SDL_strlen(mbp->caption)
+							+ 16;
+						char *ecap =
+							SDL_malloc(ecap_sz);
+
+						(void)SDL_snprintf(ecap,
+							ecap_sz, mbp->caption,
+							mbp->v.ranged_int.curr);
+						SDLPUI_EVENT_TRACER(
+							"menu ranged int",
+							c, ecap,
+							"lost key focus");
+						SDL_free(ecap);
+#endif
+						d->c_key = NULL;
+					} else if (!mbp->has_key) {
+#ifndef NDEBUG
+						size_t ecap_sz =
+							SDL_strlen(mbp->caption)
+							+ 16;
+						char *ecap =
+							SDL_malloc(ecap_sz);
+
+						(void)SDL_snprintf(ecap,
+							ecap_sz, mbp->caption,
+							mbp->v.ranged_int.curr);
+						SDLPUI_EVENT_TRACER(
+							"menu ranged int",
+							c, ecap,
+							"gained key focus");
+						SDL_free(ecap);
+#endif
+						d->c_key = c;
+					}
+					mbp->has_key = mbp->has_mouse;
+				}
+				d->dirty = true;
+				sdlpui_signal_redraw(w);
+			}
+		}
+		return true;
+	}
+	/*
+	 * Otherwise, visually indicate that the mouse has left the control
+	 * and let the dialog handle the motion to see if it enters another
+	 * control.
+	 */
+	if (c->ftb->lose_mouse) {
+		(*c->ftb->lose_mouse)(c, d, w, e);
+		if (d->c_mouse == c) {
+			d->c_mouse = NULL;
+		}
+	}
+	return false;
+}
+
+
+static bool handle_mb_mousewheel(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		const struct SDL_MouseWheelEvent *e)
+{
+	struct sdlpui_menu_button *mbp;
+	Sint32 change, result;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+	mbp = c->priv;
+
+	/*
+	 * ranged_int buttons allow vertical mouse wheel changes to adjust the
+	 * value.  Everything else swallows the mouse wheel event without
+	 * doing anything.
+	 */
+	if (mbp->subtype_code != SDLPUI_MB_RANGED_INT) {
+		return true;
+	}
+
+	change = e->y;
+#if SDL_VERSION_ATLEAST(2, 0, 4)
+	if (e->direction == SDL_MOUSEWHEEL_FLIPPED) {
+		change *= -1;
+	}
+#endif
+	/*
+	 * Also flip if the left side of the control has focus (so the default
+	 * direction of changes is negative).
+	 */
+	if (mbp->has_mouse == 1) {
+		change *= -1;
+	}
+	result = mbp->v.ranged_int.curr + change;
+	if (result < mbp->v.ranged_int.min) {
+		result = mbp->v.ranged_int.min;
+	} else if (result > mbp->v.ranged_int.max) {
+		result = mbp->v.ranged_int.max;
+	}
+	if (mbp->v.ranged_int.curr != result) {
+#ifndef NDEBUG
+		size_t ecap_sz = SDL_strlen(mbp->caption) + 16;
+		char *ecap = SDL_malloc(ecap_sz);
+
+		(void)SDL_snprintf(ecap, ecap_sz, mbp->caption,
+			mbp->v.ranged_int.curr);
+		SDLPUI_EVENT_TRACER("menu ranged int", c, ecap,
+			"value changed by mouse wheel");
+		SDL_free(ecap);
+#endif
+		mbp->v.ranged_int.old = mbp->v.ranged_int.curr;
+		mbp->v.ranged_int.curr = (int)result;
+		d->dirty = true;
+		sdlpui_signal_redraw(w);
+		if (mbp->callback) {
+			(*mbp->callback)(c, d, w);
+		}
+	} else {
+#ifndef NDEBUG
+		size_t ecap_sz = SDL_strlen(mbp->caption) + 16;
+		char *ecap = SDL_malloc(ecap_sz);
+
+		(void)SDL_snprintf(ecap, ecap_sz, mbp->caption,
+			mbp->v.ranged_int.curr);
+		SDLPUI_EVENT_TRACER("menu ranged int", c, ecap,
+			"value left as is by mouse wheel");
+		SDL_free(ecap);
+#endif
+	}
+	return true;
+}
+
+
+static void change_mb_caption(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		const char *new_caption)
+{
+	struct sdlpui_label *mbp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+	mbp = c->priv;
+	SDL_free(mbp->caption);
+	mbp->caption = SDL_strdup(new_caption);
+	resize_mb(c, d, w, c->rect.w, c->rect.h);
+	d->dirty = true;
+	sdlpui_signal_redraw(w);
+}
+
+
+static void render_mb(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		SDL_Renderer *r)
+{
+	const SDL_Color *fg = sdlpui_get_color(w, SDLPUI_COLOR_MENU_FG);
+	TTF_Font *font = sdlpui_get_ttf(w);
+	struct sdlpui_menu_button *mbp;
+	struct SDL_Rect dst_r;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+	mbp = c->priv;
+	SDLPUI_RENDER_TRACER("menu button", c, mbp->caption, c->rect,
+		mbp->caption_rect, d->texture);
+
+	SDL_SetRenderDrawColor(r, fg->r, fg->g, fg->b, fg->a);
+
+	if (mbp->caption_rect.h > 0 && mbp->caption_rect.w > 0) {
+		dst_r = mbp->caption_rect;
+		dst_r.x += c->rect.x;
+		dst_r.y += c->rect.y;
+		if (!d->texture) {
+			dst_r.x += d->rect.x;
+			dst_r.y += d->rect.y;
+		}
+		if (mbp->subtype_code != SDLPUI_MB_RANGED_INT) {
+			sdlpui_render_utf8_line(r, font, fg, &dst_r,
+				mbp->caption);
+		} else {
+			/* Fill in the current value in the caption. */
+			size_t ecap_sz = SDL_strlen(mbp->caption) + 16;
+			char *ecap = SDL_malloc(ecap_sz);
+
+			(void)SDL_snprintf(ecap, ecap_sz, mbp->caption,
+				mbp->v.ranged_int.curr);
+			sdlpui_render_utf8_line(r, font, fg, &dst_r, ecap);
+			SDL_free(ecap);
+		}
+
+		if ((mbp->subtype_code == SDLPUI_MB_TOGGLE
+				|| mbp->subtype_code == SDLPUI_MB_INDICATOR)
+				&& mbp->v.toggled && mbp->caption_rect.h > 4
+				&& c->rect.w > mbp->caption_rect.x
+					+ mbp->caption_rect.w
+					+ SDLPUI_DEFAULT_CTRL_BORDER
+					+ mbp->caption_rect.h) {
+			/*
+			 * Add an indicator that this control has been toggled
+			 * on.  Use a square drawn on the right side of the
+			 * control with a side length set by the height of the
+			 * caption minus 4.
+			 */
+			dst_r.x = c->rect.x + c->rect.w
+				- SDLPUI_DEFAULT_CTRL_BORDER
+				- (mbp->caption_rect.h - 2);
+			dst_r.y = c->rect.y
+				+ (c->rect.h - mbp->caption_rect.h + 4) / 2;
+			dst_r.w = mbp->caption_rect.h - 4;
+			dst_r.h = dst_r.w;
+
+			if (!d->texture) {
+				dst_r.x += d->rect.x;
+				dst_r.y += d->rect.y;
+			}
+			SDL_RenderFillRect(r, &dst_r);
+		}
+	}
+
+	if (mbp->has_key || mbp->has_mouse) {
+		/*
+		 * Put a border on it to signal that it has focus.  The border
+		 * leaves space for the highlighting that happens if armed.
+		 */
+		if (mbp->subtype_code != SDLPUI_MB_RANGED_INT
+				|| (mbp->has_key && mbp->has_mouse
+				&& mbp->has_key != mbp->has_mouse)) {
+			dst_r = c->rect;
+			if (!d->texture) {
+				/*
+				 * Rendering directly to the window's buffer
+				 * so use its coordinates.
+				 */
+				dst_r.x += d->rect.x;
+				dst_r.y += d->rect.y;
+			}
+			--dst_r.w;
+			--dst_r.h;
+			SDL_RenderDrawRect(r, &dst_r);
+		} else {
+			/*
+			 * Only the left or right side has focus.  Don't draw
+			 * the line that would split the button in two.
+			 */
+			SDL_Point points[4];
+
+			if (mbp->has_key == 1 || mbp->has_mouse == 1) {
+				points[0].x = c->rect.x + c->rect.w / 2;
+				points[0].y = c->rect.y;
+				if (!d->texture) {
+					points[0].x += d->rect.x;
+					points[0].y += d->rect.y;
+				}
+				points[1].x = points[0].x - c->rect.w / 2;
+				points[1].y = points[0].y;
+			} else {
+				points[0].x = c->rect.x + c->rect.w / 2 + 1;
+				points[0].y = c->rect.y;
+				if (!d->texture) {
+					points[0].x += d->rect.x;
+					points[0].y += d->rect.y;
+				}
+				points[1].x = points[0].x +
+					(c->rect.w + 1) / 2 - 2;
+				points[1].y = points[0].y;
+			}
+			points[2].x = points[1].x;
+			points[2].y = points[1].y + c->rect.h - 1;
+			points[3].x = points[0].x;
+			points[3].y = points[2].y;
+			SDL_RenderDrawLines(r, points, 4);
+		}
+	}
+
+	if (mbp->armed) {
+		/*
+		 * Button is depressed.  Was flat with the surface; now
+		 * highlight right and bottom edges as if there's lighting from
+		 * the upper left.
+		 */
+		SDL_Point points[3];
+		int npt;
+
+		if (mbp->subtype_code != SDLPUI_MB_RANGED_INT
+				|| mbp->armed == 3) {
+			points[0].x = c->rect.x;
+			points[0].y = c->rect.y + c->rect.h - 1;
+			if (!d->texture) {
+				points[0].x += d->rect.x;
+				points[0].y += d->rect.y;
+			}
+			points[1].x = points[0].x + c->rect.w - 1;
+			points[1].y = points[0].y;
+			points[2].x = points[1].x;
+			points[2].y = points[1].y - c->rect.h + 1;
+			npt = 3;
+		} else if (mbp->armed == 1) {
+			/* Only the left side is depressed. */
+			points[0].x = c->rect.x;
+			points[0].y = c->rect.y + c->rect.h - 1;
+			if (!d->texture) {
+				points[0].x += d->rect.x;
+				points[0].y += d->rect.y;
+			}
+			points[1].x = points[0].x + c->rect.w / 2;
+			points[1].y = points[0].y;
+			npt = 2;
+		} else {
+			SDL_assert(mbp->armed == 2);
+			/* Only the right side is depressed. */
+			points[0].x = c->rect.x + c->rect.w / 2 + 1;
+			points[0].y = c->rect.y + c->rect.h - 1;
+			if (!d->texture) {
+				points[0].x += d->rect.x;
+				points[0].y += d->rect.y;
+			}
+			points[1].x = points[0].x + (c->rect.w + 1) / 2 - 2;
+			points[1].y = points[0].y;
+			points[2].x = points[1].x;
+			points[2].y = points[1].y - c->rect.h + 1;
+			npt = 3;
+		}
+		SDL_RenderDrawLines(r, points, npt);
+	}
+
+	if (mbp->disabled) {
+		struct sdlpui_stipple *stipple = sdlpui_get_stipple(w);
+
+		dst_r = c->rect;
+		if (!d->texture) {
+			dst_r.x += d->rect.x;
+			dst_r.y += d->rect.y;
+		}
+		sdlpui_stipple_rect(r, stipple, &dst_r);
+	}
+}
+
+
+static void respond_default_mb(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		enum sdlpui_action_hint hint)
+{
+	struct sdlpui_menu_button *mbp;
+	int inci, newi;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+	mbp = c->priv;
+
+	if (mbp->disabled) {
+		return;
+	}
+
+	switch (mbp->subtype_code) {
+	case SDLPUI_MB_SUBMENU:
+		if (!mbp->v.submenu.child) {
+			struct sdlpui_dialog *other_child =
+				sdlpui_get_dialog_child(d);
+
+			if (other_child) {
+				sdlpui_popdown_dialog(other_child, w, false);
+			}
+			help_mb_popup_submenu(c, d, w);
+		} else {
+			SDLPUI_EVENT_TRACER("menu submenu button", c,
+				mbp->caption, "child menu already displayed");
+		}
+		/* Give the first button in the child menu keyboard focus. */
+		if (mbp->v.submenu.child->ftb->goto_first_control) {
+			(*mbp->v.submenu.child->ftb->goto_first_control)(
+				mbp->v.submenu.child, w);
+		}
+		break;
+
+	case SDLPUI_MB_RANGED_INT:
+		if (hint == SDLPUI_ACTION_HINT_KEY
+				|| mbp->has_key == mbp->has_mouse) {
+			inci = (mbp->has_key == 1) ?
+				-1 : ((mbp->has_key == 2) ? 1 : 0);
+		} else if (hint == SDLPUI_ACTION_HINT_MOUSE
+				|| mbp->has_key == 0) {
+			inci = (mbp->has_mouse == 1) ?
+				-1 : ((mbp->has_mouse == 2) ? 1 : 0);
+		} else if (mbp->has_mouse == 0) {
+			inci = (mbp->has_key == 1) ?
+				-1 : ((mbp->has_key == 2) ? 1 : 0);
+		} else {
+			/* It's not clear what should be done, so do nothing. */
+			inci = 0;
+		}
+		newi = mbp->v.ranged_int.curr + inci;
+		if (newi < mbp->v.ranged_int.min) {
+			newi = mbp->v.ranged_int.min;
+		} else if (newi > mbp->v.ranged_int.max) {
+			newi = mbp->v.ranged_int.max;
+		}
+		if (newi == mbp->v.ranged_int.curr) {
+#ifndef NDEBUG
+			size_t ecap_sz = SDL_strlen(mbp->caption) + 16;
+			char *ecap = SDL_malloc(ecap_sz);
+
+			(void)SDL_snprintf(ecap, ecap_sz, mbp->caption,
+				mbp->v.ranged_int.curr);
+			SDLPUI_EVENT_TRACER("menu ranged int", c, ecap,
+				"left unchanged by default response");
+			SDL_free(ecap);
+#endif
+			return;
+		}
+#ifndef NDEBUG
+		{
+			size_t ecap_sz = SDL_strlen(mbp->caption) + 16;
+			char *ecap = SDL_malloc(ecap_sz);
+
+			(void)SDL_snprintf(ecap, ecap_sz, mbp->caption, newi);
+			SDLPUI_EVENT_TRACER("menu ranged int", c, ecap,
+				"changed by default response");
+			SDL_free(ecap);
+		}
+#endif
+		mbp->v.ranged_int.old = mbp->v.ranged_int.curr;
+		mbp->v.ranged_int.curr = newi;
+		d->dirty = true;
+		sdlpui_signal_redraw(w);
+		break;
+
+	case SDLPUI_MB_TOGGLE:
+		SDLPUI_EVENT_TRACER("menu toggle", c, mbp->caption,
+			"changed by default response");
+		mbp->v.toggled = !mbp->v.toggled;
+		d->dirty = true;
+		sdlpui_signal_redraw(w);
+		break;
+
+	default:
+		break;
+	}
+
+	if (mbp->callback) {
+		(*mbp->callback)(c, d, w);
+	}
+}
+
+
+static void gain_key_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, int comp_ind)
+{
+	struct sdlpui_menu_button *mbp;
+	int old;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+	mbp = c->priv;
+
+	SDLPUI_EVENT_TRACER("menu entry", c, mbp->caption,
+		"gained key focus");
+	old = mbp->has_key;
+	if (mbp->subtype_code == SDLPUI_MB_RANGED_INT) {
+		if (comp_ind < 0) {
+			comp_ind += 2;
+		}
+		SDL_assert(comp_ind == 0 || comp_ind == 1);
+		mbp->has_key = comp_ind + 1;
+	} else if (mbp->subtype_code == SDLPUI_MB_INDICATOR) {
+		SDL_assert(0);
+	} else {
+		SDL_assert(comp_ind == 0 || comp_ind == -1);
+		mbp->has_key = 1;
+	}
+	if (old != mbp->has_key) {
+		d->dirty = true;
+		sdlpui_signal_redraw(w);
+	}
+	if (mbp->subtype_code == SDLPUI_MB_SUBMENU && !mbp->v.submenu.child) {
+		help_mb_popup_submenu(c, d, w);
+	}
+}
+
+
+static void lose_key_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, bool following_mouse)
+{
+	struct sdlpui_menu_button *mbp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+	mbp = c->priv;
+
+	if (mbp->has_key) {
+		SDLPUI_EVENT_TRACER("menu entry", c, mbp->caption,
+			"lost key focus");
+		mbp->has_key = 0;
+		d->dirty = true;
+		sdlpui_signal_redraw(w);
+	}
+	/*
+	 * If losing key focus because losing mouse focus, the handling of
+	 * the child dialog is done while losing mouse focus and doesn't
+	 * have to be done here.
+	 */
+	if (!following_mouse && mbp->subtype_code == SDLPUI_MB_SUBMENU
+			&& mbp->v.submenu.child) {
+		SDLPUI_EVENT_TRACER("submenu entry", c, mbp->caption,
+			"popping down submenu");
+		sdlpui_popdown_dialog(mbp->v.submenu.child, w, false);
+		mbp->v.submenu.child = NULL;
+	}
+}
+
+
+static void gain_mouse_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, int comp_ind)
+{
+	struct sdlpui_menu_button *mbp;
+	int old;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+	mbp = c->priv;
+
+	SDLPUI_EVENT_TRACER("menu entry", c, mbp->caption,
+		"gained mouse focus");
+	old = mbp->has_mouse;
+	if (mbp->subtype_code == SDLPUI_MB_RANGED_INT) {
+		if (comp_ind < 0) {
+			comp_ind += 2;
+		}
+		SDL_assert(comp_ind == 0 || comp_ind == 1);
+		mbp->has_mouse = comp_ind + 1;
+	} else if (mbp->subtype_code == SDLPUI_MB_INDICATOR) {
+		SDL_assert(0);
+	} else {
+		SDL_assert(comp_ind == 0 || comp_ind == -1);
+		mbp->has_mouse = 1;
+	}
+	if (old != mbp->has_mouse) {
+		d->dirty = true;
+		sdlpui_signal_redraw(w);
+	}
+	if (mbp->subtype_code == SDLPUI_MB_SUBMENU && !mbp->v.submenu.child) {
+		help_mb_popup_submenu(c, d, w);
+	}
+}
+
+
+static void lose_mouse_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e)
+
+{
+	struct sdlpui_menu_button *mbp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+	mbp = c->priv;
+
+	if (mbp->has_mouse) {
+		SDLPUI_EVENT_TRACER("menu entry", c, mbp->caption,
+			"lost mouse focus");
+		mbp->has_mouse = 0;
+		d->dirty = true;
+		sdlpui_signal_redraw(w);
+	}
+	if (mbp->subtype_code == SDLPUI_MB_SUBMENU && mbp->v.submenu.child
+			&& (!e || !sdlpui_is_in_dialog(mbp->v.submenu.child,
+			e->x, e->y))) {
+		SDLPUI_EVENT_TRACER("submenu entry", c, mbp->caption,
+			"popping down submenu");
+		sdlpui_popdown_dialog(mbp->v.submenu.child, w, false);
+		mbp->v.submenu.child = NULL;
+	}
+}
+
+
+static void lose_child_mb(struct sdlpui_control *c, struct sdlpui_dialog *child)
+{
+	struct sdlpui_menu_button *mbp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+	mbp = c->priv;
+	SDL_assert(mbp->subtype_code == SDLPUI_MB_SUBMENU);
+
+	if (mbp->v.submenu.child) {
+		SDL_assert(mbp->v.submenu.child == child);
+		mbp->v.submenu.child = NULL;
+	}
+}
+
+
+static void arm_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, enum sdlpui_action_hint hint)
+{
+	struct sdlpui_menu_button *mbp;
+	int old;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+	mbp = c->priv;
+
+	SDLPUI_EVENT_TRACER("menu entry", c, mbp->caption, "arming");
+	old = mbp->armed;
+	if (mbp->subtype_code != SDLPUI_MB_RANGED_INT) {
+		mbp->armed = 1;
+	} else {
+		if (hint == SDLPUI_ACTION_HINT_KEY
+				|| hint == SDLPUI_ACTION_HINT_NONE) {
+			mbp->armed |= mbp->has_key;
+		}
+		if (hint == SDLPUI_ACTION_HINT_MOUSE
+				|| hint == SDLPUI_ACTION_HINT_NONE) {
+			mbp->armed |= mbp->has_mouse;
+		}
+	}
+	if (old != mbp->armed) {
+		d->dirty = true;
+		sdlpui_signal_redraw(w);
+	}
+}
+
+
+static void disarm_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, enum sdlpui_action_hint hint)
+{
+	struct sdlpui_menu_button *mbp;
+	int old;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+	mbp = c->priv;
+
+	SDLPUI_EVENT_TRACER("menu entry", c, mbp->caption, "disarming");
+	old = mbp->armed;
+	if (mbp->subtype_code != SDLPUI_MB_RANGED_INT
+			|| hint == SDLPUI_ACTION_HINT_NONE) {
+		mbp->armed = 0;
+	} else {
+		if (hint == SDLPUI_ACTION_HINT_KEY) {
+			mbp->armed &= ~mbp->has_key;
+		} else if (hint == SDLPUI_ACTION_HINT_MOUSE) {
+			mbp->armed &= ~mbp->has_mouse;
+		}
+	}
+	if (old != mbp->armed) {
+		d->dirty = true;
+		sdlpui_signal_redraw(w);
+	}
+}
+
+
+static int get_mb_interactable_component(struct sdlpui_control *c, bool first)
+{
+	struct sdlpui_menu_button *mbp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+	mbp = c->priv;
+
+	if (mbp->disabled || mbp->subtype_code == SDLPUI_MB_INDICATOR) {
+		return 0;
+	}
+	if (mbp->subtype_code != SDLPUI_MB_RANGED_INT) {
+		return 1;
+	}
+	if (first) {
+		if (mbp->v.ranged_int.curr > mbp->v.ranged_int.min) {
+			return 1;
+		} else if (mbp->v.ranged_int.curr < mbp->v.ranged_int.max) {
+			return 2;
+		}
+	} else {
+		if (mbp->v.ranged_int.curr < mbp->v.ranged_int.max) {
+			return 2;
+		} else if (mbp->v.ranged_int.curr > mbp->v.ranged_int.min) {
+			return 1;
+		}
+	}
+	return 0;
+}
+
+
+static bool step_within_mb(struct sdlpui_control *c, bool forward)
+{
+	struct sdlpui_menu_button *mbp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+	mbp = c->priv;
+
+	SDL_assert(mbp->has_key);
+	if (mbp->subtype_code == SDLPUI_MB_RANGED_INT) {
+		if (forward) {
+			if (mbp->has_key == 1 && mbp->v.ranged_int.curr
+					< mbp->v.ranged_int.max) {
+				mbp->has_key = 2;
+				return true;
+			}
+		} else {
+			if (mbp->has_key == 2 && mbp->v.ranged_int.curr
+					> mbp->v.ranged_int.min) {
+				mbp->has_key = 1;
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+
+static int get_mb_interactable_component_at(struct sdlpui_control *c, Sint32 x,
+		Sint32 y)
+{
+	struct sdlpui_menu_button *mbp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+	mbp = c->priv;
+
+	if (mbp->disabled || mbp->subtype_code == SDLPUI_MB_INDICATOR
+			|| x < c->rect.x || x >= c->rect.x + c->rect.w
+			|| y < c->rect.y || y >= c->rect.y + c->rect.h) {
+		return 0;
+	}
+	if (mbp->subtype_code == SDLPUI_MB_RANGED_INT) {
+		if (x <= c->rect.x + c->rect.w / 2) {
+			return (mbp->v.ranged_int.curr > mbp->v.ranged_int.min) ?
+				1 : 0;
+		}
+		return (mbp->v.ranged_int.curr < mbp->v.ranged_int.max) ? 2 : 0;
+	}
+	return 1;
+}
+
+
+static void resize_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, int width, int height)
+{
+	TTF_Font *font = sdlpui_get_ttf(w);
+	struct sdlpui_menu_button *mbp;
+	int sw, sh, tw, border, nw, nh;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+	mbp = c->priv;
+
+	if (mbp->subtype_code == SDLPUI_MB_RANGED_INT) {
+		size_t ecap_sz = SDL_strlen(mbp->caption) + 16;
+		char *ecap = SDL_malloc(ecap_sz);
+		int wtmp, htmp;
+
+		(void)SDL_snprintf(ecap, ecap_sz, mbp->caption,
+			mbp->v.ranged_int.min);
+		sdlpui_get_utf8_metrics(font, ecap, &sw, &sh);
+		(void)SDL_snprintf(ecap, ecap_sz, mbp->caption,
+			mbp->v.ranged_int.max);
+		sdlpui_get_utf8_metrics(font, ecap, &wtmp, &htmp);
+		SDL_free(ecap);
+		if (sw < wtmp) {
+			sw = wtmp;
+		}
+		if (sh < htmp) {
+			sh = htmp;
+		}
+	} else {
+		sdlpui_get_utf8_metrics(font, mbp->caption, &sw, &sh);
+	}
+	if (mbp->subtype_code == SDLPUI_MB_TOGGLE
+			|| mbp->subtype_code == SDLPUI_MB_INDICATOR) {
+		tw = sh;
+	} else {
+		tw = 0;
+	}
+	border = 2 * SDLPUI_DEFAULT_CTRL_BORDER;
+	nw = sw + tw + border;
+	nh = sh + border;
+
+	if (width <= tw + border || height <= border) {
+		/* No room to display anything at all. */
+		mbp->caption_rect.x = 0;
+		mbp->caption_rect.y = 0;
+		mbp->caption_rect.w = 0;
+		mbp->caption_rect.h = 0;
+		return;
+	}
+
+	/*
+	 * If necessary, truncate what will be displaced to the given size.
+	 */
+	mbp->caption_rect.h = (height >= nh) ? sh : height - border;
+	if (width >= nw) {
+		mbp->caption_rect.w = sw;
+	} else {
+		mbp->caption_rect.w = width - border - tw;
+	}
+
+	/*
+	 * In x, honor the alignment specified when created.  In y, center
+	 * if the full size of the control exceeds the inner rectangle's height
+	 * plus the vertical borders.
+	 */
+	SDL_assert(width >= mbp->caption_rect.w + tw + border);
+	switch(mbp->halign) {
+	case SDLPUI_HOR_LEFT:
+		mbp->caption_rect.x = SDLPUI_DEFAULT_CTRL_BORDER;
+		break;
+
+	case SDLPUI_HOR_RIGHT:
+		mbp->caption_rect.x = width - mbp->caption_rect.w - tw
+			- SDLPUI_DEFAULT_CTRL_BORDER;
+		break;
+
+	default:
+		mbp->caption_rect.x =
+			(width - mbp->caption_rect.w - tw - border) / 2
+			+ SDLPUI_DEFAULT_CTRL_BORDER;
+		break;
+	}
+	SDL_assert(height >= mbp->caption_rect.h + border);
+	mbp->caption_rect.y = (height - mbp->caption_rect.h - border) / 2
+		+ SDLPUI_DEFAULT_CTRL_BORDER;
+	c->rect.w = width;
+	c->rect.h = height;
+}
+
+
+static void query_mb_natural_size(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		int *width, int *height)
+{
+	TTF_Font *font = sdlpui_get_ttf(w);
+	struct sdlpui_menu_button *mbp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+	mbp = c->priv;
+
+	if (mbp->subtype_code == SDLPUI_MB_RANGED_INT) {
+		size_t ecap_sz = SDL_strlen(mbp->caption) + 16;
+		char *ecap = SDL_malloc(ecap_sz);
+		int wtmp, htmp;
+
+		(void)SDL_snprintf(ecap, ecap_sz, mbp->caption,
+			mbp->v.ranged_int.min);
+		sdlpui_get_utf8_metrics(font, ecap, width, height);
+		(void)SDL_snprintf(ecap, ecap_sz, mbp->caption,
+			mbp->v.ranged_int.max);
+		sdlpui_get_utf8_metrics(font, ecap, &wtmp, &htmp);
+		SDL_free(ecap);
+		if (*width < wtmp) {
+			*width = wtmp;
+		}
+		if (*height < htmp) {
+			*height = htmp;
+		}
+	} else {
+		sdlpui_get_utf8_metrics(font, mbp->caption, width, height);
+	}
+	if (mbp->subtype_code == SDLPUI_MB_TOGGLE
+			|| mbp->subtype_code == SDLPUI_MB_INDICATOR) {
+		*width += (*height) * 3;
+	}
+	*width += SDLPUI_DEFAULT_CTRL_BORDER * 2;
+	*height += SDLPUI_DEFAULT_CTRL_BORDER * 2;
+}
+
+
+static bool is_mb_disabled(const struct sdlpui_control *c)
+{
+	const struct sdlpui_menu_button *mbp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+	mbp = c->priv;
+	return mbp->disabled;
+}
+
+
+static bool set_mb_disabled(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, bool disabled)
+{
+	struct sdlpui_menu_button *mbp;
+	bool old_value;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+	mbp = c->priv;
+	old_value = mbp->disabled;
+	if (old_value != disabled) {
+		mbp->disabled = disabled;
+		d->dirty = true;
+		sdlpui_signal_redraw(w);
+	}
+	return old_value;
+}
+
+
+static int get_mb_tag(const struct sdlpui_control *c)
+{
+	const struct sdlpui_menu_button *mbp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+	mbp = c->priv;
+	return mbp->tag;
+}
+
+
+static int set_mb_tag(struct sdlpui_control *c, int new_tag)
+{
+	struct sdlpui_menu_button *mbp;
+	int old_tag;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+	mbp = c->priv;
+	old_tag = mbp->tag;
+	mbp->tag = new_tag;
+	return old_tag;
+}
+
+
+static void cleanup_mb(struct sdlpui_control *c)
+{
+	struct sdlpui_menu_button *mbp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+	mbp = c->priv;
+	SDL_free(mbp->caption);
+	SDL_free(mbp);
+}
+
+
+/**
+ * Determine if a given coordinate, relative to the window, is in a control.
+ *
+ * \param c is the control of interest.
+ * \param d is the dialog that holds the control.
+ * \param x is the horizontal coordinate, relative to the window's upper left
+ * corner, to test.
+ * \param y is the vertical coordinate, relative to the window's upper left
+ * corner, to test.
+ * \return true if (x, y) is in the control and false otherwise.
+ */
+bool sdlpui_is_in_control(const struct sdlpui_control *c,
+		const struct sdlpui_dialog *d, Sint32 x, Sint32 y)
+{
+	if (x < d->rect.x + c->rect.x || y < d->rect.y + c->rect.y
+			|| x >= d->rect.x + c->rect.x + c->rect.w
+			|| y >= d->rect.y + c->rect.y + c->rect.h) {
+		return false;
+	}
+	return true;
+}
+
+
+/**
+ * Return whether a control is disabled.
+ *
+ * \param c is the control to query.
+ * \return whether or not the control is disabled.  If the control does not
+ * support being disabled/enabled, the return value will be false.
+ */
+bool sdlpui_is_disabled(const struct sdlpui_control *c)
+{
+	return (c->ftb->is_disabled) ? (*c->ftb->is_disabled)(c) : false;
+}
+
+
+/**
+ * Change whether a control is disabled or not.
+ *
+ * \param c is the control to modify.
+ * \param d is the dialog containing the control.
+ * \param w is the window containing the dialog.
+ * \param disabled is whether the control should be disabled or not.
+ * \return whether or not the prior state of the control was disabled.  If
+ * the control does not support changing the disabled/enabled state, the
+ * return value will be false.
+ */
+bool sdlpui_set_disabled(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, bool disabled)
+{
+	return (c->ftb->set_disabled) ?
+		(*c->ftb->set_disabled)(c, d, w, disabled) : false;
+}
+
+
+/**
+ * Get the application-specified tag on a control, if it has one.
+ *
+ * \param c is the control to query.
+ * \return the tag's value.  If the control does not have a tag, the
+ * returned value will be zero.
+ */
+int sdlpui_get_tag(const struct sdlpui_control *c)
+{
+	return (c->ftb->get_tag) ? (*c->ftb->get_tag)(c) : 0;
+}
+
+
+/**
+ * Set the application-specified tag on a control.
+ *
+ * \param c is the control to modify.
+ * \param new_tag is new value for the tag.
+ * \return the old value for the tag.  If the control does not have a tag,
+ * the returned value will be zero and the new tag will not be applied.
+ */
+int sdlpui_set_tag(struct sdlpui_control *c, int new_tag)
+{
+	return (c->ftb->set_tag) ? (*c->ftb->set_tag)(c, new_tag) : 0;
+}
+
+
+/**
+ * Change the caption for a control.
+ *
+ * \param c is the control to modify.
+ * \param d is the dialog containing the control.
+ * \param w is the window containing the dialog.
+ * \param new_caption is the new caption for the control.
+ *
+ * If the control does not support changing the caption, has no effect.
+ * The internals of the control are adjusted for the new caption, but the
+ * external dimensions of the control remain unchanged.
+ */
+void sdlpui_change_caption(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const char *new_caption)
+{
+	if (c->ftb->change_caption) {
+		(*c->ftb->change_caption)(c, d, w, new_caption);
+	}
+}
+
+
+/**
+ * Handle a keyboard event for a simple control.
+ *
+ * \param c is the control receiving the event.  The events handled here
+ * are appropriate if c is simple:  not a compound control and only having
+ * at most one action (the default one; with the associated arming and
+ * disarming).
+ * \param d is the dialog containing the control.
+ * \param w is the window containing the dialog.
+ * \param e is the event to handle.
+ * \return true if the event is handled and doesn't need further processing by
+ * the dialog; otherwise return false.
+ */
+bool sdlpui_control_handle_key(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		const struct SDL_KeyboardEvent *e)
+{
+	if (e->keysym.sym == SDLK_RETURN) {
+		SDL_Keymod mods = sdlpui_get_interesting_keymods();
+
+		if (e->state == SDL_PRESSED) {
+			if (mods == KMOD_NONE && c->ftb->arm) {
+				(*c->ftb->arm)(c, d, w, SDLPUI_ACTION_HINT_KEY);
+			}
+		} else {
+			/*
+			 * Always disarm, regardless of the modifier state,
+			 * in case a modifier key was pressed between
+			 * depressing and releasing the key.
+			 */
+			if (c->ftb->disarm) {
+				(*c->ftb->disarm)(c, d, w,
+					SDLPUI_ACTION_HINT_KEY);
+			}
+			if (mods == KMOD_NONE) {
+				if (c->ftb->respond_default) {
+					SDLPUI_EVENT_TRACER("control", c,
+						"(not extracted)",
+						"invoking default reponse");
+					(*c->ftb->respond_default)(c, d, w,
+						SDLPUI_ACTION_HINT_KEY);
+				} else if (d->ftb->respond_default) {
+					SDLPUI_EVENT_TRACER("dialog", d,
+						"(not extracted)",
+						"invoking default reponse");
+					(*d->ftb->respond_default)(d, w);
+				}
+			}
+		}
+		return true;
+	}
+
+	/* Let the containing dialog handle everything else. */
+	return false;
+}
+
+
+/*
+ * Handle a mouse button event for a simple control.
+ *
+ * \param c is the control receiving the event.  The events handled here
+ * are appropriate if c is simple:  not a compound control and only having
+ * at most one action (the default one; with the associated arming and
+ * disarming).
+ * \param d is the dialog containing the control.
+ * \param w is the window containing the dialog.
+ * \param e is the event to handle.
+ * \return true if the event is handled and doesn't need further processing by
+ * the dialog; otherwise return false.
+ */
+bool sdlpui_control_handle_mouseclick(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		const struct SDL_MouseButtonEvent *e)
+{
+	if (e->button == SDL_BUTTON_LEFT) {
+		if (e->state == SDL_PRESSED) {
+			if (c->ftb->arm) {
+				(*c->ftb->arm)(c, d, w,
+					 SDLPUI_ACTION_HINT_MOUSE);
+			}
+		} else {
+			if (c->ftb->disarm) {
+				(*c->ftb->disarm)(c, d, w,
+					SDLPUI_ACTION_HINT_MOUSE);
+			}
+			if (c->ftb->respond_default) {
+				SDLPUI_EVENT_TRACER("control", c,
+					"(not extracted)",
+					"invoking default response");
+				(*c->ftb->respond_default)(c, d, w,
+					SDLPUI_ACTION_HINT_MOUSE);
+			}
+		}
+	}
+	/* Swallow the event, even if nothing was done. */
+	return true;
+}
+
+
+/*
+ * Handle a mouse motion event for a simple control.
+ *
+ * \param c is the control receiving the event.  The events handled here
+ * are appropriate if c is simple:  not a compound control and only having
+ * at most one action (the default one; with the associated arming and
+ * disarming).
+ * \param d is the dialog containing the control.
+ * \param w is the window containing the dialog.
+ * \param e is the event to handle.
+ * \return true if the event is handled and doesn't need further processing by
+ * the dialog; otherwise return false.
+ */
+bool sdlpui_control_handle_mousemove(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		const struct SDL_MouseMotionEvent *e)
+{
+	/*
+	 * Ignore motion events while a mouse button is pressed (at least
+	 * up to the point that the mouse leaves the window).  If the mouse
+	 * is moving within the control, it also does nothing.
+	 */
+	if (e->state != 0 || sdlpui_is_in_control(c, d, e->x, e->y)) {
+		return true;
+	}
+	/*
+	 * Otherwise, visually indicate that the mouse has left the control
+	 * and let the dialog handle the motion to see if it enters another
+	 * control.
+	 */
+	if (c->ftb->lose_mouse) {
+		SDLPUI_EVENT_TRACER("control", c, "(not extracted)",
+			"lost mouse focus");
+		(*c->ftb->lose_mouse)(c, d, w, e);
+		if (d->c_mouse == c) {
+			d->c_mouse = NULL;
+		}
+	}
+	return false;
+}
+
+
+/**
+ * Invoke the given dialog's default action.  Suitable for use as a callback
+ * for buttons.
+ *
+ * \param c is the control which was activated.
+ * \param d is the dialog containing the control.
+ * \param w is the window containing the dialog.
+ */
+void sdlpui_invoke_dialog_default_action(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w)
+{
+	if (d->ftb->respond_default) {
+		SDLPUI_EVENT_TRACER("control", c, "(not extracted)",
+			"invoking containing dialog's default action");
+		(*d->ftb->respond_default)(d, w);
+	}
+}
+
+
+/*
+ * Initializes the contents of c to be appropriate for an image control.
+ *
+ * \param c points to the control to be initialized.  Must not be NULL.
+ * \param image is the texture holding the image to be used for the control.
+ * The control will assume ownership of the texture and call
+ * SDL_DestroyTexture() on it when the control is destroyed.
+ * \param halign specifies how the image should be horizontally aligned within
+ * the control's bounds if the control is wider than the image.
+ * \param top_margin is the amount of space, in pixels, to leave between the
+ * top of the control and the top of the image.  Must be non-negative.
+ * \param bottom_margin is the amount of space, in pixels, to leave between the
+ * bottom of the control and the bottom of the image.  Must be non-negative.
+ * \param left_margin is the amount of space, in pixels to leave between the
+ * left side of the control and the left side of the image.  Must be
+ * non-negative.
+ * \param right_margin is the amount of space, in pixels to leave between the
+ * right side of the control and the right side of the image.  Must be
+ * non-negative.
+ *
+ * Note that the bounding rectangle for the control is not set.  The caller
+ * should use c->ftb->resize to set that (perhaps in conjunction with
+ * c->ftb->query_natural_size) and set c->rect.x and c->rect.y directly to
+ * position the control in a dialog.
+ */
+void sdlpui_create_image(struct sdlpui_control *c, SDL_Texture *image,
+		enum sdlpui_hor_align halign, int top_margin, int bottom_margin,
+		int left_margin, int right_margin)
+{
+	struct sdlpui_image *ip = SDL_malloc(sizeof(*ip));
+
+	ip->image = image;
+	ip->halign = halign;
+	ip->top_margin = (top_margin > 0) ? top_margin : 0;
+	ip->bottom_margin = (bottom_margin > 0) ? bottom_margin : 0;
+	ip->left_margin = (left_margin > 0) ? left_margin : 0;
+	ip->right_margin = (right_margin > 0) ? right_margin : 0;
+	c->ftb = &image_funcs;
+	c->priv = ip;
+	c->type_code = SDLPUI_CTRL_IMAGE;
+}
+
+
+/*
+ * Initializes the contents of c to be appropriate for a label control.
+ *
+ * \param c points to the control to be initialized.  Must not be NULL.
+ * \param caption is the null-terminated UTF-8 string to use as the label.
+ * The contents of caption are copied, so the lifetime of what's passed is
+ * independent of the lifetime of the control.
+ * \param halign specifies how the label should be horizontally aligned within
+ * the control's bounds if the control is wider than the label.
+ *
+ * Note that the bounding rectangle for the control is not set.  The caller
+ * should use c->ftb->resize to set that (perhaps in conjunction with
+ * c->ftb->query_natural_size) and set c->rect.x and c->rect.y directly to
+ * position the control in a dialog.
+ */
+void sdlpui_create_label(struct sdlpui_control *c, const char *caption,
+		enum sdlpui_hor_align halign)
+{
+	struct sdlpui_label *lp = SDL_malloc(sizeof(*lp));
+
+	lp->caption = SDL_strdup(caption);
+	lp->halign = halign;
+	c->ftb = &label_funcs;
+	c->priv = lp;
+	c->type_code = SDLPUI_CTRL_LABEL;
+}
+
+
+/*
+ * Initializes the contents of c to be appropriate for a push button control.
+ *
+ * \param c points to the control to be initialized.  Must not be NULL.
+ * \param caption is the null-terminated UTF-8 string to use as the label.
+ * The contents of caption are copied, so the lifetime of what's passed is
+ * independent of the lifetime of the control.
+ * \param halign specifies how the label should be horizontally aligned within
+ * the control's bounds if the control is wider than the label.
+ * \param callback is the function to invoke when the button is released.  It
+ * may be NULL.
+ * \param tag is a value the application can use as it wishes to have buttons
+ * with the same callback act differently.
+ * \param disabled will, if true, cause the button to ignore button or keyboard
+ * events and be displayed with an altered appearance until the button is
+ * reenabled.
+ *
+ * Note that the bounding rectangle for the control is not set.  The caller
+ * should use c->ftb->resize to set that (perhaps in conjunction with
+ * c->ftb->query_natural_size) and set c->rect.x and c->rect.y directly to
+ * position the control in a dialog.
+ */
+void sdlpui_create_push_button(struct sdlpui_control *c, const char *caption,
+		enum sdlpui_hor_align halign, void (*callback)(
+		struct sdlpui_control*, struct sdlpui_dialog*,
+		struct sdlpui_window*), int tag, bool disabled)
+{
+	struct sdlpui_push_button *pbp = SDL_malloc(sizeof(*pbp));
+
+	pbp->caption = SDL_strdup(caption);
+	pbp->callback = callback;
+	pbp->halign = halign;
+	pbp->tag = tag;
+	pbp->disabled = disabled;
+	pbp->has_key = false;
+	pbp->has_mouse = false;
+	pbp->armed = false;
+	c->ftb = &push_button_funcs;
+	c->priv = pbp;
+	c->type_code = SDLPUI_CTRL_PUSH_BUTTON;
+}
+
+
+/*
+ * Initializes the contents of c to be appropriate for a menu button control.
+ *
+ * \param c points to the control to be initialized.  Must not be NULL.
+ * \param caption is the null-terminated UTF-8 string to use as the label.
+ * The contents of caption are copied, so the lifetime of what's passed is
+ * independent of the lifetime of the control.
+ * \param halign specifies how the label should be horizontally aligned within
+ * the control's bounds if the control is wider than the label.
+ * \param callback is the function to invoke when the button is released.  It
+ * may be NULL.
+ * \param tag is a value the application can use as it wishes to have buttons
+ * with the same callback act differently.
+ * \param disabled will, if true, cause the button to ignore button or keyboard
+ * events and be displayed with an altered appearance until the button is
+ * reenabled.
+ *
+ * Note that the bounding rectangle for the control is not set.  The caller
+ * should use c->ftb->resize to set that (perhaps in conjunction with
+ * c->ftb->query_natural_size) and set c->rect.x and c->rect.y directly to
+ * position the control in a dialog.
+ */
+void sdlpui_create_menu_button(struct sdlpui_control *c, const char *caption,
+		enum sdlpui_hor_align halign, void (*callback)(
+		struct sdlpui_control*, struct sdlpui_dialog*,
+		struct sdlpui_window*w), int tag, bool disabled)
+{
+	struct sdlpui_menu_button *mbp = SDL_malloc(sizeof(*mbp));
+
+	mbp->caption = SDL_strdup(caption);
+	mbp->callback = callback;
+	mbp->halign = halign;
+	mbp->tag = tag;
+	mbp->has_key = 0;
+	mbp->has_mouse = 0;
+	mbp->armed = 0;
+	mbp->disabled = disabled;
+	mbp->subtype_code = SDLPUI_MB_NONE;
+	c->ftb = &menu_button_funcs;
+	c->priv = mbp;
+	c->type_code = SDLPUI_CTRL_MENU_BUTTON;
+}
+
+
+/*
+ * Initializes the contents of c to be appropriate for a menu indicator control.
+ *
+ * \param c points to the control to be initialized.  Must not be NULL.
+ * \param caption is the null-terminated UTF-8 string to use as the label.
+ * The contents of caption are copied, so the lifetime of what's passed is
+ * independent of the lifetime of the control.
+ * \param halign specifies how the label should be horizontally aligned within
+ * the control's bounds if the control is wider than the label.
+ * \param tag is a value the application can use as it wishes to have otherwise
+ * similar indicators act differently.
+ * \param curr_value is whether or not the indicator is currently on.
+ *
+ * Note that the bounding rectangle for the control is not set.  The caller
+ * should use c->ftb->resize to set that (perhaps in conjunction with
+ * c->ftb->query_natural_size) and set c->rect.x and c->rect.y directly to
+ * position the control in a dialog.
+ */
+void sdlpui_create_menu_indicator(struct sdlpui_control *c, const char *caption,
+		enum sdlpui_hor_align halign, int tag, bool curr_value)
+{
+	struct sdlpui_menu_button *mbp = SDL_malloc(sizeof(*mbp));
+
+	mbp->caption = SDL_strdup(caption);
+	mbp->callback = NULL;
+	mbp->halign = halign;
+	mbp->tag = tag;
+	mbp->has_key = 0;
+	mbp->has_mouse = 0;
+	mbp->armed = 0;
+	mbp->disabled = false;
+	mbp->subtype_code = SDLPUI_MB_INDICATOR;
+	mbp->v.toggled = curr_value;
+	c->ftb = &menu_button_funcs;
+	c->priv = mbp;
+	c->type_code = SDLPUI_CTRL_MENU_BUTTON;
+}
+
+
+/*
+ * Initializes the contents of c to be appropriate for a menu button
+ * controlling an integer parameter limited to a fixed range.
+ *
+ * \param c points to the control to be initialized.  Must not be NULL.
+ * \param caption is the null-terminated UTF-8 string to use as the label.
+ * The contents of caption are copied, so the lifetime of what's passed is
+ * independent of the lifetime of the control.
+ * \param halign specifies how the label should be horizontally aligned within
+ * the control's bounds if the control is wider than the label.
+ * \param callback is the function to invoke when the value associated with
+ * button changes due to a user interface event.  It may be NULL.
+ * \param tag is a value the application can use as it wishes to have buttons
+ * with the same callback act differently.
+ * \param disabled will, if true, cause the button to ignore button or keyboard
+ * events and be displayed with an altered appearance until the button is
+ * reenabled.
+ * \param curr_value is the current value for the integer associated with the
+ * button.
+ * \param min_value is the minimum value for the integer associated with the
+ * button.
+ * \param max_value is the minimum value for the integer associated with the
+ * button.  max_value must be greater than or equal to min_value.
+ *
+ * Note that the bounding rectangle for the control is not set.  The caller
+ * should use c->ftb->resize to set that (perhaps in conjunction with
+ * c->ftb->query_natural_size) and set c->rect.x and c->rect.y directly to
+ * position the control in a dialog.
+ */
+void sdlpui_create_menu_ranged_int(struct sdlpui_control *c,
+		const char *caption, enum sdlpui_hor_align halign,
+		void (*callback)(struct sdlpui_control*, struct sdlpui_dialog*,
+		struct sdlpui_window*), int tag, bool disabled, int curr_value,
+		int min_value, int max_value)
+{
+	struct sdlpui_menu_button *mbp = SDL_malloc(sizeof(*mbp));
+
+	mbp->caption = SDL_strdup(caption);
+	mbp->callback = callback;
+	mbp->halign = halign;
+	mbp->tag = tag;
+	mbp->has_key = 0;
+	mbp->has_mouse = 0;
+	mbp->armed = 0;
+	mbp->disabled = disabled;
+	mbp->subtype_code = SDLPUI_MB_RANGED_INT;
+	mbp->v.ranged_int.min = min_value;
+	mbp->v.ranged_int.max = max_value;
+	mbp->v.ranged_int.curr = curr_value;
+	mbp->v.ranged_int.old = curr_value;
+	c->ftb = &menu_button_funcs;
+	c->priv = mbp;
+	c->type_code = SDLPUI_CTRL_MENU_BUTTON;
+}
+
+
+/*
+ * Initializes the contents of c to be appropriate for a toggleable control
+ * in a menu.
+ *
+ * \param c points to the control to be initialized.  Must not be NULL.
+ * \param caption is the null-terminated UTF-8 string to use as the label.
+ * The contents of caption are copied, so the lifetime of what's passed is
+ * independent of the lifetime of the control.
+ * \param halign specifies how the label should be horizontally aligned within
+ * the control's bounds if the control is wider than the label.
+ * \param callback is the function to invoke when the button is released.  It
+ * may be NULL.
+ * \param tag is a value the application can use as it wishes to have buttons
+ * with the same callback act differently.
+ * \param disabled will, if true, cause the button to ignore button or keyboard
+ * events and be displayed with an altered appearance until the button is
+ * reenabled.
+ * \param curr_value is whether the toggle is currently on.
+ *
+ * Note that the bounding rectangle for the control is not set.  The caller
+ * should use c->ftb->resize to set that (perhaps in conjunction with
+ * c->ftb->query_natural_size) and set c->rect.x and c->rect.y directly to
+ * position the control in a dialog.
+ */
+void sdlpui_create_menu_toggle(struct sdlpui_control *c, const char *caption,
+		enum sdlpui_hor_align halign, void (*callback)(
+		struct sdlpui_control*, struct sdlpui_dialog*,
+		struct sdlpui_window*), int tag, bool disabled,
+		bool curr_value)
+{
+	struct sdlpui_menu_button *mbp = SDL_malloc(sizeof(*mbp));
+
+	mbp->caption = SDL_strdup(caption);
+	mbp->callback = callback;
+	mbp->halign = halign;
+	mbp->tag = tag;
+	mbp->has_key = 0;
+	mbp->has_mouse = 0;
+	mbp->armed = 0;
+	mbp->disabled = disabled;
+	mbp->subtype_code = SDLPUI_MB_TOGGLE;
+	mbp->v.toggled = curr_value;
+	c->ftb = &menu_button_funcs;
+	c->priv = mbp;
+	c->type_code = SDLPUI_CTRL_MENU_BUTTON;
+}
+
+
+/*
+ * Initializes the contents of c to be appropriate for a menu button that
+ * leads to a nested menu.
+ *
+ * \param c points to the control to be initialized.  Must not be NULL.
+ * \param caption is the null-terminated UTF-8 string to use as the label.
+ * The contents of caption are copied, so the lifetime of what's passed is
+ * independent of the lifetime of the control.
+ * \param halign specifies how the label should be horizontally aligned within
+ * the control's bounds if the control is wider than the label.
+ * \param creator is the function to invoke to create the nested menu.  It must
+ * not be NULL.  It takes five arguments:  a pointer to the parent control for
+ * menu, a pointer to the parent dialog for that control, a pointer to the
+ * window containing that dialog and control, the x coordinate (relative to
+ * the window) for the upper right corner of the nested menu, and the y
+ * coordinate (relative to the window) for the upper rgith corner of the
+ * nested menu.
+ * \param placement specifies how the nested menu will be placed relative to
+ * the menu button.
+ * \param tag is a value the application can use as it wishes to have otherwise
+ * similar buttons act differently.
+ * \param disabled will, if true, cause the button to ignore button or keyboard
+ * events and be displayed with an altered appearance until the button is
+ * reenabled.
+ *
+ * Note that the bounding rectangle for the control is not set.  The caller
+ * should use c->ftb->resize to set that (perhaps in conjunction with
+ * c->ftb->query_natural_size) and set c->rect.x and c->rect.y directly to
+ * position the control in a dialog.
+ */
+void sdlpui_create_submenu_button(struct sdlpui_control *c, const char *caption,
+		enum sdlpui_hor_align halign, struct sdlpui_dialog *(*creator)(
+		struct sdlpui_control*, struct sdlpui_dialog*,
+		struct sdlpui_window*, int ul_x_win, int ul_y_win),
+		enum sdlpui_child_menu_placement placement, int tag,
+		bool disabled)
+{
+	struct sdlpui_menu_button *mbp = SDL_malloc(sizeof(*mbp));
+
+	mbp->caption = SDL_strdup(caption);
+	mbp->callback = NULL;
+	mbp->halign = halign;
+	mbp->tag = tag;
+	mbp->has_key = 0;
+	mbp->has_mouse = 0;
+	mbp->armed = 0;
+	mbp->disabled = disabled;
+	mbp->subtype_code = SDLPUI_MB_SUBMENU;
+	mbp->v.submenu.creator = creator;
+	mbp->v.submenu.child = NULL;
+	mbp->v.submenu.placement = placement;
+	c->ftb = &menu_button_funcs;
+	c->priv = mbp;
+	c->type_code = SDLPUI_CTRL_MENU_BUTTON;
+}

--- a/src/sdl2/pui-ctrl.h
+++ b/src/sdl2/pui-ctrl.h
@@ -1,0 +1,413 @@
+/**
+ * \file sdl2/pui-ctrl.h
+ * \brief Declare the interface for controls that can be included in menus or
+ * dialogs created by the primitive UI toolkit for SDL2.
+ */
+#ifndef INCLUDED_SDL2_SDLPUI_CONTROL_H
+#define INCLUDED_SDL2_SDLPUI_CONTROL_H
+
+#include "SDL.h" /* SDL_*Event, SDL_Rect, SDL_Renderer, Sint32 */
+#include <stdbool.h>
+
+struct sdlpui_control;
+struct sdlpui_dialog;
+struct sdlpui_window;
+
+/*
+ * Default width for empty space around labels, push buttons, and menu buttons
+ */
+#define SDLPUI_DEFAULT_CTRL_BORDER 8
+
+/*
+ * Set out predefined values for the type_code field of struct sdlpui_control.
+ * These are initialized by sdlpui_init().  For custom controls, you can get
+ * a code with sdlpui_register_code().
+ */
+extern Uint32 SDLPUI_CTRL_IMAGE;
+extern Uint32 SDLPUI_CTRL_LABEL;
+extern Uint32 SDLPUI_CTRL_MENU_BUTTON;
+extern Uint32 SDLPUI_CTRL_PUSH_BUTTON;
+
+/*
+ * Set out possible values for the subtype_code field of struct
+ * sdlpui_menu_button.
+ */
+enum sdlpui_menu_button_type {
+	SDLPUI_MB_INVALID = 0,
+	SDLPUI_MB_NONE,
+	SDLPUI_MB_INDICATOR,
+	SDLPUI_MB_RANGED_INT,
+	SDLPUI_MB_SUBMENU,
+	SDLPUI_MB_TOGGLE,
+};
+
+/*
+ * Since mouse focus and keyboard focus can be directed to different controls
+ * within a compound control, provide a hint about the cause for invoking an
+ * action on a control.
+ */
+enum sdlpui_action_hint {
+	SDLPUI_ACTION_HINT_NONE,
+	SDLPUI_ACTION_HINT_KEY,
+	SDLPUI_ACTION_HINT_MOUSE
+};
+
+/* How to horizontally align something (usually a label) in a larger box. */
+enum sdlpui_hor_align {
+	SDLPUI_HOR_INVALID = 0,
+	SDLPUI_HOR_CENTER,
+	SDLPUI_HOR_LEFT,
+	SDLPUI_HOR_RIGHT
+};
+
+/* How to place a created menu relative to its parent control. */
+enum sdlpui_child_menu_placement {
+	SDLPUI_CHILD_MENU_ABOVE,
+	SDLPUI_CHILD_MENU_BELOW,
+	SDLPUI_CHILD_MENU_LEFT,
+	SDLPUI_CHILD_MENU_RIGHT
+};
+
+/* Holds a function table to be used for a class of controls. */
+struct sdlpui_control_funcs {
+	/*
+	 * Respond to events.  Return true if the event was handled and
+	 * shouldn't be passed on to another handler.  Otherwise, return false.
+	 * Any can be NULL if the control doesn't do anything with that type
+	 * of event and wants the dialog or window to handle the event.
+	 */
+	bool (*handle_key)(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const SDL_KeyboardEvent *e);
+	bool (*handle_textin)(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const SDL_TextInputEvent *e);
+	bool (*handle_textedit)(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		const SDL_TextEditingEvent *e);
+	bool (*handle_mouseclick)(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		const SDL_MouseButtonEvent *e);
+	bool (*handle_mousemove)(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		const SDL_MouseMotionEvent *e);
+	bool (*handle_mousewheel)(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		const SDL_MouseWheelEvent *e);
+	/*
+	 * Change the caption for the control.  May be NULL if the control
+	 * does not have a caption or otherwise does not want
+	 * sdlpui_change_caption() to work with the control.  Does resize
+         * the internals of the control for the new caption but does not
+         * change its external dimensions.
+	 */
+	void (*change_caption)(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		const char *new_caption);
+	/*
+	 * Render the control.  Can be NULL, but then the control will be
+	 * invisible.  Assumes the renderer's target has been set to
+	 * d->texture.
+	 */
+	void (*render)(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, SDL_Renderer *r);
+	/* Do the default action for a control.  Can be NULL. */
+	void (*respond_default)(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		enum sdlpui_action_hint hint);
+	/*
+	 * Signal that the given control has gained keyboard focus and
+	 * perhaps should change its appearance when rendered.  comp_ind is
+	 * only relevant for compound controls and is the index of the component
+	 * that should receive focus.  Negative indices are relative to the
+	 * number of controls in the compound control so -1 is the "last"
+	 * control.  Can be NULL.
+	 */
+	void (*gain_key)(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, int comp_ind);
+	/*
+	 * Signal that the given control has lost keyboard focus.  Can be NULL.
+	 * following_mouse is true if the control is losing key focus because
+	 * it is losing mouse focus at the same time.
+	 */
+	void (*lose_key)(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, bool following_mouse);
+	/*
+	 * Signal that the given control has gained mouse focus and
+	 * perhaps should change its appearance when rendered.  comp_ind
+	 * has the same meaning as for gain_key above.  Can be NULL.
+	 */
+	void (*gain_mouse)(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, int comp_ind);
+	/*
+	 * Signal that the given control has lost mouse focus.  Can be NULL.
+	 * e is the motion event causing the loss of focus or NULL if focus
+	 * is lost for another reason.
+	 */
+	void (*lose_mouse)(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e);
+	/*
+	 * Signal that the child dialog for a control has been removed.  Can
+	 * be NULL if the control doesn't create a dialog, set the created
+	 * dialog's parent control to the control, or record the pointer
+	 * to the dialog.
+	 */
+	void (*lose_child)(struct sdlpui_control *c,
+		struct sdlpui_dialog *child);
+	/*
+	 * Signal that the control has become armed (i.e. key or mouse button
+	 * depressed while the control has focus).  Can be NULL.
+	 */
+	void (*arm)(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, enum sdlpui_action_hint hint);
+	/*
+	 * Signal that the control has become disarmed (i.e. key or mouse button
+	 * released while the control has focus).  Can be NULL.
+	 */
+	void (*disarm)(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, enum sdlpui_action_hint hint);
+	/*
+	 * For simple controls, either returns zero (the control doesn't
+	 * accept focus) or one (it does).  For compound controls it returns:
+	 *     a) Zero if none of the components accepts focus.
+	 *     b) If first is true, returns the one-based index of the first
+	 *        component that can accept focus.
+	 *     c) If first is false, returns the one-based index of the last
+	 *        component that can accept focus.
+	 * May be NULL:  callers will then assume the control can't accept
+	 * focus.
+	 */
+	int (*get_interactable_component)(struct sdlpui_control *c, bool first);
+	/*
+	 * Step (forward if forward is true; backward otherwise; never wrap
+	 * around) between the interactable components within the given
+	 * control, assumed to already have key focus, and transfer the key
+	 * focus to the result of the step.  Return true if stepping was
+	 * possible or false otherwise.  May be NULL:  callers will then assume
+	 * that any attempt to step within the control will be ineffective.
+	 */
+	bool (*step_within)(struct sdlpui_control *c, bool forward);
+	/*
+	 * For a simple control, either returns zero (the control doesn't
+	 * accept focus or contain the given coordinates, relative to the
+	 * dialog) or one (the control accepts focus and the given coordinates
+	 * are in the control).  For a compound control return zero if there's
+	 * no component that accepts focus and contains the given coordinates.
+	 * May be NULL:  callers will then assume the control is simple,
+	 * accepts focus if get_interactable_component is not NULL and
+	 * returns a non-zero value, and will test the coordinate directly
+	 * against the control's rectangle.
+	 */
+	int (*get_interactable_component_at)(struct sdlpui_control *c,
+		Sint32 x, Sint32 y);
+	/*
+	 * Resize the control so it has the given dimensions.  May be NULL
+	 * if resizing the control is as simple as setting c->rect.w and
+	 * c->rect.h to the desired dimensions.
+	 */
+	void (*resize)(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, int width, int height);
+	/*
+	 * Set width and height to the natural size for the control.  May not
+	 * be NULL.
+	 */
+	void (*query_natural_size)(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w, int *width,
+		int *height);
+	/*
+	 * Get whether the control is disabled.  May be NULL:  the control
+	 * doesn't support enabling/disabling.
+	 */
+	bool (*is_disabled)(const struct sdlpui_control *c);
+	/*
+	 * Change whether the control is disabled and return whether or not
+	 * its prior state was disabled.  May be NULL:  the control doesn't
+	 * support enabling/disabling.
+	 */
+	bool (*set_disabled)(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, bool disabled);
+	/*
+	 * Get the application-assigned tag for a control.  May be NULL:  the
+	 * control doesn't support application-assigned tags.
+	 */
+	int (*get_tag)(const struct sdlpui_control *c);
+	/*
+	 * Change the application-assigned tag for a control and return its
+	 * prior tag.  May be NULL:  the control doesn't support
+	 * application-assigned tags.
+	 */
+	int (*set_tag)(struct sdlpui_control *c, int new_tag);
+	/*
+	 * Handle releasing resources for the private data, if any.  May be
+	 * NULL to have no special cleanup done.
+	 */
+	void (*cleanup)(struct sdlpui_control *c);
+};
+
+/* Represents a button or other sort of control in a dialog or menu. */
+struct sdlpui_control {
+	const struct sdlpui_control_funcs *ftb;
+	/* Holds data specific to the particular type of control. */
+	void *priv;
+	/*
+	 * Holds the position, relative to the containing dialog/menu's
+	 * upper left corner, and size of the control.
+	 */
+	SDL_Rect rect;
+	/* Allow for a check before casting priv to another type. */
+	Uint32 type_code;
+};
+
+/*
+ * Holds the private data for a sdlpui_control used to represent an image for
+ * use in general dialogs.  The corresponding type_code value is
+ * SDLPUI_CTRL_IMAGE.
+ */
+struct sdlpui_image {
+	/* x and y are relative to the (x, y) from the control's rectangle. */
+	SDL_Rect image_rect;
+	SDL_Texture *image;
+	enum sdlpui_hor_align halign;
+	int top_margin, bottom_margin, left_margin, right_margin;
+};
+
+/*
+ * Holds the private data for a sdlpui_control used to represent a single line
+ * label for use in general dialogs.  The corresponding type_code value is
+ * SDLPUI_CTRL_LABEL.
+ */
+struct sdlpui_label {
+	/* x and y are relative to the (x, y) from the control's rectangle. */
+	SDL_Rect caption_rect;
+	char *caption;
+	enum sdlpui_hor_align halign;
+};
+
+/*
+ * Holds the private data for a sdlpui_control used to represent a button in
+ * menu.  The corressponding type_code value is SDLPUI_CTRL_MENU_BUTTON.
+ */
+struct sdlpui_menu_button {
+	SDL_Rect caption_rect;
+	char *caption;
+	/* Invoked by the menu button's respond_default handler. */
+	void (*callback)(struct sdlpui_control*, struct sdlpui_dialog*,
+		struct sdlpui_window *w);
+	enum sdlpui_hor_align halign;
+	/*
+	 * This is a hook for the application to differentiate buttons with
+	 * the same contents for callback, subtype_code, and v.
+	 */
+	int tag;
+	int has_key;	/* 0 = no key focus, 1 = key focus (for ranged_int
+				button, left side has focus), 2 = key focus
+				for right side of ranged_int button */
+	int has_mouse;	/* 0 = no mouse focus, 1 = mouse focus (for ranged_int
+				button, left side has focus), 2 = mouse focus
+				for right side of ranged_int button */
+	int armed;	/* 0 = not depressed, 1 = button depressed (for
+				ranged_int button, left side depressed), 2 =
+				ranged_int button right side depressed,
+				3 = ranged_int button both sides depressed */
+	bool disabled;	/* if true, no response to events and different look */
+	enum sdlpui_menu_button_type subtype_code;
+	union {
+		struct { int min, max, curr, old; } ranged_int;
+		struct {
+			struct sdlpui_dialog *(*creator)(
+				struct sdlpui_control*,
+				struct sdlpui_dialog*,
+				struct sdlpui_window*,
+				int ul_x_win,
+				int ul_y_win);
+			struct sdlpui_dialog *child;
+			enum sdlpui_child_menu_placement placement;
+		} submenu;
+		bool toggled; /* subtype_code is SDLPUI_MB_INDICATOR or
+					SDLPUI_MB_TOGGLE */
+	} v;
+};
+
+/*
+ * Holds the private data for a sdlpui_control used to represent a push button
+ * used in general dialogs.  The corresponding type_code value is
+ * SDLPUI_CTRL_PUSH_BUTTON.
+ */
+struct sdlpui_push_button {
+	SDL_Rect caption_rect;
+	char *caption;
+	/* Invoked by the push button's respond_default handler. */
+	void (*callback)(struct sdlpui_control*, struct sdlpui_dialog*,
+		struct sdlpui_window*);
+	enum sdlpui_hor_align halign;
+	/*
+	 * This is a hook for the application to differentiate push buttons
+	 * with the same callback.
+	 */
+	int tag;
+	bool disabled;	/* if true, no response to events and different look */
+	bool has_key;	/* if true, has key focus */
+	bool has_mouse;	/* if true, has mouse focus */
+	bool armed;	/* if true, button is depressed */
+};
+
+
+bool sdlpui_is_in_control(const struct sdlpui_control *c,
+		const struct sdlpui_dialog *d, Sint32 x, Sint32 y);
+bool sdlpui_is_disabled(const struct sdlpui_control *c);
+bool sdlpui_set_disabled(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, bool disabled);
+int sdlpui_get_tag(const struct sdlpui_control *c);
+int sdlpui_set_tag(struct sdlpui_control *c, int new_tag);
+void sdlpui_change_caption(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const char *new_caption);
+
+/* Standard event handlers for simple controls */
+bool sdlpui_control_handle_key(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		const struct SDL_KeyboardEvent *e);
+bool sdlpui_control_handle_mouseclick(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		const struct SDL_MouseButtonEvent *e);
+bool sdlpui_control_handle_mousemove(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		const struct SDL_MouseMotionEvent *e);
+
+/* Standard callbacks for button controls */
+void sdlpui_invoke_dialog_default_action(struct sdlpui_control *c,
+		struct sdlpui_dialog *d, struct sdlpui_window *w);
+
+/* Constructors for controls in generic dialogs */
+void sdlpui_create_image(struct sdlpui_control *c, SDL_Texture *image,
+		enum sdlpui_hor_align halign, int top_margin, int bottom_margin,
+		int left_margin, int right_margin);
+void sdlpui_create_label(struct sdlpui_control *c, const char *caption,
+		enum sdlpui_hor_align halign);
+void sdlpui_create_push_button(struct sdlpui_control *c, const char *caption,
+		enum sdlpui_hor_align halign, void (*callback)(
+		struct sdlpui_control*, struct sdlpui_dialog*,
+		struct sdlpui_window*), int tag, bool disabled);
+
+/* Constructors for controls in menus */
+void sdlpui_create_menu_button(struct sdlpui_control *c, const char *caption,
+		enum sdlpui_hor_align halign, void (*callback)(
+		struct sdlpui_control*, struct sdlpui_dialog*,
+		struct sdlpui_window*), int tag, bool disabled);
+void sdlpui_create_menu_indicator(struct sdlpui_control *c, const char *caption,
+		enum sdlpui_hor_align halign, int tag, bool curr_value);
+void sdlpui_create_menu_ranged_int(struct sdlpui_control *c,
+		const char *caption, enum sdlpui_hor_align halign,
+		void (*callback)(struct sdlpui_control*, struct sdlpui_dialog*,
+		struct sdlpui_window*), int tag, bool disabled, int curr_value,
+		int min_value, int max_value);
+void sdlpui_create_menu_toggle(struct sdlpui_control *c, const char *caption,
+		enum sdlpui_hor_align halign, void (*callback)(
+		struct sdlpui_control*, struct sdlpui_dialog*,
+		struct sdlpui_window*), int tag, bool disabled,
+		bool curr_value);
+void sdlpui_create_submenu_button(struct sdlpui_control *c, const char *caption,
+		enum sdlpui_hor_align halign, struct sdlpui_dialog *(*creator)(
+		struct sdlpui_control*, struct sdlpui_dialog*, struct
+		sdlpui_window*, int ul_x_win, int ul_y_win),
+		enum sdlpui_child_menu_placement placement, int tag,
+		bool disabled);
+
+#endif /* INCLUDED_SDL2_SDLPUI_CONTROL_H */

--- a/src/sdl2/pui-dlg.c
+++ b/src/sdl2/pui-dlg.c
@@ -1,0 +1,2236 @@
+/**
+ * \file sdl2/pui-dlg.c
+ * \brief Define the interface for menus and dialogs created by the primitive
+ * UI toolkit for SDL2.
+ *
+ * Copyright (c) 2023 Eric Branlund
+ *
+ * This work is free software; you can redistribute it and/or modify it
+ * under the terms of either:
+ *
+ * a) the GNU General Public License as published by the Free Software
+ *    Foundation, version 2, or
+ *
+ * b) the "Angband licence":
+ *    This software may be copied and distributed for educational, research,
+ *    and not for profit purposes provided that this copyright and statement
+ *    are included in all such copies.  Other copyrights may also apply.
+ */
+
+#include "pui-dlg.h"
+#include "pui-misc.h"
+#include "pui-win.h"
+#include <limits.h> /* INT_MAX */
+
+static bool handle_simple_menu_key(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_KeyboardEvent *e);
+static bool handle_simple_menu_textin(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_TextInputEvent *e);
+static void render_simple_menu(struct sdlpui_dialog *d,
+		struct sdlpui_window *w);
+static void goto_simple_menu_first_control(struct sdlpui_dialog *d,
+		struct sdlpui_window *w);
+static void step_simple_menu_control(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, struct sdlpui_control *c,
+		bool forward);
+static struct sdlpui_control *find_simple_menu_control_containing(
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		Sint32 x, Sint32 y, int *comp_ind);
+static struct sdlpui_dialog *get_simple_menu_parent(struct sdlpui_dialog *d);
+static struct sdlpui_dialog *get_simple_menu_child(struct sdlpui_dialog *d);
+static struct sdlpui_control *get_simple_menu_parent_ctrl(
+		struct sdlpui_dialog *d);
+static void set_simple_menu_child(struct sdlpui_dialog *d,
+		struct sdlpui_dialog *child);
+static void resize_simple_menu(struct sdlpui_dialog *d, struct sdlpui_window *w,
+		int width, int height);
+static void query_simple_menu_natural_size(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, int *width, int *height);
+static void query_simple_menu_minimum_size(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, int *width, int *height);
+static void cleanup_simple_menu(struct sdlpui_dialog *d);
+
+static void render_simple_info(struct sdlpui_dialog *d,
+		struct sdlpui_window *w);
+static void goto_simple_info_first_control(struct sdlpui_dialog *d,
+		struct sdlpui_window *w);
+static struct sdlpui_control *find_simple_info_control_containing(
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		Sint32 x, Sint32 y, int *comp_ind);
+static void resize_simple_info(struct sdlpui_dialog *d, struct sdlpui_window *w,
+		int width, int height);
+static void query_simple_info_natural_size(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, int *width, int *height);
+static void cleanup_simple_info(struct sdlpui_dialog *d);
+
+Uint32 SDLPUI_DIALOG_SIMPLE_MENU = 0;
+Uint32 SDLPUI_DIALOG_SIMPLE_INFO = 0;
+
+static const struct sdlpui_dialog_funcs simple_menu_funcs = {
+	handle_simple_menu_key,
+	handle_simple_menu_textin,
+	sdlpui_dialog_handle_textedit,
+	sdlpui_menu_handle_mouseclick,
+	sdlpui_dialog_handle_mousemove,
+	sdlpui_dialog_handle_mousewheel,
+	sdlpui_menu_handle_loses_mouse,
+	sdlpui_menu_handle_loses_key,
+	sdlpui_menu_handle_window_loses_mouse,
+	sdlpui_menu_handle_window_loses_key,
+	render_simple_menu,
+	NULL,
+	goto_simple_menu_first_control,
+	step_simple_menu_control,
+	find_simple_menu_control_containing,
+	get_simple_menu_parent,
+	get_simple_menu_child,
+	get_simple_menu_parent_ctrl,
+	set_simple_menu_child,
+	resize_simple_menu,
+	query_simple_menu_natural_size,
+	query_simple_menu_minimum_size,
+	cleanup_simple_menu
+};
+
+static const struct sdlpui_dialog_funcs simple_info_funcs = {
+	sdlpui_dialog_handle_key,
+	sdlpui_dialog_handle_textin,
+	sdlpui_dialog_handle_textedit,
+	sdlpui_dialog_handle_mouseclick,
+	sdlpui_dialog_handle_mousemove,
+	sdlpui_dialog_handle_mousewheel,
+	sdlpui_dialog_handle_loses_mouse,
+	sdlpui_dialog_handle_loses_key,
+	sdlpui_dialog_handle_window_loses_mouse,
+	sdlpui_dialog_handle_window_loses_key,
+	render_simple_info,
+	sdlpui_dismiss_dialog,
+	goto_simple_info_first_control,
+	NULL,
+	find_simple_info_control_containing,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	resize_simple_info,
+	query_simple_info_natural_size,
+	NULL,
+	cleanup_simple_info
+};
+
+
+/*
+ * Menus react to some additional keyboard events since the geometry allows
+ * for easy interpretations of cursor movements.  Otherwise, they act like
+ * simple dialogs.
+ */
+static bool handle_simple_menu_key(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_KeyboardEvent *e)
+{
+	/*
+	 * Swap which keys do what depending on the orientation of the menu.
+	 * fwd_alt1, fwd_alt2, fwd_alt3 are for the keys corresponding to
+	 * the in-game east (for vertical menus) or south (for horizontal
+	 * menus) motion commands from either keyset.
+	 */
+	struct k_dirsyms {
+		SDL_Keycode fwd, fwd_alt1, fwd_alt2, fwd_alt3, bck, nxt, prv;
+	};
+	static const struct k_dirsyms vsyms = {
+		SDLK_RIGHT,
+		SDLK_4,
+		SDLK_KP_4,
+		SDLK_l,
+		SDLK_LEFT,
+		SDLK_DOWN,
+		SDLK_UP
+	};
+	static const struct k_dirsyms hsyms = {
+		SDLK_DOWN,
+		SDLK_2,
+		SDLK_KP_2,
+		SDLK_j,
+		SDLK_UP,
+		SDLK_RIGHT,
+		SDLK_LEFT
+	};
+	const struct k_dirsyms *csyms;
+	/*
+	 * Most of the additional event handling is as a proxy for the menu's
+	 * control with keyboard focus so remember what that is.
+	 */
+	struct sdlpui_control *c = d->c_key;
+	struct sdlpui_simple_menu *p;
+	SDL_Keymod mods;
+
+	/* Relay to the control with focus.  if it handles it we're done. */
+	if (c && c->ftb->handle_key && (*c->ftb->handle_key)(c, d, w, e)) {
+		return true;
+	}
+
+	SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
+	p = d->priv;
+	csyms = (p->vertical) ? &vsyms : &hsyms;
+
+	mods = sdlpui_get_interesting_keymods();
+	if (e->keysym.sym == csyms->fwd) {
+		/*
+		 * Invoke the default action for a menu entry which will
+		 * descend deeper into the menu hierarchy if that entry leads
+		 * to a submenu.  If there's no entry with keyboard focus,
+		 * give focus to the first active entry.
+		 */
+		if (c) {
+			if (e->state == SDL_PRESSED) {
+				if (mods == KMOD_NONE) {
+					(*c->ftb->arm)(c, d, w,
+						SDLPUI_ACTION_HINT_KEY);
+				}
+			} else {
+				/*
+				 * Always disarm, regardless of the modifier
+				 * state, in case the modifier keys changed
+				 * between the press and release.
+				 */
+				if (c->ftb->disarm) {
+					(*c->ftb->disarm)(c, d, w,
+						SDLPUI_ACTION_HINT_KEY);
+				}
+				if (mods == KMOD_NONE
+						&& c->ftb->respond_default) {
+					SDLPUI_EVENT_TRACER("control", c,
+						"(not extracted)",
+						"invoking default response");
+					(*c->ftb->respond_default)(c, d, w,
+						SDLPUI_ACTION_HINT_KEY);
+				}
+			}
+		} else if (e->state == SDL_RELEASED
+				&& d->ftb->goto_first_control) {
+			(*d->ftb->goto_first_control)(d, w);
+		}
+		return true;
+	}
+
+	if (e->keysym.sym == csyms->fwd_alt1 || e->keysym.sym == csyms->fwd_alt2
+			|| e->keysym.sym == csyms->fwd_alt3) {
+		/*
+		 * Like fwd, but as these symbols also trigger the text input
+		 * handler, just handle arming and disarming of the menu
+		 * button here.
+		 */
+		if (c) {
+			if (e->state == SDL_PRESSED) {
+				if (mods == KMOD_NONE && c->ftb->arm) {
+					(*c->ftb->arm)(c, d, w,
+						SDLPUI_ACTION_HINT_KEY);
+				}
+			} else {
+				/*
+				 * Always disarm, regardless of the modifier
+				 * state, in case the modifier keys changed
+				 * between the press and release.
+				 */
+				if (c->ftb->disarm) {
+					(*c->ftb->disarm)(c, d, w,
+						SDLPUI_ACTION_HINT_KEY);
+				}
+			}
+		}
+		return true;
+	}
+
+	if (e->keysym.sym == csyms->bck) {
+		/*
+		 * Back out to the previous level of the menu hierarchy, if any.
+		 */
+		if (e->state == SDL_RELEASED && mods == KMOD_NONE) {
+			sdlpui_dialog_give_key_focus_to_parent(d, w);
+		}
+		return true;
+	}
+
+	if (e->keysym.sym == csyms->nxt) {
+		/*
+		 * Go to the next active button in the menu or wrap around to
+		 * the first active button in the menu if already at the end.
+		 * If the menu doesn't already have key focus, give it key
+		 * focus and go to the first active button.
+		 */
+		if (e->state == SDL_RELEASED && mods == KMOD_NONE) {
+			if (c) {
+				if (d->ftb->step_control) {
+					(*d->ftb->step_control)(d, w, c, true);
+				}
+			} else if (d->ftb->goto_first_control) {
+				(*d->ftb->goto_first_control)(d, w);
+			}
+		}
+		return true;
+	}
+
+	if (e->keysym.sym == csyms->prv) {
+		/*
+		 * Go to the previous active button in the menu or wrap around
+		 * to the first active button in the menu if already at the end.
+		 * If the menu doesn't already have key focus, give it key
+		 * focus and go to the first active button.
+		 */
+		if (e->state == SDL_RELEASED && mods == KMOD_NONE) {
+			if (c) {
+				if (d->ftb->step_control) {
+					(*d->ftb->step_control)(d, w, c, false);
+				}
+			} else if (d->ftb->goto_first_control) {
+				(*d->ftb->goto_first_control)(d, w);
+			}
+		}
+		return true;
+	}
+
+	return sdlpui_dialog_handle_key(d, w, e);
+}
+
+
+static bool handle_simple_menu_textin(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_TextInputEvent *e)
+{
+	/*
+	 * Swap which keys do what depending on the orientation of the menu.
+	 * All correspond to in-game motion commands from either keyset.
+	 */
+	struct ti_dirsyms {
+		uint32_t fwd_alt1, fwd_alt2, bck_alt1, bck_alt2, nxt_alt1,
+			nxt_alt2, prv_alt1, prv_alt2;
+	};
+	static const struct ti_dirsyms vsyms = {
+		/* East descends into the menu hierarchy. */
+		'6', 'l',
+		/* West backs out. */
+		'4', 'h',
+		/* South goes to the next item in this menu. */
+		'2', 'j',
+		/* North goes to the previous item in this menu. */
+		'8', 'k'
+	};
+	static const struct ti_dirsyms hsyms = {
+		/* South descends. */
+		'2', 'j',
+		/* North backs out. */
+		'8', 'k',
+		/* East goes to the next item in this menu. */
+		'6', 'l',
+		/* West goes to the previous item in this menu. */
+		'4', 'h'
+	};
+	const struct ti_dirsyms *csyms;
+	/*
+	 * Most of the additional event handling is as a proxy for the menu's
+	 * control with keyboard focus so remember what that is.
+	 */
+	struct sdlpui_control *c = d->c_key;
+	struct sdlpui_simple_menu *p;
+	uint32_t ch = sdlpui_utf8_to_codepoint(e->text);
+
+	SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
+	p = d->priv;
+	csyms = (p->vertical) ? &vsyms : &hsyms;
+
+	if (ch == csyms->fwd_alt1 || ch == csyms->fwd_alt2) {
+		/*
+		 * Invoke the default action on the menu entry which will
+		 * descend deeper into the menu hierarchy if the entry leads
+		 * to a submenu.  If there's no menu entry with keyboard focus,
+		 * give keyboard focus to the first active entry.
+		 */
+		if (c) {
+			if (c->ftb->respond_default) {
+				SDLPUI_EVENT_TRACER("control", c,
+					"(not extracted)",
+					"invoking default response");
+				(*c->ftb->respond_default)(c, d, w,
+					SDLPUI_ACTION_HINT_KEY);
+			}
+		} else if (d->ftb->goto_first_control) {
+			(*d->ftb->goto_first_control)(d, w);
+		}
+		return true;
+	}
+
+	if (ch == csyms->bck_alt1 || ch == csyms->bck_alt2) {
+		/*
+		 * Back out to the previous level of the menu hierarchy, if any.
+		 */
+		sdlpui_dialog_give_key_focus_to_parent(d, w);
+		return true;
+	}
+
+	if (ch == csyms->nxt_alt1 || ch == csyms->nxt_alt2) {
+		/*
+		 * Go to the next active button in the menu or wrap around to
+		 * the first active button in the menu if already at the end.
+		 * If the menu doesn't already have key focus, give it key
+		 * focus and go to the first active button.
+		 */
+		if (c) {
+			if (d->ftb->step_control) {
+				(*d->ftb->step_control)(d, w, c, true);
+			}
+		} else if (d->ftb->goto_first_control) {
+			(*d->ftb->goto_first_control)(d, w);
+		}
+		return true;
+	}
+
+	if (ch == csyms->prv_alt1 || ch == csyms->prv_alt2) {
+		/*
+		 * Got to the previous active button in the menu or wrap around
+		 * to the last active button in the menu if already at the
+		 * beginning.  If the menu doesn't already have key focus,
+		 * give it key focus and go to the first active button.
+		 */
+		if (c) {
+			if (d->ftb->step_control) {
+				(*d->ftb->step_control)(d, w, c, false);
+			}
+		} else if (d->ftb->goto_first_control) {
+			(*d->ftb->goto_first_control)(d, w);
+		}
+		return true;
+	}
+
+	return sdlpui_dialog_handle_textin(d, w, e);
+}
+
+
+static void render_simple_menu(struct sdlpui_dialog *d, struct sdlpui_window *w)
+{
+	struct SDL_Renderer *r = sdlpui_get_renderer(w);
+	SDL_Rect dst_r = d->rect;
+	int i = 0;
+	struct sdlpui_simple_menu *p;
+	const SDL_Color *color;
+
+	SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
+	p = d->priv;
+	SDLPUI_RENDER_TRACER("simple menu", d, "(not extracted)", d->rect,
+		d->rect, d->texture);
+
+	SDL_SetRenderTarget(r, d->texture);
+	color = sdlpui_get_color(w, SDLPUI_COLOR_MENU_BG);
+	SDL_SetRenderDrawColor(r, color->r, color->g, color->b, color->a);
+	if (d->texture) {
+		dst_r.x = 0;
+		dst_r.y = 0;
+		SDL_RenderClear(r);
+	} else {
+		SDL_RenderFillRect(r, &dst_r);
+	}
+	while (1) {
+		if (i >= p->n_vis) {
+			break;
+		}
+		if (p->v_ctrls[i]->ftb->render) {
+			(*p->v_ctrls[i]->ftb->render)(p->v_ctrls[i], d, w, r);
+		}
+		++i;
+	}
+	if (p->border) {
+		color = sdlpui_get_color(w, SDLPUI_COLOR_MENU_BORDER);
+
+		SDL_SetRenderDrawColor(r, color->r, color->g, color->b,
+			color->a);
+		SDL_RenderDrawRect(r, &dst_r);
+	}
+	d->dirty = false;
+}
+
+
+static void goto_simple_menu_first_control(struct sdlpui_dialog *d,
+		struct sdlpui_window *w)
+{
+	struct sdlpui_simple_menu *p;
+	int i = 0;
+
+	SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
+	p = d->priv;
+
+	while (1) {
+		int comp_ind;
+
+		if (i >= p->n_vis) {
+			/* There's no members that can take focus. */
+			SDLPUI_EVENT_TRACER("dialog", d, "(not extracted)",
+				"gains key focus");
+			if (d->c_key && d->c_key->ftb->lose_key) {
+				(*d->c_key->ftb->lose_key)(d->c_key, d, w,
+					false);
+			}
+			d->c_key = NULL;
+			/* Anyways, still give the dialog key focus. */
+			sdlpui_dialog_gain_key_focus(w, d);
+			return;
+		}
+		comp_ind = (p->v_ctrls[i]->ftb->get_interactable_component) ?
+			(p->v_ctrls[i]->ftb->get_interactable_component)(
+				p->v_ctrls[i], true) : 0;
+		if (comp_ind) {
+			SDLPUI_EVENT_TRACER("dialog", d, "(not extracted)",
+				"gains key focus");
+			SDL_assert(p->v_ctrls[i]->ftb->gain_key);
+			(*p->v_ctrls[i]->ftb->gain_key)(
+				p->v_ctrls[i], d, w, comp_ind - 1);
+			if (d->c_key && d->c_key != p->v_ctrls[i]
+					&& d->c_key->ftb->lose_key) {
+				(*d->c_key->ftb->lose_key)(d->c_key, d, w,
+					false);
+			}
+			d->c_key = p->v_ctrls[i];
+			sdlpui_dialog_gain_key_focus(w, d);
+			return;
+		}
+		++i;
+	}
+}
+
+
+static void step_simple_menu_control(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, struct sdlpui_control *c,
+		bool forward)
+{
+	struct sdlpui_simple_menu *p;
+	int istart, itry;
+
+	SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
+	p = d->priv;
+	SDL_assert(c >= p->controls && c < p->controls + p->number);
+
+	if (c->ftb->step_within && (*c->ftb->step_within)(c, forward)) {
+		return;
+	}
+
+	istart = 0;
+	while (1) {
+		if (istart >= p->n_vis) {
+			/*
+			 * c should be an active control in the menu, but it is
+			 * not.
+			 */
+			SDL_assert(0);
+			return;
+		}
+		if (c == p->v_ctrls[istart]) {
+			break;
+		}
+		++istart;
+	}
+	itry = istart;
+	while (1) {
+		int comp_ind;
+
+		if (forward) {
+			++itry;
+			if (itry == p->n_vis) {
+				itry = 0;
+			}
+		} else {
+			--itry;
+			if (itry == -1) {
+				itry = p->n_vis - 1;
+			}
+		}
+		if (itry == istart) {
+			/*
+			 * Wrapped around without finding another control that
+			 * can accept focus.
+			 */
+			SDL_assert(d->c_key == c);
+			break;
+		}
+		comp_ind = (p->v_ctrls[itry]->ftb->get_interactable_component) ?
+			(*p->v_ctrls[itry]->ftb->get_interactable_component)(
+				p->v_ctrls[itry], forward) : 0;
+		if (comp_ind) {
+			if (d->c_key && d->c_key != p->v_ctrls[itry]
+					&& d->c_key->ftb->lose_key) {
+				(*d->c_key->ftb->lose_key)(d->c_key, d, w,
+					false);
+			}
+			if (p->v_ctrls[itry]->ftb->gain_key) {
+				(*p->v_ctrls[itry]->ftb->gain_key)(
+					p->v_ctrls[itry], d, w, comp_ind - 1);
+			}
+			d->c_key = p->v_ctrls[itry];
+			break;
+		}
+	}
+}
+
+
+static struct sdlpui_control *find_simple_menu_control_containing(
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		Sint32 x, Sint32 y, int *comp_ind)
+{
+	struct sdlpui_simple_menu *p;
+	int ilo, ihi;
+
+	SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
+	p = d->priv;
+
+	SDL_assert(p->n_vis >= 0);
+	if (p->n_vis == 0 || !sdlpui_is_in_dialog(d, x, y)) {
+		*comp_ind = 0;
+		return NULL;
+	}
+
+	/* Make the coordinates relative to the dialog. */
+	x -= d->rect.x;
+	y -= d->rect.y;
+
+	/* Use a binary search to locate the control */
+	ilo = 0;
+	ihi = p->n_vis;
+	while (1) {
+		int imid;
+
+		if (ilo == ihi - 1) {
+			if (x < p->v_ctrls[ilo]->rect.x
+					|| x >= p->v_ctrls[ilo]->rect.x
+						+ p->v_ctrls[ilo]->rect.w
+					|| y < p->v_ctrls[ilo]->rect.y
+					|| y >= p->v_ctrls[ilo]->rect.y
+						+ p->v_ctrls[ilo]->rect.h) {
+				*comp_ind = 0;
+				return NULL;
+			}
+			if (p->v_ctrls[ilo]->ftb->get_interactable_component_at) {
+				int ind = (*p->v_ctrls[ilo]->ftb->get_interactable_component_at)(
+					p->v_ctrls[ilo], x, y);
+
+				if (ind == 0) {
+					*comp_ind = 0;
+					return NULL;
+				}
+				*comp_ind = ind - 1;
+			} else if (!p->v_ctrls[ilo]->ftb->get_interactable_component
+					|| !(*p->v_ctrls[ilo]->ftb->get_interactable_component)(p->v_ctrls[ilo], true)) {
+				*comp_ind = 0;
+				return NULL;
+			} else {
+				*comp_ind = 0;
+			}
+			return p->v_ctrls[ilo];
+		}
+		imid = (ilo + ihi) / 2;
+		if (p->vertical) {
+			if (p->v_ctrls[imid]->rect.y > y) {
+				ihi = imid;
+				continue;
+			}
+			if (p->v_ctrls[imid]->rect.y + p->v_ctrls[imid]->rect.h
+					<= y) {
+				ilo = imid;
+				continue;
+			}
+			if (x < p->v_ctrls[imid]->rect.x
+					|| x >= p->v_ctrls[imid]->rect.x
+						+ p->v_ctrls[imid]->rect.w) {
+				*comp_ind = 0;
+				return NULL;
+			}
+		} else {
+			if (p->v_ctrls[imid]->rect.x > x) {
+				ihi = imid;
+				continue;
+			}
+			if (p->v_ctrls[imid]->rect.x + p->v_ctrls[imid]->rect.w
+					<= x) {
+				ilo = imid;
+				continue;
+			}
+			if (y < p->v_ctrls[imid]->rect.y
+					|| y >= p->v_ctrls[imid]->rect.y
+						+ p->v_ctrls[imid]->rect.h) {
+				*comp_ind = 0;
+				return NULL;
+			}
+		}
+		if (p->v_ctrls[imid]->ftb->get_interactable_component_at) {
+			int ind = (*p->v_ctrls[imid]->ftb->get_interactable_component_at)(
+				p->v_ctrls[imid], x, y);
+
+			if (ind == 0) {
+				*comp_ind = 0;
+				return NULL;
+			}
+			*comp_ind = ind - 1;
+		} else if (!p->v_ctrls[imid]->ftb->get_interactable_component
+				|| !(*p->v_ctrls[imid]->ftb->get_interactable_component)(p->v_ctrls[imid], true)) {
+			*comp_ind = 0;
+			return NULL;
+		} else {
+			*comp_ind = 0;
+		}
+		return p->v_ctrls[imid];
+	}
+}
+
+
+static struct sdlpui_dialog *get_simple_menu_parent(struct sdlpui_dialog *d)
+{
+	struct sdlpui_simple_menu *p;
+
+	SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
+	p = d->priv;
+	return p->parent;
+}
+
+
+static struct sdlpui_dialog *get_simple_menu_child(struct sdlpui_dialog *d)
+{
+	struct sdlpui_simple_menu *p;
+
+	SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
+	p = d->priv;
+	return p->child;
+}
+
+
+static struct sdlpui_control *get_simple_menu_parent_ctrl(
+		struct sdlpui_dialog *d)
+{
+	struct sdlpui_simple_menu *p;
+
+	SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
+	p = d->priv;
+	return p->parent_ctrl;
+}
+
+
+static void set_simple_menu_child(struct sdlpui_dialog *d,
+		struct sdlpui_dialog *child)
+{
+	struct sdlpui_simple_menu *p;
+
+	SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
+	p = d->priv;
+	p->child = child;
+}
+
+
+/*
+ * Requires that the height (if the menu is vertical) or width (if the menu is
+ * horizontal) is at least as large as the minimum returned by
+ * query_simple_menu_minimum_size().
+ */
+static void resize_simple_menu(struct sdlpui_dialog *d, struct sdlpui_window *w,
+		int width, int height)
+{
+	struct sdlpui_simple_menu *p;
+	bool *vis;
+	int i, ivis, first_end, work;
+
+	SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
+	p = d->priv;
+
+	/*
+	 * First pass:  determine which buttons will definitely be visible
+	 * and the boundary between the buttons attached to the front and
+	 * the buttons attached to the end
+	 */
+	vis = SDL_calloc(p->number, sizeof(*vis));
+	first_end = p->number;
+	work = 0;
+	for (i = 0; i < p->number; ++i) {
+		int cw, ch;
+
+		if (p->control_flags[i] & SDLPUI_MFLG_END_GRAVITY) {
+			if (first_end == p->number) {
+				first_end = i;
+			}
+		} else {
+			/*
+			 * Fail if there's more than one boundary between
+			 * the buttons with different gravities.
+			 */
+			SDL_assert(first_end == p->number);
+		}
+		if ((p->control_flags[i] & SDLPUI_MFLG_CAN_HIDE)) {
+			continue;
+		}
+		vis[i] = true;
+		(*p->controls[i].ftb->query_natural_size)(&p->controls[i],
+			d, w, &cw, &ch);
+		if (p->vertical) {
+			work += ch;
+			SDL_assert(work <= height);
+		} else {
+			work += cw;
+			SDL_assert(work <= width);
+		}
+	}
+
+	/*
+	 * Second pass:  make others visible up to the size imposed;
+	 * give preference to those earlier in the array of controls
+	 */
+	for (i = 0; i < p->number; ++i) {
+		int cw, ch;
+
+		if (!(p->control_flags[i] & SDLPUI_MFLG_CAN_HIDE)) {
+			continue;
+		}
+		(*p->controls[i].ftb->query_natural_size)(&p->controls[i],
+			d, w, &cw, &ch);
+		if (p->vertical) {
+			if (work + ch > height) {
+				break;
+			}
+			work += ch;
+		} else {
+			if (work + cw > width) {
+				break;
+			}
+			work += cw;
+		}
+		vis[i] = true;
+	}
+
+	/*
+	 * Third pass:  fill in v_ctrls and assign positions to all of the
+	 * visible controls that are anchored to the front of the menu.
+	 */
+	work = 0;
+	ivis = 0;
+	for (i = 0; i < first_end; ++i) {
+		int cw, ch;
+
+		if (!vis[i]) {
+			continue;
+		}
+		p->v_ctrls[ivis] = &p->controls[i];
+		++ivis;
+		(*p->controls[i].ftb->query_natural_size)(&p->controls[i],
+			d, w, &cw, &ch);
+		if (p->vertical) {
+			p->controls[i].rect.x = 0;
+			p->controls[i].rect.y = work;
+			work += ch;
+			if (p->controls[i].ftb->resize) {
+				(*p->controls[i].ftb->resize)(&p->controls[i],
+					d, w, width, ch);
+			} else {
+				p->controls[i].rect.w = width;
+				p->controls[i].rect.h = ch;
+			}
+		} else {
+			p->controls[i].rect.x = work;
+			p->controls[i].rect.y = 0;
+			work += cw;
+			if (p->controls[i].ftb->resize) {
+				(*p->controls[i].ftb->resize)(&p->controls[i],
+					d, w, cw, height);
+			} else {
+				p->controls[i].rect.w = cw;
+				p->controls[i].rect.h = height;
+			}
+		}
+	}
+
+	/*
+	 * Fourth pass:  fill in v_ctrls for the visible controls anchored to
+	 * the end of the menu.
+	 */
+	for (i = first_end; i < p->number; ++i) {
+		if (!vis[i]) {
+			continue;
+		}
+		p->v_ctrls[ivis] = &p->controls[i];
+		++ivis;
+	}
+	p->n_vis = ivis;
+
+	/*
+	 * Fifth pass:  assign positions to all of the visible controls
+	 * that are anchored to the end of the menu.
+	 */
+	i = p->number;
+	work = (p->vertical) ? height : width;
+	while (i > first_end) {
+		int cw, ch;
+
+		--i;
+		if (!vis[i]) {
+			continue;
+		}
+		(*p->controls[i].ftb->query_natural_size)(&p->controls[i],
+			d, w, &cw, &ch);
+		if (p->vertical) {
+			work -= ch;
+			p->controls[i].rect.x = 0;
+			p->controls[i].rect.y = work;
+			if (p->controls[i].ftb->resize) {
+				(*p->controls[i].ftb->resize)(&p->controls[i],
+					d, w, width, ch);
+			} else {
+				p->controls[i].rect.w = width;
+				p->controls[i].rect.h = ch;
+			}
+		} else {
+			work -= cw;
+			p->controls[i].rect.x = work;
+			p->controls[i].rect.y = 0;
+			if (p->controls[i].ftb->resize) {
+				(*p->controls[i].ftb->resize)(&p->controls[i],
+					d, w, cw, height);
+			} else {
+				p->controls[i].rect.w = cw;
+				p->controls[i].rect.h = height;
+			}
+		}
+	}
+
+	SDL_free(vis);
+	d->rect.w = width;
+	d->rect.h = height;
+}
+
+
+static void query_simple_menu_natural_size(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, int *width, int *height)
+{
+	struct sdlpui_simple_menu *p;
+	int i;
+
+	SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
+	p = d->priv;
+
+	*width = 0;
+	*height = 0;
+	for (i = 0; i < p->number; ++i) {
+		int cw, ch;
+
+		SDL_assert(p->controls[i].ftb->query_natural_size);
+		(*p->controls[i].ftb->query_natural_size)(&p->controls[i], d, w,
+			&cw, &ch);
+		if (p->vertical) {
+			if (*width < cw) {
+				*width = cw;
+			}
+			*height += ch;
+		} else {
+			*width += cw;
+			if (*height < ch) {
+				*height = ch;
+			}
+		}
+	}
+}
+
+
+static void query_simple_menu_minimum_size(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, int *width, int *height)
+{
+	struct sdlpui_simple_menu *p;
+	int i;
+
+	SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
+	p = d->priv;
+
+	*width = 0;
+	*height = 0;
+	for (i = 0; i < p->number; ++i) {
+		int cw, ch;
+
+		if (p->control_flags[i] & SDLPUI_MFLG_CAN_HIDE) {
+			continue;
+		}
+		SDL_assert(p->controls[i].ftb->query_natural_size);
+		(*p->controls[i].ftb->query_natural_size)(&p->controls[i], d, w,
+			&cw, &ch);
+		if (p->vertical) {
+			if (*width < cw) {
+				*width = cw;
+			}
+			*height += ch;
+		} else {
+			*width += cw;
+			if (*height < ch) {
+				*height = ch;
+			}
+		}
+	}
+}
+
+
+static void cleanup_simple_menu(struct sdlpui_dialog *d)
+{
+	struct sdlpui_simple_menu *p;
+	int i;
+
+	SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
+	p = d->priv;
+
+	for (i = 0; i < p->number; ++i) {
+		if (p->controls[i].ftb->cleanup) {
+			(*p->controls[i].ftb->cleanup)(&p->controls[i]);
+		}
+	}
+	SDL_free(p->controls);
+	SDL_free(p->v_ctrls);
+	SDL_free(p->control_flags);
+	SDL_free(p);
+}
+
+
+static void render_simple_info(struct sdlpui_dialog *d,
+		struct sdlpui_window *w)
+{
+	SDL_Renderer *r = sdlpui_get_renderer(w);
+	SDL_Rect dst_r = d->rect;
+	struct sdlpui_simple_info *id;
+	const SDL_Color *color;
+	int i;
+
+	SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_INFO && d->priv);
+	id = d->priv;
+	SDLPUI_RENDER_TRACER("simple info", d, "(not extracted)", d->rect,
+		d->rect, d->texture);
+
+	SDL_SetRenderTarget(r, d->texture);
+	color = sdlpui_get_color(w, SDLPUI_COLOR_DIALOG_BG);
+	SDL_SetRenderDrawColor(r, color->r, color->g, color->b, color->a);
+	if (d->texture) {
+		SDL_RenderClear(r);
+		dst_r.x = 0;
+		dst_r.y = 0;
+	} else {
+		SDL_RenderFillRect(r, &dst_r);
+	}
+	for (i = 0; i < id->number; ++i) {
+		if (id->labels[i].ftb->render) {
+			(*id->labels[i].ftb->render)(&id->labels[i], d, w, r);
+		}
+	}
+	if (id->button.ftb->render) {
+		(*id->button.ftb->render)(&id->button, d, w, r);
+	}
+	/* Give it a border. */
+	color = sdlpui_get_color(w, SDLPUI_COLOR_DIALOG_BORDER);
+	SDL_RenderDrawRect(r, &dst_r);
+	color = sdlpui_get_color(w, SDLPUI_COLOR_COUNTERSINK);
+	++dst_r.x;
+	++dst_r.y;
+	dst_r.w -= 2;
+	dst_r.h -= 2;
+	SDL_RenderDrawRect(r, &dst_r);
+	d->dirty = false;
+}
+
+
+static void goto_simple_info_first_control(struct sdlpui_dialog *d,
+		struct sdlpui_window *w)
+{
+	struct sdlpui_simple_info *id;
+
+	SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_INFO && d->priv);
+	id = d->priv;
+
+	SDL_assert(id->button.ftb->gain_key);
+	(*id->button.ftb->gain_key)(&id->button, d, w, 0);
+	SDL_assert(!d->c_key || d->c_key == &id->button);
+	d->c_key = &id->button;
+	sdlpui_dialog_gain_key_focus(w, d);
+}
+
+
+static struct sdlpui_control *find_simple_info_control_containing(
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		Sint32 x, Sint32 y, int *comp_ind)
+{
+	struct sdlpui_simple_info *id;
+
+	SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_INFO && d->priv);
+	id = d->priv;
+
+	*comp_ind = 0;
+	return (sdlpui_is_in_control(&id->button, d, x, y)) ?
+		&id->button : NULL;
+}
+
+
+static void resize_simple_info(struct sdlpui_dialog *d, struct sdlpui_window *w,
+		int width, int height)
+{
+	struct sdlpui_simple_info *psi;
+	int i, y, ch, cw;
+
+	SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_INFO);
+	psi = (struct sdlpui_simple_info*)d->priv;
+#if NDEBUG
+	{
+		int dw, dh;
+
+		query_simple_info_natural_size(d, w, &dw, &dh);
+		SDL_assert(width >= dw && height >= dh);
+	}
+#endif
+
+	y = 0;
+	for (i = 0; i < psi->number; ++i) {
+		(*psi->labels[i].ftb->query_natural_size)(&psi->labels[i],
+			d, w, &cw, &ch);
+		if (psi->labels[i].ftb->resize) {
+			(*psi->labels[i].ftb->resize)(&psi->labels[i], d, w,
+				width, ch);
+		} else {
+			psi->labels[i].rect.w = width;
+			psi->labels[i].rect.h = ch;
+		}
+		psi->labels[i].rect.x = 0;
+		psi->labels[i].rect.y = y;
+		y += ch;
+	}
+	(*psi->button.ftb->query_natural_size)(&psi->button, d, w, &cw, &ch);
+	if (psi->button.ftb->resize) {
+		(*psi->button.ftb->resize)(&psi->button, d, w, cw, ch);
+	} else {
+		psi->button.rect.w = cw;
+		psi->button.rect.h = ch;
+	}
+	SDL_assert(width >= cw);
+	psi->button.rect.x = (width - cw) / 2;
+	SDL_assert(y < height - ch);
+	psi->button.rect.y = height - ch;
+	d->rect.w = width;
+	d->rect.h = height;
+}
+
+
+static void query_simple_info_natural_size(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, int *width, int *height)
+{
+	int dw = 0, dh = 0, cw, ch, i;
+	struct sdlpui_simple_info *psi;
+
+	SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_INFO);
+	psi = (struct sdlpui_simple_info*)d->priv;
+	for (i = 0; i < psi->number; ++i) {
+		(*psi->labels[i].ftb->query_natural_size)(&psi->labels[i],
+			d, w, &cw, &ch);
+		dw = (dw >= cw) ? dw : cw;
+		dh += ch;
+	}
+	(*psi->button.ftb->query_natural_size)(&psi->button, d, w, &cw, &ch);
+	dw = (dw >= cw) ? dw : cw;
+	/* Leave space between the labels and the button. */
+	dh += ch + ch;
+	*width = dw;
+	*height = dh;
+}
+
+
+static void cleanup_simple_info(struct sdlpui_dialog *d)
+{
+	struct sdlpui_simple_info *id;
+	int i;
+
+	SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_INFO && d->priv);
+	id = d->priv;
+
+	for (i = 0; i < id->number; ++i) {
+		if (id->labels[i].ftb->cleanup) {
+			(*id->labels[i].ftb->cleanup)(&id->labels[i]);
+		}
+	}
+	SDL_free(id->labels);
+	SDL_free(id);
+}
+
+
+/**
+ * Determine if a given coordinate, relative to the window, is in a dialog.
+ *
+ * \param d is the dialog of interest.
+ * \param x is the horizontal coordinate, relative to the window's upper left
+ * corner, to test.
+ * \param y is the vertical coordinate, relative to the window's upper left
+ * corner, to test.
+ * \return true if (x, y) is in the control and false otherwise.
+ */
+bool sdlpui_is_in_dialog(const struct sdlpui_dialog *d, Sint32 x, Sint32 y)
+{
+	if (x < d->rect.x || y < d->rect.y || x >= d->rect.x + d->rect.w
+			|| y >= d->rect.y + d->rect.h) {
+		return false;
+	}
+	return true;
+}
+
+
+/**
+ * Pop up a dialog.
+ *
+ * \param d is the dialog of interest.
+ * \param w is the window containing the dialog.
+ * \param give_key_focus, if true, causes the dialog to be given key focus
+ * when it is popped up.
+ */
+void sdlpui_popup_dialog(struct sdlpui_dialog *d, struct sdlpui_window *w,
+		bool give_key_focus)
+{
+	/* Assume it may have been obscured and needs to be redrawn. */
+	d->dirty = true;
+	sdlpui_dialog_push_to_top(w, d);
+	if (give_key_focus) {
+		sdlpui_dialog_gain_key_focus(w, d);
+	}
+}
+
+
+/**
+ * Remove the dialog, any of its child dialogs, and, if all_parents is true,
+ * any of its parents up to the first parent that is pinned.
+ *
+ * \param d is the dialog to remove.
+ * \param w is the window containing the dialog.
+ * \param all_parents will cause all of the parents, up to the first parent
+ * that is pinned, if true.
+ */
+void sdlpui_popdown_dialog(struct sdlpui_dialog *d, struct sdlpui_window *w,
+		bool all_parents)
+{
+	struct sdlpui_dialog *stopping_point = (all_parents) ?
+		NULL : sdlpui_get_dialog_parent(d);
+
+	while (1) {
+		struct sdlpui_dialog *child = sdlpui_get_dialog_child(d);
+
+		if (!child) {
+			break;
+		}
+		d = child;
+	}
+
+	while (1) {
+		struct sdlpui_dialog *parent = sdlpui_get_dialog_parent(d);
+		struct sdlpui_control *parent_ctrl =
+			sdlpui_get_dialog_parent_ctrl(d);
+
+		if (d->pop_callback) {
+			(*d->pop_callback)(d, w, false);
+		}
+		sdlpui_dialog_pop(w, d);
+		if (parent_ctrl && parent_ctrl->ftb->lose_child) {
+			(*parent_ctrl->ftb->lose_child)(parent_ctrl, d);
+		}
+		if (parent) {
+			SDL_assert(parent->ftb->set_child);
+			(*parent->ftb->set_child)(parent, NULL);
+
+			/*
+			 * If the parent control has key focus but not mouse
+			 * focus, lose that focus when the child is lost.
+			 */
+			if (parent_ctrl && parent->c_key == parent_ctrl
+					&& parent->c_mouse != parent_ctrl
+					&& parent_ctrl->ftb->lose_key) {
+				(*parent_ctrl->ftb->lose_key)(parent_ctrl,
+					parent, w, false);
+			}
+		}
+		if (d->ftb->cleanup) {
+			(*d->ftb->cleanup)(d);
+		}
+		SDL_free(d);
+
+		if (parent == stopping_point || (parent && parent->pinned)) {
+			break;
+		}
+		d = parent;
+	}
+}
+
+
+/**
+ * Give the keyboard focus for a dialog or menu to its parent.  If there is no
+ * parent and the dialog is not pinned, acts like sdlpui_popdown_dialog(d, w,
+ * false).
+ *
+ * \param d is the dialog that's ceding focus.
+ * \param w is the window containing the dialog.
+ */
+void sdlpui_dialog_give_key_focus_to_parent(struct sdlpui_dialog *d,
+		struct sdlpui_window *w)
+{
+	struct sdlpui_dialog *parent = sdlpui_get_dialog_parent(d);
+
+	if (parent) {
+		if (d->c_key != NULL && d->c_key->ftb->lose_key) {
+			(*d->c_key->ftb->lose_key)(d->c_key, d, w, false);
+		}
+		d->c_key = NULL;
+		SDLPUI_EVENT_TRACER("dialog", d,
+			"(not extracted)", "yields key focus");
+		sdlpui_dialog_yield_key_focus(w, d);
+		SDLPUI_EVENT_TRACER("dialog", parent,
+			"(not extracted)", "gains key focus");
+		sdlpui_dialog_gain_key_focus(w, parent);
+	} else {
+		SDLPUI_EVENT_TRACER("dialog", d,
+			"(not extracted)", "yields key focus");
+		sdlpui_dialog_yield_key_focus(w, d);
+		if (!d->pinned) {
+			SDLPUI_EVENT_TRACER("dialog", d,
+				"(not extracted)", "popping down");
+			sdlpui_popdown_dialog(d, w, false);
+		}
+	}
+}
+
+
+/**
+ * For a nested menu/dialog, return its parent.
+ *
+ * \param d is the dialog to query.
+ * \return the parent.  That will be NULL if the menu/dialog does not have
+ * a parent.
+ */
+struct sdlpui_dialog *sdlpui_get_dialog_parent(struct sdlpui_dialog *d)
+{
+	return (d->ftb->get_parent) ? (*d->ftb->get_parent)(d) : NULL;
+}
+
+
+/**
+ * For a nested menu/dialog, return its child.
+ *
+ * \param d is the dialog to query.
+ * \return the child.  That will be NULL if the menu/dialog does not have
+ * a child.
+ */
+struct sdlpui_dialog *sdlpui_get_dialog_child(struct sdlpui_dialog *d)
+{
+	return (d->ftb->get_child) ? (*d->ftb->get_child)(d) : NULL;
+}
+
+
+/**
+ * For a nested menu/dialog, return its parent control.
+ *
+ * \param d is the dialog to query.
+ * \return the parent control for the dialog.  That will be NULL if the
+ * menu/dialog is not a nested menu.
+ */
+struct sdlpui_control *sdlpui_get_dialog_parent_ctrl(struct sdlpui_dialog *d)
+{
+	return (d->ftb->get_parent_ctrl) ? (*d->ftb->get_parent_ctrl)(d) : NULL;
+}
+
+
+/**
+ * Perform basic handling of a keyboard event for a dialog or menu.
+ *
+ * \param d is the dialog or menu.
+ * \param w is the window containing the dialog or menu.
+ * \param e is the event to handle.
+ * \return true if the event is handled and doesn't need further processing by
+ * the window; otherwise return false.
+ */
+bool sdlpui_dialog_handle_key(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_KeyboardEvent *e)
+{
+	SDL_Keymod mods;
+
+	/* Relay to the control with focus.  If it handles it, we are done. */
+	if (d->c_key && d->c_key->ftb->handle_key
+			&& (*d->c_key->ftb->handle_key)(d->c_key, d, w, e)) {
+		return true;
+	}
+
+	mods = sdlpui_get_interesting_keymods();
+	switch (e->keysym.sym) {
+	case SDLK_ESCAPE:
+		if (e->state == SDL_RELEASED && mods == KMOD_NONE) {
+			while (1) {
+				struct sdlpui_dialog *child =
+					sdlpui_get_dialog_child(d);
+
+				if (!child) {
+					break;
+				}
+				d = child;
+			}
+			if (!d->pinned) {
+				SDLPUI_EVENT_TRACER("dialog", d,
+					"(not extracted)", "popping down");
+				sdlpui_popdown_dialog(d, w, true);
+			}
+		}
+		break;
+
+	case SDLK_RETURN:
+		if (e->state == SDL_RELEASED && mods == KMOD_NONE
+				&& d->ftb->respond_default) {
+			SDLPUI_EVENT_TRACER("dialog", d, "(not extracted)",
+				"invoking default response");
+			(*d->ftb->respond_default)(d, w);
+		}
+		break;
+
+	case SDLK_TAB:
+		if (e->state == SDL_RELEASED
+				&& (mods & ~(KMOD_SHIFT | KMOD_CTRL))
+				== KMOD_NONE) {
+			if (!d->c_key) {
+				if (d->ftb->goto_first_control) {
+					(*d->ftb->goto_first_control)(d, w);
+				}
+			} else if (d->ftb->step_control) {
+				(*d->ftb->step_control)(d, w, d->c_key,
+					(mods & (KMOD_SHIFT)) == 0);
+			}
+		}
+		break;
+	}
+
+	/* Swallow the event, even if nothing was done. */
+	return true;
+}
+
+
+/**
+ * Perform basic handling of a text input event for a dialog or menu.
+ *
+ * \param d is the dialog or menu.
+ * \param w is the window containing the dialog or menu.
+ * \param e is the event to handle.
+ * \return true if the event is handled and doesn't need further processing by
+ * the window; otherwise return false.
+ */
+bool sdlpui_dialog_handle_textin(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_TextInputEvent *e)
+{
+	/* Relay to the control with focus.  If it handles it, we are done. */
+	if (d->c_key && d->c_key->ftb->handle_textin
+			&& (*d->c_key->ftb->handle_textin)(d->c_key, d, w, e)) {
+		return true;
+	}
+
+	/* Do nothing and swallow the event. */
+	return true;
+}
+
+
+/**
+ * Perform basic handling of a text editing event for a dialog or menu.
+ *
+ * \param d is the dialog or menu.
+ * \param w is the window containing the dialog or menu.
+ * \param e is the event to handle.
+ * \return true if the event is handled and doesn't need further processing by
+ * the window; otherwise return false.
+ */
+bool sdlpui_dialog_handle_textedit(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_TextEditingEvent *e)
+{
+	/* Relay to the control with focus.  If it handles it, we are done. */
+	if (d->c_key && d->c_key->ftb->handle_textedit
+			&& (*d->c_key->ftb->handle_textedit)(
+				d->c_key, d, w, e)) {
+		return true;
+	}
+
+	/* Do nothing and swallow the event. */
+	return true;
+}
+
+
+/**
+ * Perform basic handling of a mouse button event for a dialog.
+ *
+ * \param d is the dialog.
+ * \param w is the window containing the dialog.
+ * \param e is the event to handle.
+ * \return true if the event is handled and doesn't need further processing by
+ * the window; otherwise return false.
+ */
+bool sdlpui_dialog_handle_mouseclick(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_MouseButtonEvent *e)
+{
+	/* Relay to the control with focus.  If it handles it, we are done. */
+	if (d->c_mouse && d->c_mouse->ftb->handle_mouseclick
+			&& (*d->c_mouse->ftb->handle_mouseclick)(
+				d->c_mouse, d, w, e)) {
+		return true;
+	}
+
+	/* Do nothing and swallow the event. */
+	return true;
+}
+
+
+/**
+ * Perform basic handling of a mouse button event for a menu.
+ *
+ * \param d is the menu.
+ * \param w is the window containing the menu.
+ * \param e is the event to handle.
+ * \return true if the event is handled and doesn't need further processing by
+ * the window; otherwise return false.
+ */
+bool sdlpui_menu_handle_mouseclick(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_MouseButtonEvent *e)
+{
+	/* Relay to the control with focus.  If it handles it, we are done. */
+	if (d->c_mouse && d->c_mouse->ftb->handle_mouseclick
+			&& (*d->c_mouse->ftb->handle_mouseclick)(
+				d->c_mouse, d, w, e)) {
+		return true;
+	}
+
+	/*
+	 * Button events while the mouse is outside the menu will act as if
+	 * the menu lost mouse focus to another dialog.
+	 */
+	if (!sdlpui_is_in_dialog(d, e->x, e->y)) {
+		sdlpui_menu_handle_loses_mouse(d, w, NULL);
+		return true;
+	}
+
+	/* Do nothing and swallow the event. */
+	return true;
+}
+
+
+/**
+ * Perform basic handling of a mouse motion event for a menu or dialog.
+ *
+ * \param d is the menu or dialog.
+ * \param w is the window containing the menu or dialog.
+ * \param e is the event to handle.
+ * \return true if the event is handled and doesn't need further processing by
+ * the window; otherwise return false.
+ */
+bool sdlpui_dialog_handle_mousemove(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e)
+{
+	struct sdlpui_control *c_mouse, *c;
+	int comp_ind;
+
+	/* Relay to the control with focus.  If it handles it, we are done. */
+	c_mouse = d->c_mouse;
+	if (d->c_mouse && d->c_mouse->ftb->handle_mousemove
+			&& (*d->c_mouse->ftb->handle_mousemove)(
+				d->c_mouse, d, w, e)) {
+		return true;
+	}
+
+	/*
+	 * Ignore motion events while a mouse button is pressed (at least up
+	 * to the point that the mouse leaves the window).
+	 */
+	if (e->state != 0) {
+		return true;
+	}
+
+	/*
+	 * Otherwise, see if the mouse has entered another control in the
+	 * dialog.  If it has, give focus to that control.
+	 */
+	c = (d->ftb->find_control_containing) ?
+		(*d->ftb->find_control_containing)(d, w, e->x, e->y, &comp_ind) :
+		NULL;
+	if (c) {
+		SDL_assert(!d->c_mouse);
+
+		if (c->ftb->gain_mouse) {
+			SDLPUI_EVENT_TRACER("control", c, "(not extracted)",
+				"gains mouse focus");
+			(*c->ftb->gain_mouse)(c, d, w, comp_ind);
+		}
+	}
+	d->c_mouse = c;
+	/* Have keyboard focus follow the mouse. */
+	if (d->c_key != c) {
+		if (d->c_key && d->c_key->ftb->lose_key) {
+			SDLPUI_EVENT_TRACER("control", d->c_key,
+				"(not extracted)", "loses key focus");
+			(*d->c_key->ftb->lose_key)(d->c_key, d, w,
+				c_mouse == d->c_key);
+		}
+		if (c && c->ftb->gain_key) {
+			SDLPUI_EVENT_TRACER("control", c, "(not extracted)",
+				"gains key focus");
+			(c->ftb->gain_key)(c, d, w, comp_ind);
+		}
+		d->c_key = c;
+	}
+	if (c || sdlpui_is_in_dialog(d, e->x, e->y)) {
+		SDLPUI_EVENT_TRACER("dialog", d, "(not extracted)",
+			"gains mouse focus");
+		SDLPUI_EVENT_TRACER("dialog", d, "(not extracted)",
+			"gains key focus");
+		sdlpui_dialog_gain_mouse_focus(w, d);
+		sdlpui_dialog_gain_key_focus(w, d);
+		return true;
+	}
+
+	/*
+	 * Let the window handle the mouse motion.  For now keep focus though
+	 * moving into another dialog could cause it to be lost.
+	 */
+	return false;
+}
+
+
+/**
+ * Perform basic handling of a mouse wheel event for a dialog or menu.
+ *
+ * \param d is the dialog or menu.
+ * \param w is the window containing the dialog or menu.
+ * \param e is the event to handle.
+ * \return true if the event is handled and doesn't need further processing by
+ * the window; otherwise return false.
+ */
+bool sdlpui_dialog_handle_mousewheel(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_MouseWheelEvent *e)
+{
+	/* Relay to the control with focus.  If it handles it, we're done. */
+	if (d->c_mouse && d->c_mouse->ftb->handle_mousewheel
+			&& (*d->c_mouse->ftb->handle_mousewheel)(
+				d->c_mouse, d, w, e)) {
+		return true;
+	}
+
+	/* Do nothing and swallow the event. */
+	return true;
+}
+
+
+/**
+ * This is a synonym for sdlpui_popdown_dialog(d, w, false), usable as the
+ * respond_default hook for a dialog.
+ *
+ * \param d is the dialog or menu to pop down.
+ * \param w is the window containing the dialog or menu.
+ */
+void sdlpui_dismiss_dialog(struct sdlpui_dialog *d, struct sdlpui_window *w)
+{
+	SDLPUI_EVENT_TRACER("dialog", d, "(not extracted)",
+		"popping down dialog");
+	sdlpui_popdown_dialog(d, w, false);
+}
+
+
+/**
+ * Respond to the mouse leaving the containing window.
+ *
+ * \param d is the dialog.
+ * \param w is the window containing the dialog.
+ */
+void sdlpui_dialog_handle_window_loses_mouse(struct sdlpui_dialog *d,
+		struct sdlpui_window *w)
+{
+	if (d->c_mouse) {
+		if (d->c_mouse->ftb->disarm) {
+			(*d->c_mouse->ftb->disarm)(d->c_mouse, d, w,
+				SDLPUI_ACTION_HINT_NONE);
+		}
+		if (d->c_mouse->ftb->lose_mouse) {
+			(*d->c_mouse->ftb->lose_mouse)(d->c_mouse, d, w, NULL);
+		}
+		/* Key focus follows mouse. */
+		if (d->c_key == d->c_mouse && d->c_mouse->ftb->lose_key) {
+			(*d->c_mouse->ftb->lose_key)(d->c_mouse, d, w, true);
+		}
+	}
+	/* Key focus follows mouse. */
+	if (d->c_key && d->c_key != d->c_mouse) {
+		if (d->c_key->ftb->disarm) {
+			(*d->c_key->ftb->disarm)(d->c_key, d, w,
+				SDLPUI_ACTION_HINT_NONE);
+		}
+		if (d->c_key->ftb->lose_key) {
+			(*d->c_key->ftb->lose_key)(d->c_key, d, w, false);
+		}
+	}
+	d->c_mouse = NULL;
+	d->c_key = NULL;
+	sdlpui_dialog_yield_mouse_focus(w, d);
+	sdlpui_dialog_yield_key_focus(w, d);
+}
+
+
+/**
+ * Respond to the mouse leaving the containing window for a pulldown/popup menu.
+ *
+ * \param d is the menu.
+ * \param w is the window containing the menu.
+ */
+void sdlpui_menu_handle_window_loses_mouse(struct sdlpui_dialog *d,
+		struct sdlpui_window *w)
+{
+	struct sdlpui_dialog *deepest = d;
+
+	while (1) {
+		struct sdlpui_dialog *child = sdlpui_get_dialog_child(deepest);
+
+		if (!child) {
+			break;
+		}
+		deepest = child;
+	}
+	if (!deepest->pinned) {
+		sdlpui_popdown_dialog(deepest, w, true);
+	} else {
+		sdlpui_dialog_handle_window_loses_mouse(d, w);
+	}
+}
+
+
+/**
+ * Respond to the containing window losing key focus.
+ *
+ * \param d is the dialog.
+ * \param w is the window containing the dialog or menu.
+ */
+void sdlpui_dialog_handle_window_loses_key(struct sdlpui_dialog *d,
+		struct sdlpui_window *w)
+{
+	if (d->c_key) {
+		if (d->c_key->ftb->disarm) {
+			(*d->c_key->ftb->disarm)(d->c_key, d, w,
+				SDLPUI_ACTION_HINT_KEY);
+		}
+		if (d->c_key->ftb->lose_key) {
+			(*d->c_key->ftb->lose_key)(d->c_key, d, w, false);
+		}
+	}
+	d->c_key = NULL;
+	sdlpui_dialog_yield_key_focus(w, d);
+}
+
+
+/**
+ * Respond to the containing window losing key focus for a pulldown/popup menu.
+ *
+ * \param d is the menu.
+ * \param w is the window containing the menu.
+ */
+void sdlpui_menu_handle_window_loses_key(struct sdlpui_dialog *d,
+		struct sdlpui_window *w)
+{
+	/*
+	 * Dimiss all the child dialogs up to the one which has mouse focus
+	 * or has a parent control with mouse focus.  If the dialog itself
+	 * is not dismissed in that process, treat it like a generic dialog
+	 * when the window loses key focus.
+	 */
+	struct sdlpui_dialog *deepest = d;
+
+	while (1) {
+		struct sdlpui_dialog *child = sdlpui_get_dialog_child(deepest);
+
+		if (!child) {
+			break;
+		}
+		deepest = child;
+	}
+	while (1) {
+		struct sdlpui_dialog *parent;
+		struct sdlpui_control *parent_ctrl;
+
+		parent = sdlpui_get_dialog_parent(deepest);
+		parent_ctrl = sdlpui_get_dialog_parent_ctrl(deepest);
+		if (deepest->pinned || deepest->c_mouse
+				|| (parent && parent->c_mouse == parent_ctrl)) {
+			if (deepest == d) {
+				sdlpui_dialog_handle_window_loses_key(d, w);
+			}
+			break;
+		}
+		sdlpui_popdown_dialog(deepest, w, false);
+		if (!parent || deepest == d) {
+			break;
+		}
+		deepest = parent;
+	}
+}
+
+
+/**
+ * Respond to another dialog or menu taking mouse focus from this dialog.
+ *
+ * \param d is the dialog.
+ * \param w is the window containing the menu.
+ * \param e is the mouse motion event causing the other dialog to take focus.
+ * May be NULL if not available.
+ */
+void sdlpui_dialog_handle_loses_mouse(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e)
+{
+	/*
+	 * Gets the same treatment as if the mouse left the window containing
+	 * the dialog.
+	 */
+	sdlpui_dialog_handle_window_loses_mouse(d, w);
+}
+
+
+/**
+ * Respond to another dialog or menu taking mouse focus from this pulldown/popup
+ * menu.
+ *
+ * \param d is the dialog.
+ * \param w is the window containing the menu.
+ * \param e is the mouse motion event causing the other dialog to take focus.
+ * May be NULL if not available.
+ */
+void sdlpui_menu_handle_loses_mouse(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e)
+{
+	/*
+	 * The mouse left the menu.  If the mouse is not in a child menu,
+	 * pop down the menu's children.  If this menu's parent control does
+	 * not contain the mouse and this menu is not pinned, pop down this
+	 * menu and all parents up to the first that is pinned or contains the
+	 * mouse.  If not popping down this menu, behave as if it was an
+	 * ordinary dialog and the mouse left the window containing it.
+	 */
+	bool remains = false;
+
+	if (e) {
+		struct sdlpui_dialog *d2 = d;
+		struct sdlpui_control *c;
+
+		while (1) {
+			struct sdlpui_dialog *child =
+				sdlpui_get_dialog_child(d2);
+
+			if (!child) {
+				break;
+			}
+			if (sdlpui_is_in_dialog(child, e->x, e->y)) {
+				sdlpui_dialog_handle_window_loses_mouse(d, w);
+				return;
+			}
+			d2 = child;
+		}
+
+		d2 = sdlpui_get_dialog_parent(d);
+		c = sdlpui_get_dialog_parent_ctrl(d);
+		if (d2 && c && sdlpui_is_in_control(c, d2, e->x, e->y)) {
+			remains = true;
+		}
+	}
+
+	if (d->pinned || remains) {
+		struct sdlpui_dialog *child = sdlpui_get_dialog_child(d);
+
+		if (child && !child->pinned) {
+			SDLPUI_EVENT_TRACER("dialog", child, "(not extracted)",
+				"popping down");
+			sdlpui_popdown_dialog(child, w, false);
+		}
+		sdlpui_dialog_handle_window_loses_mouse(d, w);
+		return;
+	}
+
+	while (1) {
+		struct sdlpui_dialog *d2 = sdlpui_get_dialog_parent(d);
+
+		if (!d2 || d2->pinned
+				|| (e && sdlpui_is_in_dialog(d2, e->x, e->y))) {
+			break;
+		}
+		d = d2;
+	}
+	SDLPUI_EVENT_TRACER("dialog", d, "(not extracted)", "popping down");
+	sdlpui_popdown_dialog(d, w, false);
+}
+
+
+/**
+ * Respond to another dialog or menu taking key focus from this dialog.
+ *
+ * \param d is the dialog.
+ * \param w is the window containing the menu.
+ * \param e is the mouse motion event causing the other dialog to take focus.
+ * May be NULL if not available.
+ */
+void sdlpui_dialog_handle_loses_key(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e)
+{
+	/*
+	 * Gets the same treatment as if the window containing the dialog lost
+	 * key focus.
+	 */
+	sdlpui_dialog_handle_window_loses_key(d, w);
+}
+
+
+/**
+ * Respond to another dialog or menu taking key focus from this popup/pulldown
+ * menu.
+ *
+ * \param d is the menu.
+ * \param w is the window containing the menu.
+ * \param e is the mouse motion event causing the other dialog to take focus.
+ * May be NULL if not available.
+ */
+void sdlpui_menu_handle_loses_key(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e)
+{
+	/*
+	 * The menu lost key focus.  If the mouse is not in a child menu, pop
+	 * down this menu's children.  If this menu is not pinned and the mouse
+	 * is not in this menu's parent control, pop down this menu and
+	 * all parents up to the first that is pinned or contains the mouse.
+	 *  If not popping down this menu, behave as if it was an ordinary
+	 * dialog and the mouse left the window containing it.
+	 */
+	bool remains = false;
+
+	if (e) {
+		struct sdlpui_dialog *d2 = d;
+		struct sdlpui_control *c;
+
+		while (1) {
+			struct sdlpui_dialog *child =
+				sdlpui_get_dialog_child(d2);
+
+			if (!child) {
+				break;
+			}
+			if (sdlpui_is_in_dialog(child, e->x, e->y)) {
+				sdlpui_dialog_handle_window_loses_mouse(d, w);
+				return;
+			}
+			d2 = child;
+		}
+
+		d2 = sdlpui_get_dialog_parent(d);
+		c = sdlpui_get_dialog_parent_ctrl(d);
+		if (d2 && c && sdlpui_is_in_control(c, d2, e->x, e->y)) {
+			remains = true;
+		}
+	}
+
+	if (d->pinned || remains) {
+		struct sdlpui_dialog *child = sdlpui_get_dialog_child(d);
+
+		if (child && !child->pinned) {
+			SDLPUI_EVENT_TRACER("dialog", child, "(not extracted)",
+				"popping down");
+			sdlpui_popdown_dialog(child, w, false);
+		}
+		sdlpui_dialog_handle_window_loses_mouse(d, w);
+		return;
+	}
+
+	while (1) {
+		struct sdlpui_dialog *d2 = sdlpui_get_dialog_parent(d);
+
+		if (!d2 || d2->pinned
+				|| (e && sdlpui_is_in_dialog(d2, e->x, e->y))) {
+			break;
+		}
+		d = d2;
+	}
+	SDLPUI_EVENT_TRACER("dialog", d, "(not extracted)", "popping down");
+	sdlpui_popdown_dialog(d, w, false);
+}
+
+
+/**
+ * Begin constructing a simple menu.
+ *
+ * \param parent is the parent menu for the menu to be created or NULL if
+ * the menu to be created is not nested.
+ * \param parent_ctrl is the control in parent which the user interacted
+ * with to create the new menu or NULL if the menu to be created does not
+ * have a parent.
+ * \param preallocated is the number of controls to allocate space for when
+ * creating the menu.  The actual number of controls added can be greater than
+ * that but that'll incur the extra work to resize the storage for the
+ * controls.
+ * \param vertical will,  if true, causes the controls in the new menu to
+ * be layed out in a single column; if false, it causes the controls to layed
+ * out in a single row.
+ * \param border will, if true, cause a border to be drawn about the menu.
+ * \return a pointer to the structure describing the menu.
+ */
+struct sdlpui_dialog *sdlpui_start_simple_menu(struct sdlpui_dialog *parent,
+		struct sdlpui_control *parent_ctrl, int preallocated,
+		bool vertical, bool border, void (*pop_callback)(
+			struct sdlpui_dialog *d, struct sdlpui_window *w,
+			bool up), int tag)
+{
+	struct sdlpui_dialog *result = SDL_malloc(sizeof(*result));
+	struct sdlpui_simple_menu *psm = SDL_malloc(sizeof(*psm));
+
+	psm->parent = parent;
+	psm->child = NULL;
+	psm->parent_ctrl = parent_ctrl;
+	if (preallocated > 0) {
+		psm->size = preallocated;
+		psm->controls = SDL_malloc(psm->size * sizeof(*psm->controls));
+		psm->v_ctrls = SDL_malloc(psm->size * sizeof(*psm->v_ctrls));
+		psm->control_flags = SDL_malloc(psm->size
+			* sizeof(*psm->control_flags));
+	} else {
+		psm->size = 0;
+		psm->controls = NULL;
+		psm->v_ctrls = NULL;
+		psm->control_flags = NULL;
+	}
+	psm->number = 0;
+	psm->n_vis = 0;
+	psm->vertical = vertical;
+	psm->border = border;
+
+	result->ftb = &simple_menu_funcs;
+	result->pop_callback = pop_callback;
+	result->next = NULL;
+	result->prev = NULL;
+	result->texture = NULL;
+	result->c_mouse = NULL;
+	result->c_key = NULL;
+	result->priv = psm;
+	result->type_code = SDLPUI_DIALOG_SIMPLE_MENU;
+	result->tag = tag;
+	result->pinned = false;
+	result->dirty = true;
+
+	return result;
+}
+
+
+/**
+ * Get the space for the next control to be added to a simple menu.
+ * \param d is the menu to add the control to.  d must be the result of a
+ * sdlpui_start_simple_menu() and has not had sdlpui_complete_simple_menu()
+ * called for it.
+ * \param flags controls how the menu handles the new control.  It can be
+ * bitwise-or of one or more of the following:
+ *     SDLPUI_MFLG_NONE:  if no other bit is set, the new control has the
+ *         default behavior.  It is positioned from the top edge (if the menu
+ *         is vertical) or left edge (if the menu is horizontal):  with the
+ *         controls added before it being placed between that edge and the
+ *         new control.  The new control will also always be visible, provided
+ *         that the menu has space for it.
+ *    SDLPUI_MFLG_END_GRAVITY:  if this bit is set, the new control is
+ *         positioned from the bottom edge (if the menu is vertical) or
+ *         right edge (if the menu is vertical):  with the controls added
+ *         after if being placed between that edge and the new control.  All
+ *         the controls after it must also have the SDLPUI_MFLG_END_GRAVITY
+ *         bit set when they are created.
+ *    SDLPUI_MFLG_CAN_HIDE:  if this bit is set and the menu is not large
+ *         enough to display all of its controls, the menu may hide this
+ *         control so there's enough space to display the controls that do
+ *         not have the SDLPUI_MFLG_CAN_HIDE bit set.  When there are
+ *         multiple controls with the SDLPUI_MFLG_CAN_HIDE bit set, the ones
+ *         that are added later will be the ones that are hidden first.
+ * \return a pointer to the space for the new control.
+ */
+struct sdlpui_control* sdlpui_get_simple_menu_next_unused(
+		struct sdlpui_dialog *d, int flags)
+{
+	struct sdlpui_simple_menu *psm;
+	int n;
+
+	SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU);
+	psm = (struct sdlpui_simple_menu*)d->priv;
+	SDL_assert(psm->number >= 0 && psm->number <= psm->size);
+	if (psm->number == psm->size) {
+		if (psm->size > INT_MAX / 2) {
+			SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION,
+				"Too many menu entries");
+			sdlpui_force_quit();
+		}
+		psm->size = (psm->size) ? psm->size + psm->size : 8;
+		psm->controls = SDL_realloc(psm->controls,
+			psm->size * sizeof(*psm->controls));
+		psm->v_ctrls = SDL_realloc(psm->v_ctrls,
+			psm->size * sizeof(*psm->v_ctrls));
+		psm->control_flags = SDL_realloc(psm->control_flags,
+			psm->size * sizeof(*psm->control_flags));
+	}
+	n = psm->number;
+	++psm->number;
+	SDL_memset(psm->controls + n, 0, sizeof(*psm->controls));
+	psm->control_flags[n] = flags;
+	return psm->controls + n;
+}
+
+
+/**
+ * Complete the construction of a simple menu.
+ *
+ * \param d is the menu of interest.
+ * \param w is the window containing the menu.
+ *
+ * Once this function is called for a menu, sdlpui_start_simple_menu() and
+ * sdlpui_get_simple_menu_next_unused() must not be called for that menu.
+ */
+void sdlpui_complete_simple_menu(struct sdlpui_dialog *d,
+		struct sdlpui_window *w)
+{
+	int dw, dh;
+
+	(*d->ftb->query_natural_size)(d, w, &dw, &dh);
+	if (d->ftb->resize) {
+		(*d->ftb->resize)(d, w, dw, dh);
+	} else {
+		d->rect.w = dw;
+		d->rect.h = dh;
+	}
+}
+
+
+/**
+ * Begin constructing a simple information dialog.
+ *
+ * \param button_label is the text label to use for the button that dismisses
+ * the dialog.
+ * \return a pointer to the structure describing the dialog.
+ */
+struct sdlpui_dialog *sdlpui_start_simple_info(const char *button_label,
+		void (*pop_callback)(struct sdlpui_dialog *d,
+			struct sdlpui_window *w, bool up), int tag)
+{
+	struct sdlpui_dialog *result = SDL_malloc(sizeof(*result));
+	struct sdlpui_simple_info *psi = SDL_malloc(sizeof(*psi));
+
+	psi->labels = NULL;
+	sdlpui_create_push_button(&psi->button, button_label,
+		SDLPUI_HOR_CENTER, sdlpui_invoke_dialog_default_action,
+		0, false);
+	psi->size = 0;
+	psi->number = 0;
+
+	result->ftb = &simple_info_funcs;
+	result->pop_callback = pop_callback;
+	result->next = NULL;
+	result->prev = NULL;
+	result->texture = NULL;
+	result->c_mouse = NULL;
+	result->c_key = NULL;
+	result->priv = psi;
+	result->type_code = SDLPUI_DIALOG_SIMPLE_INFO;
+	result->tag = tag;
+	result->pinned = false;
+	result->dirty = true;
+
+	return result;
+}
+
+
+/**
+ * Add an image to a simple information dialog.
+ *
+ * \param image is the texture containing the image to add.  The dialog assumes
+ * ownership of the texture and calls SDL_DestroyTexture() on it when the dialog
+ * is destroyed.
+ * \param halign specifies how to horizontally align the image within the
+ * dialog if the dialog is wider than the image.
+ * \param top_margin specifies the height, in pixels, of an empty space
+ * to leave along the top of the image.
+ * \param bottom_margin specifies the height, in pixels, of an empty space
+ * to leave along the bottom of the image.
+ * \param left_margin specifies the width, in pixels, of an empty space
+ * to leave along the left of the image.
+ * \param right_margin specifies the width, in pixels, of an empty space
+ * to leave along the left of the image.
+ *
+ * Images and labels added to the dialog are displayed from top to bottom in
+ * the dialog in the order they were added.
+ */
+void sdlpui_simple_info_add_image(struct sdlpui_dialog *d, SDL_Texture *image,
+		enum sdlpui_hor_align halign, int top_margin, int bottom_margin,
+		int left_margin, int right_margin)
+{
+	struct sdlpui_simple_info *psi;
+	int n;
+
+	SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_INFO);
+	psi = (struct sdlpui_simple_info*)d->priv;
+	SDL_assert(psi->number >= 0 && psi->number <= psi->size);
+	if (psi->number == psi->size) {
+		if (psi->size > INT_MAX / 2) {
+			SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION,
+				"Too many info dialog entries");
+			sdlpui_force_quit();
+		}
+		psi->size = (psi->size) ? psi->size + psi->size : 8;
+		psi->labels = SDL_realloc(psi->labels,
+			psi->size * sizeof(*psi->labels));
+	}
+	n = psi->number;
+	++psi->number;
+	sdlpui_create_image(&psi->labels[n], image, halign, top_margin,
+		bottom_margin, left_margin, right_margin);
+}
+
+
+/**
+ * Add a label to a simple information dialog.
+ *
+ * \param label is the null-terminated UTF-8 string to use as the label.
+ * The contents of label are copied, so the lifetime of what's passed is
+ * independent of the lifetime of the control.
+ * \param halign specifies how to horizontally align the label within the
+ * dialog if the dialog is wider than the label.
+ *
+ * Images and labels added to the dialog are displayed from top to bottom in
+ * the dialog in the order they were added.
+ */
+void sdlpui_simple_info_add_label(struct sdlpui_dialog *d, const char *label,
+		enum sdlpui_hor_align halign)
+{
+	struct sdlpui_simple_info *psi;
+	int n;
+
+	SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_INFO);
+	psi = (struct sdlpui_simple_info*)d->priv;
+	SDL_assert(psi->number >= 0 && psi->number <= psi->size);
+	if (psi->number == psi->size) {
+		if (psi->size > INT_MAX / 2) {
+			SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION,
+				"Too many info dialog entries");
+			sdlpui_force_quit();
+		}
+		psi->size = (psi->size) ? psi->size + psi->size : 8;
+		psi->labels = SDL_realloc(psi->labels,
+			psi->size * sizeof(*psi->labels));
+	}
+	n = psi->number;
+	++psi->number;
+	sdlpui_create_label(&psi->labels[n], label, halign);
+}
+
+
+/**
+ * Complete the construction of a simple information dialog.
+ *
+ * \param d is the dialog of interest.
+ * \param w is the window containing the dialog.
+ *
+ * Once this function is called for a menu, sdlpui_start_simple_info(),
+ * sdlpui_simple_info_add_image(), and sdlpui_simple_info_add_label()
+ * must not be called for that menu.
+ */
+void sdlpui_complete_simple_info(struct sdlpui_dialog *d,
+		struct sdlpui_window *w)
+{
+	int dw, dh;
+
+	(*d->ftb->query_natural_size)(d, w, &dw, &dh);
+	if (d->ftb->resize) {
+		(*d->ftb->resize)(d, w, dw, dh);
+	} else {
+		d->rect.w = dw;
+		d->rect.h = dh;
+	}
+}

--- a/src/sdl2/pui-dlg.h
+++ b/src/sdl2/pui-dlg.h
@@ -1,0 +1,321 @@
+/**
+ * \file sdl2/pui-dlg.h
+ * \brief Declare the interface for menus and dialogs created by the primitive
+ * UI toolkit for SDL2.
+ */
+#ifndef INCLUDED_SDL2_SDLPUI_DIALOG_H
+#define INCLUDED_SDL2_SDLPUI_DIALOG_H
+
+#include "pui-ctrl.h"
+
+struct sdlpui_dialog;
+struct sdlpui_window;
+
+/*
+ * Set out predefined values for the type_code field of struct sdlpui_dialog.
+ * These are initialized by sdlpui_init().  For custom dialogs, you can get
+ * a code with sdlpui_register_code().
+ */
+extern Uint32 SDLPUI_DIALOG_SIMPLE_MENU;
+extern Uint32 SDLPUI_DIALOG_SIMPLE_INFO;
+
+/* Set out possible flags that can be set for buttons in a simple menu. */
+enum sdlpui_menu_flags {
+	SDLPUI_MFLG_NONE = 0,
+	SDLPUI_MFLG_END_GRAVITY = 1,	/* when the menu is bigger than needed
+						for the buttons, the button
+						prefers to have its position
+						stack from the end of the
+						menu */
+	SDLPUI_MFLG_CAN_HIDE = 2,	/* if the menu is smaller than its
+						natural size, this button can
+						be hidden */
+};
+
+/* Holds a function table to be used for a class of dialogs. */
+struct sdlpui_dialog_funcs {
+	/*
+	 * Respond to events.  Return true if the event was handled and
+	 * should not be passed on to another handler.  Otherwise, return false.
+	 * Any can be NULL if the dialog and the controls it contains do not
+	 * do anything with that type of event and want the window to handle it.
+	 */
+	bool (*handle_key)(struct sdlpui_dialog *d, struct sdlpui_window *w,
+		const SDL_KeyboardEvent *e);
+	bool (*handle_textin)(struct sdlpui_dialog *d, struct sdlpui_window *w,
+		const SDL_TextInputEvent *e);
+	bool (*handle_textedit)(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const SDL_TextEditingEvent *e);
+	bool (*handle_mouseclick)(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const SDL_MouseButtonEvent *e);
+	bool (*handle_mousemove)(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const SDL_MouseMotionEvent *e);
+	bool (*handle_mousewheel)(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const SDL_MouseWheelEvent *e);
+	/*
+	 * Respond to the mouse focus being taken by another dialog.  May be
+	 * NULL.
+	 */
+	void (*handle_loses_mouse)(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const SDL_MouseMotionEvent *e);
+	/*
+	 * Respond to the key focus being taken by another dialog.  May be NULL.
+	 */
+	void (*handle_loses_key)(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const SDL_MouseMotionEvent *e);
+	/*
+	 * Respond to the mouse leaving the containing window if the dialog
+	 * had mouse focus when that happened.  May be NULL.
+	 */
+	void (*handle_window_loses_mouse)(struct sdlpui_dialog *d,
+		struct sdlpui_window *w);
+	/*
+	 * Respond to the containing window losing key focus if the dialog
+	 * had key focus when that happened.  May be NULL.
+	 */
+	void (*handle_window_loses_key)(struct sdlpui_dialog *d,
+		struct sdlpui_window *w);
+	/*
+	 * Redraw for the current state of the dialog/menu.  Can be NULL,
+	 * but then the dialog is not redrawn by standard event handling.
+	 */
+	void (*render)(struct sdlpui_dialog *d, struct sdlpui_window *w);
+	/* Do the default action for a dialog or menu.  Can be NULL. */
+	void (*respond_default)(struct sdlpui_dialog *d,
+		struct sdlpui_window *w);
+	/*
+	 * Go to the dialog's primary (or first) control that can accept
+	 * focus and give it key focus.  May be NULL if there is nothing in the
+	 * dialog that can accept focus.
+	 */
+	void (*goto_first_control)(struct sdlpui_dialog *d,
+		struct sdlpui_window *w);
+	/*
+	 * If forward is true, go to the dialog's next (with wrap around)
+	 * control after c that can accept focus.  If forward is false, go to
+	 * the dialog's previous (with wrap around) control before c that
+	 * can accept focus.  May be NULL if the dialog never accepts focus
+	 * (goto_first_control is NULL or never changes d->c_key from NULL and
+	 * find_control_containing is NULL or always returns NULL) or if it
+	 * only has one, simple, control that can accept focus.
+	 */
+	void (*step_control)(struct sdlpui_dialog *d, struct sdlpui_window *w,
+		struct sdlpui_control *c, bool forward);
+	/*
+	 * Find the dialog's control that's willing to accept focus and
+	 * contains the given coordinate, relative to the window.  For simple
+	 * controls, set *comp_ind to zero.  For compound controls, set
+	 * *comp_ind to the index of the control, in the compound control, that
+	 * accepts focus and holds the coordinate.  May be NULL:  then mouse
+	 * motion will never cause the dialog to accept focus.
+	 */
+	struct sdlpui_control *(*find_control_containing)(
+		struct sdlpui_dialog *d, struct sdlpui_window *w, Sint32 x,
+		Sint32 y, int *comp_ind);
+	/*
+	 * For a nested menu, return the parent or child respectively for the
+	 * menu.  May be NULL for a dialog that is not a nested menu.
+	 */
+	struct sdlpui_dialog *(*get_parent)(struct sdlpui_dialog *d);
+	struct sdlpui_dialog *(*get_child)(struct sdlpui_dialog *d);
+	/*
+	 * For a nested menu, get the parent control for the menu.  May be
+	 * NULL for a dialog that is not a nested menu.
+	 */
+	struct sdlpui_control *(*get_parent_ctrl)(struct sdlpui_dialog *d);
+	/*
+	 * For a nested menu, allow changing the child menu.  May be NULL
+	 * for a dialog that is not a nested menu.
+	 */
+	void (*set_child)(struct sdlpui_dialog *d, struct sdlpui_dialog *child);
+	/*
+	 * Resize the dialog so it has the given dimensions.  May be NULL
+	 * if resizing the dialog is as simple as setting d->rect.w and
+	 * d->rect.h to the desired dimensions.
+	 */
+	void (*resize)(struct sdlpui_dialog *d, struct sdlpui_window *w,
+		int width, int height);
+	/* Get the natural size for the dialog.  May not be NULL. */
+	void (*query_natural_size)(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, int *width, int *height);
+	/*
+	 * Get the minimum size for the dialog.  May be NULL:  the caller
+	 * will assume the natural size is the minimum size.
+	 */
+	void (*query_minimum_size)(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, int *width, int *height);
+	/*
+	 * Handle releasing resources for the private data, if any.  May
+	 * be NULL to have no special cleanup done.
+	 */
+	void (*cleanup)(struct sdlpui_dialog *d);
+};
+
+/* Represents a menu or dialog displayed on top of a window. */
+struct sdlpui_dialog {
+	const struct sdlpui_dialog_funcs *ftb;
+	/*
+	 * Called with up set to true when popping the dialog up.  Called
+	 * with up set to false when popping the dialog down.
+	 */
+	void (*pop_callback)(struct sdlpui_dialog *d, struct sdlpui_window *w,
+		bool up);
+	/*
+	 * Managed by the containing window so it can keep a stack of its
+	 * menus and dialogs.
+	 */
+	struct sdlpui_dialog *next, *prev;
+	/*
+	 * Holds the rendered contents of the dialog/menu.  May be NULL to
+	 * directly render to the window's backing buffer.
+	 */
+	SDL_Texture *texture;
+	/*
+	 * These point to the control which should receive mouse or keyboard
+	 * events, respectively.  If NULL, events will be directed to the
+	 * dialog itself.
+	 */
+	struct sdlpui_control *c_mouse, *c_key;
+	/* Holds menu/dialog-specific data. */
+	void *priv;
+	/*
+	 * Holds the position, relative to the window's upper left corner,
+	 * and size of the dialog/menu.
+	 */
+	SDL_Rect rect;
+	/* Allow for a check before casting priv to another type. */
+	Uint32 type_code;
+	/*
+	 * Allow for different behavior for different dialogs with the same
+	 * pop_callback.
+	 */
+	int tag;
+	/*
+	 * The dialog/menu is pinned and should not be automatically removed
+	 * when popping down a child.
+	 */
+	bool pinned;
+	/*
+	 * Dialog/menu's texture is out-of-date with respect to the state of
+	 * the dialog and should be rerendered.
+	 */
+	bool dirty;
+};
+
+
+/*
+ * Holds the private data for a sdlpui_dialog used to represent a simple menu
+ * (either a standalone popup menu, a vertical menu pane that's part of a
+ * system of nested menus, or a horizontal menu bar).  The corresponding
+ * type_code value is SDLPUI_DIALOG_SIMPLE_MENU.
+ */
+struct sdlpui_simple_menu {
+	struct sdlpui_dialog *parent, *child;
+	struct sdlpui_control *parent_ctrl;
+	struct sdlpui_control *controls;
+					/* flat array of the menu buttons */
+	struct sdlpui_control **v_ctrls;
+					/* flat array referring to the subset
+						of buttons that are visible */
+	int *control_flags;		/* flat array of flags
+						(SDLPUI_MFLG_END_GRAVITY and
+						SDLPUI_MFLG_CAN_HIDE) for each
+						button */
+	int size, number, n_vis;	/* allocated number of buttons for
+						controls, a_ctrls, and
+						control_flags; the number of
+						buttons in controls and
+						control_flags; the number of
+						buttons in v_ctrls */
+	bool vertical;
+	bool border;			/* is it rendered with a border */
+};
+
+
+/*
+ * Holds the private data for a sdlpui_dialog used to a dialog with zero or
+ * more labels or images and a button that dismisses the dialog.  The
+ * corresponding type_code value is SDLPUI_DIALOG_SIMPLE_INFO.
+ */
+struct sdlpui_simple_info {
+	struct sdlpui_control *labels;	/* flat array of controls like labels
+						or images that don't accept
+						focus */
+	struct sdlpui_control button;	/* single button to dismiss the
+						dialog */
+	int size, number;		/* allocated number of controls for
+						labels; the number of
+						controls in labels */
+};
+
+
+bool sdlpui_is_in_dialog(const struct sdlpui_dialog *d, Sint32 x, Sint32 y);
+void sdlpui_popup_dialog(struct sdlpui_dialog *d, struct sdlpui_window *w,
+		bool give_key_focus);
+void sdlpui_popdown_dialog(struct sdlpui_dialog *d, struct sdlpui_window *w,
+		bool all_parents);
+void sdlpui_dialog_give_key_focus_to_parent(struct sdlpui_dialog *d,
+		struct sdlpui_window *w);
+struct sdlpui_dialog *sdlpui_get_dialog_parent(struct sdlpui_dialog *d);
+struct sdlpui_dialog *sdlpui_get_dialog_child(struct sdlpui_dialog *d);
+struct sdlpui_control *sdlpui_get_dialog_parent_ctrl(struct sdlpui_dialog *d);
+
+/* Standard event handlers for dialogs. */
+bool sdlpui_dialog_handle_key(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_KeyboardEvent *e);
+bool sdlpui_dialog_handle_textin(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_TextInputEvent *e);
+bool sdlpui_dialog_handle_textedit(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_TextEditingEvent *e);
+bool sdlpui_dialog_handle_mouseclick(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_MouseButtonEvent *e);
+bool sdlpui_menu_handle_mouseclick(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_MouseButtonEvent *e);
+bool sdlpui_dialog_handle_mousemove(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e);
+bool sdlpui_menu_handle_mousemove(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e);
+bool sdlpui_dialog_handle_mousewheel(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_MouseWheelEvent *e);
+void sdlpui_dismiss_dialog(struct sdlpui_dialog *d, struct sdlpui_window *w);
+void sdlpui_dialog_handle_window_loses_mouse(struct sdlpui_dialog *d,
+		struct sdlpui_window *w);
+void sdlpui_menu_handle_window_loses_mouse(struct sdlpui_dialog *d,
+		struct sdlpui_window *w);
+void sdlpui_dialog_handle_window_loses_key(struct sdlpui_dialog *d,
+		struct sdlpui_window *w);
+void sdlpui_menu_handle_window_loses_key(struct sdlpui_dialog *d,
+		struct sdlpui_window *w);
+void sdlpui_dialog_handle_loses_mouse(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e);
+void sdlpui_menu_handle_loses_mouse(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e);
+void sdlpui_dialog_handle_loses_key(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e);
+void sdlpui_menu_handle_loses_key(struct sdlpui_dialog *d,
+		struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e);
+
+/* Construct a simple menu */
+struct sdlpui_dialog *sdlpui_start_simple_menu(struct sdlpui_dialog *parent,
+		struct sdlpui_control *parent_ctrl, int preallocated,
+		bool vertical, bool border, void (*pop_callback)(
+			struct sdlpui_dialog *d, struct sdlpui_window *w,
+			bool up), int tag);
+struct sdlpui_control *sdlpui_get_simple_menu_next_unused(
+		struct sdlpui_dialog *d, int flags);
+void sdlpui_complete_simple_menu(struct sdlpui_dialog *d,
+		struct sdlpui_window *w);
+
+/* Construct a simple information dialog. */
+struct sdlpui_dialog *sdlpui_start_simple_info(const char *button_label,
+		void (*pop_callback)(struct sdlpui_dialog *d,
+			struct sdlpui_window *w, bool up), int tag);
+void sdlpui_simple_info_add_image(struct sdlpui_dialog *d, SDL_Texture *image,
+		enum sdlpui_hor_align halign, int top_margin, int bottom_margin,
+		int left_margin, int right_margin);
+void sdlpui_simple_info_add_label(struct sdlpui_dialog *d, const char *label,
+		enum sdlpui_hor_align halign);
+void sdlpui_complete_simple_info(struct sdlpui_dialog *d,
+		struct sdlpui_window *w);
+
+#endif /* INCLUDED_SDL2_SDLPUI_DIALOG_H */

--- a/src/sdl2/pui-misc.c
+++ b/src/sdl2/pui-misc.c
@@ -1,0 +1,464 @@
+/**
+ * \file sdl2/pui-misc.c
+ * \brief Define miscellaneous utilities for the primitive UI toolkit for SDL2.
+ *
+ * Copyright (c) 2023 Eric Branlund
+ *
+ * This work is free software; you can redistribute it and/or modify it
+ * under the terms of either:
+ *
+ * a) the GNU General Public License as published by the Free Software
+ *    Foundation, version 2, or
+ *
+ * b) the "Angband licence":
+ *    This software may be copied and distributed for educational, research,
+ *    and not for profit purposes provided that this copyright and statement
+ *    are included in all such copies.  Other copyrights may also apply.
+ */
+
+#include "pui-misc.h"
+#include "pui-ctrl.h"
+#include "pui-dlg.h"
+
+
+struct sdlpui_code {
+	char *name;
+	Uint32 code;
+};
+
+struct sdlpui_code_registry {
+	SDL_mutex* lock;
+	struct sdlpui_code *entries;
+	size_t count, alloc;
+	Uint32 serial;
+};
+
+static struct sdlpui_code_registry my_registry = { NULL, NULL, 0, 0, 0 };
+
+
+/*
+ * Initialize the resources needed by the sdlpui_*() calls.
+ *
+ * Can safely be called multiple times without an intervening sdlpui_quit().
+ * For multithreaded applications, a race condition condition is possible
+ * if sdlpui_init() can be called while a call to sdlpui_quit() is in progress.
+ * Those applications should be structured to avoid that possibility.
+ */
+int sdlpui_init(void)
+{
+#if defined(SDLPUI_TRACE_EVENTS) || defined (SDLPUI_TRACE_RENDER)
+	SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION,
+		SDL_LOG_PRIORITY_VERBOSE);
+#endif
+
+	if (!my_registry.lock) {
+		my_registry.lock = SDL_CreateMutex();
+	
+		/* Initialize predefined type codes from pui-dlg.h. */
+		SDLPUI_DIALOG_SIMPLE_MENU =
+			sdlpui_register_code("SDLPUI_DIALOG_SIMPLE_MENU");
+		SDLPUI_DIALOG_SIMPLE_INFO =
+			sdlpui_register_code("SDLPUI_DIALOG_SIMPLE_INFO");
+		if (!SDLPUI_DIALOG_SIMPLE_MENU || !SDLPUI_DIALOG_SIMPLE_INFO) {
+			sdlpui_force_quit();
+			return 1;
+		}
+
+		/* Initialize predefined type codes from pui-ctrl.h. */
+		SDLPUI_CTRL_IMAGE = sdlpui_register_code("SDLPUI_CTRL_IMAGE");
+		SDLPUI_CTRL_LABEL = sdlpui_register_code("SDLPUI_CTRL_LABEL");
+		SDLPUI_CTRL_MENU_BUTTON =
+			sdlpui_register_code("SDLPUI_CTRL_MENU_BUTTON");
+		SDLPUI_CTRL_PUSH_BUTTON =
+			sdlpui_register_code("SDLPUI_CTRL_PUSH_BUTTON");
+		if (!SDLPUI_CTRL_IMAGE || !SDLPUI_CTRL_LABEL
+				|| !SDLPUI_CTRL_MENU_BUTTON
+				|| !SDLPUI_CTRL_PUSH_BUTTON) {
+			sdlpui_force_quit();
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+
+/**
+ * Release the resources allocated by sdlpui_init().
+ *
+ * Can safey be called multiple times without an intervening call to.
+ * sdlpui_init().  Once called, the only sdlpui_*() calls that can be safely
+ * used are sdlpui_init() and sdlpui_quit().  For multithreaded applications,
+ * race condtitions are possible if sdlpui_init() or sdlpui_quit() can be
+ * called while a call to sdlpui_quit() is in progress.  Those applications
+ * should be structured to avoid that possibility.
+ */
+void sdlpui_quit()
+{
+	SDL_mutex *lock = my_registry.lock;
+
+	if (lock) {
+		struct sdlpui_code *entries;
+		Uint32 i, n;
+		int retn;
+
+		retn = SDL_LockMutex(lock);
+		SDL_assert(!retn);
+		entries = my_registry.entries;
+		n = my_registry.count;
+		my_registry.entries = 0;
+		my_registry.count = 0;
+		my_registry.alloc = 0;
+		my_registry.serial = 0;
+		my_registry.lock = 0;
+		retn = SDL_UnlockMutex(lock);
+		SDL_assert(!retn);
+		for (i = 0; i < n; ++i) {
+			SDL_free(entries[i].name);
+		}
+		SDL_free(entries);
+		SDL_DestroyMutex(lock);
+	} else {
+		SDL_assert(!my_registry.entries);
+		SDL_assert(!my_registry.count);
+		SDL_assert(!my_registry.alloc);
+		SDL_assert(!my_registry.serial);
+	}
+}
+
+
+Uint32 sdlpui_register_code(const char *name)
+{
+	Uint32 code = 0, ilo, ihi;
+	int unlocked;
+
+	if (!name || !my_registry.lock || SDL_LockMutex(my_registry.lock)) {
+		return code;
+	}
+
+	/* Sorted alphabetically by name so use a binary search. */
+	SDL_assert(my_registry.count <= my_registry.alloc);
+	ilo = 0;
+	ihi = my_registry.count;
+	while (1) {
+		Uint32 imid;
+		int cmp;
+
+		if (ilo == ihi) {
+			/*
+			 * It is not present.  Shift entries starting with ilo
+			 * up by one to create space for a new entry.
+			 */
+			Uint32 i;
+
+			if (my_registry.serial == SDL_MAX_UINT32) {
+				/*
+				 * Exhausted all the serial numbers.  Give up.
+				 */
+				break;
+			}
+			if (my_registry.count == my_registry.alloc) {
+				size_t new_alloc;
+				struct sdlpui_code *new_entries;
+
+				if (my_registry.alloc == 0) {
+					new_alloc = 8;
+				} else if (my_registry.alloc <
+						(size_t)-1 / 2
+						&& my_registry.alloc
+						< (size_t)-1
+						/ sizeof(struct sdlpui_code)) {
+					new_alloc = my_registry.alloc +
+						my_registry.alloc;
+				} else {
+					/*
+					 * Will exceed the range of a size_t.
+					 * Give up.
+					 */
+					break;
+				}
+				new_entries = SDL_realloc(my_registry.entries,
+					new_alloc * sizeof(struct sdlpui_code));
+				if (!new_entries) {
+					break;
+				}
+				my_registry.entries = new_entries;
+				my_registry.alloc = new_alloc;
+			}
+			for (i = my_registry.count; i > ilo; --i) {
+				my_registry.entries[i].name =
+					my_registry.entries[i - 1].name;
+				my_registry.entries[i].code =
+					my_registry.entries[i - 1].code;
+			}
+			my_registry.entries[ilo].name = SDL_strdup(name);
+			if (!my_registry.entries[ilo].name) {
+				break;
+			}
+			code = ++my_registry.serial;
+			my_registry.entries[ilo].code = code;
+			break;
+		}
+
+		imid = (ilo + ihi) / 2;
+		cmp = strcmp(my_registry.entries[imid].name, name);
+		if (cmp == 0) {
+			code = my_registry.entries[imid].code;
+			break;
+		}
+		if (cmp < 0) {
+			ilo = imid + 1;
+		} else {
+			ihi = imid;
+		}
+	}
+
+	unlocked = !SDL_UnlockMutex(my_registry.lock);
+	SDL_assert(unlocked);
+
+	return code;
+}
+
+
+/**
+ * Strip modifiers from SDL_GetModState() that are not relevant to the
+ * primitive UI toolkit.
+ *
+ * \return the modified set of keyboard modifiers.
+ *
+ * Does this also need to strip off KMOD_CAPS?
+ */
+SDL_Keymod sdlpui_get_interesting_keymods(void)
+{
+#if SDL_VERSION_ATLEAST(2, 0, 18)
+	return SDL_GetModState() & ~(KMOD_NUM | KMOD_SCROLL);
+#else
+	return SDL_GetModState() & ~(KMOD_NUM);
+#endif
+}
+
+
+/**
+ * Compute a stipple pattern for use with a given renderer.
+ *
+ * \param r is the renderer that will be used.
+ * \return the structure describing the stipple pattern.  If an error
+ * occurs, the texture element in the structure will be NULL and SDL_GetError()
+ * will describe the cause of the error.  When the stipple pattern is no
+ * longer needed, the returned texture in the structure should be released
+ * with SDL_DestroyTexture().
+ */
+struct sdlpui_stipple sdlpui_compute_stipple(SDL_Renderer *r)
+{
+	/*
+	 * The dimensions must be a multiple of two:  see the loop logic
+	 * below.
+	 */
+	const int width = 16, height = 16;
+	struct sdlpui_stipple result = { NULL, 0, 0 };
+	SDL_Surface *s;
+	Uint32 *pixels;
+	Uint32 rmask, gmask, bmask, amask, on_pixel, off_pixel;
+	int y;
+
+	/*
+	 * on_pixel is black and completely transparent.  off_pixel is gray
+	 * (0x40, 0x40, 0x40) and slightly opaque.
+	 */
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+	rmask = 0xff000000;
+	gmask = 0x00ff0000;
+	bmask = 0x0000ff00;
+	amask = 0x000000ff;
+	on_pixel = 0x000000ff;
+	off_pixel = 0x40404040;
+#else
+	rmask = 0x000000ff;
+	gmask = 0x0000ff00;
+	bmask = 0x00ff0000;
+	amask = 0xff000000;
+	on_pixel = 0xff000000;
+	off_pixel = 0x40404040;
+#endif
+
+	SDL_assert(!(width & 1) && !(height & 1));
+	pixels = SDL_malloc(width * height * sizeof(*pixels));
+	for (y = 0; y < height; y += 2) {
+		uint32_t *row = pixels + y * width;
+		int x;
+
+		for (x = 0; x < width; x += 2) {
+			row[x] = on_pixel;
+			row[x + 1] = off_pixel;
+			row[x + width] = off_pixel;
+			row[x + width + 1] = on_pixel;
+		}
+	}
+
+	s = SDL_CreateRGBSurfaceFrom(pixels, width, height, 32, 4 * width,
+		rmask, gmask, bmask, amask);
+	if (s) {
+		result.texture = SDL_CreateTextureFromSurface(r, s);
+		SDL_FreeSurface(s);
+		if (result.texture) {
+			result.w = width;
+			result.h = height;
+		}
+	}
+	SDL_free(pixels);
+
+	return result;
+}
+
+
+/**
+ * Stipple a rectangle.
+ *
+ * \param r is the renderer to use.
+ * \param stp points to the texture and the texture's dimensions to use for
+ * stippling.  Must not be NULL.
+ * \param dst_r points to the rectangle bounding the area to stipple.  Must not
+ * be NULL.
+ */
+void sdlpui_stipple_rect(SDL_Renderer *r, struct sdlpui_stipple *stp,
+		const SDL_Rect *dst_r)
+{
+	SDL_Rect src_r = { 0, 0, 0, 0 }, dst2_r;
+	int ylim = dst_r->y + dst_r->h, xlim = dst_r->x + dst_r->w;
+
+	if (!stp->texture) {
+		return;
+	}
+	for (dst2_r.y = dst_r->y; dst2_r.y < ylim; dst2_r.y += stp->h) {
+		dst2_r.h = (dst2_r.y + stp->h > ylim) ?
+			ylim - dst2_r.y : stp->h;
+		src_r.h = dst2_r.h;
+		for (dst2_r.x = dst_r->x; dst2_r.x < xlim; dst2_r.x += stp->w) {
+			dst2_r.w = (dst2_r.x + stp->w > xlim) ?
+				xlim - dst2_r.x : stp->w;
+			src_r.w = dst2_r.w;
+			SDL_RenderCopy(r, stp->texture, &src_r, &dst2_r);
+		}
+	}
+}
+
+
+/**
+ * Render a line of UTF-8 text in a given font and color.
+ *
+ * \param r is the renderer to use.
+ * \param font is the font to use.
+ * \param fg points to the color to use; must not be NULL.
+ * \param dst_r points to the rectangle to be affected by the rendering.
+ * Must not be NULL.
+ * \param s is the null-terminated UTF-8 string to render, must not be NULL.
+ * Note that the rendered result is always a single line, even if s contains
+ * embedded newlines.
+ */
+void sdlpui_render_utf8_line(SDL_Renderer *r, TTF_Font *font,
+		const SDL_Color *fg, const SDL_Rect *dst_r, const char *s)
+{
+	SDL_Surface *surface = TTF_RenderUTF8_Blended(font, s, *fg);
+	SDL_Texture *src_t;
+	SDL_Rect src_r;
+
+	if (!surface) {
+		SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION,
+			"TTF_RenderUTF8_Blended() failed: %s", TTF_GetError());
+		sdlpui_force_quit();
+	}
+	src_t = SDL_CreateTextureFromSurface(r, surface);
+	if (!src_t) {
+		SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION,
+			"SDL_CreateTextureFromSurface() failed: %s",
+			SDL_GetError());
+		sdlpui_force_quit();
+	}
+	SDL_FreeSurface(surface);
+	src_r.x = 0;
+	src_r.y = 0;
+	if (SDL_QueryTexture(src_t, NULL, NULL, &src_r.w, &src_r.h)) {
+		SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION,
+			"SDL_QueryTexture() failed: %s", SDL_GetError());
+		sdlpui_force_quit();
+	}
+	/*
+	 * Truncate rather than compress if the rendered string is bigger than
+	 * the destination.
+	 */
+	if (src_r.w > dst_r->w) {
+		src_r.w = dst_r->w;
+	}
+	if (src_r.h > dst_r->h) {
+		src_r.h = dst_r->h;
+	}
+	SDL_RenderCopy(r, src_t, &src_r, dst_r);
+	SDL_DestroyTexture(src_t);
+}
+
+
+/**
+ * Get the width and height of rendered UTF-8 text.
+ *
+ * \param font is the font to use for rendering.
+ * \param s is the null-terminated UTF-8 string.
+ * \param w is dereferenced and set to the width of the renderered string.
+ * \param h is dereferenced and set to the height of the renderered string.
+ */
+void sdlpui_get_utf8_metrics(TTF_Font *font, const char *s, int *w, int *h)
+{
+	if (TTF_SizeUTF8(font, s, w, h)) {
+		SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION,
+			"TTF_SizeUTF8() failed for '%s': %s", s,
+			TTF_GetError());
+		sdlpui_force_quit();
+	}
+}
+
+
+/**
+ * Return the UTF-32 encoding for the first codepoint in a UTF-8 string.
+ *
+ * \param utf8_string is the null-terminated string of interest.
+ * \return the UTF-32 encoding, in the native byte order, for the first
+ * codepoint in the string.
+ */
+uint32_t sdlpui_utf8_to_codepoint(const char *utf8_string)
+{
+        /* hex  == binary
+         * 0x00 == 00000000
+         * 0x80 == 10000000
+         * 0xc0 == 11000000
+         * 0xe0 == 11100000
+         * 0xf0 == 11110000
+         * 0xf8 == 11111000
+         * 0x3f == 00111111
+         * 0x1f == 00011111
+         * 0x0f == 00001111
+         * 0x07 == 00000111 */
+
+        uint32_t key = 0;
+
+#define IS_UTF8_INFO(mask, result) (((unsigned char) utf8_string[0] & (mask)) == (result))
+#define EXTRACT_UTF8_INFO(pos, mask, shift) (((unsigned char) utf8_string[(pos)] & (mask)) << (shift))
+        /* 6 is the number of information bits in a utf8 continuation byte (10xxxxxx) */
+        if (IS_UTF8_INFO(0x80, 0)) {
+                key = utf8_string[0];
+        } else if (IS_UTF8_INFO(0xe0, 0xc0)) {
+                key = EXTRACT_UTF8_INFO(0, 0x1f, 6)
+                        | EXTRACT_UTF8_INFO(1, 0x3f, 0);
+        } else if (IS_UTF8_INFO(0xf0, 0xe0)) {
+                key = EXTRACT_UTF8_INFO(0, 0x0f, 12)
+                        | EXTRACT_UTF8_INFO(1, 0x3f, 6)
+                        | EXTRACT_UTF8_INFO(2, 0x3f, 0);
+        } else if (IS_UTF8_INFO(0xf8, 0xf0)) {
+                key = EXTRACT_UTF8_INFO(0, 0x07, 18)
+                        | EXTRACT_UTF8_INFO(1, 0x3f, 12)
+                        | EXTRACT_UTF8_INFO(2, 0x3f, 6)
+                        | EXTRACT_UTF8_INFO(3, 0x3f, 0);
+        }
+#undef IS_UTF8_INFO
+#undef EXTRACT_UTF8_INFO
+
+        return key;
+}

--- a/src/sdl2/pui-misc.h
+++ b/src/sdl2/pui-misc.h
@@ -1,0 +1,34 @@
+/**
+ * \file sdl2/pui-misc.h
+ * \brief Declare miscellaneous utilities for the primitive UI toolkit for SDL2.
+ */
+#ifndef INCLUDED_SDL2_SDLPUI_MISC_H
+#define INCLUDED_SDL2_SDLPUI_MISC_H
+
+#include "pui-win.h"
+
+#ifdef SDLPUI_TRACE_EVENTS
+#define SDLPUI_EVENT_TRACER(type_name, address, label, event_name) SDL_LogVerbose(SDL_LOG_CATEGORY_APPLICATION, "%s (%p ; \"%s\") %s\n", type_name, (void*)address, label, event_name)
+#else
+#define SDLPUI_EVENT_TRACER(type_name, address, label, event_name) (void)0
+#endif
+
+#ifdef SDLPUI_TRACE_RENDER
+#define SDLPUI_RENDER_TRACER(type_name, address, label, outer_rect, inner_rect, texture) SDL_LogVerbose(SDL_LOG_CATEGORY_APPLICATION, "%s (%p ; \"%s\") rendering in outer bounds, (%d,%d) %d x %d, and inner bounds, (%d,%d) %d x %d, to %p\n", type_name, (void*)address, label, outer_rect.x, outer_rect.y, outer_rect.w, outer_rect.h, inner_rect.x, inner_rect.y, inner_rect.w, inner_rect.h, (void*)texture)
+#else
+#define SDLPUI_RENDER_TRACER(type_name, address, label, outer_rect, inner_rect, texture) (void)0
+#endif
+
+int sdlpui_init(void);
+void sdlpui_quit(void);
+Uint32 sdlpui_register_code(const char *name);
+SDL_Keymod sdlpui_get_interesting_keymods(void);
+struct sdlpui_stipple sdlpui_compute_stipple(SDL_Renderer *r);
+void sdlpui_stipple_rect(SDL_Renderer *r, struct sdlpui_stipple *stp,
+		const SDL_Rect *dst_r);
+void sdlpui_render_utf8_line(SDL_Renderer *r, TTF_Font *font,
+		const SDL_Color *fg, const SDL_Rect *dst_r, const char *s);
+void sdlpui_get_utf8_metrics(TTF_Font *font, const char *s, int *w, int *h);
+Uint32 sdlpui_utf8_to_codepoint(const char *uft8_string);
+
+#endif /* INCLUDED_SDL2_SDLPUI_MISC_H */

--- a/src/sdl2/pui-win.h
+++ b/src/sdl2/pui-win.h
@@ -1,0 +1,171 @@
+/**
+ * \file sdl2/pui-win.h
+ * \brief Make declarations to connect the SDL2 front end to a primitive UI
+ * toolkit based on SDL2 that will handle dialogs and menus overlayed on the
+ * front end's windows.  All functions declared here have to be implemented
+ * by the front end:  they are not implemented by the primitive UI toolkit.
+ */
+#ifndef INCLUDED_SDL2_SDLPUI_WINDOW_H
+#define INCLUDED_SDL2_SDLPUI_WINDOW_H
+
+#include "SDL.h"	/* SDL_Color, SDL_Renderer, SDL_Texture */
+#include "SDL_ttf.h"	/* TTF_Font */
+
+
+/* Forward declarations for the primitive UI toolkit implementation */
+struct sdlpui_dialog;
+
+/*
+ * Forward declaration for the application's data associated with an
+ * SDL_Window; the UI toolkit does not care about its internals
+ */
+struct sdlpui_window;
+
+struct sdlpui_stipple {
+	SDL_Texture *texture;
+	int w, h;		/* width and height */
+};
+
+
+/**
+ * Get the SDL_Renderer that the UI toolkit can use to render.
+ *
+ * \param w is the window containing what's to be rendered.
+ * \return the renderer that can be used to render directly to the window
+ * or to a texture.
+ */
+SDL_Renderer *sdlpui_get_renderer(struct sdlpui_window *w);
+
+/**
+ * Retrieve a reference to the font to use for all dialogs or menus.
+ *
+ * \param w is the window containing what's to be rendered.
+ * \return a pointer to the TTF font to use.
+ */
+TTF_Font *sdlpui_get_ttf(struct sdlpui_window *w);
+
+/**
+ * Retrieve a reference to a stipple pattern.
+ *
+ * \param w is the window containing what'll be stippled.
+ * \return a pointer to the structure describing the stippling.
+ *
+ * One can use sdlpui_compute_stipple() from sdlpui-misc.h to construct
+ * the stipple pattern.
+ */
+struct sdlpui_stipple *sdlpui_get_stipple(struct sdlpui_window *w);
+
+/*
+ * These are the roles where the primitive UI toolkit uses color.  You could
+ * either assign unique values to each (so you can lookup the appropriate
+ * color in sdlpui_get_color()) or optimize away that indirection and assign
+ * them the appopriate index for a color table that'll be directly accessed by
+ * sdlpui_get_color().
+ */
+#define SDLPUI_COLOR_MENU_BG (0)	/* background color for all menus */
+#define SDLPUI_COLOR_MENU_FG (1)	/* foreground color for all menus */
+#define SDLPUI_COLOR_MENU_BORDER (2)	/* border color for the menus that
+						have a border */
+#define SDLPUI_COLOR_DIALOG_BG (3)	/* background color for any dialog
+						that is not a menu */
+#define SDLPUI_COLOR_DIALOG_FG (4)	/* foreground color for any dialog
+						that is not a menu */
+#define SDLPUI_COLOR_DIALOG_BORDER (5)	/* border color for any dialog that
+						is not a menu */
+#define SDLPUI_COLOR_COUNTERSINK (6)	/* outer border color for push buttons
+						in dialogs and inner boundary
+						for dialogs that are not
+						menus */
+
+/**
+ * Retrieve a reference to the color to use for a specific role when
+ * rendering dialogs or menus.
+ *
+ * \param w is the window containing what's to be rendered.
+ * \param role is one of the SDLPUI_COLOR_* constants referring to how the
+ * color will be used.
+ * \return a pointer to color to use.
+ */
+const SDL_Color *sdlpui_get_color(struct sdlpui_window *w, int role);
+
+/**
+ * Signal that the window needs to be redrawn to reflect the state of the
+ * dialogs and menus.
+ */
+void sdlpui_signal_redraw(struct sdlpui_window *w);
+
+/**
+ * Push the given dialog (adding it if not already present) to the top of the
+ * window's stack of dialogs.
+ *
+ * \param w is the window containing the dialog.
+ * \param d is the dialog.
+ *
+ * Should also signal a redraw of the window is necessary if the dialog is
+ * not already at the top of the dialog stack.
+ */
+void sdlpui_dialog_push_to_top(struct sdlpui_window *w,
+		struct sdlpui_dialog *d);
+
+/**
+ * Remove the given dialog from the window's stack of dialogs.
+ *
+ * \param w is the window containing the dialog.
+ * \param d is the dialog.
+ *
+ * Has the side effect of ceding mouse and keyboard focus if the dialog has
+ * them and signalling that a redraw is necessary for the window.
+ */
+void sdlpui_dialog_pop(struct sdlpui_window *w, struct sdlpui_dialog *d);
+
+/**
+ * Tell the given window that the given dialog wants to take keyboard focus
+ * and receive all keyboard, text input, or text editing events in the window
+ * until it yields keyboard focus.
+ *
+ * \param w is the window containing the dialog.
+ * \param d is the dialog that wants to gain focus.
+ */
+void sdlpui_dialog_gain_key_focus(struct sdlpui_window *w,
+		struct sdlpui_dialog *d);
+
+/**
+ * Tell the given window that the given dialog wants to give up keyboard focus
+ * and not be sent keyboard, text input, or text editing events until it
+ * reacquires keyboard focus.
+ *
+ * \param w is the window containing the dialog.
+ * \param d is the dialog that is yielding focus.
+ */
+void sdlpui_dialog_yield_key_focus(struct sdlpui_window *w,
+		struct sdlpui_dialog *d);
+
+/**
+ * Tell the given window that the given dialog wants to take mouse focus and
+ * receive all mouse button, mouse wheel, and mouse motion events in the window
+ * until it yields mouse focus.
+ *
+ * \param w is the window containing the dialog.
+ * \param d is the dialog that wants to gain focus.
+ */
+void sdlpui_dialog_gain_mouse_focus(struct sdlpui_window *w,
+		struct sdlpui_dialog *d);
+
+/**
+ * Tell the given window that the given dialog wants to give up mouse focus
+ * and not be sent mouse button or mouse wheel events until it reacquires
+ * mouse focus.  Mouse motion events may be sent to a dialog without focus to
+ * see if that event would cause it to reacquire focus.
+ *
+ * \param w is the window containing the dialog.
+ * \param d is the dialog that is yielding focus.
+ */
+void sdlpui_dialog_yield_mouse_focus(struct sdlpui_window *w,
+		struct sdlpui_dialog *d);
+
+/**
+ * Quit the application.  Expected to not return.
+ */
+void sdlpui_force_quit(void);
+
+#endif /* INCLUDED_SDL2_SDLPUI_WINDOW_H */


### PR DESCRIPTION
Intended as preparation for adding a font selection dialog like the SDL front end now has.  The changes to appearance reduce the role of color in the menus, so as long as the colors at COLOUR_WHITE is distinct from the colors at COLOUR_SHADE and COLOUR_DARK, the menus should be usable.  That resolves https://github.com/angband/angband/issues/5596 .  Allows keyboard navigation of the menus (to avoid conflicts with user keymaps, no key is assigned for transferring focus to a menu; such keys can be configured with the "Menu Shortcuts" menu item).  Should allow mouse wheel events to change the integer menu entries (font and tile size).  Adds entries to sdl2init.txt so copies of that file generated by this version can not, without editing, be used by previous versions.

This is a rebased version of https://github.com/angband/angband/pull/5804 with changes for problems noted since that pull request was submitted.