### PR TITLE
ui-game: don't attempt to open empty paths

### DIFF
--- a/src/ui-game.c
+++ b/src/ui-game.c
@@ -690,7 +690,7 @@ static bool start_game(bool new_game)
 		}
 	}
 	safe_setuid_grab();
-	exists = file_exists(loadpath);
+	exists = loadpath[0] && file_exists(loadpath);
 	safe_setuid_drop();
 	if (exists && !savefile_load(loadpath, arg_wizard)) {
 		return false;


### PR DESCRIPTION
This mimics a check which we have a few lines below: if the path is an empty string, do not attempt to open it. This fixes an issue on the Wii, where for some reason opening an empty path is successful, but it seems a reasonable change to have on all platforms.

(we could even add this check inside `file_exists` itself, let me know if you'd prefer that instead.