### PR TITLE
borg: reincarnation crash

### DIFF
--- a/src/borg/borg-reincarnate.c
+++ b/src/borg/borg-reincarnate.c
@@ -423,6 +423,7 @@ void reincarnate_borg(void)
     /* be blank when  creating the new player */
     struct chunk* sv_cave = cave;
     struct chunk* sv_player_cave = player->cave;
+    struct loc sv_grid = player->grid;
 
     cave = NULL;
     player->cave = NULL;
@@ -586,6 +587,7 @@ void reincarnate_borg(void)
     /* restore the cave */
     cave = sv_cave;
     player->cave = sv_player_cave;
+    player->grid = sv_grid;
 
     /* the new player is now ready */
     character_generated = true;

--- a/src/borg/borg-reincarnate.c
+++ b/src/borg/borg-reincarnate.c
@@ -421,8 +421,11 @@ void reincarnate_borg(void)
 
     /* save the existing dungeon.  It is cleared later but needs to */
     /* be blank when  creating the new player */
-    struct chunk *sv_cave = cave;
-    cave                  = NULL;
+    struct chunk* sv_cave = cave;
+    struct chunk* sv_player_cave = player->cave;
+
+    cave = NULL;
+    player->cave = NULL;
 
     /* Cheat death */
     borg.trait[BI_MAXDEPTH]  = 0;
@@ -582,6 +585,7 @@ void reincarnate_borg(void)
 
     /* restore the cave */
     cave = sv_cave;
+    player->cave = sv_player_cave;
 
     /* the new player is now ready */
     character_generated = true;


### PR DESCRIPTION
try to make sure rebuilding the player variable doesn't mess with the cave.  There is some monster activity that still goes on in the background after "Die?" and before "you cheat death".  Since the borg code rebuilds the player between using player_init and outfitting with a new class/race etc, we have to make sure the cave is not messed with.  This means both the cave variable and the player->cave variable.

I am hopefully that this will fix the reincarnation crashes but I have been hopeful before.  I guess I can say that it fixes -this- (https://github.com/angband/angband/issues/6074) reincarnation crash.