### PR TITLE
borg: reduce overuse of Crush

### DIFF
--- a/src/borg/borg-fight-attack.c
+++ b/src/borg/borg-fight-attack.c
@@ -3638,7 +3638,7 @@ static int borg_attack_aux_crush(void)
     /* if there is still danger afterward, make sure the reductioning in HP */
     /* doesn't make this put us in danger */
     int new_hp = (borg.trait[BI_CURHP] - (borg.trait[BI_CLEVEL] * 2));
-    if (borg_simulate && (p2 >= new_hp || new_hp <= 5))
+    if (borg_simulate && (p2 >= (new_hp * 2) || new_hp <= 50))
         return 0;
 
     int spell_power = borg_get_spell_power(CRUSH);


### PR DESCRIPTION
make sure 
1) the player has 50hp left after casting crush (previously was 5hp)
2) the player has twice as many hp as the "new danger" after casting (previously was equal to danger level).

The borg I am testing with still cast crush a bunch but this should help him from killing himself with it.