### PR TITLE
Display recently updated messages in RED colour in message subwindow

### DIFF
--- a/src/ui-display.c
+++ b/src/ui-display.c
@@ -1892,6 +1892,8 @@ static void update_messages_subwindow(game_event_type type,
 	int i;
 	int w, h;
 	int x, y;
+	bool is_fresh = true;
+	static const char* prev_last_msg = NULL;
 
 	const char *msg;
 
@@ -1902,10 +1904,14 @@ static void update_messages_subwindow(game_event_type type,
 	Term_get_size(&w, &h);
 
 	/* Dump messages */
+	const char* last_msg = NULL;
 	for (i = 0; i < h; i++) {
-		uint8_t color = message_color(i);
 		uint16_t count = message_count(i);
 		const char *str = message_str(i);
+		if (is_fresh && prev_last_msg == str) {
+			is_fresh = false;
+		}
+		uint8_t color = is_fresh? COLOUR_RED: message_color(i);
 
 		if (count == 1)
 			msg = str;
@@ -1922,7 +1928,11 @@ static void update_messages_subwindow(game_event_type type,
 
 		/* Clear to end of line */
 		Term_erase(x, y, 255);
+		if (i == 0){
+			last_msg = str;
+		}
 	}
+	prev_last_msg = last_msg;
 
 	Term_fresh();
 	

--- a/src/ui-display.c
+++ b/src/ui-display.c
@@ -1919,7 +1919,6 @@ static void update_messages_subwindow(game_event_type type,
 			msg = " ";
 		else {
 			msg = format("%s <%dx>", str, count);
-			color = COLOUR_RED;
 		}
 
 		Term_putstr(0, (h - 1) - i, -1, color, msg);

--- a/src/ui-display.c
+++ b/src/ui-display.c
@@ -1917,8 +1917,10 @@ static void update_messages_subwindow(game_event_type type,
 			msg = str;
 		else if (count == 0)
 			msg = " ";
-		else
+		else {
 			msg = format("%s <%dx>", str, count);
+			color = COLOUR_RED;
+		}
 
 		Term_putstr(0, (h - 1) - i, -1, color, msg);
 
@@ -2271,7 +2273,7 @@ static void subwindow_flag_changed(int win_idx, uint32_t flag, bool new_state)
 
 		case PW_MESSAGE:
 		{
-			register_or_deregister(EVENT_MESSAGE,
+			register_or_deregister(EVENT_STATE,
 					       update_messages_subwindow,
 					       angband_term[win_idx]);
 			break;


### PR DESCRIPTION
This will help reading message if multiple events has occurred while a state has changed(ie. 1 key is pressed). Like when a monster attacks multiple times in single turn, Its hard to distinguish what are the recent updates in message subwindow,

Output looks like this
![image](https://github.com/angband/angband/assets/39230006/d780fd12-4399-4ca9-b7ef-89af8e825289)

Implementation is kind of hacky, there was another way to have a flag `is_fresh` in message structure, i thought this was little cleaner, let me know if you want me to try that