### PR TITLE
Rework how keymaps are handled when extracting a direction

### DIFF
--- a/src/ui-curse.c
+++ b/src/ui-curse.c
@@ -123,7 +123,7 @@ static int curse_menu(struct object *obj, char *dice_string)
 			  sizeof(header));
 	m->header = header;
 	m->selections = all_letters_nohjkl;
-	m->flags = (MN_PVT_TAGS);
+	m->flags = (MN_PVT_TAGS | MN_KEYMAP_ESC);
 	m->browse_hook = curse_menu_browser;
 
 	/* Set up the item list variables */

--- a/src/ui-effect.c
+++ b/src/ui-effect.c
@@ -43,6 +43,7 @@ static struct menu *effect_menu_new(struct effect *effect, int count,
 	char buf[80];
 
 	m->selections = all_letters_nohjkl;
+	m->flags = MN_KEYMAP_ESC;
 
 	/* Collect a string for each effect. */
 	if (count > 0) {

--- a/src/ui-input.c
+++ b/src/ui-input.c
@@ -1523,7 +1523,7 @@ static bool textui_get_rep_dir(int *dp, bool allow_5)
 
 		if (ke.type == EVT_NONE ||
 				(ke.type == EVT_KBRD
-				&& !target_dir_allow(ke.key, allow_5))) {
+				&& !target_dir_allow(ke.key, allow_5, true))) {
 			prt("Direction or <click> (Escape to cancel)? ", 0, 0);
 			ke = inkey_ex();
 		}
@@ -1558,10 +1558,17 @@ static bool textui_get_rep_dir(int *dp, bool allow_5)
 
 				/* XXX Ideally show and move the cursor here to indicate
 				 the currently "Pending" direction. XXX */
-				this_dir = target_dir_allow(ke.key, allow_5);
+				this_dir = target_dir_allow(ke.key, allow_5,
+					true);
 
-				if (this_dir)
+				if (this_dir == ESCAPE) {
+					/* Clear the prompt */
+					prt("", 0, 0);
+
+					return (false);
+				} else if (this_dir) {
 					dir = dir_transitions[dir][this_dir];
+				}
 
 				if (player->opts.lazymove_delay == 0 || ++keypresses_handled > 1)
 					break;
@@ -1673,8 +1680,12 @@ static bool textui_get_aim_dir(int *dp)
 
 					/* XXX Ideally show and move the cursor here to indicate
 					 * the currently "Pending" direction. XXX */
-					this_dir = target_dir(ke.key);
+					this_dir = target_dir_allow(ke.key,
+						false, true);
 
+					if (this_dir == ESCAPE) {
+						return false;
+					}
 					if (this_dir) {
 						dir = dir_transitions[dir][this_dir];
 					} else {

--- a/src/ui-menu.c
+++ b/src/ui-menu.c
@@ -729,9 +729,12 @@ bool menu_handle_keypress(struct menu *menu, const ui_event *in,
 		out->type = EVT_SELECT;
 	} else {
 		/* Try directional movement */
-		int dir = target_dir(in->key);
+		int dir = target_dir_allow(in->key, false,
+			menu->flags & MN_KEYMAP_ESC);
 
-		if (dir && !no_valid_row(menu, count)) {
+		if (dir == ESCAPE) {
+			out->type = EVT_ESCAPE;
+		} else if (dir && !no_valid_row(menu, count)) {
 			*out = menu->skin->process_dir(menu, dir);
 
 			if (out->type == EVT_MOVE) {

--- a/src/ui-menu.h
+++ b/src/ui-menu.h
@@ -198,7 +198,13 @@ enum
 	MN_NO_ACTION = 0x20,
 
 	/* Tags can be selected via an inscription */
-	MN_INSCRIP_TAGS = 0x40
+	MN_INSCRIP_TAGS = 0x40,
+
+	/* Allow a keymap trigger whose first character in the action is ESCAPE
+	 * to break out of the menu; note that selections, cmd_keys, and
+	 * switch_keys take precedence so a keymap trigger that is also one
+	 * of those will not break out */
+	MN_KEYMAP_ESC = 0x80
 };
 
 

--- a/src/ui-object.c
+++ b/src/ui-object.c
@@ -1157,7 +1157,7 @@ static struct object *item_menu(cmd_code cmd, int prompt_size, int mode)
 		m->selections = all_letters_nohjkl;
 	m->switch_keys = "/|-";
 	m->context_hook = use_context_menu_list_switcher;
-	m->flags = (MN_PVT_TAGS | MN_INSCRIP_TAGS);
+	m->flags = (MN_PVT_TAGS | MN_INSCRIP_TAGS | MN_KEYMAP_ESC);
 	m->browse_hook = item_menu_browser;
 
 	/* Get inscriptions */

--- a/src/ui-spell.c
+++ b/src/ui-spell.c
@@ -247,7 +247,7 @@ static struct menu *spell_menu_new(const struct object *obj,
 
 	/* Set flags */
 	m->header = "Name                             Lv Mana Fail Info";
-	m->flags = MN_CASELESS_TAGS;
+	m->flags = MN_CASELESS_TAGS | MN_KEYMAP_ESC;
 	m->selections = all_letters_nohjkl;
 	m->browse_hook = spell_menu_browser;
 	m->cmd_keys = "?";

--- a/src/ui-target.h
+++ b/src/ui-target.h
@@ -47,7 +47,7 @@
 #define TARGET_OUT_VAL_SIZE 256
 
 int target_dir(struct keypress ch);
-int target_dir_allow(struct keypress ch, bool allow_5);
+int target_dir_allow(struct keypress ch, bool allow_5, bool allow_esc);
 void target_display_help(bool monster, bool object, bool free);
 void textui_target(void);
 void textui_target_closest(void);


### PR DESCRIPTION
Only recognize a keymap trigger if its action is one walk or run command.  Also, depending on the context, allow a keymap trigger whose first key in the action is ESCAPE to break out of the selection process.  The latter resolves https://github.com/angband/angband/issues/6297 .  Such a keymap trigger can also break out of item, spell, curse, or effect selection.  They do not affect retrieving the input when the player is prompted for a string, quantity, confirmation, or single character.  Menus used in the knowledge or preferences menu are not affected unless they use the item/spell/curse/effect input methods.