### PR TITLE
Borg lunal mode comment fix

### DIFF
--- a/src/borg/borg.c
+++ b/src/borg/borg.c
@@ -781,7 +781,7 @@ void do_cmd_borg(void)
             break;
         }
 
-        /* Stop when the borg wins */
+        /* lunal mode */
         case 'l':
         case 'L': {
             borg_cfg[BORG_LUNAL_MODE] = !borg_cfg[BORG_LUNAL_MODE];


### PR DESCRIPTION
Comment was previously a copy of command above
```
/* Stop when the borg wins */
case 'k':
case 'K': {
    borg_cfg[BORG_STOP_KING] = !borg_cfg[BORG_STOP_KING];
    msg("Borg -- borg_stop_king is now %d.", borg_cfg[BORG_STOP_KING]);
    break;
}
```