### PR TITLE
Add nix flake to build via nix package manager

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1745391562,
+        "narHash": "sha256-sPwcCYuiEopaafePqlG826tBhctuJsLx/mhKKM5Fmjo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,46 @@
+{
+  description = "A very basic flake";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+      libraries = with pkgs; [
+            SDL2
+            SDL
+            SDL2_image
+            SDL2_ttf
+            SDL_mixer
+            freetype
+            glib
+            harfbuzz
+            lerc
+            libsysprof-capture
+            libtiff
+            ncurses
+            pcre2
+            xorg.libX11
+          ];
+    in
+    {
+      devShells.${system}.default = pkgs.mkShell {
+        packages = with pkgs; [
+          autoconf
+          automake
+          nushell
+          cmake
+          gdb
+          pkg-config
+        ] ++ libraries;
+        LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath libraries;
+        shellHook = ''
+          exec nu
+        '';
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -10,37 +10,140 @@
     let
       system = "x86_64-linux";
       pkgs = nixpkgs.legacyPackages.${system};
-      libraries = with pkgs; [
-            SDL2
-            SDL
-            SDL2_image
-            SDL2_ttf
-            SDL_mixer
-            freetype
-            glib
-            harfbuzz
-            lerc
-            libsysprof-capture
-            libtiff
-            ncurses
-            pcre2
-            xorg.libX11
-          ];
+      gcu_libraries = with pkgs; [
+        ncurses
+      ];
+      sdl_sound_libraries = with pkgs; [
+        SDL
+        SDL_mixer
+      ];
+      sdl2_libaries = with pkgs; [
+        SDL2
+        SDL2_image
+        SDL2_ttf
+        libtiff
+        harfbuzz
+        glib
+        lerc
+        libsysprof-capture
+        pcre2
+        freetype
+      ];
+      sdl_libraries = with pkgs; [
+        SDL
+        SDL_image
+        SDL_ttf
+      ];
+
+      x11_libraries = with pkgs; [
+        xorg.libX11
+      ];
+
+      all_libraries =
+        gcu_libraries ++ sdl_sound_libraries ++ sdl2_libaries ++ sdl_libraries ++ x11_libraries;
+      build_dependencies = with pkgs; [
+        autoconf
+        automake
+        cmake
+        pkg-config
+      ];
     in
     {
       devShells.${system}.default = pkgs.mkShell {
-        packages = with pkgs; [
-          autoconf
-          automake
-          nushell
-          cmake
-          gdb
-          pkg-config
-        ] ++ libraries;
-        LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath libraries;
+        packages =
+          with pkgs;
+          [
+            nushell
+            gdb
+          ]
+          ++ all_libraries
+          ++ build_dependencies;
+        LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath all_libraries;
         shellHook = ''
           exec nu
         '';
+      };
+      packages.${system} = {
+        angband-sdl = pkgs.stdenv.mkDerivation {
+          name = "angband";
+          src = self;
+          nativeBuildInputs = build_dependencies;
+          buildInputs = sdl_libraries ++ sdl_sound_libraries;
+          configurePhase = ''
+            cmake -B build -DSUPPORT_GCU_FRONTEND=OFF -DSUPPORT_SDL2_FRONTEND=OFF -DSUPPORT_SDL_FRONTEND=ON -DSUPPORT_X11_FRONTEND=OFF -DSUPPORT_SDL_SOUND=ON -DCMAKE_BUILD_TYPE=Release
+          '';
+          buildPhase = ''
+            cmake --build build
+          '';
+          installPhase = ''
+            mkdir -p $out/bin
+            cp build/Angband $out/bin/angband
+          '';
+        };
+        angband-gcu = pkgs.stdenv.mkDerivation {
+          name = "angband";
+          src = self;
+          nativeBuildInputs = build_dependencies;
+          buildInputs = gcu_libraries ++ sdl_sound_libraries;
+          configurePhase = ''
+            cmake -B build -DSUPPORT_GCU_FRONTEND=ON -DSUPPORT_SDL2_FRONTEND=OFF -DSUPPORT_SDL_FRONTEND=OFF -DSUPPORT_X11_FRONTEND=OFF -DSUPPORT_SDL_SOUND=ON -DCMAKE_BUILD_TYPE=Release
+          '';
+          buildPhase = ''
+            cmake --build build
+          '';
+          installPhase = ''
+            mkdir -p $out/bin
+            cp build/Angband $out/bin/angband
+          '';
+        };
+        angband-x11 = pkgs.stdenv.mkDerivation {
+          name = "angband";
+          src = self;
+          nativeBuildInputs = build_dependencies;
+          buildInputs = x11_libraries ++ sdl_sound_libraries;
+          configurePhase = ''
+            cmake -B build -DSUPPORT_GCU_FRONTEND=OFF -DSUPPORT_SDL2_FRONTEND=OFF -DSUPPORT_SDL_FRONTEND=OFF -DSUPPORT_X11_FRONTEND=ON -DSUPPORT_SDL_SOUND=ON -DCMAKE_BUILD_TYPE=Release
+          '';
+          buildPhase = ''
+            cmake --build build
+          '';
+          installPhase = ''
+            mkdir -p $out/bin
+            cp build/Angband $out/bin/angband
+          '';
+        };
+        angband-sdl2 = pkgs.stdenv.mkDerivation {
+          name = "angband";
+          src = self;
+          nativeBuildInputs = build_dependencies;
+          buildInputs = sdl2_libaries;
+          configurePhase = ''
+            cmake -B build -DSUPPORT_GCU_FRONTEND=OFF -DSUPPORT_SDL2_FRONTEND=ON -DSUPPORT_SDL_FRONTEND=OFF -DSUPPORT_X11_FRONTEND=OFF -DSUPPORT_SDL_SOUND=OFF -DCMAKE_BUILD_TYPE=Release
+          '';
+          buildPhase = ''
+            cmake --build build
+          '';
+          installPhase = ''
+            mkdir -p $out/bin
+            cp build/Angband $out/bin/angband
+          '';
+        };
+        angband = pkgs.stdenv.mkDerivation {
+          name = "angband";
+          src = self;
+          nativeBuildInputs = build_dependencies;
+          buildInputs = all_libraries;
+          configurePhase = ''
+            cmake -B build -DSUPPORT_GCU_FRONTEND=ON -DSUPPORT_SDL2_FRONTEND=OFF -DSUPPORT_SDL_FRONTEND=ON -DSUPPORT_X11_FRONTEND=ON -DSUPPORT_SDL_SOUND=ON -DCMAKE_BUILD_TYPE=Release
+          '';
+          buildPhase = ''
+            cmake --build build
+          '';
+          installPhase = ''
+            mkdir -p $out/bin
+            cp build/Angband $out/bin/angband
+          '';
+        };
       };
     };
 }


### PR DESCRIPTION
Adds  flake to build angband via nix package manager.
This will also add devshell which installs all the necessary dependencies.

This includes different build modes 
- gcu (with sound)
- X11 
- SDL2

**Feel free to close this MR if you feel like this should be in separate repository.** I happy to maintain it out of tree too, 