### PR TITLE
Adjust object's mimicking_m_idx in chunk_copy()

### DIFF
--- a/src/gen-chunk.c
+++ b/src/gen-chunk.c
@@ -438,6 +438,8 @@ bool chunk_copy(struct chunk *dest, struct player *p, struct chunk *source,
 		}
 		if (source_mon->mimicked_obj) {
 			dest_mon->mimicked_obj = source_mon->mimicked_obj;
+			dest_mon->mimicked_obj->mimicking_m_idx =
+				dest_mon->midx;
 		}
 	}
 


### PR DESCRIPTION
For cases where mon_skip is nonzero, that should avoid downstream problems if push_object() moves the mimicked object or a projection reveals the mimic (see project-obj.c).