### PR TITLE
set an object to assessed that has all its runes known

### DIFF
--- a/src/obj-knowledge.c
+++ b/src/obj-knowledge.c
@@ -1750,7 +1750,11 @@ void object_learn_unknown_rune(struct player *p, struct object *obj)
 	int i = object_find_unknown_rune(p, obj);
 
 	/* No unknown runes */
-	if (i < 0) return;
+	if (i < 0) {
+		obj->known->notice |= OBJ_NOTICE_ASSESSED;
+		player_know_object(player, obj);
+		return;
+	}
 
 	/* Learn the rune */
 	player_learn_rune(p, i, true);


### PR DESCRIPTION
I mentioned this change in the forum.  It makes it so both ID and selling an object that is in a strange state go to fully assessed.  I don't know if this is the best way to handle this since I am less familiar with base code than borg code.  
Really, the best solution is to figure out where the object got in the strange state but so far I haven't been able to track that down or even get it to happen again.