### PR TITLE
Borg strange opts

### DIFF
--- a/src/borg/borg-caution.c
+++ b/src/borg/borg-caution.c
@@ -1116,7 +1116,8 @@ bool borg_caution(void)
                 || (borg.trait[BI_CLEVEL] < 5 && pos_danger > avoidance / 2))
             && on_upstair)) /* danger and standing on stair */
     {
-        if (borg.ready_morgoth == 0 && !borg.trait[BI_KING]) {
+        if (borg.ready_morgoth == 0 && !borg.trait[BI_KING]
+            && !OPT(player, birth_force_descend)) {
             borg.stair_less = true;
             if (scaryguy_on_level)
                 borg_note("# Fleeing and leaving the level. (scaryguy)");
@@ -1130,7 +1131,7 @@ bool borg_caution(void)
                 borg_note("# Leaving level,  Some danger but I'm on a stair.");
         }
 
-        if (scaryguy_on_level)
+        if (scaryguy_on_level && !OPT(player, birth_force_descend))
             borg.stair_less = true;
 
         /* Only go down if fleeing or prepared */
@@ -1163,12 +1164,12 @@ bool borg_caution(void)
     }
 
     /* Take stairs up */
-    if (borg.stair_less) {
+    if (borg.stair_less && !OPT(player, birth_force_descend)) {
         /* Current grid */
         borg_grid *ag = &borg_grids[borg.c.y][borg.c.x];
 
         /* Usable stairs */
-        if (ag->feat == FEAT_LESS || on_upstair) {
+        if ((ag->feat == FEAT_LESS) || on_upstair) {
             /* Log it */
             borg_note(format("# Leaving via up stairs."));
 

--- a/src/borg/borg-escape.c
+++ b/src/borg/borg-escape.c
@@ -508,7 +508,7 @@ static bool borg_escape_stair(void)
     borg_grid *ag = &borg_grids[borg.c.y][borg.c.x];
 
     /* Usable stairs */
-    if (ag->feat == FEAT_LESS) {
+    if (ag->feat == FEAT_LESS && !OPT(player, birth_force_descend)) {
         /* Take the stairs */
         borg_note("# Escaping level via stairs.");
         borg_keypress('<');

--- a/src/borg/borg-flow-stairs.c
+++ b/src/borg/borg-flow-stairs.c
@@ -133,6 +133,10 @@ bool borg_flow_stair_less(int why, bool sneak)
 {
     int i;
 
+    /* forced to go up */
+    if (OPT(player, birth_force_descend))
+        return false;
+
     /* None to flow to */
     if (!track_less.num)
         return false;

--- a/src/borg/borg-flow.c
+++ b/src/borg/borg-flow.c
@@ -706,7 +706,7 @@ static bool borg_play_step(int y2, int x2)
 
         /* Up stairs. Cheat the game grid info in.
          * (cave_feat[borg.c.y][borg.c.x] == FEAT_LESS) */
-        if (ag->feat == FEAT_LESS) {
+        if (ag->feat == FEAT_LESS && !OPT(player, birth_force_descend)) {
 
             borg.goal.less   = false;
             borg_keypress('<');

--- a/src/borg/borg-init.c
+++ b/src/borg/borg-init.c
@@ -568,7 +568,7 @@ void borg_init(void)
             borg_init_failure = true;
         }
 
-        if (OPT(player, birth_connect_stairs)) {
+        if (!OPT(player, birth_connect_stairs)) {
             borg_note("**STARTUP FAILURE** must connect stairs");
             borg_note("** birth option failure **");
             borg_init_failure = true;

--- a/src/borg/borg-init.c
+++ b/src/borg/borg-init.c
@@ -86,6 +86,7 @@ struct borg_setting borg_settings[] = {
     { "borg_dump_level", 'i', 1 }, 
     { "borg_save_death", 'i', 1 },
     { "borg_stop_on_bell", 'b', false },
+    { "borg_allow_strange_opts", 'b', false},
     { 0, 0, 0 }};
 
 
@@ -557,6 +558,33 @@ void borg_init(void)
         || !streq(player_id2class(CLASS_BLACKGUARD)->name, "Blackguard")) {
         borg_note("**STARTUP FAILURE** classes do not match");
         borg_init_failure = true;
+    }
+
+    /* Don't allow the user to do stupid things unless they ask to */
+    if (!borg_cfg[BORG_ALLOW_STRANGE_OPTS]) {
+        if (OPT(player, birth_force_descend)) {
+            borg_note("**STARTUP FAILURE** must allow up stairs");
+            borg_note("** birth option failure **");
+            borg_init_failure = true;
+        }
+
+        if (OPT(player, birth_connect_stairs)) {
+            borg_note("**STARTUP FAILURE** must connect stairs");
+            borg_note("** birth option failure **");
+            borg_init_failure = true;
+        }
+
+        if (OPT(player, birth_no_recall)) {
+            borg_note("**STARTUP FAILURE** must allow recall");
+            borg_note("** birth option failure **");
+            borg_init_failure = true;
+        }
+
+        if (OPT(player, birth_percent_damage)) {
+            borg_note("**STARTUP FAILURE** strange damage calculation");
+            borg_note("** birth option failure **");
+            borg_init_failure = true;
+        }
     }
 
     /* Official message */

--- a/src/borg/borg-think-dungeon-util.c
+++ b/src/borg/borg-think-dungeon-util.c
@@ -190,7 +190,8 @@ bool borg_think_dungeon_light(void)
         borg_note("# Testing for stairs .");
 
         /* Test for stairs */
-        borg_keypress('<');
+        if (!OPT(player, birth_force_descend))
+            borg_keypress('<');
 
         /* If on a glowing grid, got some food, and low mana, then rest here */
         if ((borg.trait[BI_CURSP] < borg.trait[BI_MAXSP]
@@ -298,7 +299,7 @@ bool borg_think_dungeon_light(void)
         }
 
         /* Try to flow to upstairs if on level one */
-        if (borg_flow_stair_less(GOAL_FLEE, false)) {
+        if (borg_flow_stair_less(GOAL_FLEE, false) && !OPT(player, birth_force_descend)) {
             /* Take the stairs */
             /* Log */
             borg_note("# Taking up Stairs stairs (low Light).");
@@ -503,7 +504,7 @@ bool borg_think_stair_scum(bool from_town)
                 return true;
             }
 
-            if (tmp_ag->feat == FEAT_LESS) {
+            if (tmp_ag->feat == FEAT_LESS && !OPT(player, birth_force_descend)) {
                 /* Take the Up Stair */
                 borg_keypress('<');
                 return true;
@@ -870,9 +871,11 @@ bool borg_leave_level(bool bored)
 
     /* Go Up */
     if (g < 0) {
-        /* Take next stairs */
-        borg_note("# Looking for up stairs.  Going up.");
-        borg.stair_less = true;
+        if (!OPT(player, birth_force_descend)) {
+            /* Take next stairs */
+            borg_note("# Looking for up stairs.  Going up.");
+            borg.stair_less = true;
+        }
 
         /* Hack -- recall if going to town */
         if (borg.goal.rising && ((borg_time_town + (borg_t - borg_began)) > 200)

--- a/src/borg/borg-think-dungeon.c
+++ b/src/borg/borg-think-dungeon.c
@@ -283,7 +283,7 @@ static bool borg_think_dungeon_lunal(void)
                 return true;
             }
 
-            if (tmp_ag->feat == FEAT_LESS) {
+            if (tmp_ag->feat == FEAT_LESS && !OPT(player, birth_force_descend)) {
                 /* Take the Up Stair */
                 borg_keypress('<');
                 return true;
@@ -384,7 +384,7 @@ static bool borg_think_dungeon_lunal(void)
                 return true;
             }
 
-            if (tmp_ag->feat == FEAT_LESS) {
+            if (tmp_ag->feat == FEAT_LESS && !OPT(player, birth_force_descend)) {
                 /* Take the Up Stair */
                 borg_keypress('<');
                 return true;
@@ -643,7 +643,7 @@ static bool borg_think_dungeon_munchkin(void)
                 return true;
             }
 
-            if (tmp_ag->feat == FEAT_LESS) {
+            if (tmp_ag->feat == FEAT_LESS && !OPT(player, birth_force_descend)) {
                 /* Take the Up Stair */
                 borg_keypress('<');
                 return true;
@@ -704,7 +704,7 @@ static bool borg_think_dungeon_munchkin(void)
                 return true;
             }
 
-            if (tmp_ag->feat == FEAT_LESS) {
+            if (tmp_ag->feat == FEAT_LESS && !OPT(player, birth_force_descend)) {
                 /* Take the Up Stair */
                 borg_keypress('<');
                 return true;
@@ -812,7 +812,7 @@ static bool borg_think_dungeon_munchkin(void)
                 return true;
             }
 
-            if (tmp_ag->feat == FEAT_LESS) {
+            if (tmp_ag->feat == FEAT_LESS && !OPT(player, birth_force_descend)) {
                 /* Take the Up Stair */
                 borg_keypress('<');
                 return true;
@@ -902,7 +902,7 @@ static bool borg_think_dungeon_munchkin(void)
         /* Try to find some stairs */
         if (borg_flow_stair_both(GOAL_FLEE, false))
             return true;
-        if (ag->feat == FEAT_LESS) {
+        if (ag->feat == FEAT_LESS && !OPT(player, birth_force_descend)) {
             /* Take the Up Stair */
             borg_keypress('<');
             return true;
@@ -983,6 +983,9 @@ static bool borg_think_dungeon_brave(void)
 
         if (borg.ready_morgoth == 0)
             borg.stair_less = true;
+
+        if (OPT(player, birth_force_descend))
+            borg.stair_less = false;
 
         if (borg.stair_less == true) {
             borg_note("# Fleeing and leaving the level. Brave Thinking.");
@@ -1515,7 +1518,8 @@ bool borg_think_dungeon(void)
         borg.goal.less = true;
 
         /* Take stairs */
-        if (borg_grids[borg.c.y][borg.c.x].feat == FEAT_LESS) {
+        if (borg_grids[borg.c.y][borg.c.x].feat == FEAT_LESS
+            && !OPT(player, birth_force_descend)) {
             borg_keypress('<');
             return true;
         }
@@ -1762,6 +1766,9 @@ bool borg_think_dungeon(void)
     if (borg.goal.fleeing && !borg.goal.recalling) {
         /* Hack -- Take the next stairs */
         borg.stair_less = borg.stair_more = true;
+        if (OPT(player, birth_force_descend))
+            borg.stair_less = false;
+
         borg_note("# Fleeing and leaving the level. (Looking for any stair)");
 
         /* Continue fleeing the level */
@@ -1889,8 +1896,7 @@ bool borg_think_dungeon(void)
     if ((borg.goal.leaving && !borg.goal.recalling && !unique_on_level)
         || (borg.trait[BI_CDEPTH] && borg.trait[BI_CLEVEL] < 25
             && borg.trait[BI_GOLD] < 25000 && borg_count_sell() >= 13)) {
-        /* Hack -- Take the next stairs */
-        if (borg.ready_morgoth == 0) {
+        if (borg.ready_morgoth == 0 && !OPT(player, birth_force_descend)) {
             borg_note(
                 "# Fleeing and leaving the level (Looking for Up Stair).");
             borg.stair_less = true;

--- a/src/borg/borg.h
+++ b/src/borg/borg.h
@@ -74,6 +74,7 @@ enum {
     BORG_DUMP_LEVEL,
     BORG_SAVE_DEATH,
     BORG_STOP_ON_BELL,
+    BORG_ALLOW_STRANGE_OPTS,
     BORG_MAX_SETTINGS
 };
 extern int *borg_cfg;

--- a/src/borg/borg.txt
+++ b/src/borg/borg.txt
@@ -83,6 +83,10 @@ borg_kills_uniques = FALSE
 
 borg_uses_swaps = TRUE
 
+# some birth options don't allow the borg to run well.  If you want to allow
+# the borg to run anyways, set this to true and run at your own risk.
+borg_allow_strange_opts = false
+
 
 # Respawn
 


### PR DESCRIPTION
okay with issue https://github.com/angband/angband/issues/6034 I decided to see what would happen if I just turned off him going upstairs and "flowing" to up stairs (targeting them as a destination).  Well, it kinda works but really it should give an error and say "don't do that".  So I decided to split the difference and add an option to allow it for those brave souls who want to see the borg die of not being able to go to town and making stupid decisions based on being able to.  It defaults to false so if a user really wants to, they can make it true and allow "strange" options.