### PR TITLE
Add Initial Borg Developer Documentation

### DIFF
--- a/docs/hacking/borg.rst
+++ b/docs/hacking/borg.rst
@@ -1,0 +1,16 @@
+====
+Borg
+====
+
+The Borg is an "Automatic Angband Player".
+
+It was first written for about 2.8.0, separate from the game as
+distributed. It was pulled into the game in around 3.3. It was removed
+in 4.0 as there was too much conflict with the big changes made then.
+It was reincorporated in around 4.2.3.
+
+Running The Borg
+================
+
+Historical information on how to run the Borg can be found in
+``borgread.txt``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,6 +48,7 @@ Angband is a very complex game, and it may be difficult to grasp everything at f
    hacking/debug
    hacking/how-it-works
    hacking/metadoc
+   hacking/borg
 
 
 Indices and tables


### PR DESCRIPTION
From issue: https://github.com/angband/angband/issues/6253

Creates the initial Borg developer documentation.

This is just the start of the documentation that we can build upon. I have additional thoughts and questions that I'll post in the issue linked above.

Screenshots of rendered html:

<img width="1020" alt="Screenshot 2025-06-18 at 8 52 56 PM" src="https://github.com/user-attachments/assets/ae5eba84-dba6-44c2-91f3-79658c06296d" />
<img width="237" alt="Screenshot 2025-06-18 at 8 53 01 PM" src="https://github.com/user-attachments/assets/4cac0554-be11-410a-8622-782c07a574f8" />
<img width="312" alt="Screenshot 2025-06-18 at 8 53 05 PM" src="https://github.com/user-attachments/assets/f77e37e4-eaf1-4f4c-9399-a640a899059d" />