### PR TITLE
borg: fix two warnings

### DIFF
--- a/src/borg/borg-fight-attack.c
+++ b/src/borg/borg-fight-attack.c
@@ -389,7 +389,7 @@ static int borg_best_mult(borg_item *obj, struct monster_race *r_ptr)
         struct slay *slay = &slays[i];
         if (obj) {
             /* Slay is on an object */
-            if (!obj->slays || !obj->slays[i])
+            if (!obj->slays[i])
                 continue;
         } else {
             /* Temporary slay */

--- a/src/borg/borg-trait-swap.c
+++ b/src/borg/borg-trait-swap.c
@@ -867,18 +867,16 @@ void borg_notice_armour_swap(void)
             armour_swap_slay_dragon = item->slays[RF_DRAGON];
             if (of_has(item->flags, OF_IMPACT))
                 armour_swap_impact = true;
-            if (item->brands) {
-                if (item->brands[ELEM_ACID])
-                    armour_swap_brand_acid = true;
-                if (item->brands[ELEM_ELEC])
-                    armour_swap_brand_elec = true;
-                if (item->brands[ELEM_FIRE])
-                    armour_swap_brand_fire = true;
-                if (item->brands[ELEM_COLD])
-                    armour_swap_brand_cold = true;
-                if (item->brands[ELEM_POIS])
-                    armour_swap_brand_pois = true;
-            }
+            if (item->brands[ELEM_ACID])
+                armour_swap_brand_acid = true;
+            if (item->brands[ELEM_ELEC])
+                armour_swap_brand_elec = true;
+            if (item->brands[ELEM_FIRE])
+                armour_swap_brand_fire = true;
+            if (item->brands[ELEM_COLD])
+                armour_swap_brand_cold = true;
+            if (item->brands[ELEM_POIS])
+                armour_swap_brand_pois = true;
 
             /* Affect infravision */
             armour_swap_see_infra += item->modifiers[OBJ_MOD_INFRA];


### PR DESCRIPTION
borg_item->brands and borg_item->slays can never be null since both of these are inline array members of the struct in question, so testing whether they are non-null is always true.