### PR TITLE
borg: light beam seems wrong and selling unID'd items if they stack

### DIFF
--- a/src/borg/borg-light.c
+++ b/src/borg/borg-light.c
@@ -585,6 +585,7 @@ bool borg_light_beam(bool simulation)
     bool spell_ok = false;
     int  i;
     bool blocked  = false;
+    bool bold     = false;
 
     borg_grid *ag = &borg_grids[borg.c.y][borg.c.x];
 
@@ -605,20 +606,22 @@ bool borg_light_beam(bool simulation)
     if (borg.c.y - borg.trait[BI_CURLITE] - 1 > 0) {
         /* Look just beyond my light */
         ag = &borg_grids[borg.c.y - borg.trait[BI_CURLITE] - 1][borg.c.x];
+        bold = borg_cave_floor_bold(
+            borg.c.y - borg.trait[BI_CURLITE] - 1, borg.c.x);
 
         /* Must be on the panel */
         if (panel_contains(borg.c.y - borg.trait[BI_CURLITE] - 1, borg.c.x)) {
             /* Check each grid in our light radius along the course */
             for (i = 0; i <= borg.trait[BI_CURLITE]; i++) {
-                if (borg_cave_floor_bold(borg.c.y - i, borg.c.x)
-                    && !borg_cave_floor_bold(
-                        borg.c.y - borg.trait[BI_CURLITE] - 1, borg.c.x)
-                    && ag->feat < FEAT_OPEN && blocked == false) {
+                if (borg_cave_floor_bold(borg.c.y - i, borg.c.x) && !bold
+                    && ag->feat < FEAT_SECRET && ag->feat != FEAT_CLOSED
+                    && blocked == false) {
                     /* note the direction */
                     dir = 8;
                 } else {
                     dir     = 5;
                     blocked = true;
+                    break;
                 }
             }
         }
@@ -628,23 +631,26 @@ bool borg_light_beam(bool simulation)
 
     /* Quick Boundary check */
     if (borg.c.y + borg.trait[BI_CURLITE] + 1 < AUTO_MAX_Y && dir == 5) {
+        blocked = false;
         /* Look just beyond my light */
         ag = &borg_grids[borg.c.y + borg.trait[BI_CURLITE] + 1][borg.c.x];
+        bold = borg_cave_floor_bold(
+            borg.c.y + borg.trait[BI_CURLITE] + 1, borg.c.x);
 
         /* Must be on the panel */
         if (panel_contains(borg.c.y + borg.trait[BI_CURLITE] + 1, borg.c.x)) {
             /* Check each grid in our light radius along the course */
             for (i = 0; i <= borg.trait[BI_CURLITE]; i++) {
                 /* all floors */
-                if (borg_cave_floor_bold(borg.c.y + i, borg.c.x)
-                    && !borg_cave_floor_bold(
-                        borg.c.y + borg.trait[BI_CURLITE] + 1, borg.c.x)
-                    && ag->feat < FEAT_OPEN && blocked == false) {
+                if (borg_cave_floor_bold(borg.c.y + i, borg.c.x) && !bold
+                    && ag->feat < FEAT_SECRET && ag->feat != FEAT_CLOSED
+                    && blocked == false) {
                     /* note the direction */
                     dir = 2;
                 } else {
                     dir     = 5;
                     blocked = true;
+                    break;
                 }
             }
         }
@@ -654,23 +660,26 @@ bool borg_light_beam(bool simulation)
 
     /* Quick Boundary check */
     if (borg.c.x + borg.trait[BI_CURLITE] + 1 < AUTO_MAX_X && dir == 5) {
+        blocked = false;
         /* Look just beyond my light */
         ag = &borg_grids[borg.c.y][borg.c.x + borg.trait[BI_CURLITE] + 1];
+        bold = borg_cave_floor_bold(
+            borg.c.y, borg.c.x + borg.trait[BI_CURLITE] + 1);
 
         /* Must be on the panel */
         if (panel_contains(borg.c.y, borg.c.x + borg.trait[BI_CURLITE] + 1)) {
             /* Check each grid in our light radius along the course */
             for (i = 0; i <= borg.trait[BI_CURLITE]; i++) {
                 /* all floors */
-                if (borg_cave_floor_bold(borg.c.y, borg.c.x + i)
-                    && !borg_cave_floor_bold(
-                        borg.c.y, borg.c.x + borg.trait[BI_CURLITE] + 1)
-                    && ag->feat < FEAT_OPEN && blocked == false) {
+                if (borg_cave_floor_bold(borg.c.y, borg.c.x + i) && !bold
+                    && ag->feat < FEAT_SECRET && ag->feat != FEAT_CLOSED
+                    && blocked == false) {
                     /* note the direction */
                     dir = 6;
                 } else {
                     dir     = 5;
                     blocked = true;
+                    break;
                 }
             }
         }
@@ -680,8 +689,11 @@ bool borg_light_beam(bool simulation)
 
     /* Quick Boundary check */
     if (borg.c.x - borg.trait[BI_CURLITE] - 1 > 0 && dir == 5) {
+        blocked = false;
         /* Look just beyond my light */
-        ag = &borg_grids[borg.c.y][borg.c.x - borg.trait[BI_CURLITE] - 1];
+        ag   = &borg_grids[borg.c.y][borg.c.x - borg.trait[BI_CURLITE] - 1];
+        bold = borg_cave_floor_bold(
+            borg.c.y, borg.c.x - borg.trait[BI_CURLITE] - 1);
 
         /* Must be on the panel */
         if (panel_contains(borg.c.y, borg.c.x - borg.trait[BI_CURLITE] - 1)) {
@@ -690,16 +702,15 @@ bool borg_light_beam(bool simulation)
                 /* Verify that there are no blockers in my light radius and
                  * the 1st grid beyond my light is not a floor nor a blocker
                  */
-                if (borg_cave_floor_bold(borg.c.y, borg.c.x - i)
-                    && /* all see through */
-                    !borg_cave_floor_bold(
-                        borg.c.y, borg.c.x - borg.trait[BI_CURLITE] - 1)
-                    && ag->feat < FEAT_OPEN && blocked == false) {
+                if (borg_cave_floor_bold(borg.c.y, borg.c.x - i) && !bold
+                    && ag->feat < FEAT_SECRET && ag->feat != FEAT_CLOSED
+                    && blocked == false) {
                     /* note the direction */
                     dir = 4;
                 } else {
                     dir     = 5;
                     blocked = true;
+                    break;
                 }
             }
         }
@@ -707,6 +718,7 @@ bool borg_light_beam(bool simulation)
 
     /* Don't do it if on the edge of shifting the panel. */
     if (dir == 5 || spell_ok == false || blocked == true
+// !FIX !TODO !AJG make sure these panel edge checks are right.
         || (dir == 2
             && (borg.c.y == 18 
                 || borg.c.y == 19 

--- a/src/borg/borg-store-sell.c
+++ b/src/borg/borg-store-sell.c
@@ -807,7 +807,8 @@ static bool borg_good_sell(borg_item *item, int who)
     }
 
     /* Never sell valuable non-id'd items */
-    if (borg_item_note_needs_id(item))
+    /* unless you have a stack, in which case, sell one to ID them */
+    if (borg_item_note_needs_id(item) && item->iqty < 2)
         return (false);
 
     /* Worshipping gold or scumming will allow the sale */
@@ -846,7 +847,7 @@ static bool borg_good_sell(borg_item *item, int who)
 
             /* Never sell if not "known" */
             if (!item->ident && borg_item_worth_id(item)
-                && (borg.trait[BI_MAXDEPTH] > 35))
+                && (borg.trait[BI_MAXDEPTH] > 35) && item->iqty == 1)
                 return (false);
 
             break;
@@ -867,7 +868,7 @@ static bool borg_good_sell(borg_item *item, int who)
         case TV_DRAG_ARMOR:
 
             /* Only sell "known" items (unless "icky") */
-            if (!item->ident && borg_item_worth_id(item))
+            if (!item->ident && borg_item_worth_id(item) && item->iqty == 1)
                 return (false);
 
             break;
@@ -881,7 +882,7 @@ static bool borg_good_sell(borg_item *item, int who)
         return (false);
     }
     /* Do not sell stuff that is not fully id'd and should be  */
-    if (!item->ident && item->ego_idx) {
+    if (!item->ident && item->ego_idx && item->iqty == 1) {
         if (borg_ego_has_random_power(
                 &e_info[borg_items[INVEN_OUTER].ego_idx])) {
             return (false);


### PR DESCRIPTION
had a borg shooting beam of light over and over at a spot.  This seems to clean that up.
borgs generally hold onto things (weapons/armor) that need ID but if they stack it seems like selling one will help the ID process for non-mages.