### PR TITLE
Suspend word of recall counter when in an arena

### DIFF
--- a/src/game-world.c
+++ b/src/game-world.c
@@ -774,8 +774,8 @@ void process_world(struct chunk *c)
 
 	/*** Involuntary Movement ***/
 
-	/* Delayed Word-of-Recall */
-	if (player->word_recall) {
+	/* Delayed Word-of-Recall; suspended in arenas */
+	if (player->word_recall && !player->upkeep->arena_level) {
 		/* Count down towards recall */
 		player->word_recall--;
 


### PR DESCRIPTION
Resolves https://github.com/angband/angband/issues/5886 (single combat used in dungeon while recall counter in progress; assertion failure when recall triggers) and player getting stuck in an empty arena (single combat used in town while recall counter in progress; recall triggering in the arena kills the monster and transports player to an emtpy arena).