### PR TITLE
Compiling docs: correct CMake SHARED_INSTALL example

### DIFF
--- a/docs/hacking/compiling.rst
+++ b/docs/hacking/compiling.rst
@@ -241,7 +241,7 @@ CMake.  As an example, this would build a shared installation with an
 executable that is setgid for the games group::
 
     mkdir build && cd build
-    cmake -DSUPPORT_GCU_FRONTEND=ON ..
+    cmake -DSHARED_INSTALL=ON -DSUPPORT_GCU_FRONTEND=ON ..
     make
     sudo make install
 
@@ -552,7 +552,8 @@ Using eclipse (Indigo) on Windows (with MinGW)
 * Go to C/C++ Build | Toolchain Editor, select "Gnu Make Builder" instead of "CDT Internal Builder"
 * go to C/C++ Build, uncheck "Generate Makefiles automatically"
 
-You still need to run ./autogen.sh, if your source files are from cloning the
+You still need to run ./autogen.sh, if your source files are from a
+"Source code" link on the github releases page or from cloning the
 git repository, and ./configure manually, outside eclipse (see above)
 
 Using Visual Studio


### PR DESCRIPTION
Also clarify when autogen.sh is needed if using eclipse.  Both are leftovers from 28ec39af31e9b8300404bd90b2983029fd4e066a .