### PR TITLE
borg: change how deep descent works and when recall is reset

### DIFF
--- a/src/borg/borg-fight-attack.c
+++ b/src/borg/borg-fight-attack.c
@@ -5298,7 +5298,7 @@ bool borg_attack(bool boosted_bravery)
                        || borg_time_town + (borg_t - borg_began) >= 3000) {
                 /* Try to fight been there too long. */
             } else if (boosted_bravery || borg.no_retreat >= 1
-                       || borg.goal.recalling) {
+                       || borg.goal.recalling || borg.goal.descending) {
                 /* Try to fight if being Boosted or recall engaged. */
                 borg_note("# Bored, or recalling and fighting a monster on "
                           "Scaryguy Level.");

--- a/src/borg/borg-messages.c
+++ b/src/borg/borg-messages.c
@@ -684,6 +684,15 @@ static void borg_parse_aux(char *msg, int len)
         return;
     }
 
+    /* Deep Descent -- Ignition */
+    if (prefix(msg, "The air around you starts ")) {
+        /* Initiate descent */
+        /* Guess how long it will take to lift off */
+        /* Guess. game turns x 1000 ( 3+rand(4))*/
+        borg.goal.descending = 3000 + 2000;
+        return;
+    }
+
     /* Word of Recall -- Lift off */
     if (prefix(msg, "You feel yourself yanked ")) {
         /* Flush our key-buffer */
@@ -696,10 +705,29 @@ static void borg_parse_aux(char *msg, int len)
         return;
     }
 
+    /* Deep Descent  -- Lift off */
+    if (prefix(msg, "The floor opens beneath you!")) {
+        /* Flush our key-buffer */
+        /* this is done in case the borg had been aiming a */
+        /* shot before descent hit */
+        borg_flush();
+
+        /* Recall complete */
+        borg.goal.descending = 0;
+        return;
+    }
+
     /* Word of Recall -- Cancelled */
     if (prefix(msg, "A tension leaves ")) {
         /* Hack -- Oops */
         borg.goal.recalling = 0;
+        return;
+    }
+
+    /* Deep Descent -- Cancelled (only happens on death) */
+    if (prefix(msg, "The air around you stops ")) {
+        /* Hack -- Oops */
+        borg.goal.descending = 0;
         return;
     }
 

--- a/src/borg/borg-prepared.c
+++ b/src/borg/borg-prepared.c
@@ -37,8 +37,8 @@ static char borg_prepared_buffer[MAX_REASON];
 
 /* Track how many uniques are around at your depth */
 int          borg_numb_live_unique;
-unsigned int borg_living_unique_index;
-int          borg_unique_depth;
+unsigned int borg_first_living_unique;
+int          borg_depth_hunted_unique;
 
 /*
  * Determine if the Borg meets the "minimum" requirements for a level
@@ -635,12 +635,12 @@ const char *borg_prepared(int depth)
             return ((char *)NULL);
 
         /* Check for the dlevel of the unique */
-        if (depth <= borg_unique_depth)
+        if (depth <= borg_depth_hunted_unique)
             return ((char *)NULL);
 
         /* To avoid double calls to format() */
         /* Reset our description for not diving */
-        r_ptr = &r_info[borg_living_unique_index];
+        r_ptr = &r_info[borg_first_living_unique];
         strnfmt(borg_prepared_buffer, MAX_REASON, "Must kill %s.", r_ptr->name);
         return (borg_prepared_buffer);
 
@@ -651,13 +651,14 @@ const char *borg_prepared(int depth)
         struct monster_race *r_ptr;
 
         /* Access the living unique obtained from borg_update() */
-        r_ptr = &r_info[borg_living_unique_index];
+        r_ptr = &r_info[borg_first_living_unique];
 
         /* -1 is unknown. */
         borg.ready_morgoth = -1;
 
+        /* is only Morgoth alive? */
         if (borg_numb_live_unique < 1
-            || borg_living_unique_index == borg_morgoth_id) /* Morgoth */
+            || borg_first_living_unique == borg_morgoth_id)
         {
             if (depth >= 99)
                 borg.ready_morgoth = 1;

--- a/src/borg/borg-prepared.h
+++ b/src/borg/borg-prepared.h
@@ -26,8 +26,8 @@
 #ifdef ALLOW_BORG
 
 extern int          borg_numb_live_unique;
-extern unsigned int borg_living_unique_index;
-extern int          borg_unique_depth;
+extern unsigned int borg_first_living_unique;
+extern int          borg_depth_hunted_unique;
 
 /*
  * Determine what level the borg is prepared to dive to.

--- a/src/borg/borg-trait.h
+++ b/src/borg/borg-trait.h
@@ -359,6 +359,7 @@ struct goals {
     bool less; /* return to, but don't use, the next up stairs */
 
     int recalling; /* waiting for recall, guessing turns left */
+    int descending; /* waiting for deep descent */
 
     int16_t shop; /* Next shop to visit */
     int16_t ware; /* Next item to buy there */

--- a/src/borg/borg-update.c
+++ b/src/borg/borg-update.c
@@ -2230,8 +2230,8 @@ void borg_update(void)
 
         /* Clear our Uniques vars */
         borg_numb_live_unique    = 0;
-        borg_living_unique_index = 0;
-        borg_unique_depth        = 0;
+        borg_first_living_unique = 0;
+        borg_depth_hunted_unique = 0;
         int unique_depths[4] = {0, 0, 0, 0};
 
         /*Extract dead uniques and set some Prep code numbers */
@@ -2265,7 +2265,7 @@ void borg_update(void)
 
             /* Keep track of the three shallowest uniques.  */
             /* note that the uniques might not be in depth order */
-            if (borg_numb_live_unique < 3) {
+            if (borg_numb_live_unique < 4) {
                 /* track the depth of the three shallowest live uniques */
                 unique_depths[borg_numb_live_unique] = r_ptr->level;
 
@@ -2273,13 +2273,15 @@ void borg_update(void)
 
                 /* this is the first living unique */
                 if (borg_numb_live_unique == 1)
-                    borg_living_unique_index = u_i;
+                    borg_first_living_unique = u_i;
 
                 /* sort the top 3*/
                 if (borg_numb_live_unique == 3)
                     qsort(unique_depths, 3, sizeof(int), intcomp);
 
             } else {
+                borg_numb_live_unique++;
+
                 /* sort this in to only keep top (lowest) 3*/
                 if (r_ptr->level < unique_depths[2]) {
                     unique_depths[3] = r_ptr->level;
@@ -2290,7 +2292,14 @@ void borg_update(void)
         /* slight cheat here since we know if there is less than 3 */
         /* live uniques the deepest one is likely to be morgoth */
         /* and if there is 3 or more we have sorted the list */
-        borg_unique_depth = unique_depths[borg_numb_live_unique-1];
+        if (borg_numb_live_unique >= 3) {
+            borg_depth_hunted_unique = unique_depths[2];
+        } else {
+            if (borg_numb_live_unique != 0)
+                borg_depth_hunted_unique = unique_depths[borg_numb_live_unique - 1];
+            else
+                borg_depth_hunted_unique = 127;
+        }
 
         /* Forget the map */
         borg_forget_map();


### PR DESCRIPTION
Triggering the reset of recall depth on the unique will keep it from resetting when you are exploring deep but then run out of stuff and now are only prepared for shallow.  
This code should also now better take into account that deep descent is delay action.