### PR TITLE
Clang warning invalid utf8 in comment

### DIFF
--- a/src/borg/borg-fight-attack.c
+++ b/src/borg/borg-fight-attack.c
@@ -4011,14 +4011,14 @@ int borg_calculate_attack_effectiveness(int attack_type)
         return (borg_attack_aux_spell_bolt(
             RIVER_OF_LIGHTNING, rad, dam, BORG_ATTACK_PLASMA, 20, true));
 
-    /* spell -- Spear of Oromë */
+    /* spell -- Spear of Orom(e + diaresis) */
     case BF_SPELL_SPEAR_OF_OROME:
         rad = 0;
         dam = ((borg.trait[BI_CLEVEL] / 2) + (8 + 1)) / 2;
         return (borg_attack_aux_spell_bolt(
             SPEAR_OF_OROME, rad, dam, BORG_ATTACK_HOLY_ORB, z_info->max_range, false));
 
-    /* spell -- Light of Manwë */
+    /* spell -- Light of Manw(e + diaresis) */
     case BF_SPELL_LIGHT_OF_MANWE:
         rad = 0;
         dam = borg.trait[BI_CLEVEL] * 5 + 100;
@@ -4425,7 +4425,7 @@ int borg_calculate_attack_effectiveness(int attack_type)
         return (borg_attack_aux_activation(
             act_cold_ball50, rad, dam, BORG_ATTACK_COLD, true, -1));
 
-    /* Artifact -- Aranrúth- frost bolt 12d8*/
+    /* Artifact -- Aranr(u + acute accent)th- frost bolt 12d8*/
     case BF_ACT_COLD_BOLT2:
         rad = 0;
         dam = (12 * (8 + 1) / 2);
@@ -4507,7 +4507,7 @@ int borg_calculate_attack_effectiveness(int attack_type)
         return (borg_attack_aux_activation(
             act_dispel_evil, rad, dam, BORG_ATTACK_DISP_EVIL, true, -1));
 
-    /* Artifact -- Eöl -- Mana Bolt 12d8 */
+    /* Artifact -- E(o + diaresis)l -- Mana Bolt 12d8 */
     case BF_ACT_MANA_BOLT:
         rad = 0;
         dam = (12 * (8 + 1)) / 2;

--- a/src/borg/borg-io.c
+++ b/src/borg/borg-io.c
@@ -443,10 +443,11 @@ keycode_t borg_get_queued_direction(void)
 }
 
 /*
- * *HACK* this handles the é and á in some monster names but, gods it is
- * ugly convert to wide and back to match the processing of special characters
- * this routine will allocate any memory it needs and it is up to the caller 
- * to detect that memory was allocated and free it.
+ * *HACK* this handles the non-ASCII (examples are U+00E9, e + acute accent
+ * and U+00E1, a + acute accent) characters in some monster names but, gods it
+ * is ugly convert to wide and back to match the processing of special
+ * characters this routine will allocate any memory it needs and it is up to
+ * the caller to detect that memory was allocated and free it.
  */
 char *borg_massage_special_chars(char *name)
 {

--- a/src/borg/borg-io.h
+++ b/src/borg/borg-io.h
@@ -89,7 +89,7 @@ extern void      borg_queue_direction(keycode_t k);
 extern keycode_t borg_get_queued_direction(void);
 
 /*
- * Handle the é and á in some names
+ * Handle non-ASCII characters in some names
  */
 extern char *borg_massage_special_chars(char *name);
 

--- a/src/borg/borg-light.c
+++ b/src/borg/borg-light.c
@@ -145,7 +145,7 @@ bool borg_check_light_only(void)
          * 4 corners   3 corners    2 corners    1 corner    0 corners
          * ###         ##.  #..     ##.  #..     .#.         .#.  ... .#.
          * .@.         .@.  .@.     .@.  .@.     .@.         #@#  .@. .@.
-         * ###         ###  ###     ##.  #..     ##.         .#.  ... .#.
+         * ###         ###  ###     ##.  #..     ##.         .#.  ... .#.
          *
          * There's actually no way to tell which are rooms and which are
          * corridors from diagonals except 4 (always a corridor) and

--- a/src/borg/borg-magic.c
+++ b/src/borg/borg-magic.c
@@ -133,8 +133,8 @@ static borg_spell_rating borg_spell_ratings_PRIEST[] =
     { "Banish Evil", 85, BANISH_EVIL },
     { "Word of Destruction", 75, WORD_OF_DESTRUCTION },
     { "Holy Word", 85, HOLY_WORD },
-    { "Spear of Orom\xC3\xab", 85, SPEAR_OF_OROME }, /* "Spear of Oromë" */
-    { "Light of Manw\xC3\xab", 85, LIGHT_OF_MANWE } /* "Light of Manwë"*/
+    { "Spear of Orom\xC3\xab", 85, SPEAR_OF_OROME }, /* "Spear of Orom(e + diaresis)" */
+    { "Light of Manw\xC3\xab", 85, LIGHT_OF_MANWE } /* "Light of Manw(e + diaresis)"*/
 };
 static borg_spell_rating borg_spell_ratings_NECROMANCER[] =
 {


### PR DESCRIPTION
this fixes the issue.  I don't love it because I find it less clear than having the "invalid UTF" right in the comment, which is why I just let it sit this way but it is valuable to not have the warnings.  Probably more valuable than the comment being 100% obvious.