### PR TITLE
Fix handling of negative spell points

### DIFF
--- a/src/player-util.c
+++ b/src/player-util.c
@@ -584,7 +584,7 @@ int32_t player_adjust_mana_precise(struct player *p, int32_t sp_gain)
 			assert(p->csp > INT16_MIN);
 			p->csp -= 1;
 		} else {
-			p->chp_frac = 0;
+			p->csp_frac = 0;
 		}
 	} else {
 		p->csp = (int16_t)(new_32 >> 16);   /* div 65536 */


### PR DESCRIPTION
Could erroneously set the fractional hit points to zero rather than the fractional spell points.  Seen while looking for the source of https://github.com/NickMcConnell/FAangband/issues/406 but should have no effect on that issue.