### PR TITLE
Rename square_isnotknown(); make it and square_isknown() useful for player->cave

### DIFF
--- a/src/cave-map.c
+++ b/src/cave-map.c
@@ -238,7 +238,7 @@ void square_note_spot(struct chunk *c, struct loc grid)
 	}
 	square_memorize_traps(c, grid);
 
-	if (!square_isnotknown(c, grid))
+	if (!square_ismemorybad(c, grid))
 		return;
 
 	/* Memorize this grid */
@@ -450,9 +450,14 @@ void wiz_light(struct chunk *c, struct player *p, bool full)
 				square_sense_pile(c, grid, NULL);
 			}
 
-			/* Forget unprocessed, unknown grids in the mapping area */
-			if (!square_ismark(c, grid) && square_isnotknown(c, grid))
+			/*
+			 * Forget grids that are both unprocessed and
+			 * misremembered in the mapping area.
+			 */
+			if (!square_ismark(c, grid)
+					&& square_ismemorybad(c, grid)) {
 				square_forget(c, grid);
+			}
 		}
 	}
 
@@ -516,9 +521,14 @@ void wiz_dark(struct chunk *c, struct player *p, bool full)
 				square_sense_pile(c, grid, NULL);
 			}
 
-			/* Forget unprocessed, unknown grids in the mapping area */
-			if (!square_ismark(c, grid) && square_isnotknown(c, grid))
+			/*
+			 * Forget grids that are both unprocessed and
+			 * misremembered in the mapping area.
+			 */
+			if (!square_ismark(c, grid)
+					&& square_ismemorybad(c, grid)) {
 				square_forget(c, grid);
+			}
 		}
 	}
 

--- a/src/cave-square.c
+++ b/src/cave-square.c
@@ -396,8 +396,8 @@ bool square_isoccupied(struct chunk *c, struct loc grid) {
  * True if the player knows the terrain of the square
  */
 bool square_isknown(struct chunk *c, struct loc grid) {
-	if (c != cave) return false;
-	if (player->cave == NULL) return false;
+	if (c != cave && (!player || c != player->cave)) return false;
+	if (!player->cave) return false;
 	return square(player->cave, grid)->feat == FEAT_NONE ? false : true;
 }
 
@@ -405,10 +405,9 @@ bool square_isknown(struct chunk *c, struct loc grid) {
  * True if the player's knowledge of the terrain of the square is wrong
  * or missing
  */
-bool square_isnotknown(struct chunk *c, struct loc grid) {
-	if (c != cave) return false;
-	if (player->cave == NULL) return true;
-	return square(player->cave, grid)->feat != square(c, grid)->feat;
+bool square_ismemorybad(struct chunk *c, struct loc grid) {
+	return !square_isknown(c, grid)
+		|| square(player->cave, grid)->feat != square(cave, grid)->feat;
 }
 
 /**

--- a/src/cave.h
+++ b/src/cave.h
@@ -297,7 +297,7 @@ bool square_isshop(struct chunk *c, struct loc grid);
 bool square_isplayer(struct chunk *c, struct loc grid);
 bool square_isoccupied(struct chunk *c, struct loc grid);
 bool square_isknown(struct chunk *c, struct loc grid);
-bool square_isnotknown(struct chunk *c, struct loc grid);
+bool square_ismemorybad(struct chunk *c, struct loc grid);
 
 /* SQUARE INFO PREDICATES */
 bool square_ismark(struct chunk *c, struct loc grid);

--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -1606,7 +1606,7 @@ void do_cmd_explore(struct command *cmd)
 			struct loc grid = loc(x, y);
 
 			/* only check known locations, which are either rubble or a closed door */
-			if (square_isnotknown(cave, grid) ||
+			if (!square_isknown(cave, grid) ||
 			   (!square_iscloseddoor(player->cave, grid) && !square_isrubble(player->cave, grid))) {
 				continue;
 			}

--- a/src/effect-handler-general.c
+++ b/src/effect-handler-general.c
@@ -1251,9 +1251,13 @@ bool effect_handler_MAP_AREA(effect_handler_context_t *context)
 				}
 			}
 
-			/* Forget unprocessed, unknown grids in the mapping area */
-			if (square_isnotknown(cave, grid))
+			/*
+			 * Forget grids that are both unprocessed and
+			 * misremembered in the mapping area.
+			 */
+			if (square_ismemorybad(cave, grid)) {
 				square_forget(cave, grid);
+			}
 		}
 	}
 
@@ -1435,14 +1439,17 @@ bool effect_handler_DETECT_DOORS(effect_handler_context_t *context)
 				doors = true;
 			} else if (square_isdoor(cave, grid)) {
 				/* Detect other types of doors. */
-				if (square_isnotknown(cave, grid)) {
+				if (square_ismemorybad(cave, grid)) {
 					square_memorize(cave, grid);
 					square_light_spot(cave, grid);
 					doors = true;
 				}
 			} else if (square_isdoor(player->cave, grid)
-					&& square_isnotknown(cave, grid)) {
-				/* Forget unknown doors in the mapping area */
+					&& square_ismemorybad(cave, grid)) {
+				/*
+				 * Forget misremembered doors in the mapping
+				 * area.
+				 */
 				square_forget(cave, grid);
 			}
 		}


### PR DESCRIPTION
The new name for square_isnotknown() is square_ismemorybad().  In the case where it is passed a chunk that is neither cave nor player->cave, it will return true (no player memory).  That makes it equivalent to !square_isknown() and a check on whether the terrain in player->cave and cave is the same.  Resolves https://github.com/angband/angband/issues/5879 .