### PR TITLE
borg: standing on a throwable messes the check.  Make it a reaction

### DIFF
--- a/src/borg/borg-fight-attack.c
+++ b/src/borg/borg-fight-attack.c
@@ -2240,25 +2240,6 @@ static int borg_attack_aux_rest(void)
     return 1;
 }
 
-/* look for a throwable item */
-static bool borg_has_throwable(void)
-{
-    int i;
-    for (i = 0; i < QUIVER_END; i++) {
-        /* it will show wield in the list */
-        /* but not if that is the only thing */
-        if (i == INVEN_WIELD)
-            continue;
-
-        if (!borg_items[i].iqty)
-            continue;
-
-        if (of_has(borg_items[i].flags, OF_THROWING))
-            return true;
-    }
-    return false;
-}
-
 /*
  * Simulate/Apply the optimal result of throwing an object
  *
@@ -2359,9 +2340,6 @@ static int borg_attack_aux_object(void)
 
     /* Fire */
     borg_keypress('v');
-
-    if (borg_has_throwable())
-        borg_keypress('/');
 
     /* Use the object */
     borg_keypress(all_letters_nohjkl[b_k]);

--- a/src/borg/borg.c
+++ b/src/borg/borg.c
@@ -443,6 +443,16 @@ static struct keypress internal_borg_inkey(int flush_first)
         return key;
     }
 
+    /* make sure inventory is used for throwing */
+    if (borg_prompt && !inkey_flag && (y == 1) && (x >= 12)
+        && (prefix(buf, "Throw which item? (Throw"))) {
+        if (borg_cfg[BORG_VERBOSE])
+            borg_note("# switching to inventory for throws");
+        /* yes step in */
+        key.code = '/';
+        return key;
+    }
+
     /* Mega-Hack -- Handle death */
     if (player->is_dead) {
 #ifndef BABLOS


### PR DESCRIPTION
I tried to make this look at the item the borg was standing on.  The problem is the borg only knows about the top item of stacks so this didn't work.  I decided it was better to make it check for the prompt that says it is looking at "throwable" items and react with a / since the borg only throws items from inventory. 