### PR TITLE
SDL2: avoid some compiler warnings

### DIFF
--- a/src/sdl2/pui-dlg.c
+++ b/src/sdl2/pui-dlg.c
@@ -1067,7 +1067,7 @@ static void resize_simple_info(struct sdlpui_dialog *d, struct sdlpui_window *w,
 
 	SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_INFO);
 	psi = (struct sdlpui_simple_info*)d->priv;
-#if NDEBUG
+#ifdef NDEBUG
 	{
 		int dw, dh;
 

--- a/src/sdl2/pui-misc.c
+++ b/src/sdl2/pui-misc.c
@@ -93,7 +93,7 @@ int sdlpui_init(void)
  * called while a call to sdlpui_quit() is in progress.  Those applications
  * should be structured to avoid that possibility.
  */
-void sdlpui_quit()
+void sdlpui_quit(void)
 {
 	SDL_mutex *lock = my_registry.lock;
 


### PR DESCRIPTION
They happen with gcc using -Wundef and -Wold-style-definition.