### PR TITLE
Correct map updates after disabling a trap

### DIFF
--- a/src/cave-map.c
+++ b/src/cave-map.c
@@ -135,7 +135,7 @@ void map_info(struct loc grid, struct grid_data *g)
 
 	/* There is a known trap in this square */
 	if (square_trap(player->cave, grid) && square_isknown(cave, grid)) {
-		struct trap *trap = square(cave, grid)->trap;
+		struct trap *trap = square(player->cave, grid)->trap;
 
 		/* Scan the square trap list */
 		while (trap) {
@@ -151,7 +151,7 @@ void map_info(struct loc grid, struct grid_data *g)
 			}
 			trap = trap->next;
 		}
-    }
+	}
 
 	/* Objects */
 	for (obj = square_object(player->cave, grid); obj; obj = obj->next) {

--- a/src/trap.c
+++ b/src/trap.c
@@ -657,6 +657,7 @@ bool square_set_trap_timeout(struct chunk *c, struct loc grid, bool domsg,
 
 	/* Refresh grids that the character can see */
 	if (square_isseen(c, grid)) {
+		square_memorize_traps(c, grid);
 		square_light_spot(c, grid);
 	}
 


### PR DESCRIPTION
Copy the modified timeouts for the traps from the actual cave to the player's memory if the grid is seen.  Use the player's memory of the traps in map_info().  Prevents a change to the map if a trap is disabled while blind.