### PR TITLE
Avoid warnings for mismatched format arguments with 32-bit compilation

### DIFF
--- a/src/obj-randart.c
+++ b/src/obj-randart.c
@@ -3070,7 +3070,14 @@ static void write_randart_entry(ang_file *fff, const struct artifact *art)
 	/* Output graphics if necessary */
 	if (kind->kidx >= z_info->ordinary_kind_max) {
 		const char *attr = attr_to_text(kind->d_attr);
-		file_putf(fff, "graphics:%c:%s\n", kind->d_char, attr);
+		char *d_char = mem_alloc(text_wcsz() + 1);
+		int nbyte = text_wctomb(d_char, kind->d_char);
+
+		if (nbyte > 0) {
+			d_char[nbyte] = '\0';
+			file_putf(fff, "graphics:%s:%s\n", d_char, attr);
+		}
+		mem_free(d_char);
 	}
 
 	/* Output level, weight and cost */

--- a/src/ui-knowledge.c
+++ b/src/ui-knowledge.c
@@ -710,7 +710,7 @@ static void display_group_member(struct menu *menu, int oid,
 		uint8_t a = *o_funcs->xattr(oid);
 		char buf[12];
 
-		strnfmt(buf, sizeof(buf), "%d/%d", a, c);
+		strnfmt(buf, sizeof(buf), "%d/%ld", a, (long int)c);
 		c_put_str(attr, buf, row, 64 - (int) strlen(buf));
 	}
 }

--- a/src/ui-prefs.c
+++ b/src/ui-prefs.c
@@ -207,8 +207,8 @@ void dump_objects(ang_file *fff)
 		if (!kind->name || !kind->tval) continue;
 
 		object_short_name(name, sizeof name, kind->name);
-		file_putf(fff, "object:%s:%s:%d:%d\n", tval_find_name(kind->tval),
-				name, kind_x_attr[i], kind_x_char[i]);
+		file_putf(fff, "object:%s:%s:%d:%ld\n", tval_find_name(kind->tval),
+				name, kind_x_attr[i], (long int)kind_x_char[i]);
 	}
 }
 

--- a/src/wiz-spoil.c
+++ b/src/wiz-spoil.c
@@ -504,6 +504,7 @@ void spoil_mon_desc(const char *fname)
 	char ac[80];
 	char hp[80];
 	char exp[80];
+	char *mbbuf;
 
 	uint16_t *who;
 
@@ -541,11 +542,14 @@ void spoil_mon_desc(const char *fname)
 	/* Sort the array by dungeon depth of monsters */
 	sort(who, n, sizeof(*who), cmp_monsters);
 
+	mbbuf = mem_alloc(text_wcsz() + 1);
+
 	/* Scan again */
 	for (i = 0; i < n; i++) {
 		struct monster_race *race = &r_info[who[i]];
 		const char *name = race->name;
 		size_t u8len;
+		int n_mbbuf;
 
 		/* Get the "name" */
 		if (rf_has(race->flags, RF_QUESTOR))
@@ -577,8 +581,15 @@ void spoil_mon_desc(const char *fname)
 		strnfmt(exp, sizeof(exp), "%ld", (long)(race->mexp));
 
 		/* Hack -- use visual instead */
-		strnfmt(exp, sizeof(exp), "%s '%c'", attr_to_text(race->d_attr),
-				race->d_char);
+		n_mbbuf = text_wctomb(mbbuf, race->d_char);
+		if (n_mbbuf > 0) {
+			mbbuf[n_mbbuf] = '\0';
+			strnfmt(exp, sizeof(exp), "%s '%s'",
+				attr_to_text(race->d_attr), mbbuf);
+		} else {
+			strnfmt(exp, sizeof(exp), "%s (invalid character)",
+				attr_to_text(race->d_attr));
+		}
 
 		/*
 		 * Dump the info.  The rationale for handling the first column
@@ -600,6 +611,8 @@ void spoil_mon_desc(const char *fname)
 
 	/* End it */
 	file_putf(fh, "\n");
+
+	mem_free(mbbuf);
 
 	/* Free the "who" array */
 	mem_free(who);
@@ -633,6 +646,7 @@ void spoil_mon_info(const char *fname)
 	uint16_t *who;
 	int count = 0;
 	textblock *tb = NULL;
+	char *mbbuf;
 
 	/* Open the file */
 	path_build(buf, sizeof(buf), ANGBAND_DIR_USER, fname);
@@ -664,11 +678,15 @@ void spoil_mon_info(const char *fname)
 
 	sort(who, count, sizeof(*who), cmp_monsters);
 
+	mbbuf = mem_alloc(text_wcsz() + 1);
+
 	/* List all monsters in order. */
 	for (n = 0; n < count; n++) {
 		int r_idx = who[n];
 		const struct monster_race *race = &r_info[r_idx];
 		const struct monster_lore *lore = &l_list[r_idx];
+		int n_mbbuf;
+
 		tb = textblock_new();
 
 		/* Line 1: prefix, name, color, and symbol */
@@ -684,7 +702,13 @@ void spoil_mon_info(const char *fname)
 		textblock_append(tb, "%s", race->name);
 		textblock_append(tb, "  (");	/* ---)--- */
 		textblock_append(tb, "%s", attr_to_text(race->d_attr));
-		textblock_append(tb, " '%c')\n", race->d_char);
+		n_mbbuf = text_wctomb(mbbuf, race->d_char);
+		if (n_mbbuf > 0) {
+			mbbuf[n_mbbuf] = '\0';
+			textblock_append(tb, " '%s')\n", mbbuf);
+		} else {
+			textblock_append(tb, " (invalid character)\n");
+		}
 
 		/* Line 2: number, level, rarity, speed, HP, AC, exp */
 		textblock_append(tb, "=== ");
@@ -709,6 +733,8 @@ void spoil_mon_info(const char *fname)
 		textblock_free(tb);
 		tb = NULL;
 	}
+
+	mem_free(mbbuf);
 
 	/* Free the "who" array */
 	mem_free(who);


### PR DESCRIPTION
Seen with gcc 12.2.0 on a 32-bit versions of Debian 12.  Three (one in writing the randart file and two in writing monster spoilers) came from assuming that a wchar_t could be trivially converted to a char.