### PR TITLE
Change target handling for Lightning Strike

### DIFF
--- a/lib/gamedata/class.txt
+++ b/lib/gamedata/class.txt
@@ -553,8 +553,8 @@ effect:STRIKE:SOUND:3
 dice:$B
 expr:B:PLAYER_LEVEL:+ 5
 desc:Strikes a target from above with a lightning bolt, followed by a clap
-desc: of thunder.  Target grid must be targetable and known to the player;
-desc: no target grid will mean the player grid is hit.
+desc: of thunder.  If targeting a direction or the target is not a passable
+desc: grid in the line of sight, the player will be the target.
 
 spell:Earth Rising:14:5:40:12
 effect:SHORT_BEAM:SHARD:4:5

--- a/src/effect-handler-attack.c
+++ b/src/effect-handler-attack.c
@@ -1001,21 +1001,21 @@ bool effect_handler_SWARM(effect_handler_context_t *context)
 bool effect_handler_STRIKE(effect_handler_context_t *context)
 {
 	int dam = effect_calculate_value(context, true);
+	/*
+	 * If the target is not a passable grid in the line of sight or is a
+	 * direction, target the player.
+	 */
 	struct loc target = player->grid;
+	/* Aim at the target.  Hurt items on floor. */
 	int flg = PROJECT_JUMP | PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL;
 
-	/* Ask for a target; if no direction given, the player is struck  */
-	if ((context->dir == DIR_TARGET) && target_okay()) {
+	if (context->dir == DIR_TARGET && target_okay()) {
 		target_get(&target);
+		if (!projectable(cave, player->grid, target, PROJECT_NONE)) {
+			target = player->grid;
+		}
 	}
 
-	/* Enforce line of sight */
-	if (!projectable(cave, player->grid, target, PROJECT_NONE) ||
-		!square_isknown(cave, target)) {
-		return false;
-	}
-
-	/* Aim at the target.  Hurt items on floor. */
 	if (project(source_player(), context->radius, target, dam, context->subtype,
 				flg, 0, 0, context->obj)) {
 		context->ident = true;


### PR DESCRIPTION
Do not require a known grid.  Target the player if target is a direction or is not in the line of sight.  Resolves https://github.com/angband/angband/issues/6013 .