### PR TITLE
MSYS2 and SDL2: link to ntdll rather than ntoskrnl

### DIFF
--- a/src/Makefile.msys2.sdl2
+++ b/src/Makefile.msys2.sdl2
@@ -51,7 +51,6 @@ VIDEO_sdl2_ldflags := \
 	-laom \
 	-ldav1d \
 	-lrav1e \
-	-lSvtAv1Dec \
 	-lSvtAv1Enc \
 	-lyuv \
 	-lwebp \
@@ -79,7 +78,7 @@ VIDEO_sdl2_ldflags := \
 	-lole32 \
 	-loleaut32 \
 	-lwinmm \
-	-lntoskrnl \
+	-lntdll
 
 ## Support SDL_mixer for sound
 ifdef SOUND


### PR DESCRIPTION
Likely resolves crash reported here, https://angband.live/forums/forum/angband/vanilla/248431-fresh-install-noob-trouble-compiling-sdl2-w-sound-version?p=248453#post248453 , by smbhax .  Drop linking with libSvtAv1Dec as it is not a dependency for libavif.