### PR TITLE
SDL2: rework transferring focus

### DIFF
--- a/src/sdl2/pui-ctrl.h
+++ b/src/sdl2/pui-ctrl.h
@@ -128,11 +128,15 @@ struct sdlpui_control_funcs {
 		struct sdlpui_window *w, int comp_ind);
 	/*
 	 * Signal that the given control has lost keyboard focus.  Can be NULL.
-	 * following_mouse is true if the control is losing key focus because
-	 * it is losing mouse focus at the same time.
+	 * new_c is the control gaining key focus; it will be NULL if no
+	 * control is taking focus or new_d is NULL.
+	 * new_d is the dialog gaining key focus; it will be NULL if no
+	 * dialog is taking focus or the dialog is unknown (in another
+	 * window).
 	 */
 	void (*lose_key)(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, bool following_mouse);
+		struct sdlpui_window *w, struct sdlpui_control *new_c,
+		struct sdlpui_dialog *new_d);
 	/*
 	 * Signal that the given control has gained mouse focus and
 	 * perhaps should change its appearance when rendered.  comp_ind
@@ -142,11 +146,15 @@ struct sdlpui_control_funcs {
 		struct sdlpui_window *w, int comp_ind);
 	/*
 	 * Signal that the given control has lost mouse focus.  Can be NULL.
-	 * e is the motion event causing the loss of focus or NULL if focus
-	 * is lost for another reason.
+	 * new_c is the control gaining mouse focus; it will be NULL if no
+	 * control is taking focus or new_d is NULL.
+	 * new_d is the dialog gaining mouse focus; it will be NULL if no
+	 * dialog is taking focus or the dialog is unknown (in another
+	 * window).
 	 */
 	void (*lose_mouse)(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e);
+		struct sdlpui_window *w, struct sdlpui_control *new_c,
+		struct sdlpui_dialog *new_d);
 	/*
 	 * Signal that the child dialog for a control has been removed.  Can
 	 * be NULL if the control doesn't create a dialog, set the created

--- a/src/sdl2/pui-dlg.h
+++ b/src/sdl2/pui-dlg.h
@@ -54,15 +54,20 @@ struct sdlpui_dialog_funcs {
 		struct sdlpui_window *w, const SDL_MouseWheelEvent *e);
 	/*
 	 * Respond to the mouse focus being taken by another dialog.  May be
-	 * NULL.
+	 * NULL.  new_c is the control taking focus, it may be NULL.  new_d
+	 * is the dialog taking focus, it may be NULL.
 	 */
 	void (*handle_loses_mouse)(struct sdlpui_dialog *d,
-		struct sdlpui_window *w, const SDL_MouseMotionEvent *e);
+		struct sdlpui_window *w, struct sdlpui_control *new_c,
+		struct sdlpui_dialog *new_d);
 	/*
 	 * Respond to the key focus being taken by another dialog.  May be NULL.
+	 * new_c is the control taking focus, it may be NULL.  new_d is the
+	 * dialog taking focus; it may be NULL.
 	 */
 	void (*handle_loses_key)(struct sdlpui_dialog *d,
-		struct sdlpui_window *w, const SDL_MouseMotionEvent *e);
+		struct sdlpui_window *w, struct sdlpui_control *new_c,
+		struct sdlpui_dialog *new_d);
 	/*
 	 * Respond to the mouse leaving the containing window if the dialog
 	 * had mouse focus when that happened.  May be NULL.
@@ -250,6 +255,8 @@ struct sdlpui_simple_info {
 
 
 bool sdlpui_is_in_dialog(const struct sdlpui_dialog *d, Sint32 x, Sint32 y);
+bool sdlpui_is_descendant_dialog(struct sdlpui_dialog *ancestor,
+		const struct sdlpui_dialog *other);
 void sdlpui_popup_dialog(struct sdlpui_dialog *d, struct sdlpui_window *w,
 		bool give_key_focus);
 void sdlpui_popdown_dialog(struct sdlpui_dialog *d, struct sdlpui_window *w,
@@ -287,13 +294,17 @@ void sdlpui_dialog_handle_window_loses_key(struct sdlpui_dialog *d,
 void sdlpui_menu_handle_window_loses_key(struct sdlpui_dialog *d,
 		struct sdlpui_window *w);
 void sdlpui_dialog_handle_loses_mouse(struct sdlpui_dialog *d,
-		struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e);
+		struct sdlpui_window *w, struct sdlpui_control *new_c,
+		struct sdlpui_dialog *new_d);
 void sdlpui_menu_handle_loses_mouse(struct sdlpui_dialog *d,
-		struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e);
+		struct sdlpui_window *w, struct sdlpui_control *new_c,
+		struct sdlpui_dialog *new_d);
 void sdlpui_dialog_handle_loses_key(struct sdlpui_dialog *d,
-		struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e);
+		struct sdlpui_window *w, struct sdlpui_control *new_c,
+		struct sdlpui_dialog *new_d);
 void sdlpui_menu_handle_loses_key(struct sdlpui_dialog *d,
-		struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e);
+		struct sdlpui_window *w, struct sdlpui_control *new_c,
+		struct sdlpui_dialog *new_d);
 
 /* Construct a simple menu */
 struct sdlpui_dialog *sdlpui_start_simple_menu(struct sdlpui_dialog *parent,

--- a/src/sdl2/pui-win.h
+++ b/src/sdl2/pui-win.h
@@ -164,6 +164,16 @@ void sdlpui_dialog_yield_mouse_focus(struct sdlpui_window *w,
 		struct sdlpui_dialog *d);
 
 /**
+ * Get the dialog with key focus, if any.
+ */
+struct sdlpui_dialog *sdlpui_dialog_with_key_focus(struct sdlpui_window *w);
+
+/**
+ * Get the dialog with mouse focus, if any.
+ */
+struct sdlpui_dialog *sdlpui_dialog_with_mouse_focus(struct sdlpui_window *w);
+
+/**
  * Quit the application.  Expected to not return.
  */
 void sdlpui_force_quit(void);


### PR DESCRIPTION
May resolve Ituirth's report here, https://angband.live/forums/forum/angband/vanilla/10748-proposed-changes-for-sdl2?p=248173#post248173 (dangling reference/use after free for a dialog leads to a crash), and other problems after using a menu shortcut and then trying to interact with the menu using the mouse.