### PR TITLE
Apply BLESS_WEAPON to-hit bonus only to melee, not ranged

### DIFF
--- a/src/player-attack.c
+++ b/src/player-attack.c
@@ -88,7 +88,8 @@ int breakage_chance(const struct object *obj, bool hit_target) {
 int chance_of_melee_hit_base(const struct player *p,
 		const struct object *weapon)
 {
-	int bonus = p->state.to_h + (weapon ? object_to_hit(weapon) : 0);
+	int bonus = p->state.to_h + (weapon ? object_to_hit(weapon) : 0)
+		+ (p->state.bless_wield ? 2 : 0);
 	return p->state.skills[SKILL_TO_HIT_MELEE] + bonus * BTH_PLUS_ADJ;
 }
 

--- a/src/player-calcs.c
+++ b/src/player-calcs.c
@@ -2309,7 +2309,6 @@ void calc_bonuses(struct player *p, struct player_state *state, bool known_only,
 		if (pf_has(state->pflags, PF_BLESS_WEAPON)
 				&& (weapon->tval == TV_HAFTED
 				|| of_has(state->flags, OF_BLESSED))) {
-			state->to_h += 2;
 			state->to_d += 2;
 			state->bless_wield = true;
 		}

--- a/src/ui-player.c
+++ b/src/ui-player.c
@@ -744,6 +744,9 @@ static struct panel *get_panel_combat(void) {
 		dam += object_to_dam(obj->known);
 		hit += object_to_hit(obj->known);
 	}
+	if (player->known_state.bless_wield) {
+		hit += 2;
+	}
 
 	panel_space(p);
 	panel_line(p, COLOUR_L_BLUE, "Melee", "%dd%d,%+d", melee_dice, melee_sides, dam);


### PR DESCRIPTION
Better matches the description of BLESS_WEAPON.  Resolves https://github.com/angband/angband/issues/6156 .