### PR TITLE
Mark commands used internally by pathfinding as background commands

### DIFF
--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -1175,9 +1175,10 @@ void move_player(int dir, bool disarm)
 			 * The autopickup is a side effect of the move:
 			 * whatever command triggered the move will be the
 			 * target for CMD_REPEAT rather than repeating the
-			 * autopickup.
+			 * autopickup, and the autopickup won't trigger
+			 * bloodlust.
 			 */
-			cmdq_peek()->is_background_command = true;
+			cmdq_peek()->background_command = 2;
 		} else {
 			/* No move made so no energy spent. */
 			player->upkeep->energy_use = 0;

--- a/src/cmd-core.h
+++ b/src/cmd-core.h
@@ -245,10 +245,11 @@ struct command {
 	int nrepeats;
 
 	/*
-	 * Whether this command should be skipped when looking for CMD_REPEAT's
-	 * target.
+	 * 0: can be target for CMD_REPEAT and can trigger bloodlust
+	 * 1: can not be target for CMD_REPEAT and can trigger bloodlust
+	 * >1: can not be target for CMD_REPEAT and can not trigger bloodlust
 	 */
-	bool is_background_command;
+	int background_command;
 
 	/* Arguments */
 	struct cmd_arg arg[CMD_MAX_ARGS];
@@ -277,6 +278,9 @@ typedef void (*cmd_handler_fn)(struct command *cmd);
  * ------------------------------------------------------------------------
  * Command type functions
  * ------------------------------------------------------------------------ */
+
+void cmd_copy(struct command *dest, const struct command *src);
+void cmd_release(struct command *cmd);
 
 /* Return the verb that goes alongside the given command. */
 const char *cmd_verb(cmd_code cmd);
@@ -316,9 +320,11 @@ errr cmdq_push(cmd_code c);
 void cmdq_execute(cmd_context ctx);
 
 /**
- * Remove all commands from the queue.
+ * Remove all commands from the queue.  cmdq_release() also releases any
+ * resource allocated.
  */
 void cmdq_flush(void);
+void cmdq_release(void);
 
 /**
  * ------------------------------------------------------------------------

--- a/src/cmd-obj.c
+++ b/src/cmd-obj.c
@@ -201,7 +201,6 @@ void do_cmd_inscribe(struct command *cmd)
 		return;
 
 	obj->note = quark_add(str);
-	string_free((char *)str);
 
 	player->upkeep->notice |= (PN_COMBINE | PN_IGNORE);
 	player->upkeep->redraw |= (PR_INVEN | PR_EQUIP);

--- a/src/init.c
+++ b/src/init.c
@@ -4534,7 +4534,7 @@ void cleanup_angband(void)
 
 	cleanup_game_constants();
 
-	cmdq_flush();
+	cmdq_release();
 
 	if (play_again) return;
 

--- a/src/obj-ignore.c
+++ b/src/obj-ignore.c
@@ -690,9 +690,10 @@ void ignore_drop(struct player *p)
 				 * This drop is a side effect:  whatever
 				 * command triggered it will be the target
 				 * for CMD_REPEAT rather than repeating the
-				 * drop.
+				 * drop, and the drop will not trigger
+				 * bloodlust.
 				 */
-				drop_cmd->is_background_command = true;
+				drop_cmd->background_command = 2;
 			}
 		}
 	}

--- a/src/player-birth.c
+++ b/src/player-birth.c
@@ -1214,8 +1214,6 @@ void do_cmd_choose_name(struct command *cmd)
 
 	/* Set player name */
 	my_strcpy(player->full_name, str, sizeof(player->full_name));
-
-	string_free((char *) str);
 }
 
 void do_cmd_choose_history(struct command *cmd)
@@ -1229,8 +1227,6 @@ void do_cmd_choose_history(struct command *cmd)
 	/* Get the new history */
 	cmd_get_arg_string(cmd, "history", &str);
 	player->history = string_make(str);
-
-	string_free((char *) str);
 }
 
 void do_cmd_accept_character(struct command *cmd)

--- a/src/player-path.c
+++ b/src/player-path.c
@@ -1904,6 +1904,7 @@ void run_step(int dir)
 
 					disturb(player);
 					cmdq_push(CMD_OPEN);
+					cmdq_peek()->background_command = 1;
 					cmd_set_arg_direction(cmdq_peek(),
 						"direction", next_step_dir);
 					cmdq_push(CMD_PATHFIND);
@@ -1921,6 +1922,7 @@ void run_step(int dir)
 
 					disturb(player);
 					cmdq_push(CMD_TUNNEL);
+					cmdq_peek()->background_command = 1;
 					cmd_set_arg_direction(cmdq_peek(),
 						"direction", next_step_dir);
 					cmdq_push(CMD_PATHFIND);
@@ -2024,6 +2026,15 @@ void run_step(int dir)
 	/* Prepare the next step */
 	if (player->upkeep->running) {
 		cmdq_push(CMD_RUN);
+		if (player->upkeep->steps) {
+			/*
+			 * Running is a side effect of pathfinding.  Do allow
+			 * it to trigger bloodlust so pathfinding can not
+			 * be exploited as a way to move without the bloodlust
+			 * checks.
+			 */
+			cmdq_peek()->background_command = 1;
+		}
 		cmd_set_arg_direction(cmdq_peek(), "direction", 0);
 	} else if (player->upkeep->steps) {
 		mem_free(player->upkeep->steps);


### PR DESCRIPTION
Generally gives better behavior than 4.2.5 when repeating the last command after an interrupted pathfinding command:  repeats the pathfinding command rather than the last run used to take a step along the path.  Fixes a regression introduced by 4d76112f25e5287b9c2ebfdaef80c72d13928900 : when compiled with -fsanitize=address and -fsanitize=undefined, repeating the last command after an interrupted pathfind when no normal run had been used in the session would trigger a crash in run_test() (in that case, the last command is run with a direction of zero and prev_run_dir is zero).