### PR TITLE
Borg aware

### DIFF
--- a/src/borg/borg-fight-attack.c
+++ b/src/borg/borg-fight-attack.c
@@ -2900,7 +2900,7 @@ static int borg_attack_aux_wand_bolt_unknown(int dam, int typ)
             continue;
 
         /* known */
-        if (borg_items[i].kind)
+        if (borg_items[i].aware)
             continue;
 
         /* No charges */
@@ -2968,7 +2968,7 @@ static int borg_attack_aux_rod_bolt_unknown(int dam, int typ)
             continue;
 
         /* known */
-        if (borg_items[i].kind)
+        if (borg_items[i].aware)
             continue;
 
         /* No charges */

--- a/src/borg/borg-flow-take.c
+++ b/src/borg/borg-flow-take.c
@@ -767,7 +767,7 @@ bool borg_flow_take_lunal(bool viewable, int nearness)
                     if (borg_items[ii].iqty == z_info->quiver_slot_size)
                         continue;
 
-                    /* Both objects should have the same ID value */
+                    /* Both objects should have the same kind value */
                     if (take->kind->kidx != borg_items[ii].kind)
                         continue;
 
@@ -783,7 +783,7 @@ bool borg_flow_take_lunal(bool viewable, int nearness)
                     if (!borg_items[ii].iqty)
                         continue;
 
-                    /* Both objects should have the same ID value */
+                    /* Both objects should have the same kind value */
                     if (take->kind->kidx != borg_items[ii].kind)
                         continue;
 

--- a/src/borg/borg-formulas.c
+++ b/src/borg/borg-formulas.c
@@ -965,7 +965,7 @@ int32_t borg_power_dynamic(void)
 
         /* Some items will be used immediately and should not contribute to
          * encumbrance */
-        if (item && item->iqty
+        if (item && item->iqty && item->aware
             && ((item->tval == TV_SCROLL
                     && ((item->sval == sv_scroll_enchant_armor
                             && borg.trait[BI_AENCH_ARM] < 1000

--- a/src/borg/borg-home-notice.c
+++ b/src/borg/borg-home-notice.c
@@ -311,7 +311,7 @@ static void borg_notice_home_dupe(borg_item *item, bool check_sval, int i)
             item2 = &borg_items[((x - z_info->store_inven_max) + INVEN_WIELD)];
 
         /* skip zero quantity or unknown items */
-        if (!item2->iqty || !item2->kind)
+        if (!item2->iqty || !item2->aware)
             continue;
 
         /* if everything matches it is a duplicate item */
@@ -374,7 +374,7 @@ static void borg_notice_home_aux(borg_item *in_item, bool no_items)
 
 
         /* Hack -- skip un-aware items */
-        if (!item->kind)
+        if (!item->aware)
             continue;
 
         if (of_has(item->flags, OF_SLOW_DIGEST))

--- a/src/borg/borg-inventory.c
+++ b/src/borg/borg-inventory.c
@@ -98,7 +98,7 @@ int borg_slot(int tval, int sval)
             continue;
 
         /* Skip un-aware items */
-        if (!item->kind)
+        if (!item->aware)
             continue;
 
         /* Require correct tval */

--- a/src/borg/borg-item-analyze.c
+++ b/src/borg/borg-item-analyze.c
@@ -460,7 +460,9 @@ void borg_item_analyze(
     item->weight  = object_weight_one(real_item);
     item->timeout = real_item->timeout;
     item->level   = real_item->kind->level;
-    item->aware   = object_flavor_is_aware(real_item);
+
+    /* always aware of items in the store */
+    item->aware   = in_store || object_flavor_is_aware(real_item);
 
     /* get info from the known part of the object */
     item->ac   = o->ac;
@@ -576,8 +578,8 @@ void borg_item_analyze(
             item->pval = 0;
     }
 
-    /* Kind index -- Only if partially ID or this is a store object */
-    if (item->aware || in_store)
+    /* Kind index -- Only if we are aware of its kind */
+    if (item->aware)
         item->kind = o->kind->kidx;
 
     if (o->artifact)

--- a/src/borg/borg-item-use.c
+++ b/src/borg/borg-item-use.c
@@ -118,7 +118,7 @@ bool borg_quaff_unknown(void)
             continue;
 
         /* Skip aware items */
-        if (item->kind)
+        if (item->aware)
             continue;
 
         /* Save this item */
@@ -202,7 +202,7 @@ bool borg_read_unknown(void)
             continue;
 
         /* Skip aware items */
-        if (item->kind)
+        if (item->aware)
             continue;
 
         /* Save this item */
@@ -287,7 +287,7 @@ bool borg_eat_unknown(void)
             continue;
 
         /* Skip aware items */
-        if (item->kind)
+        if (item->aware)
             continue;
 
         /* Save this item */
@@ -328,7 +328,7 @@ bool borg_eat_food_any(void)
             continue;
 
         /* Skip unknown food */
-        if (!item->kind)
+        if (!item->aware)
             continue;
 
         /* Skip non-food */
@@ -349,7 +349,7 @@ bool borg_eat_food_any(void)
             continue;
 
         /* Skip unknown food */
-        if (!item->kind)
+        if (!item->aware)
             continue;
 
         /* Skip non-food */
@@ -537,7 +537,7 @@ bool borg_use_unknown(void)
             continue;
 
         /* Skip aware items */
-        if (item->kind)
+        if (item->aware)
             continue;
 
         /* Save this item */
@@ -722,7 +722,10 @@ bool borg_equips_ring(int ring_sval)
     for (i = INVEN_RIGHT; i < INVEN_LEFT; i++) {
         borg_item *item = &borg_items[i];
 
-        /* Skip incorrect armours */
+        if (!item->iqty || !item->aware)
+            continue;
+
+        /* Skip incorrect armors */
         if (item->tval != TV_RING)
             continue;
         if (item->sval != ring_sval)
@@ -774,6 +777,10 @@ bool borg_activate_ring(int ring_sval)
     for (i = INVEN_RIGHT; i < INVEN_LEFT; i++) {
         borg_item *item = &borg_items[i];
 
+        /*  Make Sure item is IDed */
+        if (!item->aware)
+            continue;
+
         /* Skip incorrect mails */
         if (item->tval != TV_RING)
             continue;
@@ -816,7 +823,7 @@ bool borg_equips_dragon(int drag_sval)
     /* Check the equipment */
     borg_item *item = &borg_items[INVEN_BODY];
 
-    if (!item->iqty)
+    if (!item->iqty || !item->aware)
         return false;
 
     /* Skip incorrect armours */
@@ -879,7 +886,7 @@ bool borg_activate_dragon(int drag_sval)
 
     borg_item *item = &borg_items[INVEN_BODY];
 
-    if (!item->iqty)
+    if (!item->iqty || !item->aware)
         return false;
 
     /* Skip incorrect mails */
@@ -1093,7 +1100,7 @@ bool borg_use_things(void)
         borg_item *item = &borg_items[i];
 
         /* Skip empty items */
-        if (!item->iqty)
+        if (!item->iqty || !item->aware)
             continue;
 
         /* Process "force" items */
@@ -1184,7 +1191,7 @@ bool borg_recharging(void)
             continue;
 
         /* Skip non-identified items */
-        if (!item->ident)
+        if (!item->ident || !item->aware)
             continue;
 
         if (item->note && strstr(item->note, "empty"))

--- a/src/borg/borg-item-wear.c
+++ b/src/borg/borg-item-wear.c
@@ -158,7 +158,7 @@ bool borg_test_stuff(void)
             v = item->value;
 
         /* Hack -- reward "unaware" items */
-        if (!item->kind) {
+        if (!item->aware) {
             /* Analyze the type */
             switch (item->tval) {
             case TV_RING:
@@ -438,8 +438,8 @@ bool borg_wear_rings(void)
         if (!item->iqty)
             continue;
 
-        /* Require "aware" */
-        if (!item->kind)
+        /* Require aware */
+        if (!item->aware)
             continue;
 
         /* Hack -- ignore "worthless" items */
@@ -793,8 +793,8 @@ bool borg_wear_stuff(void)
         if (!item->iqty)
             continue;
 
-        /* Require "aware" */
-        if (!item->kind)
+        /* Require aware */
+        if (!item->aware)
             continue;
 
         /* Hack -- ignore "worthless" items */
@@ -1231,8 +1231,8 @@ static void borg_best_stuff_aux(
         if (!item->iqty)
             continue;
 
-        /* Require "aware" */
-        if (!item->kind)
+        /* Require aware */
+        if (!item->aware)
             continue;
 
         /* Hack -- ignore "worthless" items */

--- a/src/borg/borg-power.c
+++ b/src/borg/borg-power.c
@@ -1849,7 +1849,7 @@ static int32_t borg_power_inventory(void)
 
         /* Some items will be used immediately and should not contribute to
          * encumbrance */
-        if (item && item->iqty
+        if (item && item->iqty && item->aware
             && ((item->tval == TV_SCROLL
                     && ((item->sval == sv_scroll_enchant_armor
                             && borg.trait[BI_AENCH_ARM] < 1000

--- a/src/borg/borg-reincarnate.c
+++ b/src/borg/borg-reincarnate.c
@@ -281,7 +281,7 @@ static void create_random_name(int race, char *name, size_t name_len)
 /*
  * Init players with some belongings
  *
- * Having an item makes the player "aware" of its purpose.
+ * Having an item makes the player aware of its purpose.
  */
 static void borg_outfit_player(struct player *p)
 {

--- a/src/borg/borg-store-buy.c
+++ b/src/borg/borg-store-buy.c
@@ -1226,6 +1226,7 @@ bool borg_think_shop_buy(void)
         /* leave the store */
         borg_keypress(ESCAPE);
         borg_keypress(ESCAPE);
+        borg_keypress(ESCAPE);
 
         /* I'm not in a store */
         borg.in_shop = false;

--- a/src/borg/borg-store-sell.c
+++ b/src/borg/borg-store-sell.c
@@ -290,7 +290,7 @@ static bool borg_think_home_sell_bad(int i, int32_t borg_empty_home_power)
     int charge_each = 0;
 
     /* Skip empty or unknown items */
-    if (!item->iqty || (!item->kind && !item->aware))
+    if (!item->iqty || !item->aware)
         return true;
 
     /* Skip swap items */

--- a/src/borg/borg-trait-swap.c
+++ b/src/borg/borg-trait-swap.c
@@ -183,7 +183,7 @@ void borg_notice_weapon_swap(void)
             continue;
 
         /* Hack -- skip un-aware items */
-        if (!item->kind)
+        if (!item->aware)
             continue;
 
         /* Skip non-wearable items */
@@ -775,7 +775,7 @@ void borg_notice_armour_swap(void)
             continue;
 
         /* Hack -- skip un-aware items */
-        if (!item->kind)
+        if (!item->aware)
             continue;
 
         /* Skip non-wearable items */

--- a/src/borg/borg-trait.c
+++ b/src/borg/borg-trait.c
@@ -2231,7 +2231,7 @@ static void borg_notice_inventory(void)
         }
 
         /* Hack -- skip un-aware items */
-        if (!item->kind)
+        if (!item->aware)
             continue;
 
         /* count up the items on the borg (do not count artifacts  */
@@ -2282,10 +2282,6 @@ static void borg_notice_inventory(void)
         case TV_FOOD:
             /* Analyze */
             {
-                /* unknown types */
-                if (!item->kind)
-                    break;
-
                 /* check for food that hurts us */
                 if (borg_obj_has_effect(item->kind, EF_CRUNCH, -1)
                     || borg_obj_has_effect(


### PR DESCRIPTION
sometimes the borg was using items when they weren't "aware" by looking at the sval when it shouldn't.  It also used the "kind" index to tell if it was aware rather than using the aware flag.
also tossed in a fix to do an extra "ESCAPE" when buying things because the "how many" prompt doesn't happen if the borg can only afford one or there is only one in the store making the extra ENTER put up a menu that needs to be ESCAPEd out of.