### PR TITLE
Depersonalize borg code references and documentation

### DIFF
--- a/src/borg/borg-flow-take.c
+++ b/src/borg/borg-flow-take.c
@@ -362,7 +362,7 @@ bool observe_take_move(int y, int x, int d, uint8_t a, wchar_t c)
         if (!borg.trait[BI_ISIMAGE] && c != k_ptr->d_char)
             continue;
 
-        /* Require matching attr if not hallucinating rr9*/
+        /* Require matching attr if not hallucinating */
         if (!borg.trait[BI_ISIMAGE] && a != k_ptr->d_attr
             && (k_ptr->d_attr != 11 && k_ptr->d_char == '!')
             /* There are serious bugs with Flasks of Oil not having the attr set

--- a/src/borg/borg-log.c
+++ b/src/borg/borg-log.c
@@ -138,7 +138,6 @@ static char borg_index_to_label(int i)
  * Write a file with the current dungeon info (Borg)
  * and his equipment, inventory and home (Player)
  * and his swap armor, weapon (Borg)
- * From Dennis Van Es,  With an addition of last messages from me (APW)
  * NOTE: this uses internal game data.  This is okay since we are just dumping 
  * the information rather than using it.
  */

--- a/src/borg/borg-log.c
+++ b/src/borg/borg-log.c
@@ -771,8 +771,8 @@ void borg_display_item(struct object *item2, int n)
         borg_prt_binary(f[2], 19, j + 32);
 }
 
-/* DVE's function for displaying the status of various info */
-/* Display what the borg is thinking DvE*/
+/* Function for displaying the status of various info */
+/* Display what the borg is thinking */
 void borg_status(void)
 {
     int j;

--- a/src/borg/borg-reincarnate.c
+++ b/src/borg/borg-reincarnate.c
@@ -48,13 +48,9 @@
 #include "borg-trait.h"
 #include "borg.h"
 
-/*
-  * Name segments for random player names
-  * Copied Cth by DvE
-  * Copied from borgband by APW
-  */
+/* Name segments for random player names */
 
-  /* Dwarves */
+/* Dwarves */
 static const char *dwarf_syllable1[] =
 {
     "B", "D", "F", "G", "Gl", "H", "K", "L",
@@ -183,10 +179,6 @@ static const char *orc_syllable3[] =
 
 /*
  * Random Name Generator
- * based on a Javascript by Michael Hensley
- * "http://geocities.com/timessquare/castle/6274/"
- * Copied from Cth by DvE
- * Copied from borgband by APW
  */
 static void create_random_name(int race, char *name, size_t name_len)
 {

--- a/src/borg/borg-store-sell.c
+++ b/src/borg/borg-store-sell.c
@@ -624,7 +624,7 @@ bool borg_think_home_sell_useful(int32_t *best_home_power)
         /* if this is not the item that was there,  */
         /* drop off the item that replaces it. */
         if (best_item[i] != i && best_item[i] != 255) {
-            /* hack don't sell DVE */
+            /* hack don't sell */
             if (!borg_items[best_item[i] - z_info->store_inven_max].iqty)
                 return false;
 

--- a/src/borg/borg.c
+++ b/src/borg/borg.c
@@ -89,7 +89,7 @@ int *borg_cfg;
 bool borg_active; /* Actually active */
 bool borg_cancel; /* Being cancelled */
 bool borg_save          = false; /* do a save next level */
-bool borg_graphics      = false; /* rr9's graphics */
+bool borg_graphics      = false; /* graphics mode */
 
 int16_t old_depth       = 128;
 int16_t borg_respawning = 0;

--- a/src/borg/borg.c
+++ b/src/borg/borg.c
@@ -112,9 +112,9 @@ uint16_t borg_step = 0;
 
 // !FIX !AJG double check this comment
 /*
- * This file implements the "Ben Borg", an "Automatic Angband Player".
+ * This file implements the Borg, an "Automatic Angband Player".
  *
- * Use of the "Ben Borg" requires re-compilation with ALLOW_BORG defined,
+ * Use of the Borg requires re-compilation with ALLOW_BORG defined,
  * and with the various "borg*.c" files linked into the executable.
  *
  * The "do_cmd_borg()" function, called when the user hits "^Z", allows
@@ -133,16 +133,16 @@ uint16_t borg_step = 0;
  * (3) Some "historical" information (killed uniques, maximum dungeon depth)
  *     is "stolen" from the game.
  *
- * The Ben Borg is only supposed to "know" what is visible on the screen,
+ * The Borg is only supposed to "know" what is visible on the screen,
  * which it learns by using the "term.c" screen access function "COLOUR_what()",
  * the cursor location function "COLOUR_locate()", and the cursor visibility
  * extraction function "COLOUR_get_cursor()".
  *
- * The Ben Borg is only supposed to "send" keypresses when the "COLOUR_inkey()"
+ * The Borg is only supposed to "send" keypresses when the "COLOUR_inkey()"
  * function asks for a keypress, which is accomplished by using a special
  * function hook in the "z-term.c" file, which allows the Borg to "steal"
  * control from the "COLOUR_inkey()" and "COLOUR_flush(0, 0, 0)" functions. This
- * allows the Ben Borg to pretend to be a normal user.
+ * allows the Borg to pretend to be a normal user.
  *
  * The Borg is thus allowed to examine the screen directly (by efficient
  * direct access of the "Term->scr->a" and "Term->scr->c" arrays, which
@@ -483,7 +483,7 @@ static struct keypress internal_borg_inkey(int flush_first)
     while (!borg_think()) /* loop */
         ;
 
-    /* DVE- Update the status screen */
+    /* Update the status screen */
     borg_status();
 
     /* Save the local random info */
@@ -526,7 +526,7 @@ static struct keypress borg_inkey_hack(int flush_first)
 
 
 /*
- * Hack -- interact with the "Ben Borg".
+ * Hack -- interact with the Borg.
  */
 void do_cmd_borg(void)
 {
@@ -1925,7 +1925,7 @@ void do_cmd_borg(void)
     /* Version of the game */
     case 'v':
     case 'V': {
-        msg("APWBorg Version: %s", borg_engine_date);
+        msg("Borg Version: %s", borg_engine_date);
         break;
     }
     /* Command: Display all known info on item */

--- a/src/borg/borg.h
+++ b/src/borg/borg.h
@@ -86,7 +86,7 @@ extern int *borg_cfg;
 extern bool borg_active; /* Actually active */
 extern bool borg_cancel; /* Being cancelled */
 extern bool borg_save; /* do a save next time we get to press a key! */
-extern bool borg_graphics; /* rr9's graphics */
+extern bool borg_graphics; /* graphics mode */
 
 extern int16_t old_depth;
 extern int16_t borg_respawning;

--- a/src/borg/borg.txt
+++ b/src/borg/borg.txt
@@ -1,5 +1,5 @@
 
-# This file will allow you to customize your APWBorg along certain themes.
+# This file will allow you to customize your borg along certain themes.
 # The borg is fairly successful, having won the game several times.
 # However, some players/observers of borgs would like to see it function
 # differently.  Some would like to see the borg play more aggressively, or

--- a/src/borg/borgread.txt
+++ b/src/borg/borgread.txt
@@ -58,35 +58,18 @@ the next one rolled up.  You can make these selections from the borg.txt file.
 The Continual Play Mode is NOT turned on by default, you will need to
 select it.
 
-This borg is updated frequently.  You can get the lastest source
-as well as executables at http://innovapain.com/borg
-
-Have Fun,
-Dr. Andrew White
-
-
 
 ===========================
  Angband Borg Screen Saver
 ===========================
-
-by Robert Ruehlmann < rr9@angband.org >
-   Andrew White     < andrew@innovapain.com >
-   
-Uses Andrew P. White's APWBorg.
-(see http://innovapain.com/borg).
 
 
 Description:
 ------------
 
 A screensaver that runs the vanilla Angband Windows version with the
-APW Borg and automatically restarts the Borg when the character dies
+Borg and automatically restarts the Borg when the character dies
 (continuous play mode).
-
-The borg engine is updated frequently, so visit Dr. White's page and
-obtain the most recent version of the borg.  You may also down-load
-an up to date executable of the screensaver from that page.
 
 Note that the Angband display is not always dynamic and may not
 protect your monitor from burning-in of images.  While this is highly
@@ -152,7 +135,7 @@ The screensaver uses the angband.ini of the normal Angband
 installation to determine the screen-layout, as well as the graphics
 and sound settings.
 
-My "ALLOW_BORG_GRAPHICS" code that is included in the APW Borg has
+My "ALLOW_BORG_GRAPHICS" code that is included in the Borg has
 been turned on, so the Borg runs nicely with the various graphics
 and "view_foo_lite" lighting settings.
 
@@ -181,27 +164,10 @@ Known problems:
 - Selecting "Show scores" while the Borg is running will probably
   crash the Borg since it can't parse the score-screen.
 - The screensaver probably won't work correctly with other Borgs that
-  don't provide a continuous play mode compatible with the APW code.
+  don't provide a continuous play mode compatible with the borg code.
 - Running the same savefile twice at the same time (for example by
   running a normal game and the screensaver with the same savefile)
   might lead to problems.
 - The size of some info windows can increase when exiting the "pseudo-
   screensaver" mode started from the options menu.
-- The Borg is a very complicated piece of code and contains lots of bugs.
-  Expect slowdowns, loops, crashes, and other problems.  If you encounter
-  a suspect bug, first consult the APWBorg Webpage for a updated screen-
-  saver, and check the Daily Log of Changes to see if your bug has been
-  fixed.  If not, then send the bug and savefile to Dr. White at
-  andrew@innovapain.com
-
-
-Links:
-------
-
-APW-Borg homepage:
-http://innovapain.com/borg
-
-Angband homepage:
-http://rephial.org/
-
 


### PR DESCRIPTION
From issue https://github.com/angband/angband/issues/6253#issuecomment-2989128387 where I asked:
> Can we simply call it Borg everywhere in code?

And @agoodman00 confirmed:
> Seems reasonable to just call it "borg" everywhere.

Removes personal names and attributions from the borg, replacing them with generic references to standardize the naming convention. Attributions are preserved in git history.

Removed some outdated information from `borgread.txt`.