### PR TITLE
Fix regression: monster opening secret door triggers assertion

### DIFF
--- a/src/cave-square.c
+++ b/src/cave-square.c
@@ -1342,7 +1342,7 @@ void square_open_door(struct chunk *c, struct loc grid)
 {
 	struct trap_kind *lock = lookup_trap("door lock");
 
-	assert(square_iscloseddoor(c, grid));
+	assert(square_iscloseddoor(c, grid) || square_issecretdoor(c, grid));
 	assert(lock);
 	square_remove_all_traps_of_type(c, grid, lock->tidx);
 	square_set_feat(c, grid, FEAT_OPEN);


### PR DESCRIPTION
Reported by agoodman00.  Regression was introduced post 4.2.5 in c631b56681b414593cedd1e46c2b63c89e735c17 .