### PR TITLE
Correct some logic where square_isknown() is used

### DIFF
--- a/src/cave-map.c
+++ b/src/cave-map.c
@@ -238,7 +238,7 @@ void square_note_spot(struct chunk *c, struct loc grid)
 	}
 	square_memorize_traps(c, grid);
 
-	if (square_isknown(c, grid))
+	if (!square_isnotknown(c, grid))
 		return;
 
 	/* Memorize this grid */

--- a/src/cave.c
+++ b/src/cave.c
@@ -662,8 +662,8 @@ int count_feats(struct loc *grid,
 		/* Must have knowledge */
 		if (!square_isknown(cave, grid1)) continue;
 
-		/* Not looking for this feature */
-		if (!((*test)(cave, grid1))) continue;
+		/* Not looking for this feature; test against player's memory */
+		if (!((*test)(player->cave, grid1))) continue;
 
 		/* Count it */
 		++count;

--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -138,7 +138,7 @@ void do_cmd_go_down(struct command *cmd)
 /**
  * Determine if a given grid may be "opened"
  */
-static bool do_cmd_open_test(struct loc grid)
+static bool do_cmd_open_test(struct player *p, struct loc grid)
 {
 	/* Must have knowledge */
 	if (!square_isknown(cave, grid)) {
@@ -149,6 +149,10 @@ static bool do_cmd_open_test(struct loc grid)
 	/* Must be a closed door */
 	if (!square_iscloseddoor(cave, grid)) {
 		msgt(MSG_NOTHING_TO_OPEN, "You see nothing there to open.");
+		if (square_iscloseddoor(p->cave, grid)) {
+			square_forget(cave, grid);
+			square_light_spot(cave, grid);
+		}
 		return false;
 	}
 
@@ -168,7 +172,7 @@ static bool do_cmd_open_aux(struct loc grid)
 	bool more = false;
 
 	/* Verify legality */
-	if (!do_cmd_open_test(grid)) return (false);
+	if (!do_cmd_open_test(player, grid)) return (false);
 
 	/* Locked door */
 	if (square_islockeddoor(cave, grid)) {
@@ -257,7 +261,7 @@ void do_cmd_open(struct command *cmd)
 	obj = chest_check(player, grid, CHEST_OPENABLE);
 
 	/* Check for door */
-	if (!obj && !do_cmd_open_test(grid)) {
+	if (!obj && !do_cmd_open_test(player, grid)) {
 		/* Cancel repeat */
 		disturb(player);
 		return;
@@ -307,7 +311,7 @@ void do_cmd_open(struct command *cmd)
 /**
  * Determine if a given grid may be "closed"
  */
-static bool do_cmd_close_test(struct loc grid)
+static bool do_cmd_close_test(struct player *p, struct loc grid)
 {
 	/* Must have knowledge */
 	if (!square_isknown(cave, grid)) {
@@ -322,6 +326,11 @@ static bool do_cmd_close_test(struct loc grid)
 	if (!square_isopendoor(cave, grid) && !square_isbrokendoor(cave, grid)) {
 		/* Message */
 		msg("You see nothing there to close.");
+		if (square_isopendoor(p->cave, grid)
+				|| square_isbrokendoor(p->cave, grid)) {
+			square_forget(cave, grid);
+			square_light_spot(cave, grid);
+		}
 
 		/* Nope */
 		return (false);
@@ -353,7 +362,7 @@ static bool do_cmd_close_aux(struct loc grid)
 	bool more = false;
 
 	/* Verify legality */
-	if (!do_cmd_close_test(grid)) return (false);
+	if (!do_cmd_close_test(player, grid)) return (false);
 
 	/* Broken door */
 	if (square_isbrokendoor(cave, grid)) {
@@ -401,7 +410,7 @@ void do_cmd_close(struct command *cmd)
 	grid = loc_sum(player->grid, ddgrid[dir]);
 
 	/* Verify legality */
-	if (!do_cmd_close_test(grid)) {
+	if (!do_cmd_close_test(player, grid)) {
 		/* Cancel repeat */
 		disturb(player);
 		return;
@@ -432,7 +441,7 @@ void do_cmd_close(struct command *cmd)
 /**
  * Determine if a given grid may be "tunneled"
  */
-static bool do_cmd_tunnel_test(struct loc grid)
+static bool do_cmd_tunnel_test(struct player *p, struct loc grid)
 {
 
 	/* Must have knowledge */
@@ -444,12 +453,21 @@ static bool do_cmd_tunnel_test(struct loc grid)
 	/* Titanium */
 	if (square_isperm(cave, grid)) {
 		msg("This seems to be permanent rock.");
+		if (!square_isperm(p->cave, grid)) {
+			square_memorize(cave, grid);
+			square_light_spot(cave, grid);
+		}
 		return (false);
 	}
 
 	/* Must be a wall/door/etc */
 	if (!(square_isdiggable(cave, grid) || square_iscloseddoor(cave, grid))) {
 		msg("You see nothing there to tunnel.");
+		if (square_isdiggable(p->cave, grid)
+				|| square_iscloseddoor(p->cave, grid)) {
+			square_forget(cave, grid);
+			square_light_spot(cave, grid);
+		}
 		return (false);
 	}
 
@@ -515,7 +533,7 @@ static bool do_cmd_tunnel_aux(struct loc grid)
 	const char *with_clause = current_weapon == NULL ? "with your hands" : "with your weapon";
 
 	/* Verify legality */
-	if (!do_cmd_tunnel_test(grid)) return (false);
+	if (!do_cmd_tunnel_test(player, grid)) return (false);
 
 	/* Find what we're digging with and our chance of success */
 	best_digger = player_best_digger(player, false);
@@ -633,7 +651,7 @@ void do_cmd_tunnel(struct command *cmd)
 	grid = loc_sum(player->grid, ddgrid[dir]);
 
 	/* Oops */
-	if (!do_cmd_tunnel_test(grid)) {
+	if (!do_cmd_tunnel_test(player, grid)) {
 		/* Cancel repeat */
 		disturb(player);
 		return;
@@ -664,7 +682,7 @@ void do_cmd_tunnel(struct command *cmd)
 /**
  * Determine if a given grid may be "disarmed"
  */
-static bool do_cmd_disarm_test(struct loc grid)
+static bool do_cmd_disarm_test(struct player *p, struct loc grid)
 {
 	/* Must have knowledge */
 	if (!square_isknown(cave, grid)) {
@@ -679,6 +697,10 @@ static bool do_cmd_disarm_test(struct loc grid)
 	/* Look for a trap */
 	if (!square_isdisarmabletrap(cave, grid)) {
 		msg("You see nothing there to disarm.");
+		if (square_isdisarmabletrap(p->cave, grid)) {
+			square_memorize_traps(cave, grid);
+			square_light_spot(cave, grid);
+		}
 		return false;
 	}
 
@@ -700,7 +722,7 @@ static bool do_cmd_lock_door(struct loc grid)
 	bool more = false;
 
 	/* Verify legality */
-	if (!do_cmd_disarm_test(grid)) return false;
+	if (!do_cmd_disarm_test(player, grid)) return false;
 
 	/* Get the "disarm" factor */
 	i = player->state.skills[SKILL_DISARM_PHYS];
@@ -757,7 +779,7 @@ static bool do_cmd_disarm_aux(struct loc grid)
 	bool more = false;
 
 	/* Verify legality */
-	if (!do_cmd_disarm_test(grid)) return (false);
+	if (!do_cmd_disarm_test(player, grid)) return (false);
 
     /* Choose first player trap */
 	while (trap) {
@@ -856,7 +878,7 @@ void do_cmd_disarm(struct command *cmd)
 	obj = chest_check(player, grid, CHEST_TRAPPED);
 
 	/* Verify legality */
-	if (!obj && !do_cmd_disarm_test(grid)) {
+	if (!obj && !do_cmd_disarm_test(player, grid)) {
 		/* Cancel repeat */
 		disturb(player);
 		return;
@@ -1071,13 +1093,28 @@ void move_player(int dir, bool disarm)
 				square_light_spot(cave, grid);
 			}
 		} else {
-			if (square_isrubble(cave, grid))
+			if (square_isrubble(cave, grid)) {
 				msgt(MSG_HITWALL,
 					 "There is a pile of rubble blocking your way.");
-			else if (square_iscloseddoor(cave, grid))
+				if (!square_isrubble(player->cave, grid)) {
+					square_memorize(cave, grid);
+					square_light_spot(cave, grid);
+				}
+			} else if (square_iscloseddoor(cave, grid)) {
 				msgt(MSG_HITWALL, "There is a door blocking your way.");
-			else
+				if (!square_iscloseddoor(player->cave, grid)) {
+					square_memorize(cave, grid);
+					square_light_spot(cave, grid);
+				}
+			} else {
 				msgt(MSG_HITWALL, "There is a wall blocking your way.");
+				if (square_ispassable(player->cave, grid)
+						|| square_isrubble(player->cave, grid)
+						|| square_iscloseddoor(player->cave, grid)) {
+					square_forget(cave, grid);
+					square_light_spot(cave, grid);
+				}
+			}
 		}
 		/*
 		 * No move but do not refund energy:  primarily so that
@@ -1153,7 +1190,7 @@ void move_player(int dir, bool disarm)
 /**
  * Determine if a given grid may be "walked"
  */
-static bool do_cmd_walk_test(struct loc grid)
+static bool do_cmd_walk_test(struct player *p, struct loc grid)
 {
 	int m_idx = square(cave, grid)->mon;
 	struct monster *mon = cave_monster(cave, m_idx);
@@ -1161,14 +1198,14 @@ static bool do_cmd_walk_test(struct loc grid)
 	/* Allow attack on obvious monsters if unafraid */
 	if (m_idx > 0 && monster_is_obvious(mon)) {
 		/* Handle player fear */
-		if (player_of_has(player, OF_AFRAID)) {
+		if (player_of_has(p, OF_AFRAID)) {
 			/* Extract monster name (or "it") */
 			char m_name[80];
 			monster_desc(m_name, sizeof(m_name), mon, MDESC_DEFAULT);
 
 			/* Message */
 			msgt(MSG_AFRAID, "You are too afraid to attack %s!", m_name);
-			equip_learn_flag(player, OF_AFRAID);
+			equip_learn_flag(p, OF_AFRAID);
 
 			/* Nope */
 			return (false);
@@ -1181,21 +1218,35 @@ static bool do_cmd_walk_test(struct loc grid)
 	if (!square_isknown(cave, grid))
 		return true;
 
-	/* Require open space */
+	/*
+	 * Require open space; if the messaging indicates what is there and
+	 * that does not agree with the player's memory then update the
+	 * player's memory
+	 */
 	if (!square_ispassable(cave, grid)) {
 		if (square_isrubble(cave, grid)) {
 			/* Rubble */
 			msgt(MSG_HITWALL, "There is a pile of rubble in the way!");
+			if (!square_isrubble(p->cave, grid)) {
+				square_memorize(cave, grid);
+				square_light_spot(cave, grid);
+			}
 		} else if (square_iscloseddoor(cave, grid)) {
 			/* Door */
 			return true;
 		} else {
 			/* Wall */
 			msgt(MSG_HITWALL, "There is a wall in the way!");
+			if (square_ispassable(p->cave, grid)
+					|| square_isrubble(p->cave, grid)
+					|| square_iscloseddoor(p->cave, grid)) {
+				square_forget(cave, grid);
+				square_light_spot(cave, grid);
+			}
 		}
 
 		/* Cancel repeat */
-		disturb(player);
+		disturb(p);
 
 		/* Nope */
 		return (false);
@@ -1238,7 +1289,7 @@ void do_cmd_walk(struct command *cmd)
 	
 	/* Verify walkability */
 	grid = loc_sum(player->grid, ddgrid[dir]);
-	if (!do_cmd_walk_test(grid))
+	if (!do_cmd_walk_test(player, grid))
 		return;
 
 	player->upkeep->energy_use = energy_per_move(player);
@@ -1278,7 +1329,7 @@ void do_cmd_jump(struct command *cmd)
 
 	/* Verify walkability */
 	grid = loc_sum(player->grid, ddgrid[dir]);
-	if (!do_cmd_walk_test(grid))
+	if (!do_cmd_walk_test(player, grid))
 		return;
 
 	player->upkeep->energy_use = energy_per_move(player);
@@ -1319,7 +1370,7 @@ void do_cmd_run(struct command *cmd)
 	/* Get location */
 	if (dir) {
 		grid = loc_sum(player->grid, ddgrid[dir]);
-		if (!do_cmd_walk_test(grid))
+		if (!do_cmd_walk_test(player, grid))
 			return;
 			
 		/* Hack: convert repeat count to running count */

--- a/src/effect-handler-general.c
+++ b/src/effect-handler-general.c
@@ -2936,7 +2936,8 @@ bool effect_handler_RUBBLE(effect_handler_context_t *context)
 	 * necessary.
 	 */
 	int rubble_grids = randint1(3);
-	int open_grids = count_feats(NULL, square_isempty, false);
+	int open_grids = count_neighbors(NULL, cave, player->grid,
+		square_isempty, false);
 
 	if (rubble_grids > open_grids) {
 		rubble_grids = open_grids;

--- a/src/project-feat.c
+++ b/src/project-feat.c
@@ -267,7 +267,7 @@ static void project_feature_handler_MAKE_DOOR(project_feature_handler_context_t 
 	square_add_door(cave, grid, true);
 
 	/* Observe */
-	if (square_isknown(cave, grid))
+	if (square_isseen(cave, grid))
 		context->obvious = true;
 
 	/* Update the visuals */

--- a/src/ui-target.c
+++ b/src/ui-target.c
@@ -1041,7 +1041,9 @@ static int draw_path(uint16_t path_n, struct loc *path_g, wchar_t *c, int *a,
 				 * an object; make it act like an object.
 				 */
 				colour = COLOUR_YELLOW;
-			} else if (!square_isprojectable(cave, grid)) {
+			} else if (square_isknown(cave, grid)
+					&& !square_isprojectable(player->cave,
+					grid)) {
 				/* The camouflaged monster looks like a wall. */
 				colour = COLOUR_BLUE;
 			} else {
@@ -1055,12 +1057,12 @@ static int draw_path(uint16_t path_n, struct loc *path_g, wchar_t *c, int *a,
 			/* Known objects are yellow. */
 			colour = COLOUR_YELLOW;
 
-		else if (!square_isprojectable(cave, grid) &&
-				 (square_isknown(cave, grid) || square_isseen(cave, grid)))
+		else if (square_isknown(cave, grid)
+				&& !square_isprojectable(player->cave, grid)) {
 			/* Known walls are blue. */
 			colour = COLOUR_BLUE;
 
-		else if (!square_isknown(cave, grid) && !square_isseen(cave, grid)) {
+		} else if (!square_isknown(cave, grid)) {
 			/* Unknown squares are grey. */
 			pastknown = true;
 			colour = COLOUR_L_DARK;


### PR DESCRIPTION
In particular:
1) square_note_spot() used square_isknown() to shield a call to square_memorize(), but !square_isnotknown() is better to handle cases where the grid is known but misremembered.
2) The MAKE_DOOR projection handler tested the grid where a door was created with square_isknown() to decide whether to set obvious to true in the event handler context; using square_isseen() is better if the grid is not seen but has been seen before.
3) The RUBBLE effect used count_feats(), causing rubble to be added only in known grids.  Use count_neighbors() instead so both known and unknown grids can be affected.
4) All uses of count_feats() are for testing whether a direction argument is necessary for a cave-altering command.  count_feats() tested the actual cave for the presence of the type of the terrain; it should tests the player's memory of what is there to avoid leaking information.
5) Cave-altering commands and movement commands give messages if the terrain at the destination grid is not appropriate.  If the player's memory of what is there contradicts those messages either memorize what is there if the message rules out all but one type of terrain or forget what is there if the message leaves some ambiguity about what is present.
6) To avoid information leaks when drawing a path for targeting, test the player's memory of what is there rather than what is actually there.  In some of those tests, replace (square_isknown() || square_isseen()) with square_isknown() since all seen squares will be known.

(4), (5), and (6) should only affect situations where the player is blind or without a light source and the terrain has changed since the player last viewed or mapped it.