### PR TITLE
SDL2: when changing fullscreen, resize backing textures if needed

### DIFF
--- a/src/main-sdl2.c
+++ b/src/main-sdl2.c
@@ -487,6 +487,7 @@ static struct sdlpui_window *get_window_by_id(struct my_app *a, Uint32 id);
 static struct sdlpui_window *get_window_direct(struct my_app *a,
 		unsigned index);
 static void resize_window(struct sdlpui_window *window, int w, int h);
+static void resize_subwindow(struct subwindow *subwindow);
 static struct subwindow *get_new_subwindow(struct my_app *a, unsigned index);
 static void load_subwindow(struct sdlpui_window *window,
 		struct subwindow *subwindow);
@@ -2231,6 +2232,13 @@ static void handle_menu_fullscreen(struct sdlpui_control *ctrl,
 					 */
 					subwindow->full_rect =
 						subwindow->stored_rect;
+				} else if (subwindow->full_rect.w
+						!= subwindow->stored_rect.w
+						|| subwindow->full_rect.h
+						!= subwindow->stored_rect.h) {
+					subwindow->sizing_rect =
+						subwindow->full_rect;
+					resize_subwindow(subwindow);
 				}
 			}
 		}


### PR DESCRIPTION
Resolves https://github.com/angband/angband/issues/6060 , a regression introduced by 850810f00481b854d10415395ed064d9cea80d60 .