### PR TITLE
Avoid possible use after free when "-l" option fails

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -281,8 +281,10 @@ static void list_saves(void)
 	savefile_getter g = NULL;
 
 	if (!got_savefile(&g)) {
+		bool nodir = !got_savefile_dir(g);
+
 		cleanup_savefile_getter(g);
-		if (!got_savefile_dir(g)) {
+		if (nodir) {
 			quit_fmt("Cannot open savefile directory");
 		}
 		printf("There are no savefiles you can use.\n");


### PR DESCRIPTION
Regression introduced by the post 4.2.5 change, 515cbb3e855ccc8b8afdc62ad8b90384911d46a5.