### PR TITLE
Tolerate non-NULL obj argument and full inventory in player_pickup_item()

### DIFF
--- a/src/cmd-pickup.c
+++ b/src/cmd-pickup.c
@@ -331,9 +331,11 @@ static uint8_t player_pickup_item(struct player *p, struct object *obj, bool men
 
 	/* We're given an object - pick it up */
 	if (obj) {
-		player_pickup_aux(p, obj, 0, domsg);
-		objs_picked_up = 1;
 		mem_free(floor_list);
+		if (inven_carry_num(p, obj) > 0) {
+			player_pickup_aux(p, obj, 0, domsg);
+			objs_picked_up = 1;
+		}
 		return objs_picked_up;
 	}
 


### PR DESCRIPTION
This is an issue in NarSil, https://github.com/NickMcConnell/NarSil/issues/443 .  Vanilla Angband does not currently seem to be affected, but do this for symmetry with how player_pickup_item() tolerates a full inventory when obj is NULL.