### PR TITLE
Avoid crash when locking file for high scores could not be opened

### DIFF
--- a/src/score.c
+++ b/src/score.c
@@ -157,14 +157,14 @@ static void highscore_write(const struct high_score scores[], size_t sz)
 
 	safe_setuid_grab();
 	lok = file_open(lok_name, MODE_WRITE, FTYPE_RAW);
-	file_lock(lok);
-	safe_setuid_drop();
-
 	if (!lok) {
+		safe_setuid_drop();
 		msg("Failed to create lock for scorefile; not writing.");
 		return;
+	} else {
+		file_lock(lok);
+		safe_setuid_drop();
 	}
-
 
 	/* Open the new file for writing */
 	safe_setuid_grab();


### PR DESCRIPTION
Address the crashing part of https://github.com/angband/angband/issues/6022 but not whatever caused openng the locking file to fail.