### PR TITLE
SDL2: set size appropriately if falling back to a vector DEFAULT_FONT

### DIFF
--- a/src/main-sdl2.c
+++ b/src/main-sdl2.c
@@ -5946,7 +5946,8 @@ static void load_subwindow(struct sdlpui_window *window,
 			++n_tries;
 		}
 		try_names[n_tries] = DEFAULT_FONT;
-		try_sizes[n_tries] = 0;
+		try_sizes[n_tries] = (suffix_i(DEFAULT_FONT, ".fon")) ?
+			0 : DEFAULT_VECTOR_FONT_SIZE;
 		++n_tries;
 		if (window->app->font_count > 0 && window->app->fonts[0].name) {
 			try_names[n_tries] = window->app->fonts[0].name;


### PR DESCRIPTION
May resolve problem reported by smbhax here, https://angband.live/forums/forum/angband/development/249329-sdl2-front-end-text-has-zero-width-error-with-ttf-set-as-default_font#post249329 .