### PR TITLE
Renaming the Potion of Intelligence to Potion of Mental Acuity.

### DIFF
--- a/lib/gamedata/object.txt
+++ b/lib/gamedata/object.txt
@@ -3032,7 +3032,7 @@ power:20000
 effect:RESTORE_STAT:STR
 effect:GAIN_STAT:STR
 
-name:Intelligence
+name:& Potion~ of Mental Acuity
 type:potion
 graphics:!:d
 level:30


### PR DESCRIPTION
I think renaming the Potion of Intelligence to Potion of Mental Acuity is reasonable, and I have made the change; is this acceptable？
This PR fixes #3857 