### PR TITLE
Move some assertions

### DIFF
--- a/src/gen-room.c
+++ b/src/gen-room.c
@@ -903,11 +903,12 @@ bool mon_pit_hook(struct monster_race *race)
 {
 	bool match_base = true;
 	bool match_color = true;
-	int innate_freq = dun->pit_type->freq_innate;
+	int innate_freq;
 
 	assert(race);
 	assert(dun->pit_type);
 
+	innate_freq = dun->pit_type->freq_innate;
 	if (rf_has(race->flags, RF_UNIQUE)) {
 		return false;
 	} else if (!rf_is_subset(race->flags, dun->pit_type->flags)) {

--- a/src/mon-make.c
+++ b/src/mon-make.c
@@ -751,9 +751,8 @@ static bool mon_create_drop(struct chunk *c, struct monster *mon,
 		uint8_t origin)
 {
 	const struct monster_drop *drop;
-	struct monster_lore *lore = get_lore(mon->race);
-	const struct monster_race *effective_race = (mon->original_race) ?
-		mon->original_race : mon->race;
+	struct monster_lore *lore;
+	const struct monster_race *effective_race;
 	bool great, good, gold_ok, item_ok;
 	bool extra_roll = false;
 	bool any = false;
@@ -763,6 +762,8 @@ static bool mon_create_drop(struct chunk *c, struct monster *mon,
 	struct object *obj;
 
 	assert(mon);
+	lore = get_lore(mon->race);
+	effective_race = (mon->original_race) ? mon->original_race : mon->race;
 
 	great = (rf_has(effective_race->flags, RF_DROP_GREAT));
 	good = great || (rf_has(effective_race->flags, RF_DROP_GOOD));

--- a/src/trap.c
+++ b/src/trap.c
@@ -175,7 +175,6 @@ bool square_remove_all_traps(struct chunk *c, struct loc grid)
 	struct trap *trap = square(c, grid)->trap;
 	bool were_there_traps = trap == NULL ? false : true;
 
-	assert(square_in_bounds(c, grid));
 	while (trap) {
 		struct trap *next_trap = trap->next;
 		mem_free(trap);
@@ -207,7 +206,6 @@ bool square_remove_trap(struct chunk *c, struct loc grid, int t_idx_remove)
 	struct trap *prev_trap = NULL;
 	struct trap *trap = square(c, grid)->trap;
 
-	assert(square_in_bounds(c, grid));
 	while (trap) {
 		struct trap *next_trap = trap->next;
 

--- a/src/z-bitflag.c
+++ b/src/z-bitflag.c
@@ -53,8 +53,6 @@ bool flag_has_dbg(const bitflag *flags, const size_t size, const int flag,
 		         fi, fl, flag, (unsigned int) size, (unsigned int) flag_offset, flag_binary);
 	}
 
-	assert(flag_offset < size);
-
 	if (flags[flag_offset] & flag_binary) return true;
 
 	return false;
@@ -222,8 +220,6 @@ bool flag_on_dbg(bitflag *flags, const size_t size, const int flag,
 		quit_fmt("Error in flag_on(%s, %s): FlagID[%d] Size[%u] FlagOff[%u] FlagBV[%d]\n",
 		         fi, fl, flag, (unsigned int) size, (unsigned int) flag_offset, flag_binary);
 	}
-
-	assert(flag_offset < size);
 
 	if (flags[flag_offset] & flag_binary) return false;
 


### PR DESCRIPTION
That's so other logic that assumes what the assertion tests happens after the assertion.  Fixes an instance reported by PowerWyrm here, https://angband.live/forums/forum/angband/vanilla/10689-angband-4-2-5?p=248214#post248214 .  Remove some redundant assertions.