### PR TITLE
borg: turn off ignore settings while the borg is running

### DIFF
--- a/src/borg/borg-init.h
+++ b/src/borg/borg-init.h
@@ -50,6 +50,11 @@ extern bool borg_init_txt_file(void);
 extern void borg_reinit_options(void);
 
 /*
+ * Reset the ignore values
+ */
+extern void borg_reset_ignore(void);
+
+/*
  * Prepare some stuff based on the player race and class
  */
 extern void borg_prepare_race_class_info(void);

--- a/src/borg/borg.c
+++ b/src/borg/borg.c
@@ -173,9 +173,9 @@ uint16_t borg_step = 0;
  */
 
 /*
- * KEYMAP_MODE_ROGUE or KEYMAP_MODE_ORIG
+ * saved initialization data to be restored when the borg stops
  */
-int key_mode;
+struct borg_save_init borg_init_save;
 
 
 /*
@@ -249,11 +249,13 @@ static struct keypress internal_borg_inkey(int flush_first)
         flush(0, 0, 0);
 
         /* Restore user key mode */
-        if (key_mode == KEYMAP_MODE_ROGUE) {
+        if (borg_init_save.key_mode == KEYMAP_MODE_ROGUE) {
             option_set("rogue_like_commands", true);
-        } else if (key_mode == KEYMAP_MODE_ORIG) {
+        } else if (borg_init_save.key_mode == KEYMAP_MODE_ORIG) {
             option_set("rogue_like_commands", false);
         }
+
+        borg_reset_ignore();
 
         /* Done */
         /* Need to flush the key buffer to change modes */

--- a/src/borg/borg.h
+++ b/src/borg/borg.h
@@ -22,6 +22,7 @@
  * must be included before ALLOW_BORG to avoid empty compilation unit
  */
 #include "../angband.h"
+#include "../obj-ignore.h"
 
 #ifdef ALLOW_BORG
 
@@ -76,6 +77,7 @@ enum {
     BORG_STOP_ON_BELL,
     BORG_ALLOW_STRANGE_OPTS,
     BORG_AUTOSAVE,
+    BORG_RESTORE_IGNORE_SETTINGS,
     BORG_MAX_SETTINGS
 };
 extern int *borg_cfg;
@@ -107,10 +109,21 @@ extern uint16_t borg_step;
 extern int w_x; /* Current panel offset (X) */
 extern int w_y; /* Current panel offset (Y) */
 
-/*
- * KEYMAP_MODE_ROGUE or KEYMAP_MODE_ORIG
- */
-extern int key_mode;
+struct borg_save_init {
+
+	/*
+	 * KEYMAP_MODE_ROGUE or KEYMAP_MODE_ORIG
+	 */
+	int         key_mode;
+
+	/*
+	 * object ignore settings
+	 */
+	uint8_t*    kinfo_ignore;
+	uint8_t     ignore_level[ITYPE_MAX];
+	bool**      ego_ignore_types;
+};
+extern struct borg_save_init borg_init_save;
 
 /*
  * Special "inkey_hack" hook.

--- a/src/borg/borg.txt
+++ b/src/borg/borg.txt
@@ -321,6 +321,10 @@ borg_munchkin_depth = 16
 
 borg_enchant_limit = 12
 
+# keep the ignore settings from before the borg was run
+
+borg_restore_ignore_settings = false
+
 
 ### Dynamic Calculations ###
 


### PR DESCRIPTION
and there is now a borg.txt setting to allow it to be restored when the borg stops.