### PR TITLE
Windows:  set both WINVER and _WIN32_WINNT to enforce minimum version

### DIFF
--- a/src/main-win.c
+++ b/src/main-win.c
@@ -72,9 +72,18 @@
 #include "ui-prefs.h"
 #include "win/win-menu.h"
 
-/* Make sure the winver allows the AlphaBlend function */
-#if (WINVER < 0x0500)
+/* Set the minimum version of Windows to accept so AlphaBlend() is available */
+#ifndef WINVER
 #define WINVER 0x0500
+#elif WINVER < 0x0500
+#undef WINVER
+#define WINVER 0x0500
+#endif
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0500
+#elif _WIN32_WINNT < 0x0500
+#undef _WIN32_WINNT
+#define _WIN32_WINNT 0x0500
 #endif
 
 #include <locale.h>


### PR DESCRIPTION
See https://learn.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt?view=msvc-170 .  Also, if either is already set, undefine first in case the compiler issues a warning for redefining a macro to a different value.