### PR TITLE
SDL2: use a smaller border around controls in menus and dialogs

### DIFF
--- a/src/sdl2/pui-ctrl.h
+++ b/src/sdl2/pui-ctrl.h
@@ -15,8 +15,11 @@ struct sdlpui_window;
 
 /*
  * Default width for empty space around labels, push buttons, and menu buttons
+ * Two is smallest useful value (one pixel to indicate focus; another to
+ * indicate arming).  Larger than that will leave some blank space between
+ * the caption for a control and what's drawn to indicate focus or arming.
  */
-#define SDLPUI_DEFAULT_CTRL_BORDER 8
+#define SDLPUI_DEFAULT_CTRL_BORDER 3
 
 /*
  * Set out predefined values for the type_code field of struct sdlpui_control.


### PR DESCRIPTION
Suggested by Ituirth.  For the default menu bar font, reproduces the height of the menu bar from before the refactoring of the SDL2 front end.  Resolves tangar's complaint here, https://forum.angband.live/forum/angband/vanilla/10748-proposed-changes-for-sdl2?p=248157#post248157 , about less usable space with the refactored front end.