### PR TITLE
Allow debugging commands to add first curse from curse.txt

### DIFF
--- a/src/cmd-wizard.c
+++ b/src/cmd-wizard.c
@@ -1015,7 +1015,7 @@ void do_cmd_wiz_curse_item(struct command *cmd)
 		}
 		cmd_set_arg_number(cmd, "index", curse_index);
 	}
-	if (curse_index <= 1 || curse_index >= z_info->curse_max) {
+	if (curse_index <= 0 || curse_index >= z_info->curse_max) {
 		return;
 	}
 


### PR DESCRIPTION
That's the "air swing" curse in Vanilla.  Regression introduced by this post 4.2.5 change, https://github.com/angband/angband/commit/ad290fbb4b9f738f16d48b4689dd02ffd78aa699 .