### PR TITLE
Remove obsolete "Enter store" command from documentation

### DIFF
--- a/docs/playing.rst
+++ b/docs/playing.rst
@@ -129,7 +129,7 @@ Original Keyset Command Summary
 ``[``  Display visible monster list  ``^m`` (special - return)
 ``]``  Display visible object list   ``^n`` (unused)
 ``-``  (unused)                      ``^o`` Show previous message
-``_``  Enter store                   ``^p`` Show previous messages
+``_``  (unused)                      ``^p`` Show previous messages
 ``+``  Alter grid                    ``^q`` (unused)
 ``=``  Set options                   ``^r`` Redraw the screen
 ``;``  Walk (with pickup)            ``^s`` Save and don't quit
@@ -191,7 +191,7 @@ Roguelike Keyset Command Summary
  ``[``  Display visible monster list  ``^m`` (special - return)
  ``]``  Display visible object list   ``^n`` (alter - south east)
  ``-``  Walk into a trap              ``^o`` Show previous message
- ``_``  Enter store                   ``^p`` Show previous messages
+ ``_``  (unused)                      ``^p`` Show previous messages
  ``+``  Alter grid                    ``^q`` (unused)
  ``=``  Set options                   ``^r`` Redraw the screen
  ``;``  Walk (with pickup)            ``^s`` Save and don't quit

--- a/lib/help/commands.txt
+++ b/lib/help/commands.txt
@@ -49,7 +49,7 @@ combination and does not pass it on.
   [    Display visible monster list    ^m   (special - return)
   ]    Display visible object list     ^n   -
   -    -                               ^o   Show previous message
-  _    Enter store                     ^p   Show previous messages
+  _    -                               ^p   Show previous messages
   +    Alter grid                      ^q   -
   =    Set options                     ^r   Redraw the screen
   ;    Walk (with pickup)              ^s   Save and don't quit

--- a/lib/help/r_comm.txt
+++ b/lib/help/r_comm.txt
@@ -49,7 +49,7 @@ combination and does not pass it on.
   [    Display visible monster list    ^m   (special - return)
   ]    Display visible object list     ^n   (alter - south east)
   -    Walk into a trap                ^o   Show previous message
-  _    Enter store                     ^p   Show previous messages
+  _    -                               ^p   Show previous messages
   +    Alter grid (steal for rogues)   ^q   -
   =    Set options                     ^r   Redraw the screen
   ;    Walk (with pickup)              ^s   Save and don't quit


### PR DESCRIPTION
Not sure if this was intentional or not, but seems non-functional since commit 7497c1a5aa94ffc834c5c6037aa96aaa79262ce4. (v4.0, 2015)

Instead, re-entering a shop can be done by staying still with `,` (`.` via the roguelike keyset; "`CMD_HOLD`") or `5`.

(Apologies if this is incorrect; this is my first time playing Angband)