### PR TITLE
Persistent levels:  don't allow reset of recall depth

### DIFF
--- a/src/effect-handler-general.c
+++ b/src/effect-handler-general.c
@@ -1126,7 +1126,8 @@ bool effect_handler_RECALL(effect_handler_context_t *context)
 	if (!player->word_recall) {
 		/* Reset recall depth */
 		if (player->depth > 0) {
-			if (player->depth != player->max_depth) {
+			if (player->depth != player->max_depth
+					&& !OPT(player, birth_levels_persist)) {
 				if (get_check("Set recall depth to current depth? ")) {
 					player->recall_depth = player->max_depth = player->depth;
 				}

--- a/src/player-util.c
+++ b/src/player-util.c
@@ -101,6 +101,13 @@ bool player_get_recall_depth(struct player *p)
 	bool level_ok = false;
 	int new = 0;
 
+	/*
+	 * No choice when have not entered the dungeon or descent is forced,
+	 * so do not prompt.
+	 */
+	if (p->max_depth <= 0 || OPT(p, birth_force_descend)) {
+		return true;
+	}
 	while (!level_ok) {
 		const char *prompt =
 			"Which level do you wish to return to (0 to cancel)? ";


### PR DESCRIPTION
Since the player has the choice of recall depth with persistent levels, resetting the recall and maximum depth only artficially limits which levels can be the destination for the recall.  In https://github.com/angband/angband/issues/6190 , very likely was the reason why the player could not recall to a previously visited level.

Also address two corner cases when getting the recall depth with persistent levels:  if the character has not visited the dungeon or is playing with forced descent on, there's no real choice for the destination so do not prompt for it.