### PR TITLE
SDL2: provide ways to summarize details about the SDL2 installation

### DIFF
--- a/src/sound-core.c
+++ b/src/sound-core.c
@@ -417,6 +417,15 @@ void close_sound(void)
 }
 
 /**
+ * Return true if there has been a succesful call to init_sound() without
+ * a later call to close_sound().  Otherwse, return false.
+ */
+bool is_sound_inited(void)
+{
+	return next_sound_id != 0;
+}
+
+/**
  * Print out the 'help' information for the sound module.
  */
 void print_sound_help(void)

--- a/src/sound.h
+++ b/src/sound.h
@@ -84,6 +84,7 @@ struct sound_hooks
 bool set_preloaded_sounds(bool new_setting);
 errr init_sound(const char *soundstr, int argc, char **argv);
 void close_sound(void);
+bool is_sound_inited(void);
 errr register_sound_pref_parser(struct parser *p);
 void print_sound_help(void);
 


### PR DESCRIPTION
The intended use is for diagnosing problems with the SDL2 front end.  The -v suboption, "angband -msdl2 -- -v", will cause details about the SDL2 installation to be pushed through SDL_Log() so those details will be printed on standard error for most platforms (Windows and Android are the known exceptions).  The "SDL Details..." entry in the first menu will dump the details to a simple dialog.  That menu entry for the main window will provide more information (library versions, platform, current video driver, list of connected displays, and audio information).  For other windows, only the details specific to that window are displayed.  For problems that cause the application to exit in init_systems(), only the -v suboption will be useful, and it will only provide limited information in that case:  the version of the SDL library.