### PR TITLE
Add missing parenthesis in monster spoiler output

### DIFF
--- a/src/wiz-spoil.c
+++ b/src/wiz-spoil.c
@@ -707,7 +707,7 @@ void spoil_mon_info(const char *fname)
 			mbbuf[n_mbbuf] = '\0';
 			textblock_append(tb, " '%s')\n", mbbuf);
 		} else {
-			textblock_append(tb, " (invalid character)\n");
+			textblock_append(tb, " (invalid character))\n");
 		}
 
 		/* Line 2: number, level, rarity, speed, HP, AC, exp */


### PR DESCRIPTION
Fixes a regression introduced by 05945f06ee197fe9b0aa83fe10d3c844383380fa .