### PR TITLE
Tweak learning of brands and slays

### DIFF
--- a/src/obj-slays.c
+++ b/src/obj-slays.c
@@ -494,19 +494,22 @@ static void learn_brand_slay_helper(struct player *p, struct object *obj1,
 		 * Check for the temporary brand (only relevant if the brand
 		 * is not already present).
 		 */
-		if (!learn && allow_temp && !player_has_temporary_brand(p, i)) {
+		if (!learn && !(allow_temp && player_has_temporary_brand(p, i))) {
 			continue;
 		}
 
 		b = &brands[i];
-		if (!rf_has(mon->race->flags, b->resist_flag)) {
+		if (!b->resist_flag || !rf_has(mon->race->flags, b->resist_flag)) {
 			/* Learn the brand */
 			if (learn) {
 				player_learn_brand(p, i);
 			}
 
 			/* Learn about the monster. */
-			lore_learn_flag_if_visible(lore, mon, b->resist_flag);
+			if (b->resist_flag) {
+				lore_learn_flag_if_visible(lore, mon,
+					b->resist_flag);
+			}
 			if (b->vuln_flag) {
 				lore_learn_flag_if_visible(lore, mon,
 					b->vuln_flag);
@@ -514,10 +517,6 @@ static void learn_brand_slay_helper(struct player *p, struct object *obj1,
 		} else if (player_knows_brand(p, i)) {
 			/* Learn about the monster. */
 			lore_learn_flag_if_visible(lore, mon, b->resist_flag);
-			if (b->vuln_flag) {
-				lore_learn_flag_if_visible(lore, mon,
-					b->vuln_flag);
-			}
 		}
 	}
 
@@ -552,14 +551,17 @@ static void learn_brand_slay_helper(struct player *p, struct object *obj1,
 		 * Check for the temporary slay (only relevant if the slay
 		 * is not already present.
 		 */
-		if (!learn && allow_temp && !player_has_temporary_slay(p, i)) {
+		if (!learn && !(allow_temp && player_has_temporary_slay(p, i))) {
 			continue;
 		}
 
 		s = &slays[i];
 		if (react_to_specific_slay(s, mon)) {
 			/* Learn about the monster. */
-			lore_learn_flag_if_visible(lore, mon, s->race_flag);
+			if (s->race_flag) {
+				lore_learn_flag_if_visible(lore, mon,
+					s->race_flag);
+			}
 			if (monster_is_visible(mon)) {
 				/* Learn the slay */
 				if (learn) {
@@ -568,7 +570,10 @@ static void learn_brand_slay_helper(struct player *p, struct object *obj1,
 			}
 		} else if (player_knows_slay(p, i)) {
 			/* Learn about unaffected monsters. */
-			lore_learn_flag_if_visible(lore, mon, s->race_flag);
+			if (s->race_flag) {
+				lore_learn_flag_if_visible(lore, mon,
+					s->race_flag);
+			}
 		}
 	}
 }


### PR DESCRIPTION
1.  Do not learn monster flags on ranged attacks when the missile does not have a relevant brand or slay.  Fixes a regression introduced by https://github.com/angband/angband/commit/f8f1bc2cf6eff9802cd7d5c5d2d1bf6f8b356cb3 .
2.  If the monster resists a brand, do not learn about the vulnerable flag, if the brand has one, since the damage is not affected by whether the monster has the vulnerable flag in that case.  Has no effect in Vanilla since there are no monsters that both have the resist and vulnerable flag for a brand.
3.  Tolerate brands which do not have a resist flag (not currently relevant in Vanilla:  all brands have a resist flag).
4.  Tolerate slays which are based on a monster base rather than a flag (not currently relevant in Vanilla:  all slays are based on a flag).