### PR TITLE
borg: shouldn't sell potions and scrolls to the wrong store

### DIFF
--- a/src/borg/borg-store-sell.c
+++ b/src/borg/borg-store-sell.c
@@ -672,6 +672,10 @@ static bool borg_store_buys(borg_item *item, int who)
         case TV_FOOD:
         case TV_MUSHROOM:
         case TV_FLASK:
+        case TV_SHOT:
+        case TV_BOLT:
+        case TV_ARROW:
+        case TV_DIGGING:
             return true;
         }
         return false;
@@ -742,8 +746,6 @@ static bool borg_store_buys(borg_item *item, int who)
         switch (item->tval) {
         case TV_AMULET:
         case TV_RING:
-        case TV_SCROLL:
-        case TV_POTION:
         case TV_STAFF:
         case TV_WAND:
         case TV_ROD:
@@ -754,6 +756,11 @@ static bool borg_store_buys(borg_item *item, int who)
 
     /* Black Market */
     case 7:
+
+        /* if we don't get money on sales, allow anything to be */
+        /* sold to the black market */
+        if (OPT(player, birth_no_selling)) 
+            return true;
 
         /* Analyze the type */
         switch (item->tval) {


### PR DESCRIPTION
additionally I put in the selling of ammo to the general store and allowed the borg to dump stuff at the black market if he is configured not to make any money on sales.
I think this issue only came up when the Alchemist (correct store for potions and scrolls) was full.