### PR TITLE
docs: correct some details for blackguards and shooting/throwing

### DIFF
--- a/docs/birth.rst
+++ b/docs/birth.rst
@@ -503,12 +503,23 @@ Fighting
    single: shooting skill; description
 
 Shooting Ability
-  Using ranged missile weapons (and throwing objects) is included in this
-  skill. Different stats apply to different weapons, but this ability may
-  modify the distance an object is thrown/fired, the amount of damage done,
-  and the ability to hit a creature. This skill increases with the level of
-  the character.
+  Firing ammunition with a bow, sling, or crossbow is included in this skill.
+  Dexterity and this skill affect the chance to hit when firing. It does
+  not influence how far amuunition can be fired (that is set by the damage
+  multiplier for the bow, sling, or crossbow) or the amount of damage a hit
+  causes. This skill increases with the level of the character.
  
+.. index::
+   single: throwing skill; description
+
+Throwing Skill
+  Throwing a weapon or ammunition is included in this skill. Weapons or
+  ammunition specially designed for throwing are much better when thrown
+  than other weapons or ammunition. Dexterity and this skill affect the chance
+  to hit when throwing. It does not influence how far an item can be thrown
+  (that is set by strength and the weight of the thrown item) or the amount
+  of damage a hit causes. This skill increases with the level of the character.
+
 .. index::
    single: saving throw; description
 
@@ -616,7 +627,7 @@ adjusted for constitution).
       Paladin      +1   -3   +1   -1   +2       6
       Rogue        +0   +1   -3   +3   -1       4
       Ranger       +0   +0   +2   +1   -1       5
-      Blackguard   +2   +0   -3   +0   +2       7
+      Blackguard   +2   +0   -3   +0   +2       8
 ================= ===  ===  ===  ===  ===  ==========
  
 Ability Tables
@@ -630,6 +641,7 @@ Ability Tables
    single: searching skill; racial bonus
    single: fighting skill; racial bonus
    single: shooting skill; racial bonus
+   single: throwing skill; racial bonus
 
 ============ =======  =======  ======  =====  =======  ======  ======  =====
   Race       DisarmP  DisarmM  Device   Save  Stealth  Search   Fight   Bows
@@ -656,6 +668,7 @@ Ability Tables
    single: searching skill; class bonus
    single: fighting skill; class bonus
    single: shooting skill; class bonus
+   single: throwing skill; class bonus
 
 ============   ======= ======= ======= ======= ======= =======  ======= =======
  Class         DisarmP DisarmM Device   Save   Stealth Search    Fight   Bows
@@ -668,7 +681,7 @@ Ability Tables
  Paladin       20(+15) 20(+10) 24(+10) 25(+11)  0(+0)  10(+12)  65(+40) 50(+30)
  Rogue         45(+20) 45(+20) 32(+10) 28(+10)  3(+1)  20(+16)  35(+45) 66(+30)
  Ranger        40(+15) 30(+10) 28(+10) 32(+10)  3(+0)  15(+15)  60(+40) 72(+45)
- Blackguard    20(+15) 20(+10) 24(+10) 25(+11)  0(+0)  10(+12)  60(+40) 50(+30)
+ Blackguard    20(+15) 20(+10) 24(+10) 18(+10) -1(-1)   8(+10)  65(+40) 35(+15)
 ============   ======= ======= ======= ======= ======= =======  ======= =======
 
 For character classes, there are two figures: the first figure is the base
@@ -676,7 +689,9 @@ level of the skill, while the second figure (in parentheses) is the bonus
 that the character gains to this skill every ten levels. So, to find out
 the total skill value of any character's skills, add the race value to the
 class value, and then the bonus once for every ten levels that the
-character has.
+character has. Throwing skill is not shown as its adjustments for race
+and class are the same as for the shooting skill except for rogues (72(+45)),
+rangers (66(+30)), and blackguards (40(+30)).
 
 Please note, however, that these numbers are only good for comparing
 characters to each other in the absence of other bonuses from high stats


### PR DESCRIPTION
Match blackguards' adjustments for hit die and skills to what is currently in class.txt.  Throwing skill is separate from shooting though only rogues, rangers, and blackguards will have different values for those two skills.  Shooting and throwing skills do not affect range and only affect the damage for a hit when using the O-combat option (because the to-hit chance affects the critical hits with that option).