### PR TITLE
CMake: use version.sh to get build ID when the host is Unix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -477,7 +477,7 @@ IF(SUPPORT_TEST_FRONTEND)
 ENDIF()
 
 # Set the build ID.
-IF(SUPPORT_WINDOWS_FRONTEND)
+IF(NOT CMAKE_HOST_UNIX)
     # Just check for the version file left in a snapshot.  If not in a snapshot,
     # don't bother to set the build ID.
     IF(EXISTS ./version)

--- a/docs/hacking/compiling.rst
+++ b/docs/hacking/compiling.rst
@@ -330,9 +330,6 @@ where make was run.  That executable can be run with wine:
 
 	wine Angband.exe
 
-TODO: building the documentation while using the cross-compiler
-(cmake -DBUILD_DOC=ON -DCMAKE_TOOLCHAIN_FILE=...) does not appear to work.
-
 Debug build
 ~~~~~~~~~~~
 


### PR DESCRIPTION
Fixes building the documentation when cross-compiling for Windows on Unix and no version stamp file was present (build ID was not set in that case causing the rewritten conf.py for the manual to call version.sh; version.sh not availble at the expected relative path to the rewritten conf.py).