### PR TITLE
Handle padding of text that could contain multibyte UTF-8 characters

### DIFF
--- a/src/ui-death.c
+++ b/src/ui-death.c
@@ -49,8 +49,8 @@ static void put_str_centred(int y, int x1, int x2, const char *fmt, ...)
 	tmp = vformat(fmt, vp);
 	va_end(vp);
 
-	/* Centre now */
-	len = strlen(tmp);
+	/* Centre now; account for possible multibyte characters */
+	len = utf8_strlen(tmp);
 	x = x1 + ((x2-x1)/2 - len/2);
 
 	put_str(tmp, y, x);

--- a/src/ui-object.c
+++ b/src/ui-object.c
@@ -301,7 +301,21 @@ static void build_obj_list(int last, struct object **list, item_tester tester,
 
 		/* Show full slot labels for equipment (or quiver in subwindow) */
 		if (equip) {
-			strnfmt(buf, sizeof(buf), "%-14s: ", equip_mention(player, i));
+			const char *mention = equip_mention(player, i);
+			size_t u8len = utf8_strlen(mention);
+
+			if (u8len < 14) {
+				strnfmt(buf, sizeof(buf), "%s%*s", mention,
+					(int)(14 - u8len), " ");
+			} else {
+				char *mention_copy = string_make(mention);
+
+				if (u8len > 14) {
+					utf8_clipto(mention_copy, 14);
+				}
+				strnfmt(buf, sizeof(buf), "%s", mention_copy);
+				string_free(mention_copy);
+			}
 			my_strcpy(items[num_obj].equip_label, buf,
 					  sizeof(items[num_obj].equip_label));
 		} else if ((in_term || dead) && quiver) {

--- a/src/ui-player.c
+++ b/src/ui-player.c
@@ -1148,10 +1148,19 @@ void write_character_dump(ang_file *fff)
 
 		file_putf(fff, "  [%s]\n\n", title);
 		for (opt = 0; opt < OPT_MAX; opt++) {
-			if (option_type(opt) != i) continue;
+			const char *desc;
+			size_t u8len;
 
-			file_putf(fff, "%-45s: %s (%s)\n",
-			        option_desc(opt),
+			if (option_type(opt) != i) continue;
+			desc = option_desc(opt);
+			u8len = utf8_strlen(desc);
+			if (u8len < 45) {
+				file_putf(fff, "%s%*s", desc,
+					(int)(45 - u8len), " ");
+			} else {
+				file_putf(fff, "%s", desc);
+			}
+			file_putf(fff, ": %s (%s)\n",
 			        player->opts.opt[opt] ? "yes" : "no ",
 			        option_name(opt));
 		}

--- a/src/ui-spell.c
+++ b/src/ui-spell.c
@@ -74,6 +74,7 @@ static void spell_menu_display(struct menu *m, int oid, bool cursor,
 	int attr;
 	const char *illegible = NULL;
 	const char *comment = "";
+	size_t u8len;
 
 	if (!spell) return;
 
@@ -102,8 +103,21 @@ static void spell_menu_display(struct menu *m, int oid, bool cursor,
 	}
 
 	/* Dump the spell --(-- */
-	strnfmt(out, sizeof(out), "%-30s%2d %4d %3d%%%s", spell->name,
-			spell->slevel, spell->smana, spell_chance(spell_index), comment);
+	u8len = utf8_strlen(spell->name);
+	if (u8len < 30) {
+		strnfmt(out, sizeof(out), "%s%*s", spell->name,
+			(int)(30 - u8len), " ");
+	} else {
+		char *name_copy = string_make(spell->name);
+
+		if (u8len > 30) {
+			utf8_clipto(name_copy, 30);
+		}
+		my_strcpy(out, name_copy, sizeof(out));
+		string_free(name_copy);
+	}
+	my_strcat(out, format("%2d %4d %3d%%%s", spell->slevel, spell->smana,
+		spell_chance(spell_index), comment), sizeof(out));
 	c_prt(attr, illegible ? illegible : out, row, col);
 }
 

--- a/src/wiz-spoil.c
+++ b/src/wiz-spoil.c
@@ -284,6 +284,9 @@ void spoil_obj_desc(const char *fname)
 					file_putf(fh, "  %s%*s", buf,
 						(int) (51 - u8len), " ");
 				} else {
+					if (u8len > 51) {
+						utf8_clipto(buf, 51);
+					}
 					file_putf(fh, "  %s", buf);
 				}
 				file_putf(fh, "%7s%6s%4d%9ld\n", dam, wgt, e,


### PR DESCRIPTION
Resolves https://github.com/NickMcConnell/FAangband/issues/395 (also present in vanilla).

The handling of some strings whose encoding is unknown (namely results from directory reads) or strings which are hardwired in the source code and currently do not contain multibyte characters has not changed.  Those are:

1. Formatting of entries for the save files in main.c
2. The speed indicator in ui-display.c
3. The depth indicator in ui-display.c
4. The section labels for the resistances panel in ui-player.c