### PR TITLE
Increase the curse removal power of a staff of remove curse

### DIFF
--- a/lib/gamedata/object.txt
+++ b/lib/gamedata/object.txt
@@ -4479,14 +4479,14 @@ type:staff
 graphics:_:d
 level:40
 weight:50
-cost:500
+cost:1500
 alloc:20:40 to 100
 attack:1d2:0:0
 armor:0:0
 charges:4+d3
-power:8
+power:13
 effect:REMOVE_CURSE
-dice:20+d20
+dice:35+d30
 
 name:the Magi
 type:staff


### PR DESCRIPTION
Suggested by Mitze here, https://angband.live/forums/forum/angband/vanilla/252105-rebalancing-device-difficulty?p=252113#post252113 .  Its ability to remove curses is now mostly between that of a scroll of remove curse and a scroll of *remove curse*.  Increase the cost and power of the staff to reflect the better effect.