### PR TITLE
SDL2: do not reset all flags when changing a subwindow's purpose

### DIFF
--- a/src/main-sdl2.c
+++ b/src/main-sdl2.c
@@ -2368,7 +2368,9 @@ static void handle_menu_pw(struct sdlpui_control *ctrl,
 	SDL_assert(ctrl->type_code == SDLPUI_CTRL_MENU_BUTTON);
 	mb = (struct sdlpui_menu_button*)ctrl->priv;
 	SDL_assert(mb->subtype_code == SDLPUI_MB_TOGGLE);
-	new_flags = mem_zalloc(N_ELEMENTS(window_flag) * sizeof(*new_flags));
+	new_flags = mem_alloc(N_ELEMENTS(window_flag) * sizeof(*new_flags));
+	memcpy(new_flags, window_flag, N_ELEMENTS(window_flag)
+		* sizeof(*new_flags));
 	if (mb->v.toggled) {
 		new_flags[subw_idx] |= (uint32_t)1 << flag_idx;
 	} else {


### PR DESCRIPTION
Fixes a post 4.2.5 regression introduced by d6886368017822967efa5911a64b8819502fd7e4 .