### PR TITLE
SDL2: size limit for vector font is one less than it should be

### DIFF
--- a/src/main-sdl2.c
+++ b/src/main-sdl2.c
@@ -1366,7 +1366,7 @@ static void calculate_subwindow_font_size_bounds(struct subwindow *subwindow,
 		int try;
 
 		if (lo == hi - 1) {
-			*max_size = lo;
+			*max_size = hi;
 			return;
 		}
 		try = (lo + hi) / 2;


### PR DESCRIPTION
Resolves https://github.com/angband/angband/issues/6043 .