### PR TITLE
Borg: fix extraction of target's name after casting Vampire Strike

### DIFF
--- a/src/borg/borg-messages.c
+++ b/src/borg/borg-messages.c
@@ -395,7 +395,7 @@ static void borg_parse_aux(char *msg, int len)
         return;
     }
     if (prefix(msg, "You bite ")) {
-        tmp = strlen("You hit ");
+        tmp = strlen("You bite ");
         strnfmt(who, 1 + len - (tmp + 1), "%s", msg + tmp);
         strnfmt(buf, 256, "HIT:%s", who);
         borg_react(msg, buf);


### PR DESCRIPTION
@agoodman00 , this appears to ~resolve~ reduce instances with the borg getting hung up at a direction prompt after killing a monster with Vampire Strike.