### PR TITLE
Clean more with "make clean-coverage"

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -92,7 +92,12 @@ splint:
 
 clean-coverage:
 	rm -f tests/ran-already
-	rm -f $(GCOVS) $(GCOBJS)
+	rm -f $(GCOVS) $(GCOBJS) borg*.c.gcov
+	env CC="$(CC)" CFLAGS="$(CFLAGS)" CPPFLAGS="$(CPPFLAGS)" \
+		LDFLAGS="$(LDFLAGS)" LDADD="$(LDADD)" LIBS="$(TEST_LIBS)" \
+		CROSS_COMPILE="$(CROSS_COMPILE)" \
+		TEST_WORKING_DIRECTORY="$(TEST_WORKING_DIRECTORY)" \
+		$(MAKE) -C tests clean-coverage
 
 coverage: CFLAGS+=-fprofile-arcs -ftest-coverage
 coverage: LDFLAGS+=-lgcov

--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -35,6 +35,9 @@ TESTPROGS := $(TESTPROGS:%=%.exe)
 
 TESTOBJS += test-utils.o unit-test.o
 
+# gcov intermediate data
+GCOBJS = $(TESTOBJS:.o=.gcno) $(TESTOBJS:.o=.gcda)
+
 include Makefile.inc
 
 build : $(TESTPROGS)
@@ -57,5 +60,8 @@ $(TESTPROGS) : ../angband.a test-utils.o unit-test.o
 clean :
 	-$(RM) $(TESTOBJS) $(TESTPROGS)
 
-.PHONY : all clean
+clean-coverage :
+	-$(RM) $(GCOBJS)
+
+.PHONY : all clean clean-coverage
 .PRECIOUS : %.o


### PR DESCRIPTION
Prior version was leaving .gcno and .gcda files in src/tests and its subdirectories.  At least with gcov 12.2.0 on Debian 12, there were also "borg#*.c.gcov" files left in src.