### PR TITLE
Borg docs misc improvements

### DIFF
--- a/docs/hacking/borg.rst
+++ b/docs/hacking/borg.rst
@@ -129,6 +129,9 @@ Once copied, you can edit ``borg.txt`` to change the Borg's behavior. To apply
 changes while the game is running, use the ``$`` command from the Borg command
 interface (``^z``).
 
+How you customize the Borg depends on whether you are using a pre-compiled
+build or compiling from source.
+
 Configuration Options
 ---------------------
 
@@ -169,8 +172,19 @@ Respawn and Continuous Play
 - ``borg_respawn_winners``: If enabled, the Borg will create a new
   character after defeating Morgoth
 
-How you customize the Borg depends on whether you are using a pre-compiled
-build or compiling from source.
+Dynamic Formulas
+****************
+
+The Borg can use either its internal hard-coded logic for decision-making
+or a more flexible system of dynamic formulas defined in ``borg.txt``. To
+enable the formula-based system, set the following in your ``borg.txt``:
+
+.. code-block:: ini
+
+  borg_uses_dynamic_calcs = TRUE
+
+The dynamic calculations are more customizable but may be slower and
+are not always as up-to-date as the internal code logic.
 
 Using Official Builds
 ---------------------

--- a/docs/hacking/borg.rst
+++ b/docs/hacking/borg.rst
@@ -140,6 +140,21 @@ behavior. Below is a summary of the key settings. For a complete list and
 detailed explanations, refer to the comments within the ``borg.txt`` file
 itself.
 
+Adjusting Borg Speed
+********************
+
+When you first run the Borg it may move very slowly. This is often due to the
+game's ``base delay factor``, a general setting that affects all animations. To
+speed up the Borg, you can reduce this value.
+
+1. Press ``=`` to open the main options menu
+2. Press ``d`` to change the ``delay factor``
+3. Decrease the value
+
+Conversely, if the Borg is moving too quickly to follow, you can increase this
+value. You can also add a Borg-specific delay by setting ``borg_delay_factor``
+in ``borg.txt``.
+
 Worships
 ********
 These settings (e.g., ``borg_worships_damage``, ``borg_worships_gold``)

--- a/docs/hacking/borg.rst
+++ b/docs/hacking/borg.rst
@@ -145,7 +145,7 @@ Adjusting Borg Speed
 
 When you first run the Borg it may move very slowly. This is often due to the
 game's ``base delay factor``, a general setting that affects all animations. To
-speed up the Borg, you can reduce this value.
+speed up the Borg you can decrease this value:
 
 1. Press ``=`` to open the main options menu
 2. Press ``d`` to change the ``delay factor``

--- a/docs/hacking/borg.rst
+++ b/docs/hacking/borg.rst
@@ -192,7 +192,7 @@ Dynamic Formulas
 
 The Borg can use either its internal hard-coded logic for decision-making
 or a more flexible system of dynamic formulas defined in ``borg.txt``. To
-enable the formula-based system, set the following in your ``borg.txt``:
+enable the formula-based system, set the following in ``borg.txt``:
 
 .. code-block:: ini
 

--- a/src/borg/borg.txt
+++ b/src/borg/borg.txt
@@ -1,3 +1,6 @@
+# This is the configuration file for the Borg. For a high-level overview
+# of the Borg and its features, see the official documentation in
+# docs/hacking/borg.rst.
 
 # This file will allow you to customize your borg along certain themes.
 # The borg is fairly successful, having won the game several times.


### PR DESCRIPTION
From: https://github.com/angband/angband/issues/6253

Improves the Borg documentation by:

- Adding a new section on how to adjust the Borg's speed, a common setup step.
- Introducing the `dynamic formula` system and how to enable it.
- Adding a comment to `borg.txt` that directs users to the documentation for a high-level overview.