### PR TITLE
remove img tag from documentation browser tab title

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,7 +83,7 @@ if (html_theme == "".join(["@", "DOC_HTML_THEME", "@"]) or html_theme == ""):
             "headtextcolor": "rgb(253, 229, 164)",
         }
 
-html_title = "<img> The Angband Manual"
+html_title = "The Angband Manual"
 html_short_title = "Home"
 html_sidebars = {
     "**": ["localtoc.html", "searchbox.html"],


### PR DESCRIPTION
The browser tab title was rendering as `Welcome to Angband - <img> The Angband Manual`.

It will now be `Welcome to Angband - The Angband Manual`.