### PR TITLE
Have more logic accommodate multiple traps in a square

### DIFF
--- a/src/cave-square.c
+++ b/src/cave-square.c
@@ -1340,18 +1340,27 @@ void square_add_door(struct chunk *c, struct loc grid, bool closed) {
 
 void square_open_door(struct chunk *c, struct loc grid)
 {
-	square_remove_all_traps(c, grid);
+	struct trap_kind *lock = lookup_trap("door lock");
+
+	assert(square_iscloseddoor(c, grid));
+	assert(lock);
+	square_remove_all_traps_of_type(c, grid, lock->tidx);
 	square_set_feat(c, grid, FEAT_OPEN);
 }
 
 void square_close_door(struct chunk *c, struct loc grid)
 {
+	assert(square_isopendoor(c, grid));
 	square_set_feat(c, grid, FEAT_CLOSED);
 }
 
 void square_smash_door(struct chunk *c, struct loc grid)
 {
-	square_remove_all_traps(c, grid);
+	struct trap_kind *lock = lookup_trap("door lock");
+
+	assert(square_isdoor(c, grid));
+	assert(lock);
+	square_remove_all_traps_of_type(c, grid, lock->tidx);
 	square_set_feat(c, grid, FEAT_BROKEN);
 }
 
@@ -1361,8 +1370,11 @@ void square_unlock_door(struct chunk *c, struct loc grid) {
 }
 
 void square_destroy_door(struct chunk *c, struct loc grid) {
+	struct trap_kind *lock = lookup_trap("door lock");
+
 	assert(square_isdoor(c, grid));
-	square_remove_all_traps(c, grid);
+	assert(lock);
+	square_remove_all_traps_of_type(c, grid, lock->tidx);
 	square_set_feat(c, grid, FEAT_FLOOR);
 }
 
@@ -1379,7 +1391,10 @@ void square_disable_trap(struct chunk *c, struct loc grid)
 
 void square_destroy_decoy(struct chunk *c, struct loc grid)
 {
-	square_remove_all_traps(c, grid);
+	struct trap_kind *decoy_kind = lookup_trap("decoy");
+
+	assert(decoy_kind);
+	square_remove_all_traps_of_type(c, grid, decoy_kind->tidx);
 	c->decoy = loc(0, 0);
 	if (los(c, player->grid, grid) && !player->timed[TMD_BLIND]){
 		msg("The decoy is destroyed!");

--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -812,8 +812,9 @@ static bool do_cmd_disarm_aux(struct loc grid)
 		player_exp_gain(player, 1 + power);
 
 		/* Trap is gone */
-		square_forget(cave, grid);
-		square_destroy_trap(cave, grid);
+		if (!square_remove_trap(cave, grid, trap, true)) {
+			assert(0);
+		}
 	} else if (randint0(100) < chance) {
 		event_signal(EVENT_INPUT_FLUSH);
 		msg("You failed to disarm the %s.", trap->kind->name);
@@ -1237,8 +1238,11 @@ void do_cmd_walk(struct command *cmd)
 	/* If we're in a web, deal with that */
 	if (square_iswebbed(cave, player->grid)) {
 		/* Clear the web, finish turn */
+		struct trap_kind *web = lookup_trap("web");
+
 		msg("You clear the web.");
-		square_destroy_trap(cave, player->grid);
+		assert(web);
+		square_remove_all_traps_of_type(cave, player->grid, web->tidx);
 		player->upkeep->energy_use = z_info->move_energy;
 		return;
 	}
@@ -1275,8 +1279,11 @@ void do_cmd_jump(struct command *cmd)
 	/* If we're in a web, deal with that */
 	if (square_iswebbed(cave, player->grid)) {
 		/* Clear the web, finish turn */
+		struct trap_kind *web = lookup_trap("web");
+
 		msg("You clear the web.");
-		square_destroy_trap(cave, player->grid);
+		assert(web);
+		square_remove_all_traps_of_type(cave, player->grid, web->tidx);
 		player->upkeep->energy_use = z_info->move_energy;
 		return;
 	}
@@ -1313,8 +1320,11 @@ void do_cmd_run(struct command *cmd)
 	/* If we're in a web, deal with that */
 	if (square_iswebbed(cave, player->grid)) {
 		/* Clear the web, finish turn */
+		struct trap_kind *web = lookup_trap("web");
+
 		msg("You clear the web.");
-		square_destroy_trap(cave, player->grid);
+		assert(web);
+		square_remove_all_traps_of_type(cave, player->grid, web->tidx);
 		player->upkeep->energy_use = z_info->move_energy;
 		return;
 	}

--- a/src/mon-move.c
+++ b/src/mon-move.c
@@ -1301,16 +1301,16 @@ static bool monster_turn_attack_glyph(struct monster *mon, struct loc new)
 
 	/* Break the ward */
 	if (randint1(z_info->glyph_hardness) < mon->race->level) {
+		struct trap_kind *rune = lookup_trap("glyph of warding");
+
 		/* Describe observable breakage */
 		if (square_isseen(cave, new)) {
 			msg("The rune of protection is broken!");
-
-			/* Forget the rune */
-			square_forget(cave, new);
 		}
 
 		/* Break the rune */
-		square_destroy_trap(cave, new);
+		assert(rune);
+		square_remove_all_traps_of_type(cave, new, rune->tidx);
 
 		return true;
 	}
@@ -1536,10 +1536,18 @@ static void monster_turn(struct monster *mon)
 				/* Insubstantial monsters go right through */
 			} else if (monster_passes_walls(mon)) {
 				/* If you can destroy a wall, you can destroy a web */
-				square_destroy_trap(cave, mon->grid);
+				struct trap_kind *web = lookup_trap("web");
+
+				assert(web);
+				square_remove_all_traps_of_type(cave,
+					mon->grid, web->tidx);
 			} else if (rf_has(mon->race->flags, RF_CLEAR_WEB)) {
 				/* Clearing costs a turn (assume there are no other "traps") */
-				square_destroy_trap(cave, mon->grid);
+				struct trap_kind *web = lookup_trap("web");
+
+				assert(web);
+				square_remove_all_traps_of_type(cave,
+					mon->grid, web->tidx);
 				return;
 			} else {
 				/* Stuck */

--- a/src/project-feat.c
+++ b/src/project-feat.c
@@ -319,7 +319,10 @@ static void project_feature_handler_FIRE(project_feature_handler_context_t *cont
 
 	/* Removes webs */
 	if (square_iswebbed(cave, context->grid)) {
-		square_destroy_trap(cave, context->grid);
+		struct trap_kind *web = lookup_trap("web");
+
+		assert(web);
+		square_remove_all_traps_of_type(cave, context->grid, web->tidx);
 	}
 
 	/* Can create lava if extremely powerful. */

--- a/src/trap.h
+++ b/src/trap.h
@@ -104,8 +104,11 @@ bool square_player_trap_allowed(struct chunk *c, struct loc grid);
 void place_trap(struct chunk *c, struct loc grid, int t_idx, int trap_level);
 void square_free_trap(struct chunk *c, struct loc grid);
 void wipe_trap_list(struct chunk *c);
+bool square_remove_trap(struct chunk *c, struct loc grid, struct trap *trap,
+		bool memorize);
 bool square_remove_all_traps(struct chunk *c, struct loc grid);
-bool square_remove_trap(struct chunk *c, struct loc grid, int t_idx);
+bool square_remove_all_traps_of_type(struct chunk *c, struct loc grid,
+		int t_idx);
 bool square_set_trap_timeout(struct chunk *c, struct loc grid, bool domsg,
 							 int t_idx, int time);
 int square_trap_timeout(struct chunk *c, struct loc grid, int t_idx);


### PR DESCRIPTION
Resolves https://github.com/angband/angband/issues/5683 .  Rename square_remove_trap() to square_remove_all_traps_of_type().  Use it for removing webs, glyphs of warding, decoys, and door locks.  Add new function, square_remove_trap(), to remove one trap.  Use it when disarming a trap and in hit_trap().  Change the meaning of square_set_trap_timeout() so it returns whether a trap was disabled rather than whether there was a trap in the grid.