### PR TITLE
Better match death logic for projections or non-player hits to mon_take_hit()

### DIFF
--- a/src/mon-util.c
+++ b/src/mon-util.c
@@ -1212,6 +1212,11 @@ bool mon_take_nonplayer_hit(int dam, struct monster *t_mon,
 
 	/* Dead or damaged monster */
 	if (t_mon->hp < 0) {
+		/* Shapechanged monsters revert on death */
+		if (t_mon->original_race) {
+			monster_revert_shape(t_mon);
+		}
+
 		/* Death message */
 		add_monster_message(t_mon, die_msg, false);
 

--- a/src/project-mon.c
+++ b/src/project-mon.c
@@ -1040,8 +1040,8 @@ static bool project_m_monster_attack(project_monster_handler_context_t *context,
 	enum mon_messages hurt_msg = context->hurt_msg;
 	struct monster *mon = context->mon;
 
-	/* "Unique" monsters can only be "killed" by the player */
-	if (monster_is_unique(mon)) {
+	/* "Unique" or arena monsters can only be "killed" by the player */
+	if (monster_is_unique(mon) || player->upkeep->arena_level) {
 		/* Reduce monster hp to zero, but don't kill it. */
 		if (dam > mon->hp) dam = mon->hp;
 	}
@@ -1058,6 +1058,11 @@ static bool project_m_monster_attack(project_monster_handler_context_t *context,
 
 	/* Dead or damaged monster */
 	if (mon->hp < 0) {
+		/* Shapechanged monsters revert on death */
+		if (mon->original_race) {
+			monster_revert_shape(mon);
+		}
+
 		/* Give detailed messages if destroyed */
 		if (!seen) die_msg = MON_MSG_MORIA_DEATH;
 
@@ -1113,6 +1118,11 @@ static bool project_m_player_attack(project_monster_handler_context_t *context)
 	 * ensures it doesn't print any death message and allows correct ordering
 	 * of messages. */
 	if (dam > mon->hp) {
+		/* Shapechanged mnsters revert oon death */
+		if (mon->original_race) {
+			monster_revert_shape(mon);
+		}
+
 		if (!seen) die_msg = MON_MSG_MORIA_DEATH;
 		if (display_dam) {
 			add_monster_message_show_damage(mon, die_msg, false,


### PR DESCRIPTION
Noted when trying to diagnose https://github.com/NickMcConnell/FAangband/issues/426 .  Specifically the changes are:
    1) A non-player projection can no longer kill an arena monster.  Has an impact only if there are monster spells that can affect the caster.
    2) Shapechanged monster reverts to original shape on death for a non-player hit or non-player projection.  The death message due to a player projection is now set after reverting the shape rather than before.  Might impact https://github.com/angband/angband/issues/4245 , but only so far as the misleading death message prior to this change confused the player.  Cases where there's mulitple history entries for killing the unique would not be fixed.