### PR TITLE
borg: tremor spell and queued response to Direction correction

### DIFF
--- a/src/borg/borg-fight-defend.c
+++ b/src/borg/borg-fight-defend.c
@@ -2221,15 +2221,22 @@ static int borg_defend_aux_earthquake(int p1)
     borg_kill *kill;
 
     /* Cast the spell */
-    if (!borg_simulate
-        && (borg_spell(TREMOR) || borg_spell(QUAKE) || borg_spell(GRONDS_BLOW)
-            || borg_activate_item(act_earthquakes))) {
+    if (!borg_simulate) {
         /* Must make a new Sea too */
         borg_needs_new_sea = true;
-        return (p2);
+
+        /* for now aim Tremor around the borg */
+        if (borg_spell(TREMOR)) {
+            borg_keypress('*');
+            borg_keypress('5');
+        } else
+            /* other spells don't need aim */
+            if (borg_spell(QUAKE) || borg_spell(GRONDS_BLOW)
+                || borg_activate_item(act_earthquakes))
+                return (p2);
     }
 
-    /* Cant when screwed */
+    /* Can't when screwed */
     if (borg.trait[BI_ISBLIND] || borg.trait[BI_ISCONFUSED]
         || borg.trait[BI_ISFORGET])
         return (0);

--- a/src/borg/borg.c
+++ b/src/borg/borg.c
@@ -352,13 +352,20 @@ static struct keypress borg_inkey_hack(int flush_first)
      * borg to work around the flush This is used only with emergency use of
      * spells like Magic Missile Attempt to catch "Direction (5 old target"
      */
-    if (borg_prompt && !inkey_flag && borg_confirm_target && (y == 0)
+    if (borg_prompt && !inkey_flag && (y == 0) && !borg_inkey(false)
         && (x >= 4) && streq(buf, "Dire")) {
-        /* reset the flag */
-        borg_confirm_target = false;
-        /* Return queued target */
-        key.code = borg_get_queued_direction();
-        return key;
+        if (borg_confirm_target) {
+            /* reset the flag */
+            borg_confirm_target = false;
+            /* Return queued target */
+            key.code = borg_get_queued_direction();
+            return key;
+        } else {
+            borg_oops("unexpected request for direction");
+            /* Hack -- Escape */
+            key.code = ESCAPE;
+            return key;
+        }
     }
 
     /* Wearing two rings.  Place this on the left hand */


### PR DESCRIPTION
Wasn't handling Tremor spell correctly (I didn't have it targeted, it was treated like a small Earthquake) and when a command could be ambiguous I recoded it to error if the direction wasn't queued and handed buffered keys better. 