### PR TITLE
macOS: allow dead key events to be passed to the game's core

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -5100,20 +5100,25 @@ static BOOL send_event(NSEvent *event)
                 [NSApp sendEvent:event];
                 break;
             }
-            
-            if (! [[event characters] length]) break;
-            
-            
+
             /* Extract some modifiers */
             int mc = !! (modifiers & NSControlKeyMask);
             int ms = !! (modifiers & NSShiftKeyMask);
             int mo = !! (modifiers & NSAlternateKeyMask);
             int mx = !! (modifiers & NSCommandKeyMask);
             int kp = !! (modifiers & NSNumericPadKeyMask);
-            
-            
+
             /* Get the Angband char corresponding to this unichar */
-            unichar c = [[event characters] characterAtIndex:0];
+            unichar c;
+            if ([[event characters] length]) {
+                c = [[event characters] characterAtIndex:0];
+#ifdef KC_MOD_ALT
+            } else if ([[event charactersIgnoringModifiers] length]) {
+                c = [[event charactersIgnoringModifiers] characterAtIndex:0];
+#endif
+            } else {
+                break;
+            }
             keycode_t ch;
             switch (c) {
                 /*


### PR DESCRIPTION
A dead key is a key combination that does not have a Unicode equivalent with the current keyboard mapping.  Potentially allows for more key combinations to be used as keymap triggers:  on macOS 12.7.6 with the US keyboard mapping, Option+E is passed to the game's core as {A}e rather than being ignored.