### PR TITLE
Reinstate link from TMD_AFRAID and TMD_TERROR to OF_AFRAID

### DIFF
--- a/lib/gamedata/player_timed.txt
+++ b/lib/gamedata/player_timed.txt
@@ -232,6 +232,7 @@ on-end:You feel bolder now.
 on-increase:You are more scared!
 msgt:AFRAID
 fail:1:PROT_FEAR
+flag-synonym:AFRAID:1
 
 name:IMAGE
 desc:hallucination
@@ -420,6 +421,7 @@ desc:terror
 grade:r:10000:Terror:You feel the need to run away and fast!
 on-end:The urge to run dissipates.
 msgt:AFRAID
+flag-synonym:AFRAID:0
 
 name:SPRINT
 desc:sprinting


### PR DESCRIPTION
Link was broken by the post 4.2.5 change, 2afd564a8f1eae648da797ae85826f39299ec3e9 .  Reported by Ingwe Ingweron here, https://angband.live/forums/forum/angband/vanilla/10689-angband-4-2-5?p=248770#post248770 .