### PR TITLE
Regularize score array after reading it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,6 +239,7 @@ ADD_LIBRARY(OurCoreLib OBJECT
         src/save-charoutput.c
         src/savefile.c
         src/score.c
+        src/score-util.c
         src/sound-core.c
         src/source.c
         src/store.c
@@ -855,6 +856,7 @@ SET(ANGBAND_TEST_CASE_SOURCES
     player/inven-wield.c
     player/pathfind.c
     player/playerstat.c
+    player/pscore.c
     player/timed.c
     player/util.c
     trivial/trivial.c

--- a/src/Makefile.src
+++ b/src/Makefile.src
@@ -244,10 +244,11 @@ ANGFILES0 = \
 	project-mon.o \
 	project-obj.o \
 	project-player.o \
-	score.o \
 	save.o \
 	savefile.o \
 	save-charoutput.o \
+	score.o \
+	score-util.o \
 	sound-core.o \
 	source.o \
 	store.o \

--- a/src/player-util.c
+++ b/src/player-util.c
@@ -286,7 +286,7 @@ void death_knowledge(struct player *p)
 	/* Retire in the town in a good state */
 	if (p->total_winner) {
 		p->depth = 0;
-		my_strcpy(p->died_from, "Ripe Old Age", sizeof(p->died_from));
+		my_strcpy(p->died_from, WINNING_HOW, sizeof(p->died_from));
 		p->exp = p->max_exp;
 		p->lev = p->max_lev;
 		p->au += 10000000L;

--- a/src/score-util.c
+++ b/src/score-util.c
@@ -1,0 +1,322 @@
+/**
+ * \file score-util.c
+ * \brief Define score functions shared by the game's core and the separate
+ * elevated privilege executable.
+ *
+ * Copyright (c) 2025 Ben Harrison, James E. Wilson, Robert A. Koeneke,
+ * Eric Branlund
+ *
+ * This work is free software; you can redistribute it and/or modify it
+ * under the terms of either:
+ *
+ * a) the GNU General Public License as published by the Free Software
+ *    Foundation, version 2, or
+ *
+ * b) the "Angband licence":
+ *    This software may be copied and distributed for educational, research,
+ *    and not for profit purposes provided that this copyright and statement
+ *    are included in all such copies.  Other copyrights may also apply.
+ */
+
+/*
+ * To simplify auditing and linking of the elevated privilege executable,
+ * functions here should not call into anything else besides what is in this
+ * file or in the C standard library.
+ */
+
+#include "score.h"
+#include <assert.h>	/* assert */
+#include <stdlib.h>	/* qsort, strtol */
+#include <string.h>	/* memchr, memset, strcmp */
+
+
+/**
+ * Compare two high score records.
+ *
+ * \param a is a pointer to a high score record cast to a const void*.
+ * \param b is a pointer to a high score record cast to a const void*.
+ * \return -1 if *a should appear before *b.  Return +1 if *a should appear
+ * after *b.  Otherwise, return zero.
+ *
+ * Assumes both records are valid and elements in the same array.
+ */
+static int highscore_cmp(const void *a, const void *b)
+{
+	const struct high_score *sa = (const struct high_score*)a;
+	const struct high_score *sb = (const struct high_score*)b;
+	int result;
+
+	/*
+	 * Empty records appear after non-empty ones.  Do not care about
+	 * the order when both are empty.
+	 */
+	if (!sa->what[0]) {
+		result = (sb->what[0]) ? 1 : 0;
+	} else if (!sb->what[0]) {
+		result = (sa->what[0]) ? -1 : 0;
+	} else {
+		/* A winning record appears before any that did not win. */
+		bool awinner = strcmp(sa->how, WINNING_HOW) == 0;
+		bool bwinner = strcmp(sb->how, WINNING_HOW) == 0;
+
+		if (awinner != bwinner) {
+			result = (awinner) ? -1 : 1;
+		} else {
+			/*
+			 * A record with more points appears before any
+			 * with the same winning status and less points.
+			 */
+			long apts = strtol(sa->pts, NULL, 0);
+			long bpts = strtol(sb->pts, NULL, 0);
+
+			if (apts != bpts) {
+				result = (apts > bpts) ? -1 : 1;
+			} else {
+				/*
+				 * With same winning status and points, keep
+				 * the same order as the records currently
+				 * have.
+				 */
+				result = (sa < sb) ? -1 : ((sa > sb) ? 1 : 0);
+			}
+		}
+	}
+	return result;
+}
+
+
+/**
+ * Check that a high score record can be used without triggering undefined
+ * behavior or failures in integer parsing.
+ *
+ * \param s points to the score record to check.
+ * \return true if the record is valid.  Otherwise, return false.
+ */
+bool highscore_valid(const struct high_score *s)
+{
+	if (s->what[0]) {
+		/* It is a non-empty record. */
+		char *p_end;
+
+		/* All fields must be null-terminated. */
+		if (!memchr(s->what, '\0', sizeof(s->what))
+			|| !memchr(s->pts, '\0', sizeof(s->pts))
+			|| !memchr(s->gold, '\0', sizeof(s->gold))
+			|| !memchr(s->turns, '\0', sizeof(s->turns))
+			|| !memchr(s->day, '\0', sizeof(s->day))
+			|| !memchr(s->who, '\0', sizeof(s->who))
+			|| !memchr(s->uid, '\0', sizeof(s->uid))
+			|| !memchr(s->p_r, '\0', sizeof(s->p_r))
+			|| !memchr(s->p_c, '\0', sizeof(s->p_c))
+			|| !memchr(s->cur_lev, '\0', sizeof(s->cur_lev))
+			|| !memchr(s->cur_dun, '\0', sizeof(s->cur_dun))
+			|| !memchr(s->max_lev, '\0', sizeof(s->max_lev))
+			|| !memchr(s->max_dun, '\0', sizeof(s->max_dun))
+			|| !memchr(s->how, '\0', sizeof(s->how))) {
+			return false;
+		}
+		/*
+		 * It must have number values that are parseable.  Except for
+		 * pts, gold, turns, and uid, the fields are short enough that
+		 * they will not reach the most restrictive bounds for an int
+		 * with c99.  For pts, gold, turns, and uid, the fields are
+		 * short enough that they will noot reach most restrictive
+		 * bounds for a long with c99.
+		 */
+		(void)strtol(s->pts, &p_end, 0);
+		if (*p_end || !s->pts[0]) {
+			return false;
+		}
+		(void)strtol(s->gold, &p_end, 0);
+		if (*p_end || !s->gold[0]) {
+			return false;
+		}
+		(void)strtol(s->turns, &p_end, 0);
+		if (*p_end || !s->turns[0]) {
+			return false;
+		}
+		(void)strtol(s->uid, &p_end, 0);
+		if (*p_end || !s->uid[0]) {
+			return false;
+		}
+		(void)strtol(s->p_r, &p_end, 0);
+		if (*p_end || !s->p_r[0]) {
+			return false;
+		}
+		(void)strtol(s->p_c, &p_end, 0);
+		if (*p_end || !s->p_c[0]) {
+			return false;
+		}
+		(void)strtol(s->cur_lev, &p_end, 0);
+		if (*p_end || !s->cur_lev[0]) {
+			return false;
+		}
+		(void)strtol(s->cur_dun, &p_end, 0);
+		if (*p_end || !s->cur_dun[0]) {
+			return false;
+		}
+		(void)strtol(s->max_lev, &p_end, 0);
+		if (*p_end || !s->max_lev[0]) {
+			return false;
+		}
+		(void)strtol(s->max_dun, &p_end, 0);
+		if (*p_end || !s->max_dun[0]) {
+			return false;
+		}
+	} else {
+		/*
+		 * It is an empty record.  All the fields must be empty
+		 * strings.
+		 */
+		if (s->pts[0]
+				|| s->gold[0]
+				|| s->turns[0]
+				|| s->day[0]
+				|| s->who[0]
+				|| s->uid[0]
+				|| s->p_r[0]
+				|| s->p_c[0]
+				|| s->cur_lev[0]
+				|| s->cur_dun[0]
+				|| s->max_lev[0]
+				|| s->max_dun[0]
+				|| s->how[0]) {
+			return false;
+		}
+	}
+	return true;
+}
+
+
+/**
+ * Force an array of high scores to all be valid and in the proper order.
+ *
+ * \param scores is the array of high scores.
+ * \param sz is the number of high scores in scores.  It may be zero.
+ * \return true if the contents of scores were modified due to irregularities.
+ * Otherwise, return false.
+ */
+bool highscore_regularize(struct high_score scores[], size_t sz)
+{
+	bool irregular = false, out_of_order = false;
+	const struct high_score *last_not_empty = NULL;
+	/*
+	 * Inclusive bounds for the indices that were copied out of and not
+	 * subsequently overwritten
+	 */
+	size_t first_copied = sz, last_copied = 0;
+	size_t i_in, i_out;
+
+	for (i_in = 0, i_out = 0; i_in < sz; ++i_in) {
+		if (!highscore_valid(scores + i_in)) {
+			/* Make an invalid score empty. */
+			(void)memset(scores + i_in, 0, sizeof(scores[i_in]));
+			irregular = true;
+			continue;
+		}
+		/* Skip empty score records. */
+		if (!scores[i_in].what[0]) {
+			continue;
+		}
+		if (last_not_empty && highscore_cmp(last_not_empty,
+				scores + i_in) > 0) {
+			out_of_order = true;
+		}
+		if (i_out != i_in) {
+			/*
+			 * Copy the record to cover gaps from invalid or
+			 * empty records.
+			 */
+			scores[i_out] = scores[i_in];
+			if (first_copied > i_in) {
+				first_copied = i_in;
+			} else if (first_copied == i_out) {
+				++first_copied;
+			}
+			last_copied = i_in;
+			irregular = true;
+		}
+		last_not_empty = scores + i_in;
+		++i_out;
+	}
+	if (out_of_order) {
+		/*
+		 * Can only be out of order if there are two or more records
+		 * that are not empty.
+		 */
+		assert(i_out >= 2 && i_out <= sz);
+		qsort(scores, i_out, sizeof(scores[0]), highscore_cmp);
+		irregular = true;
+	}
+	if (first_copied <= last_copied) {
+		/*
+		 * Copied records before.  Now guarantee that the records
+		 * copied but not overwritten are empty.
+		 */
+		assert(last_copied < sz);
+		(void)memset(scores + first_copied, 0,
+			(last_copied - first_copied + 1)
+			* sizeof(scores[i_out]));
+	}
+	return irregular;
+}
+
+
+/**
+ * Determine where a new score would be placed.
+ *
+ * \param entry points to the new score which is valid and not empty.
+ * \param scores is an array of sz valid score records, sorted from best to
+ * worst with any empty records at the end.
+ * \param sz is the number of score records scores holds.  sz must be positive.
+ * \return the index in scores, zero to sz - 1, where *entry belongs.  Zero
+ * is best, and the last entry can always be overwritten, even if its score
+ * is better than that of *entry.
+ */
+size_t highscore_where(const struct high_score *entry,
+		const struct high_score scores[], size_t sz)
+{
+	/*
+	 * Read until we get to a higher score.  The score comparison should
+	 * be the same as highscore_cmp() does except that for ties, we give
+	 * preference to the newer score, the one in *entry.
+	 */
+	bool entry_winner = strcmp(entry->how, WINNING_HOW) == 0;
+	long entry_pts = strtol(entry->pts, NULL, 0);
+	size_t i;
+
+	for (i = 0; i < sz; ++i) {
+		bool score_winner;
+		long score_pts;
+
+		/*
+		 * *entry is not empty so it would replace the first empty
+		 * record.
+		 */
+		if (!scores[i].what[0]) {
+			return i;
+		}
+
+		/* A winning record appears before any that did not win. */
+		score_winner = strcmp(scores[i].how, WINNING_HOW) == 0;
+		if (entry_winner != score_winner) {
+			if (entry_winner) {
+				return i;
+			}
+			continue;
+		}
+
+		/*
+		 * A record with more points appears before any with the
+		 * the same winning status and less points.  If a tie, put
+		 * *entry first.
+		 */
+		score_pts = strtol(scores[i].pts, NULL, 0);
+		if (entry_pts >= score_pts) {
+			return i;
+		}
+	}
+
+	/* If it was not a fit elsewhere, replace the last entry. */
+	return sz - 1;
+}

--- a/src/score.c
+++ b/src/score.c
@@ -56,43 +56,15 @@ size_t highscore_read(struct high_score scores[], size_t sz)
 			break;
 
 	file_close(scorefile);
+	/*
+	 * On a short read, also check the record one past the end in case
+	 * it was partially overwritten.
+	 */
+	(void)highscore_regularize(scores, (i < sz) ? i + 1 : sz);
 
 	return i;
 }
 
-
-/**
- * Just determine where a new score *would* be placed
- * Return the location (0 is best) or -1 on failure
- */
-size_t highscore_where(const struct high_score *entry,
-					   const struct high_score scores[], size_t sz)
-{
-	size_t i;
-
-	/* Read until we get to a higher score */
-	for (i = 0; i < sz; i++) {
-		long entry_pts = strtoul(entry->pts, NULL, 0);
-		long score_pts = strtoul(scores[i].pts, NULL, 0);
-		bool entry_winner = streq(entry->how, "Ripe Old Age");
-		bool score_winner = streq(scores[i].how, "Ripe Old Age");
-
-		if (entry_winner && !score_winner)
-			return i;
-
-		if (!entry_winner && score_winner)
-			continue;
-
-		if (entry_pts >= score_pts)
-			return i;
-
-		if (scores[i].what[0] == '\0')
-			return i;
-	}
-
-	/* The last entry is always usable */
-	return sz - 1;
-}
 
 /**
  * Place an entry into a high score array

--- a/src/score.h
+++ b/src/score.h
@@ -19,6 +19,10 @@
 #ifndef INCLUDED_SCORE_H
 #define INCLUDED_SCORE_H
 
+#include <stdbool.h>
+#include <stddef.h>
+#include <time.h>
+
 struct player;
 
 /**
@@ -26,6 +30,11 @@ struct player;
  */
 #define MAX_HISCORES    100
 
+/**
+ * What the how field of a score record or died_from field of struct player
+ * contains for a winner
+ */
+#define WINNING_HOW "Ripe Old Age"
 
 /**
  * Semi-Portable High Score List Entry (128 bytes)
@@ -57,12 +66,16 @@ struct high_score {
 
 
 size_t highscore_read(struct high_score scores[], size_t sz);
-size_t highscore_where(const struct high_score *entry,
-					   const struct high_score scores[], size_t sz);
 size_t highscore_add(const struct high_score *entry, struct high_score scores[],
 					 size_t sz);
 void build_score(struct high_score *entry, const struct player *p,
 		const char *died_from, const time_t *death_time);
 void enter_score(const struct player *p, const time_t *death_time);
+
+/* From score-util.c */
+size_t highscore_where(const struct high_score *entry,
+		const struct high_score scores[], size_t sz);
+bool highscore_valid(const struct high_score *s);
+bool highscore_regularize(struct high_score scores[], size_t sz);
 
 #endif /* INCLUDED_SCORE_H */

--- a/src/tests/player/pscore.c
+++ b/src/tests/player/pscore.c
@@ -1,0 +1,711 @@
+/* player/pscore.c */
+/* Exercise functions in score.c and score-util.c */
+
+#include "unit-test.h"
+#include "unit-test-data.h"
+#include "game-world.h"
+#include "player.h"
+#include "score.h"
+#include "z-file.h"
+#include "z-rand.h"
+#include "z-util.h"
+#include <limits.h>
+#include <string.h>
+#include <time.h>
+
+
+static struct player my_p;
+
+int setup_tests(void **state) {
+	/* Set up enough of a struct player to work with build_score(). */
+	my_p.max_exp = 1234;
+	my_p.au = 567;
+	my_p.lev = 4;
+	my_p.depth = 3;
+	my_p.max_lev = 6;
+	my_p.max_depth = 5;
+	my_strcpy(my_p.died_from, "a grue", sizeof(my_p.died_from));
+	my_p.race = &test_race;
+	my_p.class = &test_class;
+
+	/* build_score() also uses these globals. */
+	turn = 890;
+	player_uid = 10;
+
+	/*
+	 * One test randomly uses random indices when corrupting or reordering
+	 * score records.
+	 */
+	Rand_init();
+
+	return 0;
+}
+
+NOTEARDOWN
+
+/*
+ * Test highscore_valid() with score records that should be valid.
+ */
+static int test_highscore_valid0(void *state) {
+	struct high_score score;
+	time_t now;
+
+	/* An empty score record should be valid. */
+	(void)memset(&score, 0, sizeof(score));
+	require(highscore_valid(&score));
+
+	/* The result of build_score() should be valid. */
+	build_score(&score, &my_p, my_p.died_from, NULL);
+	require(highscore_valid(&score));
+	build_score(&score, &my_p, "nobody (yet)", NULL);
+	require(highscore_valid(&score));
+	now = time(NULL);
+	build_score(&score, &my_p, my_p.died_from, &now);
+	require(highscore_valid(&score));
+
+	ok;
+}
+
+/*
+ * Test highscore_valid() with score records that should be invalid.
+ */
+static int test_highscore_valid1(void *state) {
+	struct high_score score;
+
+
+	/* An empty score which has a non-empty string should be invalid. */
+	(void)memset(&score, 0, sizeof(score));
+	score.pts[0] = '1';
+	require(!highscore_valid(&score));
+	score.pts[0] = '\0';
+	score.gold[0] = '2';
+	require(!highscore_valid(&score));
+	score.gold[0] = '\0';
+	score.turns[0] = '3';
+	require(!highscore_valid(&score));
+	score.turns[0] = '\0';
+	score.day[0] = 'a';
+	require(!highscore_valid(&score));
+	score.day[0] = '\0';
+	score.who[0] = 'b';
+	require(!highscore_valid(&score));
+	score.who[0] = '\0';
+	score.uid[0] = '4';
+	require(!highscore_valid(&score));
+	score.uid[0] = '\0';
+	score.p_r[0] = '5';
+	require(!highscore_valid(&score));
+	score.p_r[0] = '\0';
+	score.p_c[0] = '6';
+	require(!highscore_valid(&score));
+	score.p_c[0] = '\0';
+	score.cur_lev[0] = '7';
+	require(!highscore_valid(&score));
+	score.cur_lev[0] = '\0';
+	score.cur_dun[0] = '8';
+	require(!highscore_valid(&score));
+	score.cur_dun[0] = '\0';
+	score.max_lev[0] = '9';
+	require(!highscore_valid(&score));
+	score.max_lev[0] = '\0';
+	score.max_dun[0] = '0';
+	require(!highscore_valid(&score));
+	score.max_dun[0] = '\0';
+	score.how[0] = 'c';
+
+	/*
+	 * A non-empty score with a string that is not null-terminated should be
+	 * invalid.
+	 */
+	build_score(&score, &my_p, my_p.died_from, NULL);
+	(void)memset(score.what, ' ', sizeof(score.what));
+	require(!highscore_valid(&score));
+	build_score(&score, &my_p, my_p.died_from, NULL);
+	(void)memset(score.pts, ' ', sizeof(score.pts));
+	require(!highscore_valid(&score));
+	build_score(&score, &my_p, my_p.died_from, NULL);
+	(void)memset(score.gold, ' ', sizeof(score.gold));
+	require(!highscore_valid(&score));
+	build_score(&score, &my_p, my_p.died_from, NULL);
+	(void)memset(score.turns, ' ', sizeof(score.turns));
+	require(!highscore_valid(&score));
+	build_score(&score, &my_p, my_p.died_from, NULL);
+	(void)memset(score.day, ' ', sizeof(score.day));
+	require(!highscore_valid(&score));
+	build_score(&score, &my_p, my_p.died_from, NULL);
+	(void)memset(score.who, ' ', sizeof(score.who));
+	require(!highscore_valid(&score));
+	build_score(&score, &my_p, my_p.died_from, NULL);
+	(void)memset(score.uid, ' ', sizeof(score.uid));
+	require(!highscore_valid(&score));
+	build_score(&score, &my_p, my_p.died_from, NULL);
+	(void)memset(score.p_r, ' ', sizeof(score.p_r));
+	require(!highscore_valid(&score));
+	build_score(&score, &my_p, my_p.died_from, NULL);
+	(void)memset(score.p_c, ' ', sizeof(score.p_c));
+	require(!highscore_valid(&score));
+	build_score(&score, &my_p, my_p.died_from, NULL);
+	(void)memset(score.cur_lev, ' ', sizeof(score.cur_lev));
+	require(!highscore_valid(&score));
+	build_score(&score, &my_p, my_p.died_from, NULL);
+	(void)memset(score.cur_dun, ' ', sizeof(score.cur_dun));
+	require(!highscore_valid(&score));
+	build_score(&score, &my_p, my_p.died_from, NULL);
+	(void)memset(score.max_lev, ' ', sizeof(score.max_lev));
+	require(!highscore_valid(&score));
+	build_score(&score, &my_p, my_p.died_from, NULL);
+	(void)memset(score.max_dun, ' ', sizeof(score.max_dun));
+	require(!highscore_valid(&score));
+	build_score(&score, &my_p, my_p.died_from, NULL);
+	(void)memset(score.how, ' ', sizeof(score.how));
+	require(!highscore_valid(&score));
+
+	/*
+	 * A non-empty score that has a number field which is not parseable
+	 * should be invalid.
+	 */
+	build_score(&score, &my_p, my_p.died_from, NULL);
+	score.pts[0] = '\0';
+	require(!highscore_valid(&score));
+	score.pts[0] = 'a';
+	require(!highscore_valid(&score));
+	score.pts[0] = '1';
+	score.pts[1] = 'a';
+	require(!highscore_valid(&score));
+	build_score(&score, &my_p, my_p.died_from, NULL);
+	score.gold[0] = '\0';
+	require(!highscore_valid(&score));
+	score.gold[0] = 'a';
+	require(!highscore_valid(&score));
+	score.gold[0] = '1';
+	score.gold[1] = 'a';
+	require(!highscore_valid(&score));
+	build_score(&score, &my_p, my_p.died_from, NULL);
+	score.turns[0] = '\0';
+	require(!highscore_valid(&score));
+	score.turns[0] = 'a';
+	require(!highscore_valid(&score));
+	score.turns[0] = '1';
+	score.turns[1] = 'a';
+	require(!highscore_valid(&score));
+	build_score(&score, &my_p, my_p.died_from, NULL);
+	score.uid[0] = '\0';
+	require(!highscore_valid(&score));
+	score.uid[0] = 'a';
+	require(!highscore_valid(&score));
+	score.uid[0] = '1';
+	score.uid[1] = 'a';
+	require(!highscore_valid(&score));
+	build_score(&score, &my_p, my_p.died_from, NULL);
+	score.p_r[0] = '\0';
+	require(!highscore_valid(&score));
+	score.p_r[0] = 'a';
+	require(!highscore_valid(&score));
+	score.p_r[0] = '1';
+	score.p_r[1] = 'a';
+	require(!highscore_valid(&score));
+	build_score(&score, &my_p, my_p.died_from, NULL);
+	score.p_c[0] = '\0';
+	require(!highscore_valid(&score));
+	score.p_c[0] = 'a';
+	require(!highscore_valid(&score));
+	score.p_c[0] = '1';
+	score.p_c[1] = 'a';
+	require(!highscore_valid(&score));
+	build_score(&score, &my_p, my_p.died_from, NULL);
+	score.cur_lev[0] = '\0';
+	require(!highscore_valid(&score));
+	score.cur_lev[0] = 'a';
+	require(!highscore_valid(&score));
+	score.cur_lev[0] = '1';
+	score.cur_lev[1] = 'a';
+	require(!highscore_valid(&score));
+	build_score(&score, &my_p, my_p.died_from, NULL);
+	score.cur_dun[0] = '\0';
+	require(!highscore_valid(&score));
+	score.cur_dun[0] = 'a';
+	require(!highscore_valid(&score));
+	score.cur_dun[0] = '1';
+	score.cur_dun[1] = 'a';
+	require(!highscore_valid(&score));
+	build_score(&score, &my_p, my_p.died_from, NULL);
+	score.max_lev[0] = '\0';
+	require(!highscore_valid(&score));
+	score.max_lev[0] = 'a';
+	require(!highscore_valid(&score));
+	score.max_lev[0] = '1';
+	score.max_lev[1] = 'a';
+	require(!highscore_valid(&score));
+	build_score(&score, &my_p, my_p.died_from, NULL);
+	score.max_dun[0] = '\0';
+	require(!highscore_valid(&score));
+	score.max_dun[0] = 'a';
+	require(!highscore_valid(&score));
+	score.max_dun[0] = '1';
+	score.max_dun[1] = 'a';
+	require(!highscore_valid(&score));
+
+	ok;
+}
+
+static int test_highscore_where0(void *state) {
+	struct high_score scores[5], score;
+	int32_t old_exp;
+	int16_t old_depth;
+	time_t now;
+
+	(void)memset(scores, 0, sizeof(scores));
+
+	/*
+	 * If all scores are empty, a new non-empty score should go in the
+	 * first slot.
+	 */
+	now = time(NULL);
+	build_score(&score, &my_p, my_p.died_from, &now);
+	eq(highscore_where(&score, scores, N_ELEMENTS(scores)), 0);
+	(void)memcpy(scores, &score, sizeof(score));
+
+	/*
+	 * A score with fewer points and the same winning status goes after a
+	 * another score with more points.
+	 */
+	old_exp = my_p.max_exp--;
+	now = time(NULL);
+	build_score(&score, &my_p, my_p.died_from, &now);
+	my_p.max_exp = old_exp;
+	eq(highscore_where(&score, scores, N_ELEMENTS(scores)), 1);
+	(void)memcpy(scores + 1, &score, sizeof(score));
+
+	/* A winning score goes before one that did not win. */
+	now = time(NULL);
+	build_score(&score, &my_p, WINNING_HOW, &now);
+	eq(highscore_where(&score, scores, N_ELEMENTS(scores)), 0);
+	(void)memmove(scores + 1, scores, 2 * sizeof(score));
+	(void)memcpy(scores, &score, sizeof(score));
+
+	/*
+	 * A score with more points and the same winning status goes before a
+	 * another score with less points.
+	 */
+	old_exp = my_p.max_exp++;
+	now = time(NULL);
+	build_score(&score, &my_p, my_p.died_from, &now);
+	my_p.max_exp = old_exp;
+	eq(highscore_where(&score, scores, N_ELEMENTS(scores)), 1);
+	(void)memmove(scores + 2, scores + 1, 2 * sizeof(score));
+	(void)memcpy(scores + 1, &score, sizeof(score));
+
+	/*
+	 * If the same winning status and same points, a newly added entry
+	 * goes first.
+	 */
+	now = time(NULL);
+	build_score(&score, &my_p, my_p.died_from, &now);
+	eq(highscore_where(&score, scores, N_ELEMENTS(scores)), 2);
+	(void)memmove(scores + 3, scores + 2, 2 * sizeof(score));
+	(void)memcpy(scores + 2, &score, sizeof(score));
+
+	/*
+	 * When the scores array is full with non-empty entries, a new score
+	 * that would not otherwise be included goes in the last slot.
+	 */
+	old_depth = my_p.max_depth;
+	my_p.max_depth -= 2;
+	now = time(NULL);
+	build_score(&score, &my_p, my_p.died_from, &now);
+	my_p.max_depth = old_depth;
+	eq(highscore_where(&score, scores, N_ELEMENTS(scores)), 4);
+
+	ok;
+}
+
+static int test_highscore_add0(void *state) {
+	struct high_score scurr[5], sadded[6];
+	int32_t old_exp;
+	int16_t old_depth;
+	time_t now;
+
+	(void)memset(scurr, 0, sizeof(scurr));
+
+	/*
+	 * If all scores are empty, a new non-empty score should go in the
+	 * first slot.
+	 */
+	now = time(NULL);
+	build_score(&sadded[0], &my_p, WINNING_HOW, &now);
+	eq(highscore_add(&sadded[0], scurr, N_ELEMENTS(scurr)), 0);
+	eq(memcmp(&scurr[0], &sadded[0], sizeof(scurr[0])), 0);
+
+	/*
+	 * A score with more points and the same winning status goes before a
+	 * another score with less points.
+	 */
+	old_exp = my_p.max_exp++;
+	now = time(NULL);
+	build_score(&sadded[1], &my_p, WINNING_HOW, &now);
+	my_p.max_exp = old_exp;
+	eq(highscore_add(&sadded[1], scurr, N_ELEMENTS(scurr)), 0);
+	eq(memcmp(&scurr[0], &sadded[1], sizeof(scurr[0])), 0);
+	eq(memcmp(&scurr[1], &sadded[0], sizeof(scurr[1])), 0);
+
+	/* A score that did not win goes after any that did. */
+	now = time(NULL);
+	build_score(&sadded[2], &my_p, my_p.died_from, &now);
+	eq(highscore_add(&sadded[2], scurr, N_ELEMENTS(scurr)), 2);
+	eq(memcmp(&scurr[0], &sadded[1], sizeof(scurr[0])), 0);
+	eq(memcmp(&scurr[1], &sadded[0], sizeof(scurr[0])), 0);
+	eq(memcmp(&scurr[2], &sadded[2], sizeof(scurr[2])), 0);
+
+	/*
+	 * A score with less points and the same winning status goes after a
+	 * another score with more points.
+	 */
+	old_exp = my_p.max_exp--;
+	now = time(NULL);
+	build_score(&sadded[3], &my_p, WINNING_HOW, &now);
+	my_p.max_exp = old_exp;
+	eq(highscore_add(&sadded[3], scurr, N_ELEMENTS(scurr)), 2);
+	eq(memcmp(&scurr[0], &sadded[1], sizeof(scurr[0])), 0);
+	eq(memcmp(&scurr[1], &sadded[0], sizeof(scurr[1])), 0);
+	eq(memcmp(&scurr[2], &sadded[3], sizeof(scurr[2])), 0);
+	eq(memcmp(&scurr[3], &sadded[2], sizeof(scurr[3])), 0);
+
+	/*
+	 * If the same winning status and same points, a newly added entry
+	 * goes first.
+	 */
+	now = time(NULL);
+	build_score(&sadded[4], &my_p, WINNING_HOW, &now);
+	eq(highscore_add(&sadded[4], scurr, N_ELEMENTS(scurr)), 1);
+	eq(memcmp(&scurr[0], &sadded[1], sizeof(scurr[0])), 0);
+	eq(memcmp(&scurr[1], &sadded[4], sizeof(scurr[1])), 0);
+	eq(memcmp(&scurr[2], &sadded[0], sizeof(scurr[2])), 0);
+	eq(memcmp(&scurr[3], &sadded[3], sizeof(scurr[3])), 0);
+	eq(memcmp(&scurr[4], &sadded[2], sizeof(scurr[4])), 0);
+
+	/*
+	 * When the scores array is full with non-empty entries, a new score
+	 * that would not otherwise be included goes in the last slot.
+	 */
+	old_depth = my_p.max_depth;
+	my_p.max_depth -= 2;
+	now = time(NULL);
+	build_score(&sadded[5], &my_p, my_p.died_from, &now);
+	my_p.max_depth = old_depth;
+	eq(highscore_add(&sadded[5], scurr, N_ELEMENTS(scurr)), 4);
+	eq(memcmp(&scurr[0], &sadded[1], sizeof(scurr[0])), 0);
+	eq(memcmp(&scurr[1], &sadded[4], sizeof(scurr[1])), 0);
+	eq(memcmp(&scurr[2], &sadded[0], sizeof(scurr[2])), 0);
+	eq(memcmp(&scurr[3], &sadded[3], sizeof(scurr[3])), 0);
+	eq(memcmp(&scurr[4], &sadded[5], sizeof(scurr[4])), 0);
+
+	ok;
+}
+
+/*
+ * Check cases where highscore_regularize() should not change the array of
+ * scores.
+ */
+static int test_highscore_regularize0(void *state)
+{
+	struct high_score scores[6], scores_good[6], score;
+	int32_t old_exp;
+	int16_t old_depth;
+	time_t now;
+
+	/*
+	 * A scores array filled with empty entries should not trigger any
+	 * changes.
+	 */
+	(void)memset(scores_good, 0, sizeof(scores_good));
+	(void)memcpy(scores, scores_good, sizeof(scores));
+	require(!highscore_regularize(scores, N_ELEMENTS(scores)));
+	eq(memcmp(scores, scores_good, sizeof(scores)), 0);
+
+	/*
+	 * Arrays with one or more non-empty elements (contents of each
+	 * element constructed by build_score() and then added with
+	 * highscore_add()) with zero or more empty elements at the end
+	 * should not trigger any changes.
+	 */
+	now = time(NULL);
+	build_score(&score, &my_p, my_p.died_from, &now);
+	(void)highscore_add(&score, scores_good, N_ELEMENTS(scores_good));
+	(void)memcpy(scores, scores_good, sizeof(scores));
+	require(!highscore_regularize(scores, N_ELEMENTS(scores)));
+	eq(memcmp(scores, scores_good, sizeof(scores)), 0);
+	old_exp = my_p.max_exp;
+	my_p.max_exp += 10;
+	now = time(NULL);
+	build_score(&score, &my_p, my_p.died_from, &now);
+	(void)highscore_add(&score, scores_good, N_ELEMENTS(scores_good));
+	(void)memcpy(scores, scores_good, sizeof(scores));
+	require(!highscore_regularize(scores, N_ELEMENTS(scores)));
+	eq(memcmp(scores, scores_good, sizeof(scores)), 0);
+	my_p.max_exp -= 5;
+	now = time(NULL);
+	build_score(&score, &my_p, my_p.died_from, &now);
+	my_p.max_exp = old_exp;
+	(void)highscore_add(&score, scores_good, N_ELEMENTS(scores_good));
+	(void)memcpy(scores, scores_good, sizeof(scores));
+	require(!highscore_regularize(scores, N_ELEMENTS(scores)));
+	eq(memcmp(scores, scores_good, sizeof(scores)), 0);
+	now = time(NULL);
+	build_score(&score, &my_p, WINNING_HOW, &now);
+	(void)highscore_add(&score, scores_good, N_ELEMENTS(scores_good));
+	(void)memcpy(scores, scores_good, sizeof(scores));
+	require(!highscore_regularize(scores, N_ELEMENTS(scores)));
+	eq(memcmp(scores, scores_good, sizeof(scores)), 0);
+	my_p.max_exp += 20;
+	now = time(NULL);
+	build_score(&score, &my_p, WINNING_HOW, &now);
+	my_p.max_exp = old_exp;
+	(void)highscore_add(&score, scores_good, N_ELEMENTS(scores_good));
+	(void)memcpy(scores, scores_good, sizeof(scores));
+	require(!highscore_regularize(scores, N_ELEMENTS(scores)));
+	eq(memcmp(scores, scores_good, sizeof(scores)), 0);
+	now = time(NULL);
+	build_score(&score, &my_p, my_p.died_from, &now);
+	(void)highscore_add(&score, scores_good, N_ELEMENTS(scores_good));
+	(void)memcpy(scores, scores_good, sizeof(scores));
+	require(!highscore_regularize(scores, N_ELEMENTS(scores)));
+	eq(memcmp(scores, scores_good, sizeof(scores)), 0);
+	old_depth = my_p.max_depth;
+	my_p.max_depth -= 3;
+	build_score(&score, &my_p, my_p.died_from, &now);
+	my_p.max_depth = old_depth;
+	(void)highscore_add(&score, scores_good, N_ELEMENTS(scores_good));
+	(void)memcpy(scores, scores_good, sizeof(scores));
+	require(!highscore_regularize(scores, N_ELEMENTS(scores)));
+
+	ok;
+}
+
+/*
+ * Check cases where highscore_regularize() should change the array of scores.
+ */
+static int test_highscore_regularize1(void *state)
+{
+	struct high_score scores[6], scores_good[6], score;
+	int32_t old_exp;
+	int i;
+
+	/*
+	 * An otherwise empty score with some field that is not empty should
+	 * be converted to an empty one.
+	 */
+	(void)memset(scores_good, 0, sizeof(scores_good));
+	(void)memcpy(scores, scores_good, sizeof(scores));
+	for (i = 0; i < (int)N_ELEMENTS(scores); ++i) {
+		scores[i].pts[0] = '3';
+		require(highscore_regularize(scores, N_ELEMENTS(scores)));
+		eq(memcmp(scores, scores_good, sizeof(scores)), 0);
+		scores[i].gold[0] = '1';
+		require(highscore_regularize(scores, N_ELEMENTS(scores)));
+		eq(memcmp(scores, scores_good, sizeof(scores)), 0);
+		scores[i].turns[0] = '2';
+		require(highscore_regularize(scores, N_ELEMENTS(scores)));
+		eq(memcmp(scores, scores_good, sizeof(scores)), 0);
+		(void)memset(scores[i].day, ' ', sizeof(scores[i].day));
+		require(highscore_regularize(scores, N_ELEMENTS(scores)));
+		eq(memcmp(scores, scores_good, sizeof(scores)), 0);
+		scores[i].who[0] = 'a';
+		require(highscore_regularize(scores, N_ELEMENTS(scores)));
+		eq(memcmp(scores, scores_good, sizeof(scores)), 0);
+		scores[i].uid[0] = '7';
+		require(highscore_regularize(scores, N_ELEMENTS(scores)));
+		eq(memcmp(scores, scores_good, sizeof(scores)), 0);
+		scores[i].p_r[0] = '8';
+		require(highscore_regularize(scores, N_ELEMENTS(scores)));
+		eq(memcmp(scores, scores_good, sizeof(scores)), 0);
+		scores[i].p_c[0] = '6';
+		require(highscore_regularize(scores, N_ELEMENTS(scores)));
+		eq(memcmp(scores, scores_good, sizeof(scores)), 0);
+		scores[i].cur_lev[0] = '5';
+		require(highscore_regularize(scores, N_ELEMENTS(scores)));
+		eq(memcmp(scores, scores_good, sizeof(scores)), 0);
+		scores[i].cur_dun[0] = '4';
+		require(highscore_regularize(scores, N_ELEMENTS(scores)));
+		eq(memcmp(scores, scores_good, sizeof(scores)), 0);
+		scores[i].max_lev[0] = '9';
+		require(highscore_regularize(scores, N_ELEMENTS(scores)));
+		eq(memcmp(scores, scores_good, sizeof(scores)), 0);
+		scores[i].max_dun[0] = '0';
+		require(highscore_regularize(scores, N_ELEMENTS(scores)));
+		eq(memcmp(scores, scores_good, sizeof(scores)), 0);
+		scores[i].how[0] = 'c';
+		require(highscore_regularize(scores, N_ELEMENTS(scores)));
+		eq(memcmp(scores, scores_good, sizeof(scores)), 0);
+	}
+
+	/*
+	 * Try corruption of entries or reordering of them when there is
+	 * at least one non-empty entry.
+	 */
+	build_score(&score, &my_p, my_p.died_from, NULL);
+	(void)highscore_add(&score, scores_good, N_ELEMENTS(scores_good));
+	(void)memcpy(scores, scores_good, sizeof(scores));
+	(void)memset(scores[rand_range(1, (int)(N_ELEMENTS(scores) - 1))].p_r,
+		' ', sizeof(scores[0].p_r));
+	require(highscore_regularize(scores, N_ELEMENTS(scores)));
+	eq(memcmp(scores, scores_good, sizeof(scores)), 0);
+
+	scores[0].max_dun[0] = 'a';
+	require(highscore_regularize(scores, N_ELEMENTS(scores)));
+	eq(memcmp(scores + 1, scores_good + 1, sizeof(scores)
+		- sizeof(scores[0])), 0);
+	eq(memcmp(scores, scores + 1, sizeof(scores[0])), 0);
+
+	(void)memcpy(scores, scores_good, sizeof(scores));
+	score = scores[0];
+	i = rand_range(1, (int)(N_ELEMENTS(scores) - 1));
+	scores[0] = scores[i];
+	scores[i] = score;
+	require(highscore_regularize(scores, N_ELEMENTS(scores)));
+	eq(memcmp(scores, scores_good, sizeof(scores)), 0);
+
+	build_score(&score, &my_p, WINNING_HOW, NULL);
+	(void)highscore_add(&score, scores_good, N_ELEMENTS(scores_good));
+	(void)memcpy(scores, scores_good, sizeof(scores));
+	scores[rand_range(2, (int)(N_ELEMENTS(scores) - 1))].who[0] = 'a';
+	require(highscore_regularize(scores, N_ELEMENTS(scores)));
+	eq(memcmp(scores, scores_good, sizeof(scores)), 0);
+
+	(void)memset(scores[0].turns, ' ', sizeof(scores[0].turns));
+	require(highscore_regularize(scores, N_ELEMENTS(scores)));
+	eq(memcmp(scores + 2, scores_good + 2, sizeof(scores)
+		- 2 * sizeof(scores[0])), 0);
+	eq(memcmp(scores, scores_good + 1, sizeof(scores[0])), 0);
+	eq(memcmp(scores + 1, scores + 2, sizeof(scores[0])), 0);
+
+	(void)memcpy(scores, scores_good, sizeof(scores));
+	scores[1].gold[0] = '+';
+	scores[1].gold[1] = 'a';
+	require(highscore_regularize(scores, N_ELEMENTS(scores)));
+	eq(memcmp(scores, scores_good, sizeof(scores[0])), 0);
+	eq(memcmp(scores + 1, scores_good + 2, sizeof(scores[0])), 0);
+	eq(memcmp(scores + 2, scores_good + 2, sizeof(scores)
+		- 2 * sizeof(scores[0])), 0);
+
+	(void)memcpy(scores, scores_good, sizeof(scores));
+	(void)memset(scores[0].cur_dun, ' ', sizeof(scores[0].cur_dun));
+	scores[1].max_lev[0] = '\0';
+	require(highscore_regularize(scores, N_ELEMENTS(scores)));
+	eq(memcmp(scores, scores_good + 2, sizeof(scores[0])), 0);
+	eq(memcmp(scores + 1, scores_good + 2, sizeof(scores[0])), 0);
+	eq(memcmp(scores + 2, scores_good + 2, sizeof(scores)
+		- 2 * sizeof(scores[0])), 0);
+
+	(void)memcpy(scores, scores_good, sizeof(scores));
+	score = scores[0];
+	i = rand_range(2, (int)(N_ELEMENTS(scores) - 1));
+	scores[0] = scores[i];
+	scores[i] = score;
+	score = scores[1];
+	i = rand_range(2, (int)(N_ELEMENTS(scores) - 1));
+	scores[1] = scores[i];
+	scores[i] = score;
+	require(highscore_regularize(scores, N_ELEMENTS(scores)));
+	eq(memcmp(scores, scores_good, sizeof(scores)), 0);
+
+	old_exp = my_p.max_exp;
+	my_p.max_exp -= 22;
+	build_score(&score, &my_p, my_p.died_from, NULL);
+	my_p.max_exp = old_exp;
+	(void)highscore_add(&score, scores_good, N_ELEMENTS(scores_good));
+	(void)memcpy(scores, scores_good, sizeof(scores));
+	(void)memset(scores[rand_range(3, (int)(N_ELEMENTS(scores) - 1))].how,
+		' ', sizeof(scores[0].how));
+	require(highscore_regularize(scores, N_ELEMENTS(scores)));
+	eq(memcmp(scores, scores_good, sizeof(scores)), 0);
+
+	scores[0].max_dun[0] = 'c';
+	require(highscore_regularize(scores, N_ELEMENTS(scores)));
+	eq(memcmp(scores, scores_good + 1, sizeof(scores)
+		- sizeof(scores[0])), 0);
+	eq(memcmp(scores + (N_ELEMENTS(scores) - 1), scores_good + 3,
+		sizeof(scores[0])), 0);
+
+	(void)memcpy(scores, scores_good, sizeof(scores));
+	scores[1].cur_lev[0] = '\0';
+	require(highscore_regularize(scores, N_ELEMENTS(scores)));
+	eq(memcmp(scores, scores_good, sizeof(scores[0])), 0);
+	eq(memcmp(scores + 1, scores_good + 2, sizeof(scores)
+		- 2 * sizeof(scores[0])), 0);
+	eq(memcmp(scores + (N_ELEMENTS(scores) - 1), scores_good + 3,
+		sizeof(scores[0])), 0);
+
+	(void)memcpy(scores, scores_good, sizeof(scores));
+	(void)memset(scores[2].day, ' ', sizeof(scores[2].day));
+	require(highscore_regularize(scores, N_ELEMENTS(scores)));
+	eq(memcmp(scores, scores_good, 2 * sizeof(scores[0])), 0);
+	eq(memcmp(scores + 2, scores_good + 3, sizeof(scores[0])), 0);
+	eq(memcmp(scores + 3, scores_good + 3, sizeof(scores)
+		- 3 * sizeof(scores[0])), 0);
+
+	(void)memcpy(scores, scores_good, sizeof(scores));
+	score = scores[0];
+	i = rand_range(3, (int)(N_ELEMENTS(scores) - 1));
+	scores[0] = scores[i];
+	scores[i] = score;
+	score = scores[1];
+	i = rand_range(3, (int)(N_ELEMENTS(scores) - 1));
+	scores[1] = scores[i];
+	scores[i] = score;
+	score = scores[2];
+	i = rand_range(3, (int)(N_ELEMENTS(scores) - 1));
+	scores[2] = scores[i];
+	scores[i] = score;
+	require(highscore_regularize(scores, N_ELEMENTS(scores)));
+	eq(memcmp(scores, scores_good, sizeof(scores)), 0);
+
+	build_score(&score, &my_p, my_p.died_from, NULL);
+	(void)highscore_add(&score, scores_good, N_ELEMENTS(scores_good));
+	old_exp = my_p.max_exp;
+	my_p.max_exp += 30;
+	build_score(&score, &my_p, WINNING_HOW, NULL);
+	(void)highscore_add(&score, scores_good, N_ELEMENTS(scores_good));
+	build_score(&score, &my_p, my_p.died_from, NULL);
+	(void)highscore_add(&score, scores_good, N_ELEMENTS(scores_good));
+	my_p.max_exp = old_exp;
+	(void)memcpy(scores, scores_good, sizeof(scores));
+	i = rand_range(0, (int)(N_ELEMENTS(scores) - 3));
+	scores[i].p_r[0] = '\0';
+	(void)memset(scores[i + 1].turns, ' ', sizeof(scores[i + 1].turns));
+	require(highscore_regularize(scores, N_ELEMENTS(scores)));
+	if (i > 0) {
+		eq(memcmp(scores, scores_good, i * sizeof(scores[0])), 0);
+	}
+	eq(memcmp(scores + i, scores_good + i + 2,
+		(N_ELEMENTS(scores) - (i + 2)) * sizeof(scores[0])), 0);
+	(void)memset(&score, 0, sizeof(score));
+	eq(memcmp(scores + (N_ELEMENTS(scores) - 2), &score, sizeof(score)), 0);
+	eq(memcmp(scores + (N_ELEMENTS(scores) - 1), &score, sizeof(score)), 0);
+
+	(void)memcpy(scores, scores_good, sizeof(scores));
+	score = scores[0];
+	scores[0] = scores[5];
+	scores[5] = score;
+	score = scores[1];
+	scores[1] = scores[4];
+	scores[4] = score;
+	score = scores[2];
+	scores[2] = scores[3];
+	scores[3] = score;
+	require(highscore_regularize(scores, N_ELEMENTS(scores)));
+	eq(memcmp(scores, scores_good, sizeof(scores)), 0);
+
+	ok;
+}
+
+const char *suite_name = "player/pscore";
+
+struct test tests[] = {
+	{ "highscore_valid0", test_highscore_valid0 },
+	{ "highscore_valid1", test_highscore_valid1 },
+	{ "highscore_where0", test_highscore_where0 },
+	{ "highscore_add0", test_highscore_add0 },
+	{ "highscore_regularize0", test_highscore_regularize0 },
+	{ "highscore_regularize1", test_highscore_regularize1 },
+	{ NULL, NULL }
+};

--- a/src/tests/player/suite.mk
+++ b/src/tests/player/suite.mk
@@ -6,5 +6,6 @@ TESTPROGS += player/birth \
              player/inven-wield \
              player/pathfind \
              player/playerstat \
+             player/pscore \
              player/timed \
              player/util

--- a/src/win/vs2019/Angband.vcxproj
+++ b/src/win/vs2019/Angband.vcxproj
@@ -312,6 +312,7 @@ xcopy $(MSBuildProjectDirectory)\lib\* $(OutDir)lib\ /DESY /exclude:$(MSBuildPro
     <ClCompile Include="src\save.c" />
     <ClCompile Include="src\savefile.c" />
     <ClCompile Include="src\score.c" />
+    <ClCompile Include="src\score-util.c" />
     <ClCompile Include="src\sound-core.c" />
     <ClCompile Include="src\source.c" />
     <ClCompile Include="src\store.c" />

--- a/src/win/vs2019/Angband.vcxproj.filters
+++ b/src/win/vs2019/Angband.vcxproj.filters
@@ -492,6 +492,9 @@
     <ClCompile Include="src\score.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\score-util.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="src\sound-core.c">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
Resolves https://github.com/angband/angband/issues/6256 .  Rearrange score code in preparation for the option to have the elevated privilege operations run in a separate executable.  While doing that, change code in highscore_where().  Resolves https://github.com/angband/angband/issues/6257 .