### PR TITLE
Use quest.txt for placement of quest monster(s), and quest completion logic

### DIFF
--- a/src/generate.c
+++ b/src/generate.c
@@ -1145,21 +1145,22 @@ static struct chunk *cave_generate(struct player *p, int height, int width)
 
 		/* Ensure quest monsters */
 		if (dun->quest) {
-			int i2;
-			for (i2 = 1; i2 < z_info->r_max; i2++) {
-				struct monster_race *race = &r_info[i2];
+			for (i = 0; i < z_info->quest_max; i++) {
+				struct quest *q = &player->quests[i];
 				struct monster_group_info info = { 0, 0 };
 				struct loc grid;
 
-				/* The monster must be an unseen quest monster of this depth. */
-				if (race->cur_num > 0) continue;
-				if (!rf_has(race->flags, RF_QUESTOR)) continue;
-				if (race->level != chunk->depth) continue;
-	
-				/* Pick a location and place the monster */
-				find_empty(chunk, &grid);
-				place_new_monster(chunk, grid, race, true, true, info,
-								  ORIGIN_DROP);
+				if (q->level != chunk->depth) continue;
+
+				/* If the quest monster is unique and has already been placed, don't place again */
+				if (rf_has(q->race->flags, RF_UNIQUE) && q->race->cur_num > 0) continue;
+
+				/* Pick a location and place the monster(s) */
+				for (int n = 0; n < q->max_num; n++) {
+					find_empty(chunk, &grid);
+					place_new_monster(chunk, grid, q->race, true, true, info,
+									  ORIGIN_DROP);
+				}
 			}
 		}
 


### PR DESCRIPTION
Currently (without this PR), quest.txt isn't actually used to place particular quest monsters on levels, and most `struct quest` properties (like cur_num, max_num) are unused.

This PR replaces hard-coded placement of QUESTOR monsters with use of quest.txt data. It also now supports quantities of quest monsters (assuming they aren't uniques).

There are a few things worth thinking about:

1. QUESTOR flag is almost useless after this PR. It is only used to print the lore message "You feel an intense desire to kill this monster... ". Perhaps the flag could be eliminated, with this last usage replaced by looking at player->quests?
2. Currently (both with and without this PR), FORCE_DEPTH monster flag is used to prevent questors appearing on the wrong level. A variant generating random quests will need a different mechanism. Probably unique monsters that appear in the player->quests list should be prevented from spawning on other levels other than their quest level.
3. If a quest monster is non-unique (say, 'kill 5 crows on dungeon level 2'), 5 crows will be placed. but there is no consideration of crows already placed on the level. This could be done (I think by looking at race->cur_num, and placing fewer if some have already randomly been placed). But this will not work properly with birth_levels_persist, maybe.

I'm happy to work on these issues, but thought they were worth a discussion first.