### PR TITLE
Refactor player-path

### DIFF
--- a/src/player-path.h
+++ b/src/player-path.h
@@ -22,8 +22,22 @@
 
 #include "z-type.h"
 
+struct pfdistances;
+
+struct pfdistances *prepare_pfdistances(struct player *p, struct loc start,
+		bool only_known, bool forbid_traps);
+int pfdistances_to_turncount(const struct pfdistances *a, struct loc grid);
+int pfdistances_to_path(const struct pfdistances *a, struct loc grid,
+		int16_t **step_dirs);
+void release_pfdistances(struct pfdistances *a);
+int path_nearest_known(struct player *p, struct loc start,
+		bool (*pred)(struct chunk*, struct loc),
+		struct loc *dest_grid, int16_t **step_dirs);
+int path_nearest_unknown(struct player *p, struct loc start,
+		struct loc *dest_grid, int16_t **step_dirs);
+int find_path(struct player *p, struct loc start, struct loc dest,
+		int16_t **step_dirs);
 int pathfind_direction_to(struct loc from, struct loc to);
-bool find_path(struct loc grid);
 void run_step(int dir);
 
 #endif /* !PLAYER_PATH_H */

--- a/src/player-util.c
+++ b/src/player-util.c
@@ -1639,6 +1639,8 @@ void disturb(struct player *p)
 	/* Cancel running */
 	if (p->upkeep->running) {
 		p->upkeep->running = 0;
+		mem_free(p->upkeep->steps);
+		p->upkeep->steps = NULL;
 
 		/* Cancel queued commands */
 		cmdq_flush();

--- a/src/player.c
+++ b/src/player.c
@@ -446,6 +446,7 @@ void player_cleanup_members(struct player *p)
 	if (p->upkeep) {
 		mem_free(p->upkeep->quiver);
 		mem_free(p->upkeep->inven);
+		mem_free(p->upkeep->steps);
 		mem_free(p->upkeep);
 		p->upkeep = NULL;
 	}

--- a/src/player.h
+++ b/src/player.h
@@ -480,7 +480,6 @@ struct player_upkeep {
 	int resting;			/* Resting counter */
 
 	int running;				/* Running counter */
-	bool running_withpathfind;	/* Are we using the pathfinder ? */
 	bool running_firststep;		/* Is this our first step running? */
 
 	struct object **quiver;	/* Quiver objects */
@@ -490,6 +489,9 @@ struct player_upkeep {
 	int equip_cnt;			/* Number of items in equipment */
 	int quiver_cnt;			/* Number of items in the quiver */
 	int recharge_pow;		/* Power of recharge effect */
+	int step_count;			/* Pathfinding: number of steps left */
+	int16_t *steps;			/* Pathfinding: steps in reverse order */
+	struct loc path_dest;		/* Pathfinding: destination grid */
 };
 
 /**

--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -22,6 +22,7 @@ SUITES = \
 	z-expression/suite.mk \
 	z-file/suite.mk \
 	z-quark/suite.mk \
+	z-queue/suite.mk \
 	z-textblock/suite.mk \
 	z-util/suite.mk \
 	z-virt/suite.mk

--- a/src/tests/unit-test-data.h
+++ b/src/tests/unit-test-data.h
@@ -1052,7 +1052,6 @@ static struct player_upkeep TEST_DATA test_player_upkeep = {
 	.create_down_stair = 0,
 
 	.running = 0,
-	.running_withpathfind = 0,
 	.running_firststep = 0,
 
 	.quiver = NULL,
@@ -1062,6 +1061,9 @@ static struct player_upkeep TEST_DATA test_player_upkeep = {
 	.inven_cnt = 0,
 	.equip_cnt = 0,
 	.quiver_cnt = 0,
+	.step_count = 0,
+	.steps = NULL,
+	.path_dest = { 0, 0 },
 };
 
 static struct object TEST_DATA test_player_knowledge = {

--- a/src/tests/z-queue/qp.c
+++ b/src/tests/z-queue/qp.c
@@ -1,0 +1,337 @@
+/* z-queue/qp.c */
+/* Exercise the priority queues declared in z-queue.h. */
+
+#include "unit-test.h"
+#include "z-queue.h"
+#include "z-virt.h"
+
+struct iidata { int priority, payload; };
+struct ipdata { int priority; void *payload; };
+
+NOSETUP
+NOTEARDOWN
+
+static int compare_iidata(const void *a, const void *b)
+{
+	const struct iidata *ai = a;
+	const struct iidata *bi = b;
+
+	if (ai->priority < bi->priority) {
+		return -1;
+	}
+	if (ai->priority > bi->priority) {
+		return 1;
+	}
+	return 0;
+}
+
+static int compare_ipdata(const void *a, const void *b)
+{
+	const struct ipdata *ai = a;
+	const struct iidata *bi = b;
+
+	if (ai->priority < bi->priority) {
+		return -1;
+	}
+	if (ai->priority > bi->priority) {
+		return 1;
+	}
+	return 0;
+}
+
+static int test_qp_trivial(void *state)
+{
+	struct priority_queue *qp = qp_new(0);
+	void *p;
+	int i;
+
+	eq(qp_size(qp), 0);
+	eq(qp_len(qp), 0);
+	require(!qp_isinvalid(qp));
+	qp_free(qp, NULL);
+
+	qp = qp_new(4);
+	eq(qp_size(qp), 4);
+	eq(qp_len(qp), 0);
+	require(!qp_isinvalid(qp));
+	qp_push_int(qp, 7, 10);
+	eq(qp_size(qp), 4);
+	eq(qp_len(qp), 1);
+	require(!qp_isinvalid(qp));
+	i = qp_peek_int(qp);
+	eq(i, 10);
+	i = qp_pop_int(qp);
+	eq(i, 10);
+	eq(qp_size(qp), 4);
+	eq(qp_len(qp), 0);
+	require(!qp_isinvalid(qp));
+	qp_free(qp, NULL);
+
+	qp = qp_new(5);
+	eq(qp_size(qp), 5);
+	eq(qp_len(qp), 0);
+	require(!qp_isinvalid(qp));
+	qp_push_ptr(qp, -3, &qp);
+	eq(qp_size(qp), 5);
+	eq(qp_len(qp), 1);
+	require(!qp_isinvalid(qp));
+	p = qp_peek_ptr(qp);
+	ptreq(p, &qp);
+	p = qp_pop_ptr(qp);
+	ptreq(p, &qp);
+	eq(qp_size(qp), 5);
+	eq(qp_len(qp), 0);
+	require(!qp_isinvalid(qp));
+	qp_free(qp, NULL);
+
+	ok;
+}
+
+static int test_qp_integer(void *state)
+{
+	const size_t size = 15;
+	struct iidata data[12] = {
+		{ 6, -3 }, { 3, 15 }, { 17, 0 }, { 16, -2 },
+		{ 0, 8 }, { 9, 11 }, { -3, -7 }, { 14, 10 },
+		{ 20, 1 }, { 11, 18 }, { 5, 7 }, { -4, 6 },
+	};
+	struct iidata sorted[12];
+	struct priority_queue *qp = qp_new(size);
+	size_t i;
+	int payload;
+
+	memcpy(sorted, data, sizeof(data));
+	qsort(sorted, sizeof(data) / sizeof(data[0]), sizeof(data[0]),
+		compare_iidata);
+
+	eq(qp_size(qp), size);
+	eq(qp_len(qp), 0);
+	require(!qp_isinvalid(qp));
+	qp_push_int(qp, data[0].priority, data[0].payload);
+	eq(qp_size(qp), size);
+	eq(qp_len(qp), 1);
+	payload = qp_peek_int(qp);
+	eq(payload, data[0].payload);
+	require(!qp_isinvalid(qp));
+	for (i = 1; i < sizeof(data) / sizeof(data[0]); ++i) {
+		qp_push_int(qp, data[i].priority, data[i].payload);
+		eq(qp_size(qp), size);
+		eq(qp_len(qp), i + 1);
+		require(!qp_isinvalid(qp));
+	}
+	for (i = 0; i < sizeof(data) / sizeof(data[0]); ++i) {
+		payload = qp_peek_int(qp);
+		eq(payload, sorted[i].payload);
+		payload = qp_pop_int(qp);
+		eq(payload, sorted[i].payload);
+		eq(qp_size(qp), size);
+		eq(qp_len(qp), (sizeof(data) / sizeof(data[0]) - i) - 1);
+		require(!qp_isinvalid(qp));
+	}
+	qp_free(qp, NULL);
+
+	ok;
+}
+
+static int test_qp_pointer(void *state)
+{
+	const size_t size = 15;
+	struct ipdata data[14] = {
+		{ 8, data + 8 }, { 19, data + 3 }, { 12, data }, { -7, data + 4},
+		{ 0, data + 2 }, { 15, data + 9 }, { 1, data + 7 }, { 13, data + 13 },
+		{ 9, data + 1 }, { 11, data + 10 }, { 3, data + 5 }, { 16, data + 11 },
+		{ -12, data + 6}, { 23, data + 12 },
+	};
+	struct ipdata sorted[14];
+	struct priority_queue *qp = qp_new(size);
+	size_t i;
+	void *payload;
+
+	memcpy(sorted, data, sizeof(data));
+	qsort(sorted, sizeof(data) / sizeof(data[0]), sizeof(data[0]),
+		compare_ipdata);
+
+	eq(qp_size(qp), size);
+	eq(qp_len(qp), 0);
+	require(!qp_isinvalid(qp));
+	qp_push_ptr(qp, data[0].priority, data[0].payload);
+	eq(qp_size(qp), size);
+	eq(qp_len(qp), 1);
+	payload = qp_peek_ptr(qp);
+	ptreq(payload, data[0].payload);
+	require(!qp_isinvalid(qp));
+	for (i = 1; i < sizeof(data) / sizeof(data[0]); ++i) {
+		qp_push_ptr(qp, data[i].priority, data[i].payload);
+		eq(qp_size(qp), size);
+		eq(qp_len(qp), i + 1);
+		require(!qp_isinvalid(qp));
+	}
+	for (i = 0; i < sizeof(data) / sizeof(data[0]); ++i) {
+		payload = qp_peek_ptr(qp);
+		ptreq(payload, sorted[i].payload);
+		payload = qp_pop_ptr(qp);
+		ptreq(payload, sorted[i].payload);
+		require(!qp_isinvalid(qp));
+		eq(qp_size(qp), size);
+		eq(qp_len(qp), (sizeof(data) / sizeof(data[0]) - i) - 1);
+	}
+	qp_free(qp, NULL);
+
+	ok;
+}
+
+static int test_qp_pushpop(void *state)
+{
+	struct priority_queue *qp = qp_new(8);
+	void *p;
+	int i;
+
+	eq(qp_len(qp), 0);
+	require(!qp_isinvalid(qp));
+	i = qp_pushpop_int(qp, 9, 76);
+	eq(i, 76);
+	eq(qp_len(qp), 0);
+	require(!qp_isinvalid(qp));
+	qp_push_int(qp, -7, 34);
+	i = qp_pushpop_int(qp, -9, 20);
+	eq(i, 20);
+	eq(qp_len(qp), 1);
+	require(!qp_isinvalid(qp));
+	i = qp_pushpop_int(qp, 11, 13);
+	eq(i, 34);
+	eq(qp_len(qp), 1);
+	require(!qp_isinvalid(qp));
+	i = qp_pop_int(qp);
+	eq(i, 13);
+	eq(qp_len(qp), 0);
+	require(!qp_isinvalid(qp));
+
+	p = qp_pushpop_ptr(qp, 13, &i);
+	ptreq(p, &i);
+	eq(qp_len(qp), 0);
+	require(!qp_isinvalid(qp));
+	qp_push_ptr(qp, 6, &p);
+	p = qp_pushpop_ptr(qp, 3, &qp);
+	ptreq(p, &qp);
+	eq(qp_len(qp), 1);
+	require(!qp_isinvalid(qp));
+	p = qp_pushpop_ptr(qp, 8, &i);
+	ptreq(p, &p);
+	eq(qp_len(qp), 1);
+	require(!qp_isinvalid(qp));
+	p = qp_pop_ptr(qp);
+	ptreq(p, &i);
+	eq(qp_len(qp), 0);
+	require(!qp_isinvalid(qp));
+
+	qp_free(qp, NULL);
+
+	ok;
+}
+
+static int test_qp_resize(void *state)
+{
+	struct priority_queue *qp = qp_new(3);
+	void *a, *b, *c, *d;
+	void *p;
+	bool failed;
+
+	a = mem_alloc(1);
+	b = mem_alloc(1);
+	c = mem_alloc(1);
+	d = mem_alloc(1);
+	qp_push_ptr(qp, 10, a);
+	qp_push_ptr(qp, 8, b);
+	qp_push_ptr(qp, 9, c);
+	require(!qp_isinvalid(qp));
+	eq(qp_len(qp), 3);
+	p = qp_peek_ptr(qp);
+	ptreq(p, b);
+	failed = qp_resize(qp, 10, mem_free);
+	require(!failed);
+	eq(qp_size(qp), 10);
+	eq(qp_len(qp), 3);
+	p = qp_peek_ptr(qp);
+	ptreq(p, b);
+	qp_push_ptr(qp, 12, d);
+	eq(qp_len(qp), 4);
+	p = qp_pop_ptr(qp);
+	eq(p, b);
+	mem_free(b);
+	p = qp_pop_ptr(qp);
+	eq(p, c);
+	mem_free(c);
+	p = qp_pop_ptr(qp);
+	eq(p, a);
+	mem_free(a);
+	p = qp_pop_ptr(qp);
+	eq(p, d);
+	mem_free(d);
+	qp_free(qp, mem_free);
+
+	qp = qp_new(3);
+	a = mem_alloc(1);
+	b = mem_alloc(1);
+	c = mem_alloc(1);
+	qp_push_ptr(qp, 10, a);
+	qp_push_ptr(qp, 8, b);
+	qp_push_ptr(qp, 9, c);
+	require(!qp_isinvalid(qp));
+	eq(qp_len(qp), 3);
+	p = qp_peek_ptr(qp);
+	ptreq(p, b);
+	failed = qp_resize(qp, 1, mem_free);
+	require(!failed);
+	require(!qp_isinvalid(qp));
+	eq(qp_size(qp), 1);
+	eq(qp_len(qp), 1);
+	p = qp_peek_ptr(qp);
+	ptreq(p, b);
+	qp_free(qp, mem_free);
+
+	ok;
+}
+
+static int test_qp_flush(void *state)
+{
+	struct priority_queue *qp = qp_new(3);
+	void *a, *b, *c;
+
+	qp_flush(qp, NULL);
+	eq(qp_size(qp), 3);
+	eq(qp_len(qp), 0);
+	require(!qp_isinvalid(qp));
+	qp_push_int(qp, 7, 21);
+	qp_push_int(qp, 5, 32);
+	qp_push_int(qp, 10, 19);
+	qp_flush(qp, NULL);
+	eq(qp_size(qp), 3);
+	eq(qp_len(qp), 0);
+	require(!qp_isinvalid(qp));
+
+	a = mem_alloc(1);
+	b = mem_alloc(1);
+	c = mem_alloc(1);
+	qp_push_ptr(qp, 9, a);
+	qp_push_ptr(qp, 12, b);
+	qp_push_ptr(qp, 4, c);
+	qp_flush(qp, mem_free);
+	eq(qp_size(qp), 3);
+	eq(qp_len(qp), 0);
+	require(!qp_isinvalid(qp));
+
+	qp_free(qp, NULL);
+
+	ok;
+}
+
+const char *suite_name = "z-queue/qp";
+struct test tests[] = {
+	{ "priority queue trivial", test_qp_trivial },
+	{ "priority queue integers", test_qp_integer },
+	{ "priority queue pointers", test_qp_pointer },
+	{ "priority queue pushpop", test_qp_pushpop },
+	{ "priority queue resize", test_qp_resize },
+	{ "priority queue flush", test_qp_flush },
+	{ NULL, NULL }
+};

--- a/src/tests/z-queue/suite.mk
+++ b/src/tests/z-queue/suite.mk
@@ -1,0 +1,2 @@
+TESTPROGS += \
+	z-queue/qp

--- a/src/z-queue.c
+++ b/src/z-queue.c
@@ -18,41 +18,522 @@
 
 #include <stdlib.h>
 #include "z-queue.h"
+#include "z-virt.h"
+
+/* Clear macro shortcuts for priority queue functions. */
+#ifdef NDEBUG
+#undef qp_size
+#undef qp_len
+#undef qp_peek_int
+#undef qp_peek_ptr
+#endif
 
 struct queue *q_new(size_t size) {
-    struct queue *q = (struct queue*)malloc(sizeof(struct queue));
+	struct queue *q;
+
+	if (size > SIZE_MAX / sizeof(uintptr_t) - 1) {
+		return NULL;
+	}
+	q = (struct queue*)mem_alloc(sizeof(struct queue));
 	if (!q) return NULL;
-    q->data = (uintptr_t*)malloc(sizeof(uintptr_t) * (size + 1));
-    q->size = size + 1;
-    q->head = 0;
-    q->tail = 0;
-    return q;
+	q->data = (uintptr_t*)malloc(sizeof(uintptr_t) * (size + 1));
+	q->size = size + 1;
+	q->head = 0;
+	q->tail = 0;
+	return q;
 }
 
-int q_len(struct queue *q) {
-    int len;
-    if (q->tail >= q->head) {
-        len = q->tail - q->head;
-    } else {
-        len = q->size - q->head + q->tail;
-    }
-    return len;
+bool q_resize(struct queue *q, size_t size) {
+	if (size > SIZE_MAX / sizeof(uintptr_t) - 1) {
+		return true;
+	}
+	assert(q->size > 0);
+	if (size < q->size - 1 && q->head != q->tail
+			&& (q->head > size || q->tail > size)) {
+		uintptr_t *new_data = mem_alloc(sizeof(uintptr_t) * (size + 1));
+
+		if (q->tail > q->head) {
+			memcpy(new_data, q->data + q->head,
+				MIN(q->tail - q->head, size + 1)
+				* sizeof(uintptr_t));
+			q->tail -= q->head;
+		} else {
+			size_t head_sz = MIN(q->size - q->head, size + 1);
+
+			memcpy(new_data, q->data + q->head, head_sz
+				* sizeof(uintptr_t));
+			if (head_sz < size + 1) {
+				memcpy(new_data + head_sz, q->data,
+					(size + 1 - head_sz)
+					* sizeof(uintptr_t));
+			}
+			q->tail = size;
+		}
+		q->head = 0;
+		mem_free(q->data);
+		q->data = new_data;
+	} else {
+		q->data = mem_realloc(q->data, sizeof(uintptr_t) * (size + 1));
+	}
+	q->size = size + 1;
+	return false;
+}
+
+size_t q_size(const struct queue *q)
+{
+	assert(q->size > 0);
+	return q->size - 1;
+}
+
+size_t q_len(struct queue *q) {
+	return (q->tail >= q->head) ? q->tail - q->head :
+		(q->size - q->head) + q->tail;
 }
 
 void q_push(struct queue *q, uintptr_t item) {
-    q->data[q->tail] = item;
-    q->tail = (q->tail + 1) % q->size;
-    if (q->tail == q->head) abort();
+	q->data[q->tail] = item;
+	q->tail = (q->tail + 1) % q->size;
+	if (q->tail == q->head) abort();
 }
 
 uintptr_t q_pop(struct queue *q) {
-    uintptr_t item = q->data[q->head];
-    if (q->head == q->tail) abort();
-    q->head = (q->head + 1) % q->size;
-    return item;
+	uintptr_t item = q->data[q->head];
+	if (q->head == q->tail) abort();
+	q->head = (q->head + 1) % q->size;
+	return item;
 }
 
 void q_free(struct queue *q) {
-    free(q->data);
-    free(q);
+	free(q->data);
+	free(q);
+}
+
+/**
+ * Help priority queue operations:  push the ith element of the heap upward
+ * if its priority is less than that of its parent.
+ */
+static void up_heap(struct priority_queue *qp, size_t i)
+{
+	while (1) {
+		size_t parent;
+		struct priority_queue_element tmp;
+
+		if (i == 0) {
+			break;
+		}
+		parent = (i - 1) >> 1;
+		if (qp->data[i].priority >= qp->data[parent].priority) {
+			break;
+		}
+		tmp = qp->data[parent];
+		qp->data[parent] = qp->data[i];
+		qp->data[i] = tmp;
+		i = parent;
+	}
+}
+
+/**
+ * Help priority queue operations:  push the ith element of the heap downward
+ * if its priority is greater than that of its children.
+ */
+static void down_heap(struct priority_queue *qp, size_t i)
+{
+	while (1) {
+		size_t child1 = (i << 1) + 1;
+		struct priority_queue_element tmp;
+
+		if (child1 >= qp->count) {
+			break;
+		}
+		if (child1 == qp->count - 1) {
+			/* There's only one child. */
+			if (qp->data[i].priority <= qp->data[child1].priority) {
+				break;
+			}
+			tmp = qp->data[i];
+			qp->data[i] = qp->data[child1];
+			qp->data[child1] = tmp;
+			break;
+		}
+		if (qp->data[i].priority > qp->data[child1].priority) {
+			if (qp->data[i].priority
+					<= qp->data[child1 + 1].priority
+					|| qp->data[child1].priority <
+					qp->data[child1 + 1].priority) {
+				tmp = qp->data[i];
+				qp->data[i] = qp->data[child1];
+				qp->data[child1] = tmp;
+				i = child1;
+			} else {
+				tmp = qp->data[i];
+				qp->data[i] = qp->data[child1 + 1];
+				qp->data[child1 + 1] = tmp;
+				i = child1 + 1;
+			}
+		} else if (qp->data[i].priority
+				> qp->data[child1 + 1].priority) {
+			tmp = qp->data[i];
+			qp->data[i] = qp->data[child1 + 1];
+			qp->data[child1 + 1] = tmp;
+			i = child1 + 1;
+		} else {
+			break;
+		}
+	}
+}
+
+/**
+ * Create a new integer priority queue.
+ *
+ * \param size is the maximum number of entries the queue can hold.
+ * \return a pointer to the queue or NULL if it could not be created.
+ *
+ * Attempts to create priority queues with sizes larger than SIZE_MAX /
+ * MAX(2, sizeof(struct priority_queue_element)) will fail.
+ */
+struct priority_queue *qp_new(size_t size)
+{
+	struct priority_queue *result;
+
+	if (size > SIZE_MAX / MAX(2, sizeof(struct priority_queue_element))) {
+		return NULL;
+	}
+	result = mem_alloc(sizeof(*result));
+	result->data = mem_alloc(size * sizeof(*result->data));
+	result->size = size;
+	result->count = 0;
+	return result;
+}
+
+/**
+ * Resize an existing priority queue to hold up to size elements.
+ *
+ * \param qp is the priority queue to modify.
+ * \param size is the new number of elements to hold.
+ * \param payload_free will, if not NULL, be called on the pointer payload
+ * of an existing element that does not fit in the new size before discarding
+ * that element.
+ * \return false if the operation was successful; otherwise return true.
+ * If the resizing fails, the existing elements, length, and size of the
+ * queue will remain unchanged.
+ *
+ * An attempt to resize a priority queue to have more than SIZE_MAX /
+ * MAX(2, sizeof(struct priority_queue_element)) elements will fail.
+ * Any existing elements that would not fit in the new size are discarded.
+ */
+bool qp_resize(struct priority_queue *qp, size_t size,
+		void (*payload_free)(void*))
+{
+	assert(qp && qp->count <= qp->size);
+	if (size > SIZE_MAX / MAX(2, sizeof(struct priority_queue_element))) {
+		return true;
+	}
+	if (size < qp->count && payload_free) {
+		size_t i;
+
+		for (i = size; i < qp->count; ++i) {
+			(*payload_free)(qp->data[i].payload.p);
+		}
+		qp->count = size;
+	}
+	qp->data = mem_realloc(qp->data, size * sizeof(*qp->data));
+	qp->size = size;
+	return false;
+}
+
+/**
+ * Remove all entries currently in a priority queue.
+ *
+ * \param qp is queue to modify.
+ * \param payload_free will, if not NULL, be called on the pointer payload
+ * for all entries removed from the queue.
+ */
+void qp_flush(struct priority_queue *qp, void (*payload_free)(void*))
+{
+	assert(qp && qp->count <= qp->size);
+	if (payload_free) {
+		size_t i;
+
+		for (i = 0; i < qp->count; ++i) {
+			(*payload_free)(qp->data[i].payload.p);
+		}
+	}
+	qp->count = 0;
+}
+
+/**
+ * Release the resources allocated by a call to qp_new().
+ *
+ * \param qp is a priority queue returned by qp_new().  It may be NULL.
+ * \param payload_free will, if not NULL, be called on the pointer payload
+ * for any existing elements in the queue.
+ */
+void qp_free(struct priority_queue *qp, void (*payload_free)(void*))
+{
+	if (!qp) {
+		return;
+	}
+	assert(qp->count <= qp->size);
+	if (payload_free) {
+		size_t i;
+
+		for (i = 0; i < qp->count; ++i) {
+			(*payload_free)(qp->data[i].payload.p);
+		}
+	}
+	mem_free(qp->data);
+	mem_free(qp);
+}
+
+/**
+ * Return the maximum number of elements a priority queue can hold.
+ */
+size_t qp_size(const struct priority_queue *qp)
+{
+	assert(qp && qp->count <= qp->size);
+	return qp->size;
+}
+
+/**
+ * Return the number of elements currently in a priority queue.
+ */
+size_t qp_len(const struct priority_queue *qp)
+{
+	assert(qp && qp->count <= qp->size);
+	return qp->count;
+}
+
+/**
+ * Push an integer, payload, with the given priority on to a priority queue.
+ *
+ * \param qp is the priority queue to modify.
+ * \param priority is the priority for the new element.
+ * \param payload is the integer payload for the new element.
+ *
+ * Has undefined behavior if the priority queue is already full or if the
+ * queue has existing elements and some of those were pushed onto the queue
+ * with pointer payloads.
+ */
+void qp_push_int(struct priority_queue *qp, int priority, int payload)
+{
+	assert(qp && qp->count < qp->size);
+	qp->data[qp->count].priority = priority;
+	qp->data[qp->count].payload.i = payload;
+	up_heap(qp, qp->count);
+	++qp->count;
+}
+
+/**
+ * Push a pointer, payload, with the given priority on to a priority queue.
+ *
+ * \param qp is the priority queue to modify.
+ * \param priority is the priority for the new element.
+ * \param payload is the pointer payload for the new element.
+ *
+ * Has undefined behavior if the priority queue is already full or if the
+ * queue has existing elements and some of those were pushed onto the queue
+ * with integer payloads.
+ */
+void qp_push_ptr(struct priority_queue *qp, int priority, void *payload)
+{
+	assert(qp && qp->count < qp->size);
+	qp->data[qp->count].priority = priority;
+	qp->data[qp->count].payload.p = payload;
+	up_heap(qp, qp->count);
+	++qp->count;
+}
+
+/**
+ * Pop the element at the head of a priority queue and return its integer
+ * payload.
+ *
+ * \param qp is the priority queue to modify.
+ * \return the integer payload for the element that was at the head of the
+ * queue.
+ *
+ * Has undefined behavior if there are no elements currently in the queue
+ * or if the queue has one or more elements that were added with pointer
+ * payloads.
+ */
+int qp_pop_int(struct priority_queue *qp)
+{
+	int result;
+
+	assert(qp && qp->count > 0 && qp->count <= qp->size);
+	result = qp->data[0].payload.i;
+	--qp->count;
+	qp->data[0] = qp->data[qp->count];
+	down_heap(qp, 0);
+	return result;
+}
+
+/**
+ * Pop the element at the head of a priority queue and return its pointer
+ * payload.
+ *
+ * \param qp is the priority queue to modify.
+ * \return the pointer payload for the element that was at the head of the
+ * queue.
+ *
+ * Has undefined behavior if there are no elements currently in the queue
+ * or if the queue has one or more elements that were added with integer
+ * payloads.
+ */
+void *qp_pop_ptr(struct priority_queue *qp)
+{
+	void *result;
+
+	assert(qp && qp->count > 0 && qp->count <= qp->size);
+	result = qp->data[0].payload.p;
+	--qp->count;
+	qp->data[0] = qp->data[qp->count];
+	down_heap(qp, 0);
+	return result;
+}
+
+/**
+ * Push an integer, payload, with the given priority on to a priority queue,
+ * pop the element at the head of the queue, and return that popped element's
+ * integer payload.
+ *
+ * \param qp is the priority queue to modify
+ * \param priority is the priority for the new element.
+ * \param payload is the integer payload for the new element.
+ * \return the integer payload for the element that was at the head of the
+ * queue after pushing the element given by priority and payload.
+ *
+ * Has better performance than calling qp_push_int(qp, priority, payload) and
+ * then qp_pop_int(qp).
+ * Has undefined behavior if the priority queue has existing elements and
+ * some of those were pushed onto the queue with pointer payloads.
+ */
+int qp_pushpop_int(struct priority_queue *qp, int priority, int payload)
+{
+	int result;
+
+	assert(qp && qp->count <= qp->size);
+	if (qp->count == 0 || priority <= qp->data[0].priority) {
+		result = payload;
+	} else {
+		result = qp->data[0].payload.i;
+		if (priority <= qp->data[qp->count - 1].priority) {
+			qp->data[0].priority = priority;
+			qp->data[0].payload.i = payload;
+		} else {
+			qp->data[0] = qp->data[qp->count - 1];
+			qp->data[qp->count - 1].priority = priority;
+			qp->data[qp->count - 1].payload.i = payload;
+		}
+		down_heap(qp, 0);
+	}
+
+	return result;
+}
+
+/**
+ * Push a pointer, payload, with the given priority on to a priority queue,
+ * pop the element at the head of the queue, and return that popped element's
+ * pointer payload.
+ *
+ * \param qp is the priority queue to modify
+ * \param priority is the priority for the new element.
+ * \param payload is the pointer payload for the new element.
+ * \return the pointer payload for the element that was at the head of the
+ * queue after pushing the element given by priority and payload.
+ *
+ * Has better performance than calling qp_push_ptr(qp, priority, payload) and
+ * then qp_pop_ptr(qp).
+ * Has undefined behavior if the priority queue has existing elements and
+ * some of those were pushed onto the queue with integer payloads.
+ */
+void *qp_pushpop_ptr(struct priority_queue *qp, int priority, void *payload)
+{
+	void *result;
+
+	assert(qp && qp->count <= qp->size);
+	if (qp->count == 0 || priority <= qp->data[0].priority) {
+		result = payload;
+	} else {
+		result = qp->data[0].payload.p;
+		if (priority <= qp->data[qp->count - 1].priority) {
+			qp->data[0].priority = priority;
+			qp->data[0].payload.p = payload;
+		} else {
+			qp->data[0] = qp->data[qp->count - 1];
+			qp->data[qp->count - 1].priority = priority;
+			qp->data[qp->count - 1].payload.p = payload;
+		}
+		down_heap(qp, 0);
+	}
+
+	return result;
+}
+
+/**
+ * Return the integer payload for the element at the head of a priority queue.
+ *
+ * Has undefined behavior if the priority queue is empty or has one or more
+ * existing elements that were pushed with pointer payloads.
+ */
+int qp_peek_int(const struct priority_queue *qp)
+{
+	assert(qp && qp->count > 0 && qp->count <= qp->size);
+	return qp->data[0].payload.i;
+}
+
+/**
+ * Return the pointer payload for the element at the head of a priority queue.
+ *
+ * Has undefined behavior if the priority queue is empty or has one or more
+ * existing elements that were pushed with integer payloads.
+ */
+void *qp_peek_ptr(const struct priority_queue *qp)
+{
+	assert(qp && qp->count > 0 && qp->count <= qp->size);
+	return qp->data[0].payload.p;
+}
+
+/**
+ * Return true if a priority queue does not satisfy the expected invariants;
+ * otherwise return false.
+ */
+bool qp_isinvalid(const struct priority_queue *qp)
+{
+	size_t start, parent;
+
+	if (!qp || qp->count > qp->size) {
+		return true;
+	}
+
+	/* Queues with less than two elements have nothing to check. */
+	if (qp->count < 2) {
+		return false;
+	}
+
+	if ((qp->count & 1) == 0) {
+		/*
+		 * On the deepest layer, there is a node that does not have
+		 * a sibling with the same parent.
+		 */
+		parent = (qp->count - 2) >> 1;
+		if (qp->data[qp->count - 1].priority
+				< qp->data[parent].priority) {
+			return true;
+		}
+		start = qp->count - 2;
+	} else {
+		/* All nodes on the deepest layer have a sibling. */
+		start = qp->count - 1;
+	}
+
+	while (start > 1) {
+		parent = (start - 1) >> 1;
+		if (qp->data[start].priority < qp->data[parent].priority
+				|| qp->data[start - 1].priority
+				< qp->data[parent].priority) {
+			return true;
+		}
+		start -= 2;
+	}
+	return false;
 }

--- a/src/z-queue.h
+++ b/src/z-queue.h
@@ -1,6 +1,6 @@
 /**
  * \file z-queue.h
- * \brief Simple circular integer queue.
+ * \brief Simple circular integer queue and integer priority queue.
  *
  * Copyright (c) 2011 Erik Osheim
  *
@@ -24,12 +24,14 @@
 struct queue {
     uintptr_t *data;
     size_t size;
-    int head;
-    int tail;
+    size_t head;
+    size_t tail;
 };
 
 struct queue *q_new(size_t size);
-int q_len(struct queue *q);
+bool q_resize(struct queue *q, size_t size);
+size_t q_size(const struct queue *q);
+size_t q_len(struct queue *q);
 
 void q_push(struct queue *q, uintptr_t item);
 uintptr_t q_pop(struct queue *q);
@@ -41,5 +43,55 @@ void q_free(struct queue *q);
 
 #define q_push_int(q, i) q_push((q), (uintptr_t)(i))
 #define q_pop_int(q) ((int)(q_pop((q))))
+
+
+/*
+ * Stores a priority queue where the priorities are integers, the lowest
+ * value for the priority is popped first, and either an integer or pointer
+ * can be stored along with the priority as a payload.  Storing both pointers
+ * and integers within the same priority queue, however, is not supported.
+ * The queue uses a min-heap packed into an array.
+ */
+struct priority_queue_element {
+	union { void *p; int i; } payload;
+	int priority;
+};
+struct priority_queue {
+	struct priority_queue_element *data;
+	size_t size, count;
+};
+
+struct priority_queue *qp_new(size_t size);
+bool qp_resize(struct priority_queue *qp, size_t size,
+		void (*payload_free)(void*));
+void qp_flush(struct priority_queue *qp, void (*payload_free)(void*));
+void qp_free(struct priority_queue *qp, void (*payload_free)(void*));
+
+size_t qp_size(const struct priority_queue *qp);
+size_t qp_len(const struct priority_queue *qp);
+
+void qp_push_int(struct priority_queue *qp, int priority, int payload);
+void qp_push_ptr(struct priority_queue *qp, int priority, void *payload);
+
+int qp_pop_int(struct priority_queue *qp);
+void *qp_pop_ptr(struct priority_queue *qp);
+
+int qp_pushpop_int(struct priority_queue *qp,
+		int priority, int payload);
+void *qp_pushpop_ptr(struct priority_queue *qp,
+		int priority, void *payload);
+
+int qp_peek_int(const struct priority_queue *qp);
+void *qp_peek_ptr(const struct priority_queue *qp);
+
+bool qp_isinvalid(const struct priority_queue *qp);
+
+/* Remove some function call overhead if assertions are stripped. */
+#ifdef NDEBUG
+#define qp_size(qp) ((qp)->size)
+#define qp_len(qp) ((qp)->count)
+#define qp_peek_int(qp) ((qp)->data[0].payload.i)
+#define qp_peek_ptr(qp) ((qp)->data[0].payload.p)
+#endif
 
 #endif /* INCLUDED_Z_QUEUE_H */


### PR DESCRIPTION
For calculating multiple paths from the same starting point, make the distance array calculation public and have it return its results rather than storing them in a static array.  In the internals of that calculation, replace the point set with a queue and explicitly have the edges of the cave as unreachable to simplify bounds checks.

With that distance calculation available, have the nearest staircase/nearest unexplored calculations in do_cmd_navigate_down(), do_cmd_navigate_up(), and do_cmd_explore() use the expected number of turns to navigate the path rather than distance().  Move the search for the nearest to path_nearest_known() and path_nearest_unknown() (declared in player-path.h; implemented in player-path.c).

Change the interface of find_path() so it returns the steps in the path rather than storing them in a static array.  Change struct player_upkeep so all the state for running with pathfinding is there.  Removes the running_with_pathfind element of that structure; test for a non-NULL steps field in that structure instead.

Change the internals of find_path() to use an A* algorithm.  Add a priority queue type in z-queue.{c,h} to use in that algorithm.

To compare the performance before and after the change, did this experiment: generate 500 random levels at a depth of 1000 feet; for each level, memorized all grids in the level that did not seem like a wall or which touched at least one grid that did not seem like a wall; then randomly selected twenty destinations in the level that were known, passable, and different from the player's starting location and for each of those destinations timed the path computations using the previous version of find_path(), the modified version of find_path(), and the combination of prepare_pfdistances(), pfdistances_to_path(), and release_pfdistances().  The results were collected on a Linux virtual machine (Debian 11 running on macOS 12.7.2 host via Parallels 18) with a 2.7 GHz Dual-Core Intel Core i5 as the processor.

Release build (CFLAGS=-O2 ; --enable-release)
                        count   mean time (seconds)     std. dev. of mean (s)
old find_path()
    successful paths     9395        0.0012599                0.0000031
    failed paths          605        0.0032737                0.0000332
new find_path()
    successful paths     9395        0.0004527                0.0000039
    failed paths          605        0.0006668                0.0000543
pf_distances_to_path()
    successful paths     9395        0.0008525                0.0000029
    failed paths          605        0.0020103                0.0000318

Non-release build (CFLAGS=-O0 ; --disable-release)
                        count   mean time (seconds)     std. dev. of mean (s)
old find_path()
    successful paths    9277         0.0014400                0.0000041
    failed paths         723         0.0036938                0.0000369
new find_path()
    successful paths    9271         0.0006211                0.0000055
    failed paths         729         0.0012218                0.0000887
pf_distances_to_path()
    successful paths    9271         0.0010382                0.0000038
    failed paths         729         0.0027164                0.0000468