### PR TITLE
Remove 'Hack --' src comments part 2

### DIFF
--- a/src/player-path.c
+++ b/src/player-path.c
@@ -1528,21 +1528,21 @@ static bool run_break_right;	/* Looking for a break (right) */
 static bool run_break_left;	/* Looking for a break (left) */
 
 /**
- * Hack -- allow quick "cycling" through the legal directions
+ * Allow quick "cycling" through the legal directions
  */
 static const uint8_t cycle[] =
 { 1, 2, 3, 6, 9, 8, 7, 4, 1, 2, 3, 6, 9, 8, 7, 4, 1 };
 
 
 /**
- * Hack -- map each direction into the "middle" of the "cycle[]" array
+ * Map each direction into the "middle" of the "cycle[]" array
  */
 static const uint8_t chome[] =
 { 0, 8, 9, 10, 7, 0, 11, 6, 5, 4 };
 
 
 /**
- * Hack -- Check for a "known wall" (see below)
+ * Check for a "known wall" (see below)
  */
 static bool see_wall(int dir, struct loc grid)
 {
@@ -1782,7 +1782,7 @@ static bool run_test(const struct player *p)
 
 	/* Looking for open area */
 	if (run_open_area) {
-		/* Hack -- look again */
+		/* Look again */
 		for (i = -max; i < 0; i++) {
 			new_dir = cycle[chome[prev_dir] + i];
 			grid = loc_sum(p->grid, ddgrid[new_dir]);
@@ -1801,7 +1801,7 @@ static bool run_test(const struct player *p)
 			}
 		}
 
-		/* Hack -- look again */
+		/* Look again */
 		for (i = max; i > 0; i--) {
 			new_dir = cycle[chome[prev_dir] + i];
 			grid = loc_sum(p->grid, ddgrid[new_dir]);
@@ -1833,7 +1833,7 @@ static bool run_test(const struct player *p)
 			/* Primary option */
 			run_cur_dir = option;
 
-			/* Hack -- allow curving */
+			/* Allow curving */
 			run_old_dir = option2;
 		}
 	}
@@ -1862,7 +1862,7 @@ void run_step(int dir)
 		/* Initialize */
 		run_init(dir);
 
-		/* Hack -- Set the run counter if no count given */
+		/* Set the run counter if no count given */
 		if (player->upkeep->running == 0)
 			player->upkeep->running = 9999;
 

--- a/src/player-util.c
+++ b/src/player-util.c
@@ -189,7 +189,7 @@ int player_apply_damage_reduction(struct player *p, int dam)
  * \param kb_str is the null-terminated string describing the cause of the
  * damage.
  *
- * Hack -- this function allows the user to save (or quit) the game
+ * This function allows the user to save (or quit) the game
  * when he dies, since the "You die." message is shown before setting
  * the player to "dead".
  */
@@ -246,7 +246,7 @@ void take_hit(struct player *p, int dam, const char *kb_str)
 					&& !get_check("Die? ")) {
 				event_signal(EVENT_CHEAT_DEATH);
 			} else {
-				/* Hack -- Note death */
+				/* Note death */
 				msgt(MSG_DEATH, "You die.");
 				event_signal(EVENT_MESSAGE_FLUSH);
 
@@ -264,7 +264,7 @@ void take_hit(struct player *p, int dam, const char *kb_str)
 
 	/* Hitpoint warning */
 	if (p->chp < warning) {
-		/* Hack -- bell on first notice */
+		/* Bell on first notice */
 		if (old_chp > warning)
 			bell();
 
@@ -311,7 +311,7 @@ void death_knowledge(struct player *p)
 	(void)time(&death_time);
 	enter_score(p, &death_time);
 
-	/* Hack -- Recalculate bonuses */
+	/* Recalculate bonuses */
 	p->upkeep->update |= (PU_BONUS);
 	handle_stuff(p);
 }
@@ -355,7 +355,7 @@ int16_t modify_stat_value(int value, int amount)
 			/* Ten points at a time */
 			if (value >= 18+10) value -= 10;
 
-			/* Hack -- prevent weirdness */
+			/* Prevent weirdness */
 			else if (value > 18) value = 18;
 
 			/* One point at a time */
@@ -700,14 +700,14 @@ void player_update_light(struct player *p)
 			/* Decrease life-span */
 			obj->timeout--;
 
-			/* Hack -- notice interesting fuel steps */
+			/* Notice interesting fuel steps */
 			if ((obj->timeout < 100) || (!(obj->timeout % 100)))
 				/* Redraw stuff */
 				p->upkeep->redraw |= (PR_EQUIP);
 
-			/* Hack -- Special treatment when blind */
+			/* Special treatment when blind */
 			if (p->timed[TMD_BLIND]) {
-				/* Hack -- save some light for later */
+				/* Save some light for later */
 				if (obj->timeout == 0) obj->timeout++;
 			} else if (obj->timeout == 0) {
 				/* The light is now out */

--- a/src/project-feat.c
+++ b/src/project-feat.c
@@ -111,7 +111,7 @@ static void project_feature_handler_KILL_WALL(project_feature_handler_context_t 
 		/* Destroy the rubble */
 		square_destroy_rubble(cave, grid);
 
-		/* Hack -- place an object */
+		/* Place an object */
 		if (randint0(100) < 10){
 			place_object(cave, grid, player->depth, false, false,
 						 ORIGIN_RUBBLE, 0);
@@ -124,7 +124,7 @@ static void project_feature_handler_KILL_WALL(project_feature_handler_context_t 
 			}
 		}
 	} else if (square_isdoor(cave, grid)) {
-		/* Hack -- special message */
+		/* Special message */
 		if (square_isseen(cave, grid)) {
 			msg("The door turns into mud!");
 			context->obvious = true;
@@ -701,7 +701,7 @@ static const project_feature_handler_f feature_handlers[] = {
  * Note that this function determines if the player can see anything that
  * happens by taking into account: blindness, line-of-sight, and illumination.
  *
- * Hack -- effects on grids which are memorized but not in view are also seen.
+ * Effects on grids which are memorized but not in view are also seen.
  */
 bool project_f(struct source origin, int r, struct loc grid, int dam, int typ)
 {

--- a/src/project.c
+++ b/src/project.c
@@ -193,7 +193,7 @@ int project_path(struct chunk *c, struct loc *gp, int range, struct loc grid1,
 			/* Save grid */
 			gp[n++] = loc(x, y);
 
-			/* Hack -- Check maximum range */
+			/* Check maximum range */
 			if ((n + (k >> 1)) >= range) break;
 
 			/* Sometimes stop at finish grid */
@@ -258,7 +258,7 @@ int project_path(struct chunk *c, struct loc *gp, int range, struct loc grid1,
 			/* Save grid */
 			gp[n++] = loc(x, y);
 
-			/* Hack -- Check maximum range */
+			/* Check maximum range */
 			if ((n + (k >> 1)) >= range) break;
 
 			/* Sometimes stop at finish grid */
@@ -317,7 +317,7 @@ int project_path(struct chunk *c, struct loc *gp, int range, struct loc grid1,
 			/* Save grid */
 			gp[n++] = loc(x, y);
 
-			/* Hack -- Check maximum range */
+			/* Check maximum range */
 			if ((n + (n >> 1)) >= range) break;
 
 			/* Sometimes stop at finish grid */
@@ -565,9 +565,9 @@ struct loc origin_get_loc(struct source origin)
  * projection path.  Note that in general, the player will *always* see part
  * of the path, since it either starts at the player or ends on the player.
  *
- * Hack -- we assume that every "projection" is "self-illuminating".
+ * We assume that every "projection" is "self-illuminating".
  *
- * Hack -- when only a single monster is affected, we automatically track
+ * When only a single monster is affected, we automatically track
  * (and recall) that monster, unless "PROJECT_JUMP" is used.
  *
  * Note that we must call "handle_stuff()" after affecting terrain features
@@ -691,7 +691,7 @@ bool project(struct source origin, int rad, struct loc finish,
 				int ny = path_grid[i].y;
 				int nx = path_grid[i].x;
 
-				/* Hack -- Balls explode before reaching walls. */
+				/* Balls explode before reaching walls. */
 				if (!square_ispassable(cave, path_grid[i]) && (rad > 0) &&
 					!(flg & (PROJECT_BEAM)))
 					break;

--- a/src/store.c
+++ b/src/store.c
@@ -574,7 +574,7 @@ static bool store_will_buy(struct store *store, const struct object *obj)
  * The "greed" value should exceed 100 when the player is "buying" the
  * object, and should be less than 100 when the player is "selling" it.
  *
- * Hack -- the black market always charges twice as much as it should.
+ * The black market always charges twice as much as it should.
  */
 int price_item(struct store *store, const struct object *obj,
 			   bool store_buying, int qty)
@@ -1079,7 +1079,7 @@ static void store_delete_random(struct store *store)
 			/* 25% of the time, destroy all objects */
 			else num = obj->number;
 
-			/* Hack -- decrement the total charges of staves and wands. */
+			/* Decrement the total charges of staves and wands. */
 			if (tval_can_have_charges(obj))
 				obj->pval -= num * obj->pval / obj->number;
 		}

--- a/src/ui-command.c
+++ b/src/ui-command.c
@@ -72,7 +72,7 @@ void do_cmd_redraw(void)
 	if (character_dungeon)
 		verify_panel();
 
-	/* Hack -- React to changes */
+	/* React to changes */
 	Term_xtra(TERM_XTRA_REACT, 0);
 
 	if (character_dungeon) {
@@ -98,7 +98,7 @@ void do_cmd_redraw(void)
 	Term_clear();
 
 	if (character_dungeon) {
-		/* Hack -- update */
+		/* Update */
 		handle_stuff(player);
 
 		/* Place the cursor on the player */
@@ -483,7 +483,7 @@ void html_screenshot(const char *path, int mode, term *other_term)
 
 
 /**
- * Hack -- save a screen dump to a file in html format
+ * Save a screen dump to a file in html format
  */
 static void do_cmd_save_screen_html(int mode, term *other_term)
 {
@@ -535,7 +535,7 @@ static void do_cmd_save_screen_html(int mode, term *other_term)
 
 
 /**
- * Hack -- save a screen dump to a file
+ * Save a screen dump to a file
  */
 void do_cmd_save_screen(void)
 {

--- a/src/ui-context.c
+++ b/src/ui-context.c
@@ -118,7 +118,7 @@ static int context_menu_player_2(int mx, int my)
 	menu_dynamic_add_label(m, "Options", '=', MENU_VALUE_OPTIONS, labels);
 	menu_dynamic_add_label(m, "Commands", '?', MENU_VALUE_HELP, labels);
 
-	/* Hack -- no flush needed */
+	/* No flush needed */
 	msg_flag = false;
 	screen_save();
 
@@ -310,7 +310,7 @@ int context_menu_player(int mx, int my)
 
 	menu_dynamic_add_label(m, "Other", ' ', MENU_VALUE_OTHER, labels);
 
-	/* Hack -- no flush needed */
+	/* No flush needed */
 	msg_flag = false;
 	screen_save();
 
@@ -504,7 +504,7 @@ int context_menu_cave(struct chunk *c, int y, int x, int adjacent, int mx,
 
 	ADD_LABEL("Throw To", CMD_THROW, MN_ROW_VALID);
 
-	/* Hack -- no flush needed */
+	/* No flush needed */
 	msg_flag = false;
 	screen_save();
 
@@ -772,7 +772,7 @@ int context_menu_object(struct object *obj)
 
 	area.width = -(r.width + 2);
 
-	/* Hack -- no flush needed */
+	/* No flush needed */
 	msg_flag = false;
 	screen_save();
 

--- a/src/ui-display.c
+++ b/src/ui-display.c
@@ -2508,7 +2508,7 @@ static void repeated_command_display(game_event_type type,
 static void new_level_display_update(game_event_type type,
 									 game_event_data *data, void *user)
 {
-	/* Hack -- enforce illegal panel */
+	/* Enforce illegal panel */
 	Term->offset_y = z_info->dungeon_hgt;
 	Term->offset_x = z_info->dungeon_wid;
 
@@ -2518,7 +2518,7 @@ static void new_level_display_update(game_event_type type,
 	/* Clear */
 	Term_clear();
 
-	/* Hack -- Invoke partial update mode */
+	/* Invoke partial update mode */
 	player->upkeep->only_partial = true;
 
 	/* Update stuff */
@@ -2553,7 +2553,7 @@ static void new_level_display_update(game_event_type type,
 	 */
 	handle_stuff(player);
 
-	/* Hack -- Kill partial update mode */
+	/* Kill partial update mode */
 	player->upkeep->only_partial = false;
 
 	/* Refresh */
@@ -2780,7 +2780,7 @@ static void ui_enter_world(game_event_type type, game_event_data *data,
 	/* Allow the player to cheat death, if appropriate */
 	event_add_handler(EVENT_CHEAT_DEATH, cheat_death, NULL);
 
-	/* Hack -- Decrease "icky" depth */
+	/* Decrease "icky" depth */
 	screen_save_depth--;
 }
 
@@ -2848,7 +2848,7 @@ static void ui_leave_world(game_event_type type, game_event_data *data,
 	/* If we've gone into a store, we need to know how to leave */
 	event_add_handler(EVENT_LEAVE_STORE, leave_store, NULL);
 
-	/* Hack -- Increase "icky" depth */
+	/* Increase "icky" depth */
 	screen_save_depth++;
 }
 

--- a/src/ui-help.c
+++ b/src/ui-help.c
@@ -227,7 +227,7 @@ bool show_file(const char *name, const char *what, int line, int mode)
 			/* Close it */
 			file_close(fff);
 
-			/* Hack -- Re-Open the file */
+			/* Re-Open the file */
 			fff = file_open(path, MODE_READ, FTYPE_TEXT);
 			if (!fff) return (true);
 
@@ -261,7 +261,7 @@ bool show_file(const char *name, const char *what, int line, int mode)
 
 		/* Dump the next lines of the file */
 		for (i = 0; i < hgt - 4; ) {
-			/* Hack -- track the "first" line */
+			/* Track the "first" line */
 			if (!i) line = next;
 
 			/* Get a line of the file or stop */
@@ -289,10 +289,10 @@ bool show_file(const char *name, const char *what, int line, int mode)
 			/* Make the line lower case */
 			if (!case_sensitive) string_lower(lc_buf);
 
-			/* Hack -- keep searching */
+			/* Keep searching */
 			if (find && !i && !strstr(lc_buf, find)) continue;
 
-			/* Hack -- stop searching */
+			/* Stop searching */
 			find = NULL;
 
 			/* Dump the line */
@@ -319,7 +319,7 @@ bool show_file(const char *name, const char *what, int line, int mode)
 			i++;
 		}
 
-		/* Hack -- failed search */
+		/* Failed search */
 		if (find) {
 			bell();
 			line = back;

--- a/src/ui-input.c
+++ b/src/ui-input.c
@@ -181,7 +181,7 @@ ui_event inkey_ex(void)
 		inkey_xtra = false;
 	}
 
-	/* Hack -- Use the "inkey_next" pointer */
+	/* Use the "inkey_next" pointer */
 	while (inkey_next && inkey_next->code) {
 		/* Get next character, and advance */
 		ke.key = *inkey_next++;
@@ -248,27 +248,27 @@ ui_event inkey_ex(void)
 		(void)Term_set_cursor(true);
 
 
-	/* Hack -- Activate main screen */
+	/* Activate main screen */
 	Term_activate(term_screen);
 
 
 	/* Get a key */
 	while (ke.type == EVT_NONE) {
-		/* Hack -- Handle "inkey_scan == SCAN_INSTANT */
+		/* Handle "inkey_scan == SCAN_INSTANT */
 		if (inkey_scan == SCAN_INSTANT &&
 			(0 != Term_inkey(&kk, false, false)))
 			break;
 
 
-		/* Hack -- Flush output once when no key ready */
+		/* Flush output once when no key ready */
 		if (!done && (0 != Term_inkey(&kk, false, false))) {
-			/* Hack -- activate proper term */
+			/* Activate proper term */
 			Term_activate(old);
 
 			/* Flush output */
 			Term_fresh();
 
-			/* Hack -- activate main screen */
+			/* Activate main screen */
 			Term_activate(term_screen);
 
 			/* Mega-Hack -- reset saved flag */
@@ -294,7 +294,7 @@ ui_event inkey_ex(void)
 			ke.key.code = ESCAPE;
 	}
 
-	/* Hack -- restore the term */
+	/* Restore the term */
 	Term_activate(old);
 
 	/* Restore the cursor */
@@ -380,7 +380,7 @@ ui_event inkey_m(void)
 
 
 /**
- * Hack -- flush
+ * Flush
  */
 static void msg_flush(int x)
 {
@@ -478,7 +478,7 @@ bool msg_flag;
  * result in the loss of information if the screen is cleared, or if anything
  * is displayed on the top line.
  *
- * Hack -- Note that "msg("%s", NULL)" will clear the top line even if no
+ * Note that "msg("%s", NULL)" will clear the top line even if no
  * messages are pending.
  */
 void display_message(game_event_type unused, game_event_data *data, void *user)
@@ -508,13 +508,13 @@ void display_message(game_event_type unused, game_event_data *data, void *user)
 	/* Obtain the size */
 	(void)Term_get_size(&w, &h);
 
-	/* Hack -- Reset */
+	/* Reset */
 	if (!msg_flag) message_column = 0;
 
 	/* Message Length */
 	n = (msg ? strlen(msg) : 0);
 
-	/* Hack -- flush when requested or needed */
+	/* Flush when requested or needed */
 	if (message_column && (!msg || ((message_column + n) > (w - 8)))) {
 		/* Flush */
 		if (message_column <= w - 8) {
@@ -608,7 +608,7 @@ void bell_message(game_event_type unused, game_event_data *data, void *user)
  */
 void message_flush(game_event_type unused, game_event_data *data, void *user)
 {
-	/* Hack -- Reset */
+	/* Reset */
 	if (!msg_flag) message_column = 0;
 
 	/* Flush when needed */
@@ -1274,7 +1274,7 @@ static bool textui_get_check(const char *prompt)
 	char buf[80];
 
 	/*
-	 * Hack -- Build a "useful" prompt; do this first so prompts built by
+	 * Build a "useful" prompt; do this first so prompts built by
 	 * format() won't run afoul of event_signal()'s side effects.
 	 */
 	strnfmt(buf, 78, "%.70s[y/n] ", prompt);
@@ -1320,7 +1320,7 @@ char get_char(const char *prompt, const char *options, size_t len, char fallback
 	/* Paranoia */
 	event_signal(EVENT_MESSAGE_FLUSH);
 
-	/* Hack -- Build a "useful" prompt */
+	/* Build a "useful" prompt */
 	strnfmt(buf, 78, "%.70s[%s] ", prompt, options);
 
 	/* Prompt for it */
@@ -1619,7 +1619,7 @@ static bool textui_get_aim_dir(int *dp)
 	/* Initialize */
 	(*dp) = 0;
 
-	/* Hack -- auto-target if requested */
+	/* Auto-target if requested */
 	if (OPT(player, use_old_target) && target_okay() && !dir) dir = 5;
 
 	/* Ask until satisfied */
@@ -1779,7 +1779,7 @@ static int textui_get_count(void)
 
 
 /**
- * Hack -- special buffer to hold the action of the current keymap
+ * Special buffer to hold the action of the current keymap
  */
 static struct keypress request_command_buffer[256];
 
@@ -1809,7 +1809,7 @@ ui_event textui_get_command(int *count)
 
 	/* Get command */
 	while (1) {
-		/* Hack -- no flush needed */
+		/* No flush needed */
 		msg_flag = false;
 
 		/* Activate "command mode" */
@@ -1913,7 +1913,7 @@ bool key_confirm_command(unsigned char c)
 {
 	int i;
 
-	/* Hack -- Scan equipment */
+	/* Scan equipment */
 	for (i = 0; i < player->body.count; i++) {
 		char verify_inscrip[] = "^*";
 		unsigned n;

--- a/src/ui-knowledge.c
+++ b/src/ui-knowledge.c
@@ -1561,7 +1561,7 @@ static void desc_art_fake(int a_idx)
 			object_copy(known_obj, obj);
 	}
 
-	/* Hack -- Handle stuff */
+	/*Handle stuff */
 	handle_stuff(player);
 
 	tb = object_info(obj, OINFO_NONE);
@@ -1883,7 +1883,7 @@ static void desc_obj_fake(int k_idx)
 		object_copy(known_obj, obj);
 	obj->known = known_obj;
 
-	/* Hack -- Handle stuff */
+	/* Handle stuff */
 	handle_stuff(player);
 
 	tb = object_info(obj, OINFO_FAKE);

--- a/src/ui-map.c
+++ b/src/ui-map.c
@@ -36,7 +36,7 @@
 
 
 /**
- * Hack -- Hallucinatory monster
+ * Hallucinatory monster
  */
 static void hallucinatory_monster(int *a, wchar_t *c)
 {
@@ -56,7 +56,7 @@ static void hallucinatory_monster(int *a, wchar_t *c)
 
 
 /**
- * Hack -- Hallucinatory object
+ * Hallucinatory object
  */
 static void hallucinatory_object(int *a, wchar_t *c)
 {
@@ -265,7 +265,7 @@ void grid_data_as_text(struct grid_data *g, int *ap, wchar_t *cp, int *tap,
 				dc = monster_x_char[mon->race->ridx];
 				c = dc;
 			} else if (a & 0x80) {
-				/* Hack -- Bizarre grid under monster */
+				/* Bizarre grid under monster */
 				a = da;
 				c = dc;
 			} else if (!rf_has(mon->race->flags, RF_CHAR_CLEAR)) {
@@ -553,7 +553,7 @@ static void print_rel_map(wchar_t c, uint8_t a, int y, int x)
 		if ((ky < 0) || (ky >= t->hgt)) continue;
 		if ((kx < 0) || (kx >= t->wid)) continue;
 
-		/* Hack -- Queue it */
+		/* Queue it */
 		Term_queue_char(t, kx, ky, a, c, 0, 0);
 
 		if ((tile_width > 1) || (tile_height > 1))
@@ -602,7 +602,7 @@ void print_rel(wchar_t c, uint8_t a, int y, int x)
 	vx = COL_MAP + (tile_width * kx);
 	vy = ROW_MAP + (tile_height * ky);
 
-	/* Hack -- Queue it */
+	/* Queue it */
 	Term_queue_char(Term, vx, vy, a, c, 0, 0);
 
 	if ((tile_width > 1) || (tile_height > 1))
@@ -734,7 +734,7 @@ void prt_map(void)
 			map_info(loc(x, y), &g);
 			grid_data_as_text(&g, &a, &c, &ta, &tc);
 
-			/* Hack -- Queue it */
+			/* Queue it */
 			Term_queue_char(Term, vx, vy, a, c, ta, tc);
 
 			if ((tile_width > 1) || (tile_height > 1))

--- a/src/ui-mon-lore.c
+++ b/src/ui-mon-lore.c
@@ -95,7 +95,7 @@ void lore_description(textblock *tb, const struct monster_race *race,
 
 	assert(tb && race && original_lore);
 
-	/* Hack -- create a copy of the monster-memory that we can modify */
+	/* Create a copy of the monster-memory that we can modify */
 	memcpy(lore, original_lore, sizeof(struct monster_lore));
 
 	/* Spoilers -- know everything */

--- a/src/ui-options.c
+++ b/src/ui-options.c
@@ -148,7 +148,7 @@ static bool option_toggle_handle(struct menu *m, const ui_event *event,
 	int page = option_type(oid);
 
 	if (event->type == EVT_SELECT) {
-		/* Hack -- birth options can not be toggled after birth */
+		/* Birth options can not be toggled after birth */
 		/* At birth, m->flags == MN_DBL_TAP. */
 		/* After birth, m->flags == MN_NO_TAGS */
 		if (!((page == OP_BIRTH) && (m->flags == MN_NO_TAGS))) {
@@ -490,7 +490,7 @@ static void do_cmd_options_win(const char *name, int row)
 			/* Toggle */
 			else if (ke.key.code == '5' || ke.key.code == 't' ||
 					ke.key.code == KC_ENTER) {
-				/* Hack -- ignore the main window */
+				/* Ignore the main window */
 				if (x == 0)
 					bell();
 
@@ -559,7 +559,7 @@ static struct keypress keymap_get_trigger(void)
 	/* Convert to ascii */
 	keypress_to_text(tmp, sizeof(tmp), buf, false);
 
-	/* Hack -- display the trigger */
+	/* Display the trigger */
 	Term_addstr(-1, COLOUR_WHITE, tmp);
 
 	/* Flush */
@@ -882,7 +882,7 @@ static void colors_modify(const char *title, int row)
 	/* Prompt */
 	prt("Command: Modify colors", 8, 0);
 
-	/* Hack -- query until done */
+	/* Query until done */
 	while (1) {
 		const char *name;
 		char index;
@@ -970,10 +970,10 @@ static void colors_modify(const char *title, int row)
 			angband_color_table[a][3] =
 				(uint8_t)(angband_color_table[a][3] - 1);
 
-		/* Hack -- react to changes */
+		/* React to changes */
 		Term_xtra(TERM_XTRA_REACT, 0);
 
-		/* Hack -- redraw */
+		/* Redraw */
 		Term_redraw();
 	}
 }

--- a/src/ui-player.c
+++ b/src/ui-player.c
@@ -1212,7 +1212,7 @@ bool dump_save(const char *path)
 
 
 /**
- * Hack -- change name
+ * Change name
  */
 void do_cmd_change_name(void)
 {

--- a/src/ui-score.c
+++ b/src/ui-score.c
@@ -43,7 +43,7 @@ static void display_score_page(const struct high_score scores[], int start,
 		char out_val[160];
 		char tmp_val[160];
 
-		/* Hack -- indicate death in yellow */
+		/* Indicate death in yellow */
 		attr = (start == highlight) ? COLOUR_L_GREEN : COLOUR_WHITE;
 
 		c = player_id2class(atoi(score->p_c));
@@ -55,7 +55,7 @@ static void display_score_page(const struct high_score scores[], int start,
 		cdun = atoi(score->cur_dun);
 		mdun = atoi(score->max_dun);
 
-		/* Hack -- extract the gold and such */
+		/* Extract the gold and such */
 		for (user = score->uid; isspace((unsigned char)*user); user++)
 			/* loop */;
 		for (when = score->day; isspace((unsigned char)*when); when++)
@@ -125,7 +125,7 @@ static void display_scores_aux(const struct high_score scores[], int from,
 	if (to < 0) to = allow_scrolling ? 5 : 10;
 	if (to > MAX_HISCORES) to = MAX_HISCORES;
 
-	/* Hack -- Count the high scores */
+	/* Count the high scores */
 	for (count = 0; count < MAX_HISCORES; count++)
 		if (!scores[count].what[0])
 			break;

--- a/src/ui-store.c
+++ b/src/ui-store.c
@@ -766,7 +766,7 @@ static void store_examine(struct store_context *ctx, int item)
 		odesc_flags |= ODESC_STORE;
 	}
 
-	/* Hack -- no flush needed */
+	/* No flush needed */
 	msg_flag = false;
 
 	/* Show full info in most stores, but normal info in player home */
@@ -776,7 +776,7 @@ static void store_examine(struct store_context *ctx, int item)
 	textui_textblock_show(tb, area, header);
 	textblock_free(tb);
 
-	/* Hack -- Browse book, then prompt for a command */
+	/* Browse book, then prompt for a command */
 	if (obj_can_browse(obj))
 		textui_book_browse(obj);
 }
@@ -824,7 +824,7 @@ static bool store_process_command_key(struct keypress kp)
 {
 	int cmd = 0;
 
-	/* Hack -- no flush needed */
+	/* No flush needed */
 	prt("", 0, 0);
 	msg_flag = false;
 
@@ -917,7 +917,7 @@ static int context_menu_store(struct store_context *ctx, const int oid, int mx, 
 	}
 	menu_dynamic_add_label(m, "Exit", '`', ACT_EXIT, labels);
 
-	/* Hack -- no flush needed */
+	/* No flush needed */
 	msg_flag = false;
 	screen_save();
 
@@ -999,7 +999,7 @@ static bool context_menu_store_item(struct store_context *ctx, const int oid, in
 		m->switch_keys = "g";
 	}
 
-	/* Hack -- no flush needed */
+	/* No flush needed */
 	msg_flag = false;
 	screen_save();
 
@@ -1036,7 +1036,7 @@ static bool store_menu_handle(struct menu *m, const ui_event *event, int oid)
 	struct store *store = ctx->store;
 	
 	if (event->type == EVT_SELECT) {
-		/* Hack -- there's no mouse event coordinates to use for */
+		/* HACK there's no mouse event coordinates to use for */
 		/* menu_store_item, so fake one as if mouse clicked on letter */
 		bool purchased = context_menu_store_item(ctx, oid, 1, m->active.row + oid);
 		ctx->flags |= (STORE_FRAME_CHANGE | STORE_GOLD_CHANGE);

--- a/src/ui-target.c
+++ b/src/ui-target.c
@@ -849,7 +849,7 @@ static bool aux_terrain(struct chunk *c, struct player *p,
 	/* Terrain feature if needed */
 	name = square_apparent_name(p->cave, auxst->grid);
 
-	/* Hack -- handle unknown grids */
+	/* Handle unknown grids */
 
 	/* Pick a preposition if needed */
 	lphrase2 = (*auxst->phrase2) ?

--- a/src/ui-term.c
+++ b/src/ui-term.c
@@ -484,7 +484,7 @@ errr Term_xtra(int n, int v)
 
 
 /**
- * Hack -- fake hook for "Term_curs()" (see above)
+ * HACK fake hook for "Term_curs()" (see above)
  */
 static errr Term_curs_hack(int x, int y)
 {
@@ -496,7 +496,7 @@ static errr Term_curs_hack(int x, int y)
 }
 
 /**
- * Hack -- fake hook for "Term_wipe()" (see above)
+ * HACK fake hook for "Term_wipe()" (see above)
  */
 static errr Term_wipe_hack(int x, int y, int n)
 {
@@ -508,7 +508,7 @@ static errr Term_wipe_hack(int x, int y, int n)
 }
 
 /**
- * Hack -- fake hook for "Term_text()" (see above)
+ * HACK fake hook for "Term_text()" (see above)
  */
 static errr Term_text_hack(int x, int y, int n, int a, const wchar_t *cp)
 {
@@ -521,7 +521,7 @@ static errr Term_text_hack(int x, int y, int n, int a, const wchar_t *cp)
 
 
 /**
- * Hack -- fake hook for "Term_pict()" (see above)
+ * HACK fake hook for "Term_pict()" (see above)
  */
 static errr Term_pict_hack(int x, int y, int n, const int *ap,
 						   const wchar_t *cp, const int *tap,
@@ -565,7 +565,7 @@ void Term_queue_char(term *t, int x, int y, int a, wchar_t c, int ta,
 	if (!ta) ta = ota;
 	if (!tc) tc = otc;
 
-	/* Hack -- Ignore non-changes */
+	/* Ignore non-changes */
 	if ((oa == a) && (oc == c) && (ota == ta) && (otc == tc)) return;
 
 	/* Save the "literal" information */
@@ -705,7 +705,7 @@ void Term_queue_chars(int x, int y, int n, int a, const wchar_t *s)
 		int ota = scr_taa[x];
 		wchar_t otc = scr_tcc[x];
 
-		/* Hack -- Ignore non-changes */
+		/* Ignore non-changes */
 		if ((oa == a) && (oc == *s) && (ota == 0) && (otc == 0)) continue;
 
 		/* Save the "literal" information */
@@ -1174,7 +1174,7 @@ static void Term_fresh_row_both(int y, int x1, int x2)
 			/* 2nd byte of bigtile */
 			if (na == 255) continue;
 
-			/* Hack -- Draw the special attr/char pair */
+			/* Draw the special attr/char pair */
 			(void)((*Term->pict_hook)(x, y, 1, &na, &nc, &nta, &ntc));
 
 			/* Skip */
@@ -1409,7 +1409,7 @@ static void Term_fresh_row_both_dblh(int y, int x1, int x2, int *pr_drw)
 			/* Skip padding element for big tiles. */
 			if (na == 255) continue;
 
-			/* Hack -- Draw the special attr/char pair */
+			/* Draw the special attr/char pair */
 			(void)((*Term->pict_hook)(x, y, 1, &na, &nc, &nta,
 				&ntc));
 
@@ -1751,7 +1751,7 @@ errr Term_fresh(void)
 		/* Physically erase the entire window */
 		Term_xtra(TERM_XTRA_CLEAR, 0);
 
-		/* Hack -- clear all "cursor" data */
+		/* Clear all "cursor" data */
 		old->cv = old->cu = false;
 		old->cx = old->cy = 0;
 		old->cnx = old->cny = 1;
@@ -1904,7 +1904,7 @@ errr Term_fresh(void)
 					/* Flush the row */
 					Term_fresh_row_text(y, x1, x2);
 				}
-				/* Hack -- Flush that row (if allowed) */
+				/* Flush that row (if allowed) */
 				if (!Term->never_frosh) Term_xtra(TERM_XTRA_FROSH, y);
 			} else if (pr_drw) {
 				/*
@@ -2149,7 +2149,7 @@ errr Term_addstr(int n, int a, const char *buf)
 	/* Advance the cursor */
 	Term->scr->cx += n;
 
-	/* Hack -- Notice "Useless" cursor */
+	/* Notice "Useless" cursor */
 	if (res) Term->scr->cu = 1;
 
 	/* Success (usually) */
@@ -2278,7 +2278,7 @@ errr Term_erase(int x, int y, int n)
 		int oa = scr_aa[x];
 		wchar_t oc = scr_cc[x];
 
-		/* Hack -- Ignore "non-changes" */
+		/* Ignore "non-changes" */
 		if ((oa == COLOUR_WHITE) && (oc == ' ')) continue;
 
 		/* Save the "literal" information */
@@ -2373,7 +2373,7 @@ errr Term_redraw(void)
 	/* Force "total erase" */
 	Term->total_erase = true;
 
-	/* Hack -- Refresh */
+	/* Refresh */
 	Term_fresh();
 
 	/* Success */
@@ -2418,7 +2418,7 @@ errr Term_redraw_section(int x1, int y1, int x2, int y2)
 		}
 	}
 
-	/* Hack -- Refresh */
+	/* Refresh */
 	Term_fresh();
 
 	/* Success */
@@ -2514,7 +2514,7 @@ errr Term_flush(void)
 	if (!Term)
 		return 0;
 
-	/* Hack -- Flush all events */
+	/* Flush all events */
 	Term_xtra(TERM_XTRA_FLUSH, 0);
 
 	/* Forget all keypresses */
@@ -2544,7 +2544,7 @@ static void log_keypress(ui_event e)
  */
 errr Term_keypress(keycode_t k, uint8_t mods)
 {
-	/* Hack -- Refuse to enqueue non-keys */
+	/* Refuse to enqueue non-keys */
 	if (!k) return (-1);
 
 	if(!Term->complex_input) {
@@ -2631,10 +2631,10 @@ errr Term_key_push(int k)
 
 errr Term_event_push(const ui_event *ke)
 {
-	/* Hack -- Refuse to enqueue non-keys */
+	/* Refuse to enqueue non-keys */
 	if (!ke) return (-1);
 
-	/* Hack -- Overflow may induce circular queue */
+	/* Overflow may induce circular queue */
 	if (Term->key_tail == 0) Term->key_tail = Term->key_size;
 
 	/* Back up, Store the char */
@@ -2667,7 +2667,7 @@ errr Term_inkey(ui_event *ch, bool wait, bool take)
 	/* Assume no key */
 	memset(ch, 0, sizeof *ch);
 
-	/* Hack -- get bored */
+	/* Get bored */
 	if (!Term->never_bored)
 		/* Process random events */
 		Term_xtra(TERM_XTRA_BORED, 0);
@@ -3039,13 +3039,13 @@ errr Term_resize(int w, int h)
  */
 errr Term_activate(term *t)
 {
-	/* Hack -- already done */
+	/* Already done */
 	if (Term == t) return (1);
 
 	/* Deactivate the old Term */
 	if (Term) Term_xtra(TERM_XTRA_LEVEL, 0);
 
-	/* Hack -- Call the special "init" hook */
+	/* Call the special "init" hook */
 	if (t && !t->active_flag) {
 		/* Call the "init" hook */
 		if (t->init_hook) (*t->init_hook)(t);
@@ -3074,7 +3074,7 @@ errr Term_activate(term *t)
  */
 errr term_nuke(term *t)
 {
-	/* Hack -- Call the special "nuke" hook */
+	/* Call the special "nuke" hook */
 	if (t->active_flag) {
 		/* Call the "nuke" hook */
 		if (t->nuke_hook) (*t->nuke_hook)(t);

--- a/src/ui-term.h
+++ b/src/ui-term.h
@@ -354,7 +354,7 @@ extern char angband_term_name[ANGBAND_TERM_MAX][16];
 extern uint32_t window_flag[ANGBAND_TERM_MAX];
 
 /**
- * Hack -- The main "screen"
+ * The main "screen"
  */
 #define term_screen	(angband_term[0])
 

--- a/src/wiz-debug.c
+++ b/src/wiz-debug.c
@@ -59,7 +59,7 @@ void wiz_cheat_death(void)
 		msg("A tension leaves the air around you...");
 		event_signal(EVENT_MESSAGE_FLUSH);
 
-		/* Hack -- Prevent recall */
+		/* Prevent recall */
 		player->word_recall = 0;
 	}
 
@@ -70,7 +70,7 @@ void wiz_cheat_death(void)
 		msg("The air around you stops swirling...");
 		event_signal(EVENT_MESSAGE_FLUSH);
 
-		/* Hack -- Prevent recall */
+		/* Prevent recall */
 		player->deep_descent = 0;
 	}
 

--- a/src/wiz-spoil.c
+++ b/src/wiz-spoil.c
@@ -236,7 +236,7 @@ void spoil_obj_desc(const char *fname)
 	for (i = 0; true; i++) {
 		/* Write out the group title */
 		if (group_item[i].name) {
-			/* Hack -- bubble-sort by cost and then level */
+			/* Bubble-sort by cost and then level */
 			for (s = 0; s < n - 1; s++) {
 				for (t = 0; t < n - 1; t++) {
 					int i1 = t;
@@ -314,7 +314,7 @@ void spoil_obj_desc(const char *fname)
 			/* Skip wrong tvals */
 			if (kind->tval != group_item[i].tval) continue;
 
-			/* Hack -- Skip instant-artifacts */
+			/* Skip instant-artifacts */
 			if (kf_has(kind->kind_flags, KF_INSTA_ART)) continue;
 
 			/* Save the index */
@@ -580,7 +580,7 @@ void spoil_mon_desc(const char *fname)
 		/* Experience */
 		strnfmt(exp, sizeof(exp), "%ld", (long)(race->mexp));
 
-		/* Hack -- use visual instead */
+		/* Use visual instead */
 		n_mbbuf = text_wctomb(mbbuf, race->d_char);
 		if (n_mbbuf > 0) {
 			mbbuf[n_mbbuf] = '\0';

--- a/src/z-form.c
+++ b/src/z-form.c
@@ -294,7 +294,7 @@ size_t vstrnfmt(char *buf, size_t max, const char *fmt, va_list vp)
 
 			/* Handle "alphabetic" or "non-alphabetic"chars */
 			if (isalpha((unsigned char)*s)) {
-				/* Hack -- handle "long" request */
+				/* Handle "long" request */
 				if (*s == 'l') {
 					/* Save the character */
 					aux[q++] = *s++;
@@ -309,17 +309,17 @@ size_t vstrnfmt(char *buf, size_t max, const char *fmt, va_list vp)
 					break;
 				}
 			} else {
-				/* Hack -- Handle 'star' (for "variable length" argument) */
+				/* Handle 'star' (for "variable length" argument) */
 				if (*s == '*') {
 					int arg;
 
 					/* Get the next argument */
 					arg = va_arg(vp, int);
 
-					/* Hack -- append the "length" */
+					/* Append the "length" */
 					snprintf(aux + q, sizeof(aux) - q, "%d", arg);
 
-					/* Hack -- accept the "length" */
+					/* Accept the "length" */
 					while (aux[q]) q++;
 
 					/* Skip the "*" */
@@ -452,7 +452,7 @@ size_t vstrnfmt(char *buf, size_t max, const char *fmt, va_list vp)
 					/* Get the next argument */
 					arg = va_arg(vp, const wchar_t *);
 
-					/* Hack -- convert NULL to EMPTY */
+					/* Convert NULL to EMPTY */
 					if (!arg) arg = L"";
 
 					/* Prevent buffer overflows and convert string to char */
@@ -489,7 +489,7 @@ size_t vstrnfmt(char *buf, size_t max, const char *fmt, va_list vp)
 					/* Get the next argument */
 					arg = va_arg(vp, const char *);
 
-					/* Hack -- convert NULL to EMPTY */
+					/* Convert NULL to EMPTY */
 					if (!arg) arg = "";
 
 					/* Prevent buffer overflows */

--- a/src/z-rand.c
+++ b/src/z-rand.c
@@ -172,7 +172,7 @@ uint32_t Rand_div(uint32_t m)
 	/* Division by zero will result if m is larger than 0x10000000 */
 	assert(m <= 0x10000000);
 
-	/* Hack -- simple case */
+	/* Simple case */
 	if (m <= 1) return (0);
 
 	if (rand_fixed)

--- a/src/z-textblock.c
+++ b/src/z-textblock.c
@@ -371,24 +371,24 @@ void textblock_to_file(textblock *tb, ang_file *f, int indent, int wrap_at)
 void (*text_out_hook)(uint8_t a, const char *str);
 
 /**
- * Hack -- Where to wrap the text when using text_out().  Use the default
+ * Where to wrap the text when using text_out().  Use the default
  * value (for example the screen width) when 'text_out_wrap' is 0.
  */
 int text_out_wrap = 0;
 
 /**
- * Hack -- Indentation for the text when using text_out().
+ * Indentation for the text when using text_out().
  */
 int text_out_indent = 0;
 
 /**
- * Hack -- Padding after wrapping
+ * Padding after wrapping
  */
 int text_out_pad = 0;
 
 
 /**
- * Hack - the destination file for text_out_to_file.
+ * The destination file for text_out_to_file.
  */
 ang_file *text_out_file = NULL;
 


### PR DESCRIPTION
Follow up from https://github.com/angband/angband/pull/6283

Removes remaining `Hack --` comments in `src` directory.

Leaves in `Mega-Hack` comments.

Replaced comment to say `HACK` for hacky solutions.