### PR TITLE
Borg docs name/history/commands + command interface completeness

### DIFF
--- a/docs/hacking/borg.rst
+++ b/docs/hacking/borg.rst
@@ -40,8 +40,8 @@ Main Commands
 ``z``  Activate the Borg
 ``u``  Update the Borg
 ``x``  Step the Borg
-``f``  Toggle flags (enters flag mode)
-``c``  Toggle cheat flags (enters cheat mode)
+``f``  Toggle flags
+``c``  Toggle cheat flags
 ``s``  Search mode
 ``g``  Display grid feature
 ``i``  Display grid info
@@ -85,5 +85,14 @@ After pressing ``f`` from the main borg interface you enter flag toggle mode.
 ``l``  Lunal mode
 ``s``  Dump savefile at each level (autosave)
 ``v``  Verbose mode
+====== ========================================
+
+Cheat Commands
+--------------
+
+After pressing ``c`` from the main borg interface you enter cheat toggle mode.
+
+====== ========================================
+``d``  Toggle cheat death
 ====== ========================================
 

--- a/docs/hacking/borg.rst
+++ b/docs/hacking/borg.rst
@@ -25,7 +25,7 @@ Borg Command Interface
 The Borg command interface is only available when Angband is compiled
 with borg support.
 
-To access the Borg command interface, press ``^z`` (Ctrl-Z) during normal
+To access the Borg command interface, press ``^z`` (Ctrl-Z) during
 gameplay. When you first run the command you'll be presented with a warning
 message you can continue through. The most common command is ``z`` which
 starts the Borg.
@@ -36,41 +36,41 @@ Main Commands
 -------------
 
 ====== ========================================
-``$``  Reload Borg.txt
-``z``  Activate the Borg
-``u``  Update the Borg
-``x``  Step the Borg
-``f``  Toggle flags
-``c``  Toggle cheat flags
-``s``  Search mode
-``g``  Display grid feature
-``i``  Display grid info
 ``a``  Display avoidances
-``k``  Display monster info
-``t``  Display object info
-``%``  Display targeting flow
-``#``  Display danger grid
-``_``  Regional Fear info
-``p``  Borg Power
-``!``  Time
-``@``  Borg LOS
-``w``  My Swap Weapon
-``q``  Auto stop on level
-``v``  Version stamp
+``c``  Toggle cheat flags
+``C``  List nasties
 ``d``  Dump spell info
+``f``  Toggle flags
+``g``  Display grid feature
 ``h``  Borg_Has function
-``y``  Last 75 steps
-``m``  Money Scum
-``^``  Flow Pathway
-``R``  Respawn Borg
-``o``  Object Flags
-``r``  Restock Stores
+``i``  Display grid info
+``k``  Display monster info
 ``l``  Create a snapshot log file
+``m``  Money Scum
+``o``  Object Flags
+``p``  Borg Power
+``q``  Auto stop on level
+``r``  Restock Stores
+``R``  Respawn Borg
+``s``  Search mode
+``t``  Display object info
+``u``  Update the Borg
+``v``  Version stamp
+``w``  My Swap Weapon
+``x``  Step the Borg
+``y``  Last 75 steps
+``z``  Activate the Borg
+``!``  Time
+``#``  Display danger grid
+``%``  Display targeting flow
+``$``  Reload Borg.txt
+``@``  Borg LOS
+``^``  Flow Pathway
+``_``  Regional Fear info
 ``;``  Display glyphs
 ``1``  Change max depth
 ``2``  Level prep info
 ``3``  Feature of grid
-``C``  List nasties
 ====== ========================================
 
 Flag Commands

--- a/docs/hacking/borg.rst
+++ b/docs/hacking/borg.rst
@@ -36,24 +36,41 @@ Main Commands
 -------------
 
 ====== ========================================
+``$``  Reload Borg.txt
 ``z``  Activate the Borg (start automation)
 ``u``  Update the Borg
 ``x``  Step the Borg (single step)
+``f``  Toggle flags (enters flag mode)
+``c``  Toggle cheat flags (enters cheat mode)
 ``s``  Search mode
+``g``  Display grid feature
+``i``  Display grid info
+``a``  Display avoidances
 ``k``  Display monster info
 ``t``  Display object info
-``p``  Display borg power
-``d``  Display borg danger
-``i``  Display borg item values
-``a``  Display borg artifacts
-``w``  Display borg weapon information
-``r``  Display borg race information
-``c``  Modify cheat flags
-``f``  Toggle flags (enters flag mode)
-``l``  Log borg messages
-``m``  Display borg messages
-``n``  Display borg notes
-``q``  Quit borg interface
+``%``  Display targeting flow
+``#``  Display danger grid
+``_``  Regional Fear info
+``p``  Borg Power
+``!``  Time
+``@``  Borg LOS
+``w``  My Swap Weapon
+``q``  Auto stop on level
+``v``  Version stamp
+``d``  Dump spell info
+``h``  Borg_Has function
+``y``  Last 75 steps
+``m``  Money Scum
+``^``  Flow Pathway
+``R``  Respawn Borg
+``o``  Object Flags
+``r``  Restock Stores
+``l``  Log file
+``;``  Display glyphs
+``1``  Change max depth
+``2``  Level prep info
+``3``  Feature of grid
+``C``  List nasties
 ====== ========================================
 
 Flag Commands
@@ -62,18 +79,11 @@ Flag Commands
 After pressing ``f`` from the main borg interface you enter flag toggle mode.
 
 ====== ========================================
-``a``  Toggle flag: Allow borg to play
-``v``  Toggle flag: Verbose mode
-``d``  Toggle flag: Debug mode
-``s``  Toggle flag: Stop on stairs
-``g``  Toggle flag: Graphics mode
-``r``  Toggle flag: Respawn
-``c``  Toggle flag: Cheat death
-``n``  Toggle flag: No retreat
-``t``  Toggle flag: Testable
-``l``  Toggle flag: Light beam
-``u``  Toggle flag: Unique tracking
-``m``  Toggle flag: Munchkin mode
-``p``  Toggle flag: Prep mode
+``b``  Stop when alert bell rings
+``c``  Self scum
+``k``  Stop when the borg wins
+``l``  Lunal mode
+``s``  Dump savefile at each level (autosave)
+``v``  Verbose mode
 ====== ========================================
 

--- a/docs/hacking/borg.rst
+++ b/docs/hacking/borg.rst
@@ -30,7 +30,7 @@ gameplay. When you first run the command you'll be presented with a warning
 message you can continue through. The most common command is ``z`` which
 starts the Borg.
 
-Pressing ``^z`` while the Borg is running will stop the Borg.
+Pressing any key while the Borg is running will stop the Borg.
 
 Main Commands
 -------------

--- a/docs/hacking/borg.rst
+++ b/docs/hacking/borg.rst
@@ -37,9 +37,9 @@ Main Commands
 
 ====== ========================================
 ``$``  Reload Borg.txt
-``z``  Activate the Borg (start automation)
+``z``  Activate the Borg
 ``u``  Update the Borg
-``x``  Step the Borg (single step)
+``x``  Step the Borg
 ``f``  Toggle flags (enters flag mode)
 ``c``  Toggle cheat flags (enters cheat mode)
 ``s``  Search mode
@@ -65,7 +65,7 @@ Main Commands
 ``R``  Respawn Borg
 ``o``  Object Flags
 ``r``  Restock Stores
-``l``  Log file
+``l``  Create a snapshot log file
 ``;``  Display glyphs
 ``1``  Change max depth
 ``2``  Level prep info

--- a/docs/hacking/borg.rst
+++ b/docs/hacking/borg.rst
@@ -12,5 +12,68 @@ It was reincorporated in around 4.2.3.
 Running The Borg
 ================
 
+It is not recommended to run the Borg on a live game, as it could
+cause unexpected behavior or even crashes. It is best to run the Borg
+on its own save file, or on a copy of your save file.
+
 Historical information on how to run the Borg can be found in
 ``borgread.txt``.
+
+Borg Command Interface
+======================
+
+The Borg command interface is only available when Angband is compiled
+with borg support.
+
+To access the Borg command interface, press ``^z`` (Ctrl-Z) during normal
+gameplay. When you first run the command you'll be presented with a warning
+message you can continue through. The most common command is ``z`` which
+starts the Borg.
+
+Pressing ``^z`` while the Borg is running will stop the Borg.
+
+Main Commands
+-------------
+
+====== ========================================
+``z``  Activate the Borg (start automation)
+``u``  Update the Borg
+``x``  Step the Borg (single step)
+``s``  Search mode
+``k``  Display monster info
+``t``  Display object info
+``p``  Display borg power
+``d``  Display borg danger
+``i``  Display borg item values
+``a``  Display borg artifacts
+``w``  Display borg weapon information
+``r``  Display borg race information
+``c``  Modify cheat flags
+``f``  Toggle flags (enters flag mode)
+``l``  Log borg messages
+``m``  Display borg messages
+``n``  Display borg notes
+``q``  Quit borg interface
+====== ========================================
+
+Flag Commands
+-------------
+
+After pressing ``f`` from the main borg interface you enter flag toggle mode.
+
+====== ========================================
+``a``  Toggle flag: Allow borg to play
+``v``  Toggle flag: Verbose mode
+``d``  Toggle flag: Debug mode
+``s``  Toggle flag: Stop on stairs
+``g``  Toggle flag: Graphics mode
+``r``  Toggle flag: Respawn
+``c``  Toggle flag: Cheat death
+``n``  Toggle flag: No retreat
+``t``  Toggle flag: Testable
+``l``  Toggle flag: Light beam
+``u``  Toggle flag: Unique tracking
+``m``  Toggle flag: Munchkin mode
+``p``  Toggle flag: Prep mode
+====== ========================================
+

--- a/docs/hacking/borg.rst
+++ b/docs/hacking/borg.rst
@@ -23,8 +23,14 @@ It is not recommended to run the Borg on a live game, as it could
 cause unexpected behavior or even crashes. It is best to run the Borg
 on its own save file, or on a copy of your save file.
 
-Historical information on how to run the Borg can be found in
-``borgread.txt``.
+To run the Borg:
+
+1. Ensure Angband is compiled with borg support
+2. Start or load a game
+3. Press ``^z`` (Ctrl-Z) to access the Borg command interface
+4. Press ``z`` to activate the Borg
+5. Watch the Borg play automatically
+6. Press any key to stop the Borg when desired
 
 Borg Command Interface
 ======================
@@ -103,3 +109,12 @@ After pressing ``c`` from the main borg interface you enter cheat toggle mode.
 ``d``  Toggle cheat death
 ====== ========================================
 
+Customizing The Borg
+====================
+
+TODO
+
+Borg Screensaver
+================
+
+TODO

--- a/docs/hacking/borg.rst
+++ b/docs/hacking/borg.rst
@@ -73,6 +73,7 @@ Main Commands
 ``x``  Step the Borg
 ``y``  Last 75 steps
 ``z``  Activate the Borg
+``?``  List Borg commands
 ``!``  Time
 ``#``  Display danger grid
 ``%``  Display targeting flow

--- a/docs/hacking/borg.rst
+++ b/docs/hacking/borg.rst
@@ -9,6 +9,13 @@ distributed. It was pulled into the game in around 3.3. It was removed
 in 4.0 as there was too much conflict with the big changes made then.
 It was reincorporated in around 4.2.3.
 
+The name comes from "The Borg" in Star Trek which, in turn, comes from
+cyborg.
+
+The primary use of the Borg is entertainment. It is fun to watch the
+Borg play the game, and it can be amusing to see how it handles
+situations. It has been used to test the game and find bugs.
+
 Running The Borg
 ================
 

--- a/docs/playing.rst
+++ b/docs/playing.rst
@@ -147,7 +147,7 @@ Original Keyset Command Summary
 ``,``  Stay still (with pickup)      ``^w`` (special - wizard mode)
 ``<``  Go up/to up staircase         ``^x`` Save and quit
 ``.``  Run                           ``^y`` (unused)
-``>``  Go down/to down staircase     ``^z`` (unused)
+``>``  Go down/to down staircase     ``^z`` Borg commands (if available)
 ``\``  (special - bypass keymap)     ``~``  Check knowledge
  \`    (special - escape)            ``?``  Display help
 ``/``  Identify symbol
@@ -213,7 +213,7 @@ Roguelike Keyset Command Summary
  ``,``  Run                           ``^w`` (special - wizard mode)
  ``<``  Go up/to up staircase         ``^x`` Save and quit
  ``.``  Stay still (with pickup)      ``^y`` (alter - north west)
- ``>``  Go down/to down staircase     ``^z`` (unused)
+ ``>``  Go down/to down staircase     ``^z`` Borg commands (if available)
  ``\``  (special - bypass keymap)     ``~``  Check knowledge
   \`    (special - escape)            ``?``  Display help
  ``/``  Identify symbol

--- a/src/borg/borg.c
+++ b/src/borg/borg.c
@@ -577,7 +577,7 @@ void do_cmd_borg(void)
         Term_putstr(
             2, i++, -1, COLOUR_WHITE, "Command 'c' modifies the cheat flags.");
         Term_putstr(
-            42, i, -1, COLOUR_WHITE, "Command 'l' activates a log file.");
+            42, i, -1, COLOUR_WHITE, "Command 'l' creates a snapshot log file.");
         Term_putstr(
             2, i++, -1, COLOUR_WHITE, "Command 's' activates search mode.");
         Term_putstr(42, i, -1, COLOUR_WHITE, "Command 'i' displays grid info.");
@@ -614,6 +614,8 @@ void do_cmd_borg(void)
         Term_putstr(2, i++, -1, COLOUR_WHITE, "Command 'R' Respawn Borg.");
         Term_putstr(42, i, -1, COLOUR_WHITE, "Command 'o' Object Flags.");
         Term_putstr(2, i++, -1, COLOUR_WHITE, "Command 'r' Restock Stores.");
+        Term_putstr(42, i, -1, COLOUR_WHITE, "Command 'C' List nasties.");
+        Term_putstr(2, i++, -1, COLOUR_WHITE, "Command ';' Display glyphs.");
 
         /* Prompt for key */
         msg("Commands: ");

--- a/src/borg/borg.c
+++ b/src/borg/borg.c
@@ -573,9 +573,9 @@ void do_cmd_borg(void)
         Term_putstr(42, i++, -1, COLOUR_WHITE, "Command 'u' updates the Borg.");
         Term_putstr(2, i++, -1, COLOUR_WHITE, "Command 'x' steps the Borg.");
         Term_putstr(
-            42, i, -1, COLOUR_WHITE, "Command 'f' modifies the normal flags.");
+            42, i, -1, COLOUR_WHITE, "Command 'f' toggle flags.");
         Term_putstr(
-            2, i++, -1, COLOUR_WHITE, "Command 'c' modifies the cheat flags.");
+            2, i++, -1, COLOUR_WHITE, "Command 'c' toggle cheat flags.");
         Term_putstr(
             42, i, -1, COLOUR_WHITE, "Command 'l' creates a snapshot log file.");
         Term_putstr(


### PR DESCRIPTION
From issue https://github.com/angband/angband/issues/6253#issuecomment-2989128387

Documentation `docs/hacking/borg.rst`:
- Add context about borg name origin and primary use case
- Replace outdated `borgread.txt` reference with step-by-step usage instructions
- Add comprehensive command interface documentation with all main, flag, and cheat commands
- Organize commands alphabetically for easier reference

Command Interface `src/borg/borg.c`:
- Add missing `C` (List nasties) and `;` (Display glyphs) commands to in-game help
- Improve help text clarity

Playing Guide `docs/playing.rst`:
- Update `^z` key documentation from "unused" to "Borg commands (if available)"