### PR TITLE
Unit tests: correct variance calculation for weapon damage

### DIFF
--- a/src/tests/object/info.c
+++ b/src/tests/object/info.c
@@ -564,7 +564,7 @@ static void collect_damage_results(double *avg, double *avg_var, int *work,
 	iavg = mean(work, NHITS, &favg);
 	ivar = variance(work, NHITS, true, true, &fvar);
 	*avg = (double)iavg + (double)favg.n / (double)favg.d;
-	*avg_var = (double)ivar + (double)favg.n / (double)favg.d;
+	*avg_var = (double)ivar + (double)fvar.n / (double)fvar.d;
 
 	/* Scale results to be per turn rather than per attack. */
 	if (launcher) {


### PR DESCRIPTION
Regression introduced by 8a21bbe0686d08a981bf57f92a10c49d4caa1ce2 .  Saw at least one test failure when NHITS is 100000000 (default is 10000); possible cause is that there is still some sloppy rounding in obj-info.c's damage calculations.

This change is already incorporated in https://github.com/NickMcConnell/FAangband/pull/405 for FAangband.