### PR TITLE
borg: react when banishment is the wonder effect

### DIFF
--- a/src/borg/borg-messages-react.c
+++ b/src/borg/borg-messages-react.c
@@ -22,7 +22,6 @@
 #ifdef ALLOW_BORG
 
 #include "../cmds.h"
-#include "../ui-input.h"
 
 #include "borg-io.h"
 #include "borg-log.h"

--- a/src/borg/borg-messages-react.c
+++ b/src/borg/borg-messages-react.c
@@ -22,6 +22,7 @@
 #ifdef ALLOW_BORG
 
 #include "../cmds.h"
+#include "../ui-event.h"
 
 #include "borg-io.h"
 #include "borg-log.h"

--- a/src/borg/borg-messages-react.c
+++ b/src/borg/borg-messages-react.c
@@ -22,7 +22,7 @@
 #ifdef ALLOW_BORG
 
 #include "../cmds.h"
-#include "../ui-event.h"
+#include "../ui-input.h"
 
 #include "borg-io.h"
 #include "borg-log.h"

--- a/src/borg/borg-messages-react.h
+++ b/src/borg/borg-messages-react.h
@@ -33,6 +33,11 @@ extern bool borg_dont_react;
 extern void borg_react(const char *msg, const char *buf);
 
 /*
+ * Handle various messages that need response
+ */
+extern bool borg_react_prompted(const char* buf, struct keypress* key, int x, int y);
+
+/*
  * Clear saved messsages
  */
 extern void borg_clear_reactions(void);

--- a/src/borg/borg-messages-react.h
+++ b/src/borg/borg-messages-react.h
@@ -22,6 +22,7 @@
  * must be included before ALLOW_BORG to avoid empty compilation unit
  */
 #include "../angband.h"
+#include "../ui-input.h"
 
 #ifdef ALLOW_BORG
 

--- a/src/borg/borg.c
+++ b/src/borg/borg.c
@@ -21,7 +21,6 @@
 
 #ifdef ALLOW_BORG
 
-#include "../cmds.h"
 #include "../game-input.h"
 #include "../game-world.h"
 #include "../player-timed.h"
@@ -312,164 +311,10 @@ static struct keypress internal_borg_inkey(int flush_first)
         borg_prompt = false;
     }
 
-    /* Mega-Hack -- Catch "Die? [y/n]" messages */
-    /* If there is text on the first line... */
-    /* And the game does not want a command... */
-    /* And the cursor is on the top line... */
-    /* And the text acquired above is "Die?" */
-    if (borg_prompt && !inkey_flag && (y == 0) && (x >= 4)
-        && prefix(buf, "Die?")
-        && borg_cheat_death) {
-        /* Flush messages */
-        borg_parse(NULL);
-
-        /* flush the buffer */
-        borg_flush();
-
-        /* Take note */
-        borg_note("# Cheating death...");
-
-#ifndef BABLOS
-        /* Dump the Character Map*/
-        if (borg.trait[BI_CLEVEL] >= borg_cfg[BORG_DUMP_LEVEL]
-            || strstr(player->died_from, "starvation"))
-            borg_write_map(false);
-
-        /* Log the death */
-        borg_log_death();
-        borg_log_death_data();
-
-#if 0
-        /* Note the score */
-        borg_enter_score();
-#endif
-
-        if (!borg_cfg[BORG_CHEAT_DEATH]) {
-            reincarnate_borg();
-            borg_respawning = 7;
-        } else
-            do_cmd_wiz_cure_all(0);
-#endif /* BABLOS */
-
-        key.code = 'n';
-        return key;
-    }
-
-    /* with 292, there is a flush(0, 0, 0) introduced as it asks for
-     * confirmation. This flush is messing up the borg.  This will allow the
-     * borg to work around the flush Attempt to catch "Attempt it anyway? [y/n]"
-     */
-    if (borg_prompt && !inkey_flag && (y == 0) && (x >= 4)
-        && prefix(buf, "Atte")) {
-        /* Return the confirmation */
-        if (borg_cfg[BORG_VERBOSE])
-            borg_note("# Confirming use of Spell/Prayer when low on mana.");
-        key.code = 'y';
-        return key;
-    }
-
-    /* Wearing two rings.  Place this on the left hand */
-    if (borg_prompt && !inkey_flag && (y == 0) && (x >= 12)
-        && (prefix(buf, "(Equip: c-d,"))) {
-        /* Left hand */
-        key.code = 'c';
-        if (borg_cfg[BORG_VERBOSE])
-            borg_note("# Putting ring on the left hand.");
-        return key;
-    }
-
-    /* 
-     * with 292, there is a flush(0, 0, 0) introduced as it asks for
-     * confirmation. This flush is messing up the borg.  This will allow the
-     * borg to work around the flush This is used only with emergency use of
-     * spells like Magic Missile Attempt to catch "Direction (5 old target"
-     */
-    if (borg_prompt && !inkey_flag && (y == 0) && !borg_inkey(false)
-        && (x >= 10) && strncmp(buf, "Direction", 9) == 0) {
-        if (borg_confirm_target) {
-            if (borg_cfg[BORG_VERBOSE])
-                borg_note("# Expected request for Direction.");
-            /* reset the flag */
-            borg_confirm_target = false;
-            /* Return queued target */
-            key.code = borg_get_queued_direction();
+    /* handle the messages the borg has to react to immediately */
+    if (borg_prompt && !inkey_flag && strlen(buf)) {
+        if (borg_react_prompted(buf, &key, x, y))
             return key;
-        } else {
-            borg_note("** UNEXPECTED REQUEST FOR DIRECTION Dumping keypress history ***");
-            borg_note(format("** line starting <%s> ***", buf));
-            borg_dump_recent_keys(20);
-            borg_oops("unexpected request for direction");
-            /* Hack -- Escape */
-            key.code = ESCAPE;
-            return key;
-        }
-    }
-
-    /* Stepping on a stack when the inventory is full gives a message */
-    /* and the keypress when given this message is requeued so the borg */
-    /* thinks it is a user keypress when it isn't */
-    if (borg_prompt && !inkey_flag && (y == 0) && (x >= 12)
-        && (prefix(buf, "You have no room"))) {
-        if (borg_cfg[BORG_VERBOSE])
-            borg_note("# 'You have no room' is a no-op");
-        /* key code 0 seems to be a no-op and ignored as a user keypress */
-        key.code = 0;
-        return key;
-    }
-
-    /* ***MEGA-HACK***  */
-    /* This will be hit if the borg uses an unidentified effect that has */
-    /* EF_SELECT/multiple effects. Always pick "one of the following at random"
-     */
-    /* when the item is used post ID, an effect will be selected */
-    if (borg_prompt && !inkey_flag && !borg_inkey(false) && (y == 1)
-        && prefix(buf, "Which effect?")) {
-        if (borg_cfg[BORG_VERBOSE])
-            borg_note("# Use of unknown object with multiple effects");
-        /* the first selection (a) is random */
-        key.code = 'a';
-        return key;
-    }
-
-    /* prompt for stepping in lava.  This should be avoided but */
-    /* if the borg is stuck, give him a pass */
-    if (borg_prompt && !inkey_flag && (y == 0) && (x >= 12)
-        && (prefix(buf, "The lava will") || prefix(buf, "Lava blocks y"))) {
-        if (borg_cfg[BORG_VERBOSE])
-            borg_note("# ignoring Lava warning");
-        /* yes step in */
-        key.code = 'y';
-        return key;
-    }
-
-    /* prompt for recall depth */
-    if (borg_prompt && !inkey_flag && !borg_inkey(false) 
-        && (y == 0) && (x >= 12)
-        && prefix(buf, "Set recall depth")) {
-        if (borg_cfg[BORG_VERBOSE])
-            borg_note("# Use of unknown object with recall");
-        /* the first selection (a) is random */
-        key.code = 'n';
-        return key;
-    }
-
-    /* make sure inventory is used for throwing */
-    if (borg_prompt && !inkey_flag && (y == 1) && (x >= 12)
-        && (prefix(buf, "Throw which item? (Throw"))) {
-        if (borg_cfg[BORG_VERBOSE])
-            borg_note("# switching to inventory for throws");
-        /* yes step in */
-        key.code = '/';
-        return key;
-    }
-
-    /* Sometimes the borg will overshoot the range limit of his shooter */
-    if (borg_prompt && !inkey_flag && (x >= 12)
-        && (prefix(buf, "Target out of range"))) {
-        /* Fire Anyway? [Y/N] */
-        /* yes step in */
-        key.code = 'y';
-        return key;
     }
 
     /* Mega-Hack -- Handle death */


### PR DESCRIPTION
One of the rare effects of WONDER (either activation or wand) is Banishment which gives an additional prompt.  I think it is the only effect that needs more prompting than the initial aim and shoot. I made the borg watch for "Choose a monster race (by symbol) to banish" and just escape out to avoid the keypress queue getting munged.
I also moved around the "messages the borg needs to react to immediately" code so it wasn't cluttering up the borg.c code.