### PR TITLE
Replace <something> with `something` where it confused doxygen

### DIFF
--- a/src/cocoa/AppDelegate.m
+++ b/src/cocoa/AppDelegate.m
@@ -50,7 +50,7 @@
  * 7) The generated .nib file will be in
  *    Contents/Resources/Base.lproj in the product directory which
  *    is something like
- *    ~/Library/Developer/Xcode/DerivedData/<product_name>-<some_string>/Build/Products/Debug/<product_name>.app
+ *    ~/Library/Developer/Xcode/DerivedData/`product_name`-`some_string`/Build/Products/Debug/`product_name`.app
  *    You can use them to replace the .nib file in src/cocoa/en.lproj in the
  *    Angband source files.  In older versions of Angband, MainMenu.nib is a
  *    directory; you'll have to remove it and replace it with the flat file

--- a/src/main.c
+++ b/src/main.c
@@ -203,11 +203,11 @@ static const struct {
 };
 
 /**
- * Handle a "-d<dir>=<path>" option.
+ * Handle a "-d`dir`=`path`" option.
  *
- * Sets any of angband's special directories to <path>.
+ * Sets any of angband's special directories to `path`.
  *
- * The "<path>" can be any legal path for the given system, and should
+ * The `path` can be any legal path for the given system, and should
  * not end in any special path separator (i.e. "/tmp" or "~/.ang-info").
  */
 static void change_path(const char *info)

--- a/src/parser.c
+++ b/src/parser.c
@@ -474,9 +474,9 @@ static errr parse_specs(struct parser_hook *h, char *fmt) {
  * Registers a parser hook.
  *
  * Hooks have the following format:
- *   <fmt>  ::= <name> [<type> <name>]* [?<type> <name>]*
- *   <type> ::= int | str | sym | rand | char
- * The first <name> is called the directive for this hook. Any other hooks with
+ *   `fmt`  ::= `name` [`type` `name`]* [?`type` `name`]*
+ *   `type` ::= int | str | sym | rand | char
+ * The first `name` is called the directive for this hook. Any other hooks with
  * the same directive are superseded by this hook. It is an error for a
  * mandatory field to follow an optional field. It is an error for any field to
  * follow a field of type `str`, since `str` fields are not delimited and will


### PR DESCRIPTION
The comments used <something> to refer to some text whose specific contents were not specified.  doxygen tried to interpret those as HTML links.  Using backticks rather than angle brackets satisfies doxygen and hopefully does not confuse other readers.