### PR TITLE
borg: make sure spell information is retrieved before borg_notice

### DIFF
--- a/src/borg/borg-magic.h
+++ b/src/borg/borg-magic.h
@@ -306,7 +306,7 @@ extern void borg_prepare_book_info(void);
 /*
  * Cheat/Parse the "spell" screen
  */
-extern void borg_cheat_spell(int book);
+extern void borg_cheat_spells(void);
 
 #endif
 

--- a/src/borg/borg-trait.c
+++ b/src/borg/borg-trait.c
@@ -37,6 +37,7 @@
 #include "borg-item-val.h"
 #include "borg-item-wear.h"
 #include "borg-magic.h"
+#include "borg-think.h"
 #include "borg-trait-swap.h"
 #include "borg.h"
 #include "borg-home-notice.h"
@@ -2851,6 +2852,12 @@ void borg_notice(bool notice_swap)
      * all the non inventory skills.
      */
     borg_notice_player();
+
+    /*** Process books/spells ***/
+    if (borg_do_spell) {
+        borg_cheat_spells();
+        borg_do_spell = false;
+    }
 
     /* Notice the equipment */
     borg_notice_equipment();

--- a/src/borg/borg.c
+++ b/src/borg/borg.c
@@ -1796,6 +1796,7 @@ void do_cmd_borg(void)
         int i = 0;
 
         /* Extract some "hidden" variables */
+        /* note: if we recode to do screen scraping again, this will fail */
         borg_cheat_equip();
         borg_cheat_inven();
 
@@ -1816,7 +1817,9 @@ void do_cmd_borg(void)
         }
         msg("Max Level: %d  Prep'd For: %d  Reason: %s",
             borg.trait[BI_MAXDEPTH], i - 1, borg_prepared(i));
-        if (borg.ready_morgoth == 1) {
+        if (!borg.trait[BI_CDEPTH]) {
+            msg("Unable to check for big fight from town.");
+        } else if (borg.ready_morgoth == 1) {
             msg("You are ready for the big fight!!");
         } else if (borg.ready_morgoth == 0) {
             msg("You are NOT ready for the big fight!!");
@@ -1854,6 +1857,7 @@ void do_cmd_borg(void)
         borg_cheat_equip();
         /* Cheat the "inven" screen */
         borg_cheat_inven();
+
         /* Examine the inventory */
         borg_notice(true);
         borg_notice_home(NULL, false);


### PR DESCRIPTION
this breaks the structure of getting all information from screen scraping but the code to scrape the spell information from the screen is long gone.  Even if i was to put it back I would need to use this sort of cheat code or add a lot of processing to handle the borg menu commands 