### PR TITLE
Tweak messaging when a trap is disabled

### DIFF
--- a/src/project-feat.c
+++ b/src/project-feat.c
@@ -221,15 +221,15 @@ static void project_feature_handler_KILL_TRAP(project_feature_handler_context_t 
 	if (square_issecretdoor(cave, grid)) {
 		place_closed_door(cave, grid);
 
-		/* Check line of sight */
+		/* Check if visible */
 		if (square_isseen(cave, grid))
 			context->obvious = true;
 	}
 
 	/* Disable traps, unlock doors */
 	if (square_isdisarmabletrap(cave, grid)) {
-		/* Check line of sight */
-		if (square_isview(cave, grid)) {
+		/* Check if visible */
+		if (square_isseen(cave, grid)) {
 			msg("The trap seizes up.");
 			context->obvious = true;
 		}
@@ -240,7 +240,7 @@ static void project_feature_handler_KILL_TRAP(project_feature_handler_context_t 
 		/* Unlock the door */
 		square_unlock_door(cave, grid);
 
-		/* Check line of sound */
+		/* Check line of sound; approximated with square_isview() */
 		if (square_isview(cave, grid)) {
 			msg("Click!");
 			context->obvious = true;

--- a/src/trap.c
+++ b/src/trap.c
@@ -649,7 +649,10 @@ bool square_set_trap_timeout(struct chunk *c, struct loc grid, bool domsg,
 		disabled = true;
 
 		/* Message if requested */
-		msg("You have disabled the %s.", current_trap->kind->name);
+		if (domsg) {
+			msg("You have disabled the %s.",
+				current_trap->kind->name);
+		}
 
 		/* Replace with the next trap */
 		current_trap = next_trap;


### PR DESCRIPTION
Have square_set_trap_timeout() honor its domsg argument.  Only issue the "trap seizes up" message if visible.  Resolves https://github.com/angband/angband/issues/5893 .