### PR TITLE
MSYS2 and SDL2: work around inability to statically link libSvtAv1Enc

### DIFF
--- a/src/Makefile.msys2.sdl2
+++ b/src/Makefile.msys2.sdl2
@@ -51,7 +51,7 @@ VIDEO_sdl2_ldflags := \
 	-laom \
 	-ldav1d \
 	-lrav1e \
-	-lSvtAv1Enc \
+	-Wl,-Bdynamic -lSvtAv1Enc -Wl,-Bstatic \
 	-lyuv \
 	-lwebp \
 	-lwebpdemux \
@@ -111,13 +111,12 @@ CFLAGS := -std=c99 \
 	-g \
 	-O2 \
 	$(WARNINGS) -pedantic \
-	-static \
 	-DUSE_PRIVATE_PATHS \
 	-DHAVE_DIRENT_H \
 	-DMSYS2_ENCODING_WORKAROUND
 
 # Linker flags
-LDFLAGS :=
+LDFLAGS := -Wl,-Bstatic
 
 # Frontends to compile
 MODULES_cflags := $(VIDEO_sdl2_cflags)


### PR DESCRIPTION
May be able to revert this at some point in the future depending on the resolution of https://github.com/msys2/MINGW-packages/issues/22439 .