### PR TITLE
Have delete_monster_idx() always call object_delete() on a carried object

### DIFF
--- a/src/gen-chunk.c
+++ b/src/gen-chunk.c
@@ -435,11 +435,13 @@ bool chunk_copy(struct chunk *dest, struct player *p, struct chunk *source,
 			for (obj = source_mon->held_obj; obj; obj = obj->next) {
 				obj->held_m_idx = dest_mon->midx;
 			}
+			source_mon->held_obj = NULL;
 		}
 		if (source_mon->mimicked_obj) {
 			dest_mon->mimicked_obj = source_mon->mimicked_obj;
 			dest_mon->mimicked_obj->mimicking_m_idx =
 				dest_mon->midx;
+			source_mon->mimicked_obj = NULL;
 		}
 	}
 

--- a/src/mon-make.c
+++ b/src/mon-make.c
@@ -376,9 +376,8 @@ void delete_monster_idx(struct chunk *c, int m_idx)
 			}
 		}
 		delist_object(c, obj);
-		if (c == cave) {
-			object_delete(cave, player->cave, &obj);
-		}
+		object_delete(c, (player && c == cave) ? player->cave : NULL,
+			&obj);
 		obj = next;
 	}
 


### PR DESCRIPTION
Resolves a regression introduced by 5540d48fb9608dbb26cf0adff2b91cbc7f44851e which made delete_monster_idx() less similar to wipe_mon_list() and plugs a memory leak in FAangband when a skipped player ghost carries objects.  To avoid the opportunity for use after free or double frees, have chunk_copy() reset the carried or mimicked objects to NULL for a monster in the source chunk once those objects have been transferred to the destination.