### PR TITLE
cumber_armor message clarity

### DIFF
--- a/src/player-calcs.c
+++ b/src/player-calcs.c
@@ -2445,9 +2445,9 @@ static void update_bonuses(struct player *p)
 		if (p->state.cumber_armor != state.cumber_armor) {
 			/* Message */
 			if (state.cumber_armor)
-				msg("The weight of your armor encumbers your movement.");
+				msg("The weight of your armor reduces your maximum SP.");
 			else
-				msg("You feel able to move more freely.");
+				msg("Your maximum SP is no longer reduced by armor weight.");
 		}
 	}
 


### PR DESCRIPTION
Resolves: https://github.com/angband/angband/issues/6226

Changes the misleading "armor encumbers your movement" message to accurately reflect that heavy armor reduces maximum SP for spellcasters, not movement speed.

Very open to the specific wording.

### Before equipping:
<img width="153" alt="Screenshot 2025-06-25 at 11 50 34 AM" src="https://github.com/user-attachments/assets/a858ac4c-57a4-474b-981d-01f2970937fe" />

### Equipping and reduction in SP:
<img width="593" alt="Screenshot 2025-06-25 at 11 49 45 AM" src="https://github.com/user-attachments/assets/afd0ea7e-d4dd-4990-bb3f-6f67a5917b4d" />

### Unequip message
<img width="745" alt="Screenshot 2025-06-25 at 11 50 06 AM" src="https://github.com/user-attachments/assets/50c021a5-2a37-400e-86b9-477c955fe2f4" />

### SP restored
<img width="736" alt="Screenshot 2025-06-25 at 11 50 12 AM" src="https://github.com/user-attachments/assets/7c3e1a15-0df8-44a9-972d-6f3a89b7c46b" />

