### PR TITLE
borg: miscalculating quiver slots

### DIFF
--- a/src/borg/borg-item.h
+++ b/src/borg/borg-item.h
@@ -154,8 +154,7 @@ struct borg_item {
 
 /* Quiver */
 #define QUIVER_START INVEN_TOTAL
-#define QUIVER_SIZE  (z_info->quiver_size)
-#define QUIVER_END   (QUIVER_START + QUIVER_SIZE)
+#define QUIVER_END   (QUIVER_START + (z_info->quiver_size))
 
 /*
  * Current "inventory"

--- a/src/borg/borg-trait-swap.c
+++ b/src/borg/borg-trait-swap.c
@@ -187,7 +187,7 @@ void borg_notice_weapon_swap(void)
             continue;
 
         /* Skip non-wearable items */
-        if (borg_slot(item->tval, item->sval) == -1)
+        if (borg_wield_slot(item) == -1)
             continue;
 
         /* Don't carry swaps until dlevel 50.  They are heavy.
@@ -779,7 +779,7 @@ void borg_notice_armour_swap(void)
             continue;
 
         /* Skip non-wearable items */
-        if (borg_slot(item->tval, item->sval) == -1)
+        if (borg_wield_slot(item) == -1)
             continue;
 
         /* Dont carry swaps until dlevel 50.  They are heavy */

--- a/src/borg/borg-trait.c
+++ b/src/borg/borg-trait.c
@@ -1123,6 +1123,11 @@ static void borg_notice_ammo(int slot)
     if (!item->iqty)
         return;
 
+
+    /* number of inventory slots the quiver used  */
+    if (slot >= QUIVER_START)
+        borg.trait[BI_QUIVER_SLOTS]++;
+
     /* total up the weight of the items */
     borg.trait[BI_WEIGHT] += borg_item_weight(item);
 
@@ -2851,12 +2856,6 @@ void borg_notice(bool notice_swap)
 
     /* Notice the inventory */
     borg_notice_inventory();
-
-    /* number of inventory slots the quiver used  */
-    borg.trait[BI_QUIVER_SLOTS]
-        = (borg.trait[BI_AMMO_COUNT] - 1) / z_info->quiver_slot_size + 1;
-
-    borg.trait[BI_EMPTY] -= borg.trait[BI_QUIVER_SLOTS];
 
     /* Notice and locate my swap weapon */
     if (notice_swap) {

--- a/src/borg/borg.c
+++ b/src/borg/borg.c
@@ -804,8 +804,6 @@ void do_cmd_borg(void)
         /* Step forever */
         borg_step = 0;
 
-        borg_notice(true);
-
         if (player->opts.lazymove_delay != 0) {
             borg_note("# Turning off lazy movement controls");
             player->opts.lazymove_delay = 0;


### PR DESCRIPTION
Quiver slots were calculated based on number of ammo/size of a slot but if you have different types they will each take up a slot. I  also noticed that the swap routines were using the "do I have this" rather than the "is this equip able" call so I fixed that while I was in there.