### PR TITLE
Workflows: update versions of used actions for compatibility with Node 20

### DIFF
--- a/.github/workflows/dos.yaml
+++ b/.github/workflows/dos.yaml
@@ -17,7 +17,7 @@ jobs:
           sudo apt-get install make
 
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: |

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -16,7 +16,7 @@ jobs:
           sudo apt-get install gcc automake autoconf make libx11-dev
 
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: |
@@ -36,7 +36,7 @@ jobs:
           sudo apt-get install gcc make cmake libx11-dev
 
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: |
@@ -55,7 +55,7 @@ jobs:
           sudo apt-get install gcc make cmake libncursesw5-dev
 
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: |
@@ -74,7 +74,7 @@ jobs:
           sudo apt-get install gcc make cmake libsdl-image1.2-dev libsdl-ttf2.0-dev libsdl-mixer1.2-dev
 
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: |
@@ -93,7 +93,7 @@ jobs:
           sudo apt-get install gcc autoconf automake make libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev
 
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: |
@@ -111,7 +111,7 @@ jobs:
           sudo apt-get install gcc autoconf automake make libsqlite3-dev libsdl1.2-dev libsdl-mixer1.2-dev
 
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Turn on sound and the test front end so more of the basic
       # infrastructure is compiled.
@@ -131,7 +131,7 @@ jobs:
           sudo apt-get install gcc make libncursesw5-dev libx11-dev libsdl-image1.2-dev libsdl-ttf2.0-dev libsdl-mixer1.2-dev libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev libsqlite3-dev
 
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: |

--- a/.github/workflows/mac.yaml
+++ b/.github/workflows/mac.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: |
@@ -30,7 +30,7 @@ jobs:
           brew install automake
 
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: |

--- a/.github/workflows/msbuild.yaml
+++ b/.github/workflows/msbuild.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1.1
 
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: |

--- a/.github/workflows/msys2.yaml
+++ b/.github/workflows/msys2.yaml
@@ -25,7 +25,7 @@ jobs:
             mingw-w64-x86_64-ncurses
 
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: |
@@ -54,7 +54,7 @@ jobs:
             mingw-w64-x86_64-SDL2_mixer
 
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: |
@@ -81,7 +81,7 @@ jobs:
             mingw-w64-i686-gcc
 
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: |

--- a/.github/workflows/nintendo.yaml
+++ b/.github/workflows/nintendo.yaml
@@ -13,7 +13,7 @@ jobs:
     container: devkitpro/devkitarm
     steps:
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Extract Names from Makefile
         id: get_names
@@ -70,7 +70,7 @@ jobs:
     container: skylyrac/blocksds:slim-latest
     steps:
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         shell: bash
@@ -85,7 +85,7 @@ jobs:
     container: devkitpro/devkitarm
     steps:
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         shell: bash

--- a/.github/workflows/nmake.yaml
+++ b/.github/workflows/nmake.yaml
@@ -13,12 +13,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Add nmake and compiler to PATH
-        uses: TheMrMilchmann/setup-msvc-dev@v2
+        uses: TheMrMilchmann/setup-msvc-dev@v3
         with:
           arch: x86
 
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,7 +67,7 @@ jobs:
       # Need commit history and tags for scripts/version.sh to work as expected
       # so use 0 for fetch-depth.
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -134,7 +134,7 @@ jobs:
       # Need commit history and tags for scripts/version.sh to work as expected
       # so use 0 for fetch-depth.
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -183,7 +183,7 @@ jobs:
       # Need commit history and tags for scripts/version.sh to work as expected
       # so use 0 for fetch-depth.
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -201,14 +201,14 @@ jobs:
           echo archive_path= '${{ steps.create_source_archive.outputs.archive_file }}' > $SRC_ARTIFACT_PATH
 
       - name: Upload Artifact with Source Archive Path
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.SRC_ARTIFACT }}
           path: ${{ env.SRC_ARTIFACT_PATH }}
           retention-days: 1
 
       - name: Upload Source Archive as Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.SRC_ARCHIVE_ARTIFACT }}
           path: ${{ steps.create_source_archive.outputs.archive_file }}
@@ -220,7 +220,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Download Artifact with Configuration Information
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.CONFIG_ARTIFACT }}
 
@@ -242,12 +242,12 @@ jobs:
       # Need commit history and tags for scripts/version.sh to work as expected
       # so use 0 for fetch-depth.
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Download Artifact with Converted Documents
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.DOC_ARTIFACT }}
 
@@ -276,14 +276,14 @@ jobs:
           echo archive_path= '${{ steps.create_windows_archive.outputs.archive_file }}' > $WIN_ARTIFACT_PATH
 
       - name: Upload Artifact with Windows Archive Path
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.WIN_ARTIFACT }}
           path: ${{ env.WIN_ARTIFACT_PATH }}
           retention-days: 1
 
       - name: Upload Windows Archive as Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.WIN_ARCHIVE_ARTIFACT }}
           path: ${{ steps.create_windows_archive.outputs.archive_file }}
@@ -295,7 +295,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Download Artifact with Configuration Information
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.CONFIG_ARTIFACT }}
 
@@ -312,12 +312,12 @@ jobs:
       # Need commit history and tags for scripts/version.sh to work as expected
       # so use 0 for fetch-depth.
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Download Artifact with Converted Documents
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.DOC_ARTIFACT }}
 
@@ -344,14 +344,14 @@ jobs:
           echo archive_path= '${{ steps.create_mac_archive.outputs.archive_file }}' > $MAC_ARTIFACT_PATH
 
       - name: Upload Artifact with Mac Archive Path
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.MAC_ARTIFACT }}
           path: ${{ env.MAC_ARTIFACT_PATH }}
           retention-days: 1
 
       - name: Upload Mac Archive as Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.MAC_ARCHIVE_ARTIFACT }}
           path: ${{ steps.create_mac_archive.outputs.archive_file }}
@@ -364,7 +364,7 @@ jobs:
     container: devkitpro/devkitarm
     steps:
       - name: Download Artifact with Configuration Information
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.CONFIG_ARTIFACT }}
 
@@ -379,12 +379,12 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Download Artifact with Converted Documents
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.DOC_ARTIFACT }}
 
@@ -457,14 +457,14 @@ jobs:
           echo archive_path= '${{ steps.create_nintendo_3ds_archive.outputs.archive_file }}' > $NIN_3DS_ARTIFACT_PATH
 
       - name: Upload Artifact with Nintendo 3DS Archive Path
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.NIN_3DS_ARTIFACT }}
           path: ${{ env.NIN_3DS_ARTIFACT_PATH }}
           retention-days: 1
 
       - name: Upload Nintendo 3DS Archive as Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.NIN_3DS_ARCHIVE_ARTIFACT }}
           path: ${{ steps.create_nintendo_3ds_archive.outputs.archive_file }}
@@ -477,7 +477,7 @@ jobs:
     container: devkitpro/devkitarm
     steps:
       - name: Download Artifact with Configuration Information
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.CONFIG_ARTIFACT }}
 
@@ -492,12 +492,12 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Download Artifact with Converted Documents
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.DOC_ARTIFACT }}
 
@@ -526,14 +526,14 @@ jobs:
           echo archive_path= '${{ steps.create_nintendo_ds_archive.outputs.archive_file }}' > $NIN_DS_ARTIFACT_PATH
 
       - name: Upload Artifact with Nintendo DS Archive Path
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.NIN_DS_ARTIFACT }}
           path: ${{ env.NIN_DS_ARTIFACT_PATH }}
           retention-days: 1
 
       - name: Upload Nintendo DS Archive as Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.NIN_DS_ARCHIVE_ARTIFACT }}
           path: ${{ steps.create_nintendo_ds_archive.outputs.archive_file }}
@@ -545,7 +545,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Artifact with Configuration Information
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.CONFIG_ARTIFACT }}
 
@@ -560,7 +560,7 @@ jobs:
           echo "draft=$draft" >> $GITHUB_OUTPUT
 
       - name: Download Artifact with Source Archive Path
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.SRC_ARTIFACT }}
 
@@ -571,12 +571,12 @@ jobs:
           echo "archive_path=$archive_path" >> $GITHUB_OUTPUT
 
       - name: Download Artifact with Source Archive
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.SRC_ARCHIVE_ARTIFACT }}
 
       - name: Download Artifact with Windows Archive Path
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.WIN_ARTIFACT }}
 
@@ -587,12 +587,12 @@ jobs:
           echo "archive_path=$archive_path" >> $GITHUB_OUTPUT
 
       - name: Download Artifact with Windows Archive
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.WIN_ARCHIVE_ARTIFACT }}
 
       - name: Download Artifact with Mac Archive Path
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.MAC_ARTIFACT }}
 
@@ -603,12 +603,12 @@ jobs:
           echo "archive_path=$archive_path" >> $GITHUB_OUTPUT
 
       - name: Download Artifact with Mac Archive
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.MAC_ARCHIVE_ARTIFACT }}
 
       - name: Download Artifact with Nintendo 3DS Archive Path
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.NIN_3DS_ARTIFACT }}
 
@@ -619,12 +619,12 @@ jobs:
           echo "archive_path=$archive_path" >> $GITHUB_OUTPUT
 
       - name: Download Artifact with Nintendo 3DS Archive
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.NIN_3DS_ARCHIVE_ARTIFACT }}
 
       - name: Download Artifact with Nintendo DS Archive Path
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.NIN_DS_ARTIFACT }}
 
@@ -635,7 +635,7 @@ jobs:
           echo "archive_path=$archive_path" >> $GITHUB_OUTPUT
 
       - name: Download Artifact with Nintendo DS Archive
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.NIN_DS_ARCHIVE_ARTIFACT }}
 

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -16,7 +16,7 @@ jobs:
           sudo apt-get install gcc-mingw-w64 automake autoconf make
 
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: |


### PR DESCRIPTION
See GitHub's notice here, https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/ , about the Node 16 to Node 20 transition.