### PR TITLE
Update licence info re Dubtrain sounds

### DIFF
--- a/docs/copying.rst
+++ b/docs/copying.rst
@@ -43,7 +43,7 @@ With the following exceptions:
 
   Currently some of the tiles in the 64x64.png tilesheet were resized from tiles made by David Gervais for the 32x32 set.
 
-* The sounds are licenced under the Creative Commons Attribution-NonCommercial-Sharealike licence.  They were created by Dubtrain <angband@dubtrain.com>. You can find them in Wave format at http://www.dubtrain.com/angband/.
+* The sounds are licenced under the Creative Commons Attribution 4.0 licence.  They were created by Dubtrain <angband@dubtrain.com>. You can find them in Wave format at http://www.dubtrain.com/angband/.
 
 * The font files are all by Leon Marrick and/or Sheldon Simms III and/or Nick McConnell, all of whom have agreed to their Angband work being released under the GPL.
 


### PR DESCRIPTION
They are now available under CC-BY 4.0. (see http://www.dubtrain.com/angband/).