### PR TITLE
SDL2: reset alpha when toggling off moving/resizing

### DIFF
--- a/src/main-sdl2.c
+++ b/src/main-sdl2.c
@@ -2072,10 +2072,12 @@ static void signal_move_state(struct sdlpui_window *window)
 	bool was_active = window->move_state.active;
 
 	SDL_assert(!window->size_state.active);
+	window->alpha = was_active ? DEFAULT_ALPHA_FULL : DEFAULT_ALPHA_LOW;
 	if (was_active) {
 		window->move_state.active = false;
 		window->move_state.moving = false;
 		window->move_state.subwindow = NULL;
+		set_subwindows_alpha(window, window->alpha);
 	} else {
 		window->move_state.active = true;
 	}
@@ -2091,7 +2093,6 @@ static void signal_move_state(struct sdlpui_window *window)
 	}
 
 	SDL_SetWindowGrab(window->window, was_active ? SDL_FALSE : SDL_TRUE);
-	window->alpha = was_active ? DEFAULT_ALPHA_FULL : DEFAULT_ALPHA_LOW;
 }
 
 static void signal_size_state(struct sdlpui_window *window)
@@ -2099,6 +2100,7 @@ static void signal_size_state(struct sdlpui_window *window)
 	bool was_active = window->size_state.active;
 
 	SDL_assert(!window->move_state.active);
+	window->alpha = was_active ? DEFAULT_ALPHA_FULL : DEFAULT_ALPHA_LOW;
 	if (was_active) {
 		window->size_state.active = false;
 		window->size_state.sizing = false;
@@ -2107,6 +2109,7 @@ static void signal_size_state(struct sdlpui_window *window)
 				sizeof(window->size_state.subwindow->sizing_rect));
 			window->size_state.subwindow = NULL;
 		}
+		set_subwindows_alpha(window, window->alpha);
 	} else {
 		window->size_state.active = true;
 	}
@@ -2122,7 +2125,6 @@ static void signal_size_state(struct sdlpui_window *window)
 	}
 
 	SDL_SetWindowGrab(window->window, was_active ? SDL_FALSE : SDL_TRUE);
-	window->alpha = was_active ? DEFAULT_ALPHA_FULL : DEFAULT_ALPHA_LOW;
 }
 
 static void handle_button_movesize(struct sdlpui_control *ctrl,
@@ -5445,14 +5447,6 @@ static void handle_button_open_subwindow(struct sdlpui_control *ctrl,
 	redraw_all_windows(subwindow->app, false);
 }
 
-static void close_status_bar_menu(struct sdlpui_window *window)
-{
-	sdlpui_popdown_dialog(window->status_bar, window, false);
-	window->status_bar = NULL;
-	window->move_button = NULL;
-	window->size_button = NULL;
-}
-
 static void load_status_bar(struct sdlpui_window *window)
 {
 	struct sdlpui_control *c;
@@ -5493,12 +5487,12 @@ static void load_status_bar(struct sdlpui_window *window)
 		SDLPUI_MFLG_END_GRAVITY);
 	window->move_button = c;
 	sdlpui_create_menu_toggle(c, "Move", SDLPUI_HOR_CENTER,
-		handle_button_movesize, 0, false, false);
+		handle_button_movesize, 0, false, window->move_state.active);
 	c = sdlpui_get_simple_menu_next_unused(window->status_bar,
 		SDLPUI_MFLG_END_GRAVITY);
 	window->size_button = c;
 	sdlpui_create_menu_toggle(c, "Size", SDLPUI_HOR_CENTER,
-		handle_button_movesize, 1, false, false);
+		handle_button_movesize, 1, false, window->size_state.active);
 	sdlpui_complete_simple_menu(window->status_bar, window);
 	if (window->status_bar->ftb->query_minimum_size) {
 		(*window->status_bar->ftb->query_minimum_size)(
@@ -5526,12 +5520,6 @@ static void load_status_bar(struct sdlpui_window *window)
 	window->status_bar->rect.y = 0;
 	window->status_bar->pinned = true;
 	sdlpui_popup_dialog(window->status_bar, window, false);
-}
-
-static void reload_status_bar(struct sdlpui_window *window)
-{
-	close_status_bar_menu(window);
-	load_status_bar(window);
 }
 
 static void fit_subwindow_in_window(const struct sdlpui_window *window,
@@ -5572,8 +5560,6 @@ static void resize_window(struct sdlpui_window *window, int w, int h)
 			fit_subwindow_in_window(window, subwindow);
 		}
 	}
-
-	reload_status_bar(window);
 
 	redraw_window(window);
 }


### PR DESCRIPTION
Resolves https://github.com/angband/angband/issues/6057 (a regression introduced by d6886368017822967efa5911a64b8819502fd7e4 ).  Simplify resizing:  do not recreate the menu bar.  Match the initial state of the move/size toggles to what's present for the window.