### PR TITLE
Have player calculations use resist and flag-synonym from player-timed.txt

### DIFF
--- a/docs/hacking/modifying.rst
+++ b/docs/hacking/modifying.rst
@@ -182,10 +182,11 @@ object_property.txt
 player_timed.txt
   This file defines some of the properties of timed effects (such as haste and
   confusion) that can apply to the player.  It chiefly contains the messages
-  on changes in these effects, and player attributes which prevent the effects.
-  To add new timed effects or change the way existing ones operate, you will
-  have to alter src/list-player-timed.h and probably other files, and
-  re-compile the game.
+  on changes in these effects, links a timed effect to a resistance or
+  object flag, and specifies player attributes which prevent the effects.
+  To add new timed effects or change the way existing ones operate beyond
+  what can be specified in player_timed.txt, you will have to alter
+  src/list-player-timed.h and probably other files, and re-compile the game.
 
 projection.txt
   This file contains a lot of the defining information about projections -

--- a/lib/gamedata/player_timed.txt
+++ b/lib/gamedata/player_timed.txt
@@ -9,16 +9,16 @@
 # It should only be done when list-player-timed.h (and other code) is also being
 # changed, and the game recompiled.
 # Changing a resist line will have to match to one of the hard-coded elements
-# from list-elements.h; currently, those resist lines are used to filter out
-# unnecessary messages when timed effects lapse and to affect selection of
-# randart activations.
+# from list-elements.h; currently, those resist lines are used in player
+# resistance calculations, to filter out unnecessary messages when timed
+# effects lapse and to affect selection of randart activations.
 # Changing a brand or slay line will have to match to an entry in brand.txt or
 # slay.txt, respectively; besides the effect on combat, those lines also
 # affect selection of randart activations.
 # Changing a flag-synonym line will have to match to an entry, of type flag, in
-# object_property.txt; those lines are currently used to filter out unnecessary
-# messages when timed effects lapse and to affect selection of randart
-# activations.
+# object_property.txt; those lines are currently used in player calculations,
+# to filter out unnecessary messages when timed effects lapse and to affect
+# selection of randart activations.
 
 # Fields:
 # name - the effect name; the name must match the first argument to one of the

--- a/src/player-calcs.c
+++ b/src/player-calcs.c
@@ -2184,20 +2184,12 @@ void calc_bonuses(struct player *p, struct player_state *state, bool known_only,
 	if (p->timed[TMD_TERROR]) {
 		state->speed += 10;
 	}
-	if (p->timed[TMD_OPP_ACID] && (state->el_info[ELEM_ACID].res_level < 2)) {
-			state->el_info[ELEM_ACID].res_level++;
-	}
-	if (p->timed[TMD_OPP_ELEC] && (state->el_info[ELEM_ELEC].res_level < 2)) {
-			state->el_info[ELEM_ELEC].res_level++;
-	}
-	if (p->timed[TMD_OPP_FIRE] && (state->el_info[ELEM_FIRE].res_level < 2)) {
-			state->el_info[ELEM_FIRE].res_level++;
-	}
-	if (p->timed[TMD_OPP_COLD] && (state->el_info[ELEM_COLD].res_level < 2)) {
-			state->el_info[ELEM_COLD].res_level++;
-	}
-	if (p->timed[TMD_OPP_POIS] && (state->el_info[ELEM_POIS].res_level < 2)) {
-			state->el_info[ELEM_POIS].res_level++;
+	for (i = 0; i < TMD_MAX; ++i) {
+		if (p->timed[i] && timed_effects[i].temp_resist != -1
+				&& state->el_info[timed_effects[i].temp_resist].res_level
+				< 2) {
+			state->el_info[timed_effects[i].temp_resist].res_level++;
+		}
 	}
 	if (p->timed[TMD_CONFUSED]) {
 		adjust_skill_scale(&state->skills[SKILL_DEVICE], -1, 4, 0);

--- a/src/player.c
+++ b/src/player.c
@@ -302,26 +302,20 @@ void player_flags(struct player *p, bitflag f[OF_SIZE])
 
 /**
  * Combine any flags due to timed effects on the player into those in f.
+ *
+ * Hack:  TMD_TRAPSAFE is excluded so a player's flags can be tested for
+ * OF_TRAP_IMMUNE and know that did not come from a timed effect; that is
+ * used for learning the trap immune rune when working with traps
  */
 void player_flags_timed(struct player *p, bitflag f[OF_SIZE])
 {
-	if (p->timed[TMD_BOLD] || p->timed[TMD_HERO] || p->timed[TMD_SHERO]) {
-		of_on(f, OF_PROT_FEAR);
-	}
-	if (p->timed[TMD_TELEPATHY]) {
-		of_on(f, OF_TELEPATHY);
-	}
-	if (p->timed[TMD_SINVIS]) {
-		of_on(f, OF_SEE_INVIS);
-	}
-	if (p->timed[TMD_FREE_ACT]) {
-		of_on(f, OF_FREE_ACT);
-	}
-	if (p->timed[TMD_AFRAID] || p->timed[TMD_TERROR]) {
-		of_on(f, OF_AFRAID);
-	}
-	if (p->timed[TMD_OPP_CONF]) {
-		of_on(f, OF_PROT_CONF);
+	int i;
+
+	for (i = 0; i < TMD_MAX; ++i) {
+		if (p->timed[i] && timed_effects[i].oflag_dup != OF_NONE
+				&& i != TMD_TRAPSAFE) {
+			of_on(f, timed_effects[i].oflag_dup);
+		}
 	}
 }
 

--- a/src/ui-entry.c
+++ b/src/ui-entry.c
@@ -1245,34 +1245,14 @@ static void modifier_to_skill(int modind, int *skillind, int *skill2mod_num,
 
 static int get_timed_element_effect(const struct player *p, int ind)
 {
-	int result;
+	int i;
 
-	switch (ind) {
-	case ELEM_ACID:
-		result = p->timed[TMD_OPP_ACID] ? 1 : 0;
-		break;
-
-	case ELEM_ELEC:
-		result = p->timed[TMD_OPP_ELEC] ? 1 : 0;
-		break;
-
-	case ELEM_FIRE:
-		result = p->timed[TMD_OPP_FIRE] ? 1 : 0;
-		break;
-
-	case ELEM_COLD:
-		result = p->timed[TMD_OPP_COLD] ? 1 : 0;
-		break;
-
-	case ELEM_POIS:
-		result = p->timed[TMD_OPP_POIS] ? 1 : 0;
-		break;
-
-	default:
-		result = 0;
-		break;
+	for (i = 0; i < TMD_MAX; ++i) {
+		if (p->timed[i] && timed_effects[i].temp_resist == ind) {
+			return 1;
+		}
 	}
-	return result;
+	return 0;
 }
 
 


### PR DESCRIPTION
That means player_timed.txt is the sole source (with the exception of a hack for TRAPSAFE) of information about linkages between timed effects and resistances or object flags.  Does have a performance cost (loop over TMD_MAX) in the affected calculations.