### PR TITLE
borg: set items with negative flags to cursed

### DIFF
--- a/src/borg/borg-item-analyze.c
+++ b/src/borg/borg-item-analyze.c
@@ -408,6 +408,23 @@ static void borg_set_curses(borg_item *item, const struct object *o)
 }
 
 /*
+ * Look for a negative flag on the object
+ */
+static bool borg_item_has_negative_flag(const borg_item* item)
+{
+    size_t i;
+    for (i = of_next(item->flags, FLAG_START); i != FLAG_END;
+        i = of_next(item->flags, i + 1)) {
+
+        /* Get the flag details */
+        struct obj_property* flag = lookup_obj_property(OBJ_PROPERTY_FLAG, i);
+        if (flag && flag->power < 0)
+            return true;
+    }
+    return false;
+}
+
+/*
  * Analyze an item, also given its name
  *
  * This cheats all the information, and maybe is getting information
@@ -483,6 +500,11 @@ void borg_item_analyze(
 
     if (o->curses != NULL)
         borg_set_curses(item, o);
+
+    /* If any of the flags are negative, count the object as cursed */
+    if (borg_item_has_negative_flag(item)) {
+        item->cursed = true;
+    }
 
     if (o->slays)
         borg_set_slays(item, o);


### PR DESCRIPTION
sets any items with a flag that is negative (power < 0) to "cursed".  This way the borg won't try to sell them.  I may need to adjust this later in case the borg is filtering out things that have a small negative and a large positive. I don't think that will happen since the "cursed" flag is mostly used in sales as opposed to the "uncursable" flag which is used when removing curses.