### PR TITLE
Allow player pathfinding to go through closed doors, impassable rubble, traps

### DIFF
--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -165,7 +165,6 @@ static bool do_cmd_open_test(struct loc grid)
  */
 static bool do_cmd_open_aux(struct loc grid)
 {
-	int i, j;
 	bool more = false;
 
 	/* Verify legality */
@@ -173,25 +172,10 @@ static bool do_cmd_open_aux(struct loc grid)
 
 	/* Locked door */
 	if (square_islockeddoor(cave, grid)) {
-		/* Disarm factor */
-		i = player->state.skills[SKILL_DISARM_PHYS];
+		int chance = calc_unlocking_chance(player,
+			square_door_power(cave, grid), no_light(player));
 
-		/* Penalize some conditions */
-		if (player->timed[TMD_BLIND] || no_light(player))
-			i = i / 10;
-		if (player->timed[TMD_CONFUSED] || player->timed[TMD_IMAGE])
-			i = i / 10;
-
-		/* Extract the lock power */
-		j = square_door_power(cave, grid);
-
-		/* Extract the difficulty XXX XXX XXX */
-		j = i - (j * 4);
-
-		/* Always have a small chance of success */
-		if (j < 2) j = 2;
-
-		if (randint0(100) < j) {
+		if (randint0(100) < chance) {
 			/* Message */
 			msgt(MSG_LOCKPICK, "You have picked the lock.");
 

--- a/src/player-calcs.c
+++ b/src/player-calcs.c
@@ -1664,6 +1664,31 @@ void calc_digging_chances(struct player_state *state, int chances[DIGGING_MAX])
 		chances[i] = MAX(0, chances[i]);
 }
 
+/*
+ * Return the chance, out of 100, for unlocking a locked door with the given
+ * lock power.
+ *
+ * \param p is the player trying to unlock the door.
+ * \param lock_power is the power of the lock.
+ * \param lock_unseen, if true, assumes the player does not have sufficient
+ * light to work with the lock.
+ */
+int calc_unlocking_chance(const struct player *p, int lock_power,
+		bool lock_unseen)
+{
+	int skill = p->state.skills[SKILL_DISARM_PHYS];
+
+	if (lock_unseen || p->timed[TMD_BLIND]) {
+		skill /= 10;
+	}
+	if (p->timed[TMD_CONFUSED] || p->timed[TMD_IMAGE]) {
+		skill /= 10;
+	}
+
+	/* Always allow some chance of unlocking. */
+	return MAX(2, skill - 4 * lock_power);
+}
+
 /**
  * Calculate the blows a player would get.
  *

--- a/src/player-calcs.h
+++ b/src/player-calcs.h
@@ -109,6 +109,8 @@ void calc_inventory(struct player *p);
 void calc_bonuses(struct player *p, struct player_state *state, bool known_only,
 				  bool update);
 void calc_digging_chances(struct player_state *state, int chances[DIGGING_MAX]);
+int calc_unlocking_chance(const struct player *p, int lock_power,
+		bool lock_unseen);
 int calc_blows(struct player *p, const struct object *obj,
 			   struct player_state *state, int extra_blows);
 


### PR DESCRIPTION
Resolves https://github.com/angband/angband/issues/5867 .

When running along the computed path, only open a door or clear impassable rubble if all the neighbors of the door or rubble are known.  Otherwise, stop before the door and rubble and let the player decide what to do.  For known visible traps, always stop unless the player is trapsafe.

When computing the path to a previously mapped location, prefer that the path only go through previously mapped squares.  if no such path is found, then allow going through squares that have not been mapped before.

When computing a path, prefer that the path does not include a known visible trap.  If no such path is found, then allow going through known visible traps.

For tests of known terrain when computing the path, use the player's memory of the cave so information is not leaked if the terrain has changed since the player saw it.  Similarly, when running along the computed path, tests of known terrain and objects use the player's memory so information is not leaked if pathfinding while blind or without a light source. 

Move computing the chance of unlocking a locked door to its own function, calc_unlocking_chance() declared in player-calcs.h, so it can be shared by do_cmd_open_aux() and the pathfinding calculations.