### PR TITLE
Avoid crash with -l option when there are no savefiles to list

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -280,9 +280,13 @@ static void list_saves(void)
 {
 	savefile_getter g = NULL;
 
-	if (!got_savefile(&g) && !got_savefile_dir(g)) {
+	if (!got_savefile(&g)) {
 		cleanup_savefile_getter(g);
-		quit_fmt("Cannot open savefile directory");
+		if (!got_savefile_dir(g)) {
+			quit_fmt("Cannot open savefile directory");
+		}
+		printf("There are no savefiles you can use.\n");
+		return;
 	}
 
 	printf("Savefiles you can use are:\n");


### PR DESCRIPTION
Crash reported by vext01 in the comments on #5952 .