### PR TITLE
Improve the show_damage option

### DIFF
--- a/src/effect-handler-general.c
+++ b/src/effect-handler-general.c
@@ -201,7 +201,15 @@ static bool uncurse_object(struct object *obj, int strength, char *dice_string)
 			/* Failure - unlucky fragile object is destroyed */
 			struct object *destroyed;
 			bool none_left = false;
-			msg("There is a bang and a flash!");
+			int dam = damroll(5, 5);
+			char dam_text[16] = "";
+
+			dam = player_apply_damage_reduction(player, dam);
+			if (dam > 0 && OPT(player, show_damage)) {
+				strnfmt(dam_text, sizeof(dam_text), " (%d)",
+					dam);
+			}
+			msg("%s%s", "There is a bang and a flash!", dam_text);
 			if (object_is_carried(player, obj)) {
 				destroyed = gear_object_for_use(player, obj,
 					1, false, &none_left);
@@ -214,7 +222,7 @@ static bool uncurse_object(struct object *obj, int strength, char *dice_string)
 			} else {
 				square_delete_object(cave, obj->grid, obj, true, true);
 			}
-			take_hit(player, damroll(5, 5), "Failed uncursing");
+			take_hit(player, dam, "Failed uncursing");
 		} else {
 			/* Non-destructive failure */
 			msg("The removal fails.");
@@ -812,14 +820,20 @@ bool effect_handler_DRAIN_STAT(effect_handler_context_t *context)
 	/* Attempt to reduce the stat */
 	if (player_stat_dec(player, stat, false)){
 		int dam = effect_calculate_value(context, false);
+		char dam_text[32] = "";
+
+		dam = player_apply_damage_reduction(player, dam);
 
 		/* Notice effect */
 		equip_learn_flag(player, flag);
 
 		/* Message */
-		msgt(MSG_DRAIN_STAT, "You feel very %s.", desc_stat(stat, false));
-		if (dam)
-			take_hit(player, dam, "stat drain");
+		if (dam > 0 && OPT(player, show_damage)) {
+			strnfmt(dam_text, sizeof(dam_text), " (%d)", dam);
+		}
+		msgt(MSG_DRAIN_STAT, "You feel very %s.%s",
+			desc_stat(stat, false), dam_text);
+		take_hit(player, dam, "stat drain");
 	}
 
 	return (true);
@@ -2361,6 +2375,10 @@ bool effect_handler_BANISH(effect_handler_context_t *context)
 	}
 
 	/* Hurt the player */
+	dam = player_apply_damage_reduction(player, dam);
+	if (dam > 0 && OPT(player, show_damage)) {
+		msg("You take %d damage.\n", dam);
+	}
 	take_hit(player, dam, "the strain of casting Banishment");
 
 	/* Update monster list window */
@@ -2409,6 +2427,10 @@ bool effect_handler_MASS_BANISH(effect_handler_context_t *context)
 	}
 
 	/* Hurt the player */
+	dam = player_apply_damage_reduction(player, dam);
+	if (dam > 0 && OPT(player, show_damage)) {
+		msg("You take %d damage.\n", dam);
+	}
 	take_hit(player, dam, "the strain of casting Mass Banishment");
 
 	/* Update monster list window */

--- a/src/game-world.c
+++ b/src/game-world.c
@@ -587,7 +587,8 @@ void process_world(struct chunk *c)
 
 	/* Take damage from poison */
 	if (player->timed[TMD_POISONED]) {
-		take_hit(player, 1, "poison");
+		take_hit(player, player_apply_damage_reduction(player, 1),
+			"poison");
 		if (player->is_dead) {
 			return;
 		}
@@ -608,7 +609,8 @@ void process_world(struct chunk *c)
 		}
 
 		/* Take damage */
-		take_hit(player, i, "a fatal wound");
+		take_hit(player, player_apply_damage_reduction(player, i),
+			"a fatal wound");
 		if (player->is_dead) {
 			return;
 		}
@@ -706,7 +708,8 @@ void process_world(struct chunk *c)
 		i = (PY_FOOD_STARVE - player->timed[TMD_FOOD]) / 10;
 
 		/* Take damage */
-		take_hit(player, i, "starvation");
+		take_hit(player, player_apply_damage_reduction(player, i),
+			"starvation");
 		if (player->is_dead) {
 			return;
 		}

--- a/src/list-mon-message.h
+++ b/src/list-mon-message.h
@@ -62,6 +62,8 @@ MON_MSG(MAINTAIN_SHAPE,		MSG_GENERIC,	false,	"maintain[s] the same shape.")
 MON_MSG(UNHARMED,			MSG_GENERIC,	false,	"[is|are] unharmed.")
 MON_MSG(APPEAR,			MSG_GENERIC,	false,	"appear[s]!")
 MON_MSG(HIT_AND_RUN,		MSG_GENERIC,	true,	"There is a puff of smoke!")
+MON_MSG(QUAKE_DEATH,		MSG_KILL,	false,	"[is|are] embedded in rock!")
+MON_MSG(QUAKE_HURT,		MSG_GENERIC,	false,	"wail[s] out in pain!")
 /* Dummy messages for monster pain - we use edit file info instead. */
 MON_MSG(95,					MSG_GENERIC,	false,	"")
 MON_MSG(75,					MSG_GENERIC,	false,	"")

--- a/src/mon-attack.c
+++ b/src/mon-attack.c
@@ -572,9 +572,6 @@ bool make_attack_normal(struct monster *mon, struct player *p)
 		int damage = 0;
 		bool do_cut = false;
 		bool do_stun = false;
-		int sound_msg = MSG_GENERIC;
-
-		char *act = NULL;
 
 		/* Extract the attack infomation */
 		struct blow_effect *effect = mon->race->blow[ap_cnt].effect;
@@ -612,11 +609,8 @@ bool make_attack_normal(struct monster *mon, struct player *p)
 				}
 			}
 
-			/* Describe the attack method */
-			act = monster_blow_method_action(method, -1);
 			do_cut = method->cut;
 			do_stun = method->stun;
-			sound_msg = method->msgt;
 
 			/* Hack -- assume all attacks are obvious */
 			obvious = true;
@@ -627,21 +621,6 @@ bool make_attack_normal(struct monster *mon, struct player *p)
 			/* Reduce damage when stunned */
 			if (mon->m_timed[MON_TMD_STUN]) {
 				damage = (damage * (100 - STUN_DAM_REDUCTION)) / 100;
-			}
-
-			/* Message */
-			if (act) {
-				const char *fullstop = ".";
-				if (suffix(act, "'") || suffix(act, "!")) {
-					fullstop = "";
-				}
-
-				if (OPT(p, show_damage)) {
-					msgt(sound_msg, "%s %s (%d)%s", m_name, act, damage,
-						 fullstop);
-				} else {
-					msgt(sound_msg, "%s %s%s", m_name, act, fullstop);
-				}
 			}
 
 			/* Perform the actual effect. */
@@ -658,6 +637,7 @@ bool make_attack_normal(struct monster *mon, struct player *p)
 					obvious,
 					blinked,
 					damage,
+					m_name
 				};
 
 				effect_handler(&context);
@@ -734,8 +714,6 @@ bool make_attack_normal(struct monster *mon, struct player *p)
 						true, true, true);
 				}
 			}
-
-			string_free(act);
 		} else {
 			/* Visible monster missed player, so notify if appropriate. */
 			if (monster_is_visible(mon) &&	method->miss) {
@@ -808,9 +786,6 @@ bool monster_attack_monster(struct monster *mon, struct monster *t_mon)
 
 		int damage = 0;
 		bool do_stun = false;
-		int sound_msg = MSG_GENERIC;
-
-		char *act = NULL;
 
 		/* Extract the attack infomation */
 		struct blow_effect *effect = mon->race->blow[ap_cnt].effect;
@@ -826,10 +801,7 @@ bool monster_attack_monster(struct monster *mon, struct monster *t_mon)
 			test_hit(chance_of_monster_hit(mon, effect), t_mon->race->ac)) {
 			melee_effect_handler_f effect_handler;
 
-			/* Describe the attack method */
-			act = monster_blow_method_action(method, t_mon->midx);
 			do_stun = method->stun;
-			sound_msg = method->msgt;
 
 			/* Hack -- assume all attacks are obvious */
 			obvious = true;
@@ -840,16 +812,6 @@ bool monster_attack_monster(struct monster *mon, struct monster *t_mon)
 			/* Reduce damage when stunned */
 			if (mon->m_timed[MON_TMD_STUN]) {
 				damage = (damage * (100 - STUN_DAM_REDUCTION)) / 100;
-			}
-
-			/* Message */
-			if (act) {
-				const char *fullstop = ".";
-				if (suffix(act, "'") || suffix(act, "!")) {
-					fullstop = "";
-				}
-
-				msgt(sound_msg, "%s %s%s", m_name, act, fullstop);
 			}
 
 			/* Perform the actual effect. */
@@ -866,6 +828,7 @@ bool monster_attack_monster(struct monster *mon, struct monster *t_mon)
 					obvious,
 					blinked,
 					damage,
+					m_name
 				};
 
 				effect_handler(&context);
@@ -899,8 +862,6 @@ bool monster_attack_monster(struct monster *mon, struct monster *t_mon)
 				if (amt)
 					(void)mon_inc_timed(t_mon, MON_TMD_STUN, amt, 0);
 			}
-
-			string_free(act);
 		} else {
 			/* Visible monster missed monster, so notify if appropriate. */
 			if (monster_is_visible(mon) && method->miss) {

--- a/src/mon-blows.h
+++ b/src/mon-blows.h
@@ -58,10 +58,13 @@ typedef struct melee_effect_handler_context_s {
 	const int rlev;
 	const struct blow_method *method;
 	const int ac;
-	const char *ddesc;
+	const char *ddesc;		/* short monster name for death
+						messages; unused if target is
+						not the player */
 	bool obvious;
 	bool blinked;
 	int damage;
+	const char *m_name;		/* monster name for messaging */
 } melee_effect_handler_context_t;
 
 /**
@@ -87,7 +90,7 @@ extern struct blow_effect *blow_effects;
 
 /* Functions */
 int blow_index(const char *name);
-char *monster_blow_method_action(struct blow_method *method, int midx);
+char *monster_blow_method_action(const struct blow_method *method, int midx);
 extern melee_effect_handler_f melee_handler_for_blow_effect(const char *name);
 
 #endif /* MON_BLOWS_H */

--- a/src/mon-msg.h
+++ b/src/mon-msg.h
@@ -31,7 +31,10 @@ enum mon_messages {
 };
 
 void message_pain(struct monster *m, int dam);
+void message_pain_show_damage(struct monster *m, int dam);
 bool add_monster_message(struct monster *m, int msg_code, bool delay);
+bool add_monster_message_show_damage(struct monster *m, int msg_code,
+		bool delay, int damage);
 void show_monster_messages(void);
 
 #endif /* MONSTER_MESSAGE_H */

--- a/src/player-util.c
+++ b/src/player-util.c
@@ -149,7 +149,38 @@ void dungeon_change_level(struct player *p, int dlev)
 
 
 /**
+ * Returns what an incoming damage amount would be after applying a player's
+ * damage reduction.
+ *
+ * \param p is the player of interest.
+ * \param dam is the incoming damaage amount.
+ * \return the damage after the player's damage reduction, if any.
+ */
+int player_apply_damage_reduction(struct player *p, int dam)
+{
+	/* Mega-Hack -- Apply "invulnerability" */
+	if (p->timed[TMD_INVULN] && (dam < 9000)) return 0;
+
+	dam -= p->state.dam_red;
+	if (dam > 0 && p->state.perc_dam_red) {
+		dam -= (dam * p->state.perc_dam_red) / 100 ;
+	}
+
+	return (dam < 0) ? 0 : dam;
+}
+
+
+/**
  * Decreases players hit points and sets death flag if necessary
+ *
+ * \param p is the player of interest.
+ * \param dam is the amount of damage to apply.  If dam is less than
+ * or equal to zero, nothing will be done.  The amount of damage should have
+ * been processed with player_apply_damage_reduction(); that is not done
+ * internally here so the caller can display messages that include the amount of
+ * damage.
+ * \param kb_str is the null-terminated string describing the cause of the
+ * damage.
  *
  * Hack -- this function allows the user to save (or quit) the game
  * when he dies, since the "You die." message is shown before setting
@@ -162,17 +193,7 @@ void take_hit(struct player *p, int dam, const char *kb_str)
 	int warning = (p->mhp * p->opts.hitpoint_warn / 10);
 
 	/* Paranoia */
-	if (p->is_dead) return;
-
-	/* Mega-Hack -- Apply "invulnerability" */
-	if (p->timed[TMD_INVULN] && (dam < 9000)) return;
-
-	/* Apply damage reduction */
-	dam -= p->state.dam_red;
-	if (p->state.perc_dam_red) {
-		dam -= (dam * p->state.perc_dam_red) / 100 ;
-	}
-	if (dam <= 0) return;
+	if (p->is_dead || dam <= 0) return;
 
 	/* Disturb */
 	disturb(p);
@@ -851,8 +872,16 @@ void player_over_exert(struct player *p, int flag, int chance, int amount)
 	/* HP */
 	if (flag & PY_EXERT_HP) {
 		if (randint0(100) < chance) {
-			msg("You cry out in sudden pain!");
-			take_hit(p, randint1(amount), "over-exertion");
+			int dam = player_apply_damage_reduction(p,
+				randint1(amount));
+			char dam_text[32] = "";
+
+			if (dam > 0 && OPT(p, show_damage)) {
+				strnfmt(dam_text, sizeof(dam_text),
+					" (%d)", dam);
+			}
+			msg("You cry out in sudden pain!%s", dam_text);
+			take_hit(p, dam, "over-exertion");
 		}
 	}
 }
@@ -896,17 +925,29 @@ int player_check_terrain_damage(struct player *p, struct loc grid, bool actual)
 void player_take_terrain_damage(struct player *p, struct loc grid)
 {
 	int dam_taken = player_check_terrain_damage(p, grid, true);
+	int dam_reduced;
 
 	if (!dam_taken) {
 		return;
 	}
 
-	/* Damage the player and inventory */
+	/*
+	 * Damage the player and inventory; inventory damage is based on
+	 * the raw incoming damage and not the value accounting for the
+	 * player's damage reduction.
+	 */
+	dam_reduced = player_apply_damage_reduction(p, dam_taken);
 	if (square_isfiery(cave, grid)) {
-		msg(square_feat(cave, grid)->hurt_msg);
+		char dam_text[32] = "";
+
+		if (dam_reduced > 0 && OPT(p, show_damage)) {
+			strnfmt(dam_text, sizeof(dam_text), " (%d)",
+				dam_reduced);
+		}
+		msg("%s%s", square_feat(cave, grid)->hurt_msg, dam_text);
 		inven_damage(p, PROJ_FIRE, dam_taken);
 	}
-	take_hit(p, dam_taken, square_feat(cave, grid)->die_msg);
+	take_hit(p, dam_reduced, square_feat(cave, grid)->die_msg);
 }
 
 /**

--- a/src/player-util.h
+++ b/src/player-util.h
@@ -64,6 +64,7 @@ int dungeon_get_next_level(struct player *p, int dlev, int added);
 void player_set_recall_depth(struct player *p);
 bool player_get_recall_depth(struct player *p);
 void dungeon_change_level(struct player *p, int dlev);
+int player_apply_damage_reduction(struct player *p, int dam);
 void take_hit(struct player *p, int dam, const char *kb_str);
 void death_knowledge(struct player *p);
 int energy_per_move(struct player *p);

--- a/src/project-mon.c
+++ b/src/project-mon.c
@@ -1103,6 +1103,8 @@ static bool project_m_player_attack(project_monster_handler_context_t *context)
 	enum mon_messages die_msg = context->die_msg;
 	enum mon_messages hurt_msg = context->hurt_msg;
 	struct monster *mon = context->mon;
+	bool display_dam = context->origin.what == SRC_PLAYER
+		&& OPT(player, show_damage);
 
 	/* The monster is going to be killed, so display a specific death message.
 	 * If the monster is not visible to the player, use a generic message.
@@ -1112,7 +1114,12 @@ static bool project_m_player_attack(project_monster_handler_context_t *context)
 	 * of messages. */
 	if (dam > mon->hp) {
 		if (!seen) die_msg = MON_MSG_MORIA_DEATH;
-		add_monster_message(mon, die_msg, false);
+		if (display_dam) {
+			add_monster_message_show_damage(mon, die_msg, false,
+				dam);
+		} else {
+			add_monster_message(mon, die_msg, false);
+		}
 	}
 
 	/* No damage is now going to mean the monster is not hit - and hence
@@ -1126,10 +1133,20 @@ static bool project_m_player_attack(project_monster_handler_context_t *context)
 	 * based on the amount of damage dealt. Also display a message
 	 * if the hit caused the monster to flee. */
 	if (!mon_died) {
-		if (seen && hurt_msg != MON_MSG_NONE)
-			add_monster_message(mon, hurt_msg, false);
-		else if (dam > 0)
-			message_pain(mon, dam);
+		if (display_dam) {
+			if (seen && hurt_msg != MON_MSG_NONE) {
+				add_monster_message_show_damage(mon, hurt_msg,
+					false, dam);
+			} else if (dam > 0) {
+				message_pain_show_damage(mon, dam);
+			}
+		} else {
+			if (seen && hurt_msg != MON_MSG_NONE) {
+				add_monster_message(mon, hurt_msg, false);
+			} else if (dam > 0) {
+				message_pain(mon, dam);
+			}
+		}
 
 		if (seen && fear)
 			add_monster_message(mon, MON_MSG_FLEE_IN_TERROR, true);

--- a/src/project-player.c
+++ b/src/project-player.c
@@ -892,17 +892,33 @@ bool project_p(struct source origin, int r, struct loc grid, int dam, int typ,
 							 res_level,
 							 true);
 	if (context.dam) {
+		int reduced;
+
 		/* Self-inflicted damage is scaled down */
 		if (self) {
 			context.dam /= 10;
 		}
-		take_hit(player, context.dam, killer);
+		/*
+		 * Account for the player's damage reduction.   That does not
+		 * affect the side effects (i.e. player_handler), so leave
+		 * context.dam unmodified.
+		 */
+		reduced = player_apply_damage_reduction(player, context.dam);
+		if (reduced > 0 && OPT(player, show_damage)) {
+			msg("You take %d damage.", reduced);
+		}
+		take_hit(player, reduced, killer);
 	}
 
 	/* Handle side effects, possibly including extra damage */
 	if (player_handler != NULL && player->is_dead == false) {
 		int xtra = player_handler(&context);
-		if (xtra) take_hit(player, xtra, killer);
+
+		xtra = player_apply_damage_reduction(player, xtra);
+		if (xtra > 0 && OPT(player, show_damage)) {
+			msg("You take an extra %d damage.", xtra);
+		}
+		take_hit(player, xtra, killer);
 	}
 
 	/* Disturb */


### PR DESCRIPTION
For player damage to monsters, provide damage notifications for projections and effects that do not use projections.
For damage to a player, provide damage notifications for all but the poison, cut, and starvation damage applied in process_world().  The damage notifications now include the effects of player invulnerability, player damage reduction, and changes to damage in monsters' blow handlers.
Resolves https://github.com/angband/angband/issues/5862 and https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=780770 .
Side effect of these changes are:
1) Messages for monsters affected by an earthquake now use add_monster_message()
 and that implies some changes to the text of the messages, ordering of the messages, and handling of duplicate messages.
2) To have the damage notifications for damage to the player include the effects of damage reduction and invulnerability, move the handling of those effects from take_hit() to a new function, player_apply_damage_reduction(), also declared in player-util.h.  Callers of take_hit() should process the damage passed to it with player_apply_damage_reduction() in order to match the old behavior of take_hit().
3) To have the damage notification from a monster blow include the changes to damage in the blow handler and the player's damage reduction, move the messaging about the blow from make_attack_normal() or monster_attack_monster() into the blow handler.  The private functions, display_blow_message_vs_player() and display_blow_message_vs_monster(), in mon-blows.c can handle the messaging for a blow handler.  A blow handler that calls monster_damage_target(), melee_effect_elemental(), or melee_effect_experience() will have the messaging done by those functions.  Blow handlers that would need changes are those that do not call those functions or those that call more than one of them (they would get multiple messages for the same blow).

With these changes and show_damage enabled, the message recall from an encounter where a mage cast Fire Ball followed by Electric Arc twice were:

```
4 wolves yelp in pain. (average 10)
2 wolves howl in agony. (average 12)
2 drúadan mages grunt with pain. (average 12)
The skeleton kobold rattles. (8)
2 monsters grunt with pain. (average 8)
The wolf howls in pain. (8)
2 wolves flee in terror!
The wolf dies. (24)
The wolf bites you. (4)
The wolf misses you.
2 drúadan mages cry out in pain. (average 14)
The drúadan mage tries to cast a spell, but fails.
3 drúadan mages cry out in pain. (average 13)
```

Without damage notifications on, the message recall would have looked like:

```
4 wolves yelp in pain.
2 wolves howl in agony.
2 drúadan mages grunt with pain.
The skeleton kobold rattles.
2 monsters grunt with pain.
The wolf howls in pain.
2 wolves flee in terror!
The wolf dies.
The wolf bites you.
The wolf misses you.
2 drúadan mages cry out in pain.
The drúadan mage tries to cast a spell, but fails.
3 drúadan mages cry out in pain.
```

So there's no change in the number of messages just the extra text for the damage notifications.