### PR TITLE
Borg: a few changes, selling un ID'd and using unblessed

### DIFF
--- a/src/borg/borg-home-notice.c
+++ b/src/borg/borg-home-notice.c
@@ -588,8 +588,8 @@ static void borg_notice_home_aux(borg_item *in_item, bool no_items)
                 /*  most edged weapons hurt magic for priests */
                 if (player_has(player, PF_BLESS_WEAPON)) {
                     /* Penalize non-blessed edged weapons */
-                    if ((item->tval == TV_SWORD || item->tval == TV_POLEARM)
-                        && !of_has(item->flags, OF_BLESSED)) {
+                    if (!(item->tval == TV_HAFTED 
+                        || of_has(item->flags, OF_BLESSED))) {
                         num_edged_weapon += item->iqty;
                     }
                 }

--- a/src/borg/borg-home-power.c
+++ b/src/borg/borg-home-power.c
@@ -337,8 +337,8 @@ static int32_t borg_power_home_aux1(void)
 
     value += home_damage;
 
-    /* if edged and priest, dump it   */
-    value -= num_edged_weapon * 3000L;
+    /* if edged and priest, small penalty   */
+    value -= num_edged_weapon * 50L;
 
     /* if gloves and mage or ranger and not FA/Dex, dump it. */
     value -= num_bad_gloves * 3000L;
@@ -428,13 +428,11 @@ static int32_t borg_power_home_aux2(void)
         value += 100L;
 
     /* Collect escape  (staff of teleport) */
-    if (borg.trait[BI_MAXCLEVEL] < 40) {
-        for (k = 0; k < 85 && k < num_escape; k++)
-            value += 2000L - k * 10L;
-    }
+    for (k = 0; k < 85 && k < num_escape; k++)
+        value += 2000L - k * 10L;
 
-    /* Collect a maximal number of staves in the home */
-    for (k = 0; k < kb_info[TV_STAFF].max_stack && k < num_tele_staves; k++)
+    /* Collect only one stack worth of teleport staffs at home */
+    for (k = kb_info[TV_STAFF].max_stack; k < num_tele_staves; k++)
         value -= 50000L;
 
     /* Collect teleport */

--- a/src/borg/borg-inventory.c
+++ b/src/borg/borg-inventory.c
@@ -271,49 +271,15 @@ int borg_first_empty_inventory_slot(void)
  */
 bool borg_item_worth_id(const borg_item *item)
 {
-    /* Never ID average stuff */
+    int        slot;
+
     if (!borg_item_note_needs_id(item))
         return false;
 
-    /** Some stuff should always be ID'd... **/
-    switch (item->tval) {
-    case TV_BOW:
-    case TV_SHOT:
-    case TV_ARROW:
-    case TV_BOLT:
-    case TV_HAFTED:
-    case TV_POLEARM:
-    case TV_SWORD:
-    case TV_BOOTS:
-    case TV_GLOVES:
-    case TV_HELM:
-    case TV_CROWN:
-    case TV_SHIELD:
-    case TV_CLOAK:
-    case TV_SOFT_ARMOR:
-    case TV_HARD_ARMOR:
-    case TV_DRAG_ARMOR:
-
-        /* Don't bother IDing unidentified items until they are pseudo'd */
-        if (!item->ident)
-            return false;
-    }
-
-    /* Not worth IDing magical items if we have better ego/artifact stuff */
-    if (borg_item_note_needs_id(item)) {
-        int        slot;
-        borg_item *inven_item;
-
-        /* Obtain the slot of the suspect item */
-        slot = borg_wield_slot(item);
-        if (slot < 0)
-            return false;
-
-        /* Obtain my equipped item in the slot */
-        inven_item = &borg_items[slot];
-        if (inven_item->ego_idx || inven_item->art_idx)
-            return false;
-    }
+    /* Things that can't be wielded can't be ID'd (potions, scrolls etc) */
+    slot = borg_wield_slot(item);
+    if (slot < 0)
+        return false;
 
     return true;
 }

--- a/src/borg/borg-item-id.c
+++ b/src/borg/borg-item-id.c
@@ -30,28 +30,7 @@
 #include "borg-trait.h"
 
 /*
- * Get the ID information
- *
- * This function pulls the information from the screen if it is not passed
- * a *real* item.  It is only passed in *real* items if the borg is allowed
- * to 'cheat' for inventory.
- * This function returns true if space needs to be pressed
- */
-bool borg_object_fully_id_aux(borg_item *item, struct object *real_item)
-{
-    bitflag f[OF_SIZE];
-    bitflag i = OF_SIZE;
-
-    /* the data directly from the real item    */
-    object_flags(real_item, f);
-    for (i = 0; i < 12 && i < OF_SIZE; i++)
-        item->flags[i] = f[i];
-
-    return (false);
-}
-
-/*
- * Look for an item that needs to be analysed because it has been IDd
+ * Look for an item that needs to be analyzed because it has been IDd
  *
  * This will go through inventory and look for items that were just ID'd
  * and examine them for their bonuses.

--- a/src/borg/borg-item-id.h
+++ b/src/borg/borg-item-id.h
@@ -28,10 +28,6 @@
 /* look for a *id*'d item */
 extern bool borg_object_fully_id(void);
 
-/* look for a *id*'d item */
-extern bool borg_object_fully_id_aux(
-    borg_item *borg_item, struct object *real_item);
-
 /*
  * The code currently inscribes items with {??} if they have unknown powers.
  */

--- a/src/borg/borg-power.c
+++ b/src/borg/borg-power.c
@@ -669,12 +669,6 @@ static int32_t borg_power_equipment(void)
     if (borg.trait[BI_CRSUNKNO])
         value -= 9999999L;
 
-    /*** Penalize bad magic ***/
-
-    /*  Hack -- most edged weapons hurt magic for priests */
-    if (player_has(player, PF_BLESS_WEAPON) && !borg.trait[BI_WBLESSED])
-        value -= 75000L;
-
 #if 0 /* I wonder if this causes the borg to change his gear so radically at   \
          depth 99 */
     /* HUGE MEGA MONDO HACK! prepare for the big fight */
@@ -1162,10 +1156,15 @@ static int32_t borg_power_inventory(void)
         k = 0;
         for (; k < 15 && k < borg.trait[BI_FOOD]; k++)
             value += 700L;
-    }
+    } 
+
     /* Prefer to buy HiCalorie foods over LowCalorie */
-    if (borg.trait[BI_FOOD_HI] <= 5)
-        value += borg.trait[BI_FOOD_HI] * 50;
+    k = 0;
+    for (; k < 7 && k < borg.trait[BI_FOOD_HI]; k++)
+        value += 52L;
+    k = 0;
+    for (; k < 15 && k < borg.trait[BI_FOOD_LO]; k++)
+        value -= 2L;
 
     /* Reward Cure Poison and Cuts*/
     if ((borg.trait[BI_ISCUT] || borg.trait[BI_ISPOISONED])

--- a/src/borg/borg-store-sell.c
+++ b/src/borg/borg-store-sell.c
@@ -1020,7 +1020,7 @@ static bool borg_good_sell(borg_item *item, int who)
             /* Never sell if not "known" */
             /* unless we have more than one or are deep */
             if (borg_item_worth_id(item)
-                && ((borg.trait[BI_MAXDEPTH] > 35) || multiple))
+                && ((borg.trait[BI_MAXDEPTH] > 35) || !multiple))
                 return (false);
 
             break;

--- a/src/borg/borg-store-sell.c
+++ b/src/borg/borg-store-sell.c
@@ -788,16 +788,178 @@ bool borg_think_home_sell_useful(bool save_best)
     return (false);
 }
 
+/* 
+ * scan inventory and equipment to see if we have 
+ * more than one of this 
+ */
+static bool borg_has_mutiple(borg_item *in_item)
+{
+    int i;
+    if (in_item->iqty > 1)
+        return true;
+
+    /* Some types of items we only want to count as a dupe in a stack */
+    /* for example two unIDd swords may look the same (both rapiers) */
+    /* but have different powers */
+    if (!in_item->ident) {
+        switch (in_item->tval) {
+        case TV_BOOTS:
+        case TV_GLOVES:
+        case TV_HELM:
+        case TV_CROWN:
+        case TV_SHIELD:
+        case TV_SOFT_ARMOR:
+        case TV_HARD_ARMOR:
+        case TV_SHOT:
+        case TV_BOLT:
+        case TV_ARROW:
+        case TV_BOW:
+        case TV_DIGGING:
+        case TV_HAFTED:
+        case TV_POLEARM:
+        case TV_SWORD:
+           return false;
+        }
+    }
+
+    /* check the pack */
+    for (i = 0; i < z_info->pack_size; i++) {
+        borg_item *item = &borg_items[i];
+        if (item == in_item)
+            continue;
+        if (item->tval == in_item->tval 
+            && item->sval == in_item->sval
+            && item->iqty != 0)
+            return true;
+    }
+
+    /* check equipment */
+    for (i = INVEN_WIELD; i < INVEN_TOTAL; i++) {
+        borg_item *item = &borg_items[i];
+        if (item->tval == in_item->tval
+            && item->sval == in_item->sval
+            && item->iqty != 0)
+            return true;
+    }
+    return false;
+}
+
+static bool borg_store_buys(borg_item *item, int who)
+{
+    switch (who + 1) {
+        /* General Store */
+    case 1:
+        /* Analyze the type */
+        switch (item->tval) {
+        case TV_FOOD:
+        case TV_MUSHROOM:
+        case TV_FLASK:
+            return true;
+        }
+        return false;
+
+    /* Armory */
+    case 2:
+
+        /* Analyze the type */
+        switch (item->tval) {
+        case TV_BOOTS:
+        case TV_GLOVES:
+        case TV_HELM:
+        case TV_CROWN:
+        case TV_SHIELD:
+        case TV_SOFT_ARMOR:
+        case TV_HARD_ARMOR:
+        case TV_DRAG_ARMOR:
+            return true;
+        }
+        return false;
+
+    /* Weapon Shop */
+    case 3:
+
+        /* Analyze the type */
+        switch (item->tval) {
+        case TV_SHOT:
+        case TV_BOLT:
+        case TV_ARROW:
+        case TV_BOW:
+        case TV_DIGGING:
+        case TV_HAFTED:
+        case TV_POLEARM:
+        case TV_SWORD:
+            return true;
+        }
+        return false;
+
+    /* Bookstore */
+    case 4:
+
+        /* Analyze the type */
+        switch (item->tval) {
+        case TV_PRAYER_BOOK:
+        case TV_MAGIC_BOOK:
+        case TV_NATURE_BOOK:
+        case TV_SHADOW_BOOK:
+        case TV_OTHER_BOOK:
+            return true;
+        }
+        return false;
+
+    /* book store --Alchemist */
+    case 5:
+
+        /* Analyze the type */
+        switch (item->tval) {
+        case TV_SCROLL:
+        case TV_POTION:
+            return true;
+        }
+        return false;
+
+    /* Magic Shop */
+    case 6:
+
+        /* Analyze the type */
+        switch (item->tval) {
+        case TV_AMULET:
+        case TV_RING:
+        case TV_SCROLL:
+        case TV_POTION:
+        case TV_STAFF:
+        case TV_WAND:
+        case TV_ROD:
+        case TV_MAGIC_BOOK:
+            return true;
+        }
+        return false;
+
+    /* Black Market */
+    case 7:
+
+        /* Analyze the type */
+        switch (item->tval) {
+        case TV_LIGHT:
+        case TV_CLOAK:
+        case TV_FOOD:
+            return true;
+        }
+        return false;
+    }
+    return false;
+}
+
 /*
- * Determine if an item can be sold in the given store
- *
- * XXX XXX XXX Consider use of "icky" test on items
+ * Determine if an item should be sold
  */
 static bool borg_good_sell(borg_item *item, int who)
 {
     int i;
+    /* do I have more than one, even if not stacked */
+    /* only used for non-IDd items */
+    bool multiple = false;
 
-    /* Never sell worthless items */
+    /* Never attempt to sell worthless items, shops won't buy them */
     if (item->value <= 0) {
         /* except unidentified potions and scrolls.  Since these can't be IDd,
          * best to sell them */
@@ -806,17 +968,25 @@ static bool borg_good_sell(borg_item *item, int who)
             return (false);
     }
 
+    /* make sure we are in the shop that buys this */
+    if (!borg_store_buys(item, who))
+        return false;
+
     /* Never sell valuable non-id'd items */
     /* unless you have a stack, in which case, sell one to ID them */
-    if (borg_item_note_needs_id(item) && item->iqty < 2)
-        return (false);
+    if (borg_item_note_needs_id(item)) {
+        /* note if we have more than one */
+        multiple = borg_has_mutiple(item);
+        if (!multiple)
+            return (false);
+    }
 
     /* Worshipping gold or scumming will allow the sale */
     if (item->value > 0
         && ((borg_cfg[BORG_WORSHIPS_GOLD] || borg.trait[BI_MAXCLEVEL] < 10)
             || ((borg_cfg[BORG_MONEY_SCUM_AMOUNT] < borg.trait[BI_GOLD])
                 && borg_cfg[BORG_MONEY_SCUM_AMOUNT] != 0))) {
-        /* Borg is allowed to continue in this routine to sell non-ID items */
+        /* Borg is allowed to continue in this routine to sell */
     } else /* Some items must be ID, or at least 'known' */
     {
         /* Analyze the type */
@@ -826,6 +996,8 @@ static bool borg_good_sell(borg_item *item, int who)
 
             /* Always sell potions and scrolls, it is the only way to ID other
              * than using */
+            if (!item->ident)
+                return true;
 
             /* Spell casters should not sell ResMana to shop unless
              * they have tons in the house
@@ -846,8 +1018,9 @@ static bool borg_good_sell(borg_item *item, int who)
         case TV_LIGHT:
 
             /* Never sell if not "known" */
-            if (!item->ident && borg_item_worth_id(item)
-                && (borg.trait[BI_MAXDEPTH] > 35) && item->iqty == 1)
+            /* unless we have more than one or are deep */
+            if (borg_item_worth_id(item)
+                && ((borg.trait[BI_MAXDEPTH] > 35) || multiple))
                 return (false);
 
             break;
@@ -868,7 +1041,7 @@ static bool borg_good_sell(borg_item *item, int who)
         case TV_DRAG_ARMOR:
 
             /* Only sell "known" items (unless "icky") */
-            if (!item->ident && borg_item_worth_id(item) && item->iqty == 1)
+            if (!item->ident && borg_item_worth_id(item) && !multiple)
                 return (false);
 
             break;
@@ -881,8 +1054,9 @@ static bool borg_good_sell(borg_item *item, int who)
         /* For now check all artifacts */
         return (false);
     }
+
     /* Do not sell stuff that is not fully id'd and should be  */
-    if (!item->ident && item->ego_idx && item->iqty == 1) {
+    if (!item->ident && item->ego_idx && item->iqty < 2) {
         if (borg_ego_has_random_power(
                 &e_info[borg_items[INVEN_OUTER].ego_idx])) {
             return (false);
@@ -902,111 +1076,7 @@ static bool borg_good_sell(borg_item *item, int who)
         }
     }
 
-    /* Switch on the store */
-    switch (who + 1) {
-        /* General Store */
-    case 1:
-        /* Analyze the type */
-        switch (item->tval) {
-        case TV_FOOD:
-        case TV_MUSHROOM:
-        case TV_FLASK:
-            return (true);
-        }
-
-        /* Won't buy anything */
-        break;
-
-    /* Armory */
-    case 2:
-
-        /* Analyze the type */
-        switch (item->tval) {
-        case TV_BOOTS:
-        case TV_GLOVES:
-        case TV_HELM:
-        case TV_CROWN:
-        case TV_SHIELD:
-        case TV_SOFT_ARMOR:
-        case TV_HARD_ARMOR:
-        case TV_DRAG_ARMOR:
-            return (true);
-        }
-        break;
-
-    /* Weapon Shop */
-    case 3:
-
-        /* Analyze the type */
-        switch (item->tval) {
-        case TV_SHOT:
-        case TV_BOLT:
-        case TV_ARROW:
-        case TV_BOW:
-        case TV_DIGGING:
-        case TV_HAFTED:
-        case TV_POLEARM:
-        case TV_SWORD:
-            return (true);
-        }
-        break;
-
-    /* Bookstore */
-    case 4:
-
-        /* Analyze the type */
-        switch (item->tval) {
-        case TV_PRAYER_BOOK:
-        case TV_MAGIC_BOOK:
-        case TV_NATURE_BOOK:
-        case TV_SHADOW_BOOK:
-        case TV_OTHER_BOOK:
-            return (true);
-        }
-        break;
-
-    /* book store --Alchemist */
-    case 5:
-
-        /* Analyze the type */
-        switch (item->tval) {
-        case TV_SCROLL:
-        case TV_POTION:
-            return (true);
-        }
-        break;
-
-    /* Magic Shop */
-    case 6:
-
-        /* Analyze the type */
-        switch (item->tval) {
-        case TV_AMULET:
-        case TV_RING:
-        case TV_SCROLL:
-        case TV_POTION:
-        case TV_STAFF:
-        case TV_WAND:
-        case TV_ROD:
-        case TV_MAGIC_BOOK:
-            return (true);
-        }
-        break;
-    /* Black Market --they buy most things.*/
-    case 7:
-
-        /* Analyze the type */
-        switch (item->tval) {
-        case TV_LIGHT:
-        case TV_CLOAK:
-        case TV_FOOD:
-            return (true);
-        }
-        break;
-    }
-
-    /* Assume not */
-    return (false);
+    return (true);
 }
 
 /*
@@ -1058,10 +1128,17 @@ bool borg_think_shop_sell_useless(void)
                 && item->sval == sv_rod_mapping && item->iqty <= 2)
                 continue;
 
-            /* Avoid selling staff of dest*/
-            if (item->tval == TV_STAFF && item->sval == sv_staff_destruction
-                && borg.trait[BI_ASTFDEST] < 2)
-                continue;
+            /* Avoid selling some staffs */
+            if (item->tval == TV_STAFF) {
+                /* destruction */
+                if (item->sval == sv_staff_destruction
+                    && borg.trait[BI_ASTFDEST] < 2)
+                    continue;
+                /* teleportation */
+                if (item->sval == sv_staff_teleportation
+                    && num_tele_staves < kb_info[TV_STAFF].max_stack)
+                    continue;
+            }
 
             /* Do not sell our attack wands if they still have charges */
             if (item->tval == TV_WAND && borg.trait[BI_CLEVEL] < 35

--- a/src/borg/borg-trait-swap.c
+++ b/src/borg/borg-trait-swap.c
@@ -194,12 +194,6 @@ void borg_notice_weapon_swap(void)
         if (borg.trait[BI_MAXDEPTH] < 50 && item->tval != TV_DIGGING)
             continue;
 
-        /* priest weapon penalty for non-blessed edged weapons */
-        if (player_has(player, PF_BLESS_WEAPON)
-            && (item->tval == TV_SWORD || item->tval == TV_POLEARM)
-            && !of_has(item->flags, OF_BLESSED))
-            continue;
-
         /* Clear all the swap weapon flags as I look at each one. */
         weapon_swap_digger       = 0;
         weapon_swap_slay_animal  = 0;

--- a/src/borg/borg-trait.c
+++ b/src/borg/borg-trait.c
@@ -886,7 +886,6 @@ const char *prefix_pref[] = {
     "wep id", /* weapon identified */
     "wep damage dice", /* weapon damage dice */
     "wep damage sides", /* weapon to damage dice sides */
-    "wep blessed",
     "bow id", /* weapon identified */
     "bow to hit", /* bow to hit */
     "bow to damage", /* bow to damage */
@@ -2013,14 +2012,12 @@ static void borg_notice_equipment(void)
 
     /* priest weapon penalty for non-blessed edged weapons */
     if (player_has(player, PF_BLESS_WEAPON)
-        && ((item->tval == TV_SWORD || item->tval == TV_POLEARM)
-            && !of_has(item->flags, OF_BLESSED))) {
+        && (item->tval == TV_HAFTED || 
+            of_has(item->flags, OF_BLESSED))) {
         /* Reduce the real bonuses */
-        borg.trait[BI_TOHIT] -= 2;
-        borg.trait[BI_TODAM] -= 2;
+        borg.trait[BI_TOHIT] += 2;
+        borg.trait[BI_TODAM] += 2;
     }
-    else 
-        borg.trait[BI_WBLESSED] = true;
 
     /*** Count needed enchantment ***/
 
@@ -2786,8 +2783,7 @@ static void borg_notice_inventory(void)
 
     /* Correct the high and low calorie foods */
     borg.trait[BI_FOOD] += borg.trait[BI_FOOD_HI];
-    if (borg.trait[BI_FOOD_HI] <= 3)
-        borg.trait[BI_FOOD] += borg.trait[BI_FOOD_LO];
+    borg.trait[BI_FOOD] += borg.trait[BI_FOOD_LO];
 
     /* If weak, do not count food spells */
     if (borg.trait[BI_ISWEAK] && (borg.trait[BI_FOOD] >= 1000))

--- a/src/borg/borg-trait.h
+++ b/src/borg/borg-trait.h
@@ -200,7 +200,6 @@ enum {
     BI_WID,
     BI_WDD,
     BI_WDS,
-    BI_WBLESSED,
     BI_BID,
     BI_BTOHIT,
     BI_BTODAM,

--- a/src/borg/borg.txt
+++ b/src/borg/borg.txt
@@ -599,8 +599,6 @@ Power
 	condition(value(trait, air swing)): reward(-10000);
 	condition(value(trait, unknown curse)): reward(-9999999);
 
-#	condition((value(class, priest) or value(class, paladin)) and !value(trait, wep blessed)): reward(-75000);
-
 # something with multiple useful bonuses
 	reward(value(trait, multi bonus) * 3000);
 
@@ -742,7 +740,8 @@ Power
 	value(trait, food): range(8, 10): condition(value(trait, str) >= 15): reward(200);
 	value(trait, food): range(1, 15): condition(value(trait, regen) and value(trait, CLEVEL) <= 15): reward(700);
 # Prefer to buy HiCalorie foods over LowCalorie
-	condition(value(trait, food high) <= 5): reward(50 * value(trait, food high));
+	value(trait, food high): range(1, 7): reward(52);
+	value(trait, food low): range(1, 15): reward(-2);
 
 # Cure Poison and Cuts
 	condition(value(trait, amt potion ccw) and (value(trait, is cut) or value(trait, is poisoned))): reward(100000);


### PR DESCRIPTION
A simple change as usual flowers out to a bunch of changes.  Started with  
1) Make the borg better about selling non-ID'd items if he has two of the same thing
ran into 
2) Priests and Paladins get a minor bonus for using blessed items and no penalty.  Make the borg more likely to do that.
3) teleport staffs kept being sold then the borg would be out of them and want some later.  Since old v3x used to have them very common for purchase and 4x doesn't, keep a stack of them in the home
4) the "use low cal food when hi cal isn't around" stuff was making the borg keep low cal even when high cal was available.  Hopefully tweaked this to make it better.
5) the borg wouldn't bother ID'ing things if he was wielding an artifact in that slot (so no bothering to ID an unIDed sword if he was wielding some other artifact).  That seemed less than ideal.
