### PR TITLE
borg: move around the short on prep code to avoid bouncing depths

### DIFF
--- a/src/borg/borg-caution.c
+++ b/src/borg/borg-caution.c
@@ -1060,14 +1060,13 @@ bool borg_caution(void)
     /* Don't take off in the middle of a fight */
     /* just to restock and it is useless to restock */
     /* if you have just left town. */
-    if (!borg_fighting_unique
-        && (borg_time_town + (borg_t - borg_began)) > 200 
-        && borg_restock(borg.trait[BI_CDEPTH], false)) {
+    if (!borg_fighting_unique && (borg_time_town + (borg_t - borg_began)) > 200
+        && borg_restock(borg.trait[BI_CDEPTH])) {
         /* Start leaving */
         if (!borg.goal.leaving) {
             /* Note */
-            borg_note(format("# Leaving (restock) %s",
-                borg_restock(borg.trait[BI_CDEPTH], false)));
+            borg_note(format(
+                "# Leaving (restock) %s", borg_restock(borg.trait[BI_CDEPTH])));
 
             /* Start leaving */
             borg.goal.leaving = true;
@@ -1077,8 +1076,8 @@ bool borg_caution(void)
             && borg.trait[BI_FOOD] > 3 && borg.trait[BI_AFUEL] > 2
             && (borg_t - borg_began) > 400) {
             /* Flee */
-            borg_note(format("# Fleeing (restock) %s",
-                borg_restock(borg.trait[BI_CDEPTH], false)));
+            borg_note(format(
+                "# Fleeing (restock) %s", borg_restock(borg.trait[BI_CDEPTH])));
 
             /* Start fleeing */
             borg.goal.fleeing = true;

--- a/src/borg/borg-prepared.c
+++ b/src/borg/borg-prepared.c
@@ -546,7 +546,7 @@ const char *borg_prepared(int depth)
     if (borg_cfg[BORG_USES_DYNAMIC_CALCS]) {
 
         /* use the base restock so special checks can be done */
-        if ((reason = borg_restock(depth, true)))
+        if ((reason = borg_restock(depth)))
             return reason;
 
         if ((reason = borg_prepared_dynamic(depth)))
@@ -554,7 +554,7 @@ const char *borg_prepared(int depth)
 
     } else {
         /* Not prepared if I need to restock */
-        if ((reason = borg_restock(depth, true)))
+        if ((reason = borg_restock(depth)))
             return (reason);
 
         /*** Require his Clevel to be greater than or equal to Depth */
@@ -691,28 +691,12 @@ const char *borg_prepared(int depth)
  * Note that we ignore "restock" issues for the first several turns
  * on each level, to prevent repeated "level bouncing".
  */
-const char *borg_restock(int depth, bool do_always_checks)
+const char *borg_restock(int depth)
 {
 
     /* We are now looking at our preparedness */
     if (-1 == borg.ready_morgoth)
         borg.ready_morgoth = 0;
-
-    /* some checks for things we are always prepared for */
-    if (do_always_checks) {
-
-        /* Always ready for the town */
-        if (!depth)
-            return ((char *)NULL);
-
-        /* Always Ready to leave town */
-        if (borg.trait[BI_CDEPTH] == 0)
-            return ((char *)NULL);
-
-        /* Always spend time on a level unless 100*/
-        if (borg_t - borg_began < 100 && borg.trait[BI_CDEPTH] != 100)
-            return ((char *)NULL);
-    }
 
     if (borg_cfg[BORG_USES_DYNAMIC_CALCS]) 
         return borg_restock_dynamic(depth);
@@ -840,5 +824,21 @@ const char *borg_restock(int depth, bool do_always_checks)
     /* Assume happy */
     return ((char *)NULL);
 }
+
+extern const char *borg_must_return_to_town(void)
+{
+    /* don't need to go to town if in town */
+    if (borg.trait[BI_CDEPTH] == 0)
+        return ((char *)NULL);
+
+    /* Always spend time on a level unless 100*/
+    if (borg_t - borg_began < 100 && borg.trait[BI_CDEPTH] != 100)
+        return ((char *)NULL);
+
+    /* need to return to town if restock is needed */
+    return borg_restock(borg.trait[BI_CDEPTH]);
+}
+
+
 
 #endif

--- a/src/borg/borg-prepared.h
+++ b/src/borg/borg-prepared.h
@@ -37,7 +37,12 @@ extern const char *borg_prepared(int depth);
 /*
  * Determine if the Borg is out of "crucial" supplies.
  */
-extern const char *borg_restock(int depth, bool do_always_checks);
+extern const char *borg_restock(int depth);
+
+/*
+ * Determine if the Borg should return to town immediately.
+ */
+extern const char *borg_must_return_to_town(void);
 
 #endif
 #endif

--- a/src/borg/borg-think-dungeon-util.c
+++ b/src/borg/borg-think-dungeon-util.c
@@ -635,7 +635,7 @@ bool borg_leave_level(bool bored)
 
         /* Case for those who cannot Teleport Level */
         if (borg.trait[BI_MAXDEPTH] == 100 && !borg_cfg[BORG_PLAYS_RISKY]) {
-            if (borg_restock(100, false)) {
+            if (borg_restock(100)) {
                 /* These pple must crawl down to 100, Sorry */
                 borg.goal.fleeing = true;
                 borg.goal.leaving = true;
@@ -771,10 +771,10 @@ bool borg_leave_level(bool bored)
             }
         }
 
-        /* if I must  go to town without delay */
-        if (NULL != borg_restock(borg.trait[BI_CDEPTH], true)) {
+        /* if I must go to town without delay */
+        if (NULL != borg_must_return_to_town()) {
             borg_note(format("# returning to town to restock(too deep: %s)",
-                borg_restock(borg.trait[BI_CDEPTH], true)));
+                borg_must_return_to_town()));
             borg.goal.rising = true;
             need_restock     = true;
         }

--- a/src/borg/borg-think-dungeon.c
+++ b/src/borg/borg-think-dungeon.c
@@ -1582,7 +1582,7 @@ bool borg_think_dungeon(void)
     }
 
     /* if I must go to town without delay */
-    if ((char *)NULL != borg_restock(borg.trait[BI_CDEPTH], true)) {
+    if ((char *)NULL != borg_must_return_to_town()) {
         if (borg_leave_level(false))
             return true;
     }


### PR DESCRIPTION
The previous changes that reorganized when restocking checked if you are leaving town or if you have been at least 100 moves on a depth broke some stuff and caused an up down bounce.