### PR TITLE
Allow the pit statistics to loop over depth and write results to a file

### DIFF
--- a/docs/hacking/debug.rst
+++ b/docs/hacking/debug.rst
@@ -158,7 +158,8 @@ Collect disconnection stats ``D``
 Collect pit stats ``P``
   Generates several pits of the room type you specify (pit, nest, or
   other) and computes a histogram of the types of monsters involved.
-  The results are written to the message window.
+  A summary of the results are written to the message window.
+  Per-level results and the summary are also written to a file.
 
 Nick hack ``_``
   Maps out the reachable grids (by the sound and scent algorithm) in

--- a/src/cmd-wizard.c
+++ b/src/cmd-wizard.c
@@ -671,7 +671,7 @@ void do_cmd_wiz_collect_obj_mon_stats(struct command *cmd)
  */
 void do_cmd_wiz_collect_pit_stats(struct command *cmd)
 {
-	int nsim, depth, pittype;
+	int nsim, depth_min, depth_max, pittype;
 	char s[80];
 
 	if (!stats_are_enabled()) return;
@@ -680,7 +680,8 @@ void do_cmd_wiz_collect_pit_stats(struct command *cmd)
 		/* Set default. */
 		strnfmt(s, sizeof(s), "%d", 1000);
 
-		if (!get_string("Number of simulations: ", s, sizeof(s))) return;
+		if (!get_string("Number of simulations per depth: ", s,
+				sizeof(s))) return;
 		if (!get_int_from_string(s, &nsim) || nsim < 1) return;
 		cmd_set_arg_number(cmd, "quantity", nsim);
 	}
@@ -695,16 +696,29 @@ void do_cmd_wiz_collect_pit_stats(struct command *cmd)
 		cmd_set_arg_choice(cmd, "choice", pittype);
 	}
 
-	if (cmd_get_arg_number(cmd, "depth", &depth) != CMD_OK) {
+	if (cmd_get_arg_number(cmd, "depth_min", &depth_min) != CMD_OK) {
 		/* Set default. */
 		strnfmt(s, sizeof(s), "%d", player->depth);
 
-		if (!get_string("Depth: ", s, sizeof(s))) return;
-		if (!get_int_from_string(s, &depth) || depth < 1) return;
-		cmd_set_arg_number(cmd, "depth", depth);
+		if (!get_string("Minimum depth: ", s, sizeof(s))) return;
+		if (!get_int_from_string(s, &depth_min)
+				|| depth_min < 1) return;
+		cmd_set_arg_number(cmd, "depth_min", depth_min);
 	}
 
-	pit_stats(nsim, pittype, depth);
+	if (cmd_get_arg_number(cmd, "depth_max", &depth_max) != CMD_OK) {
+		/* Set default. */
+		strnfmt(s, sizeof(s), "%d", depth_min);
+
+		if (!get_string("Maximum depth: ", s, sizeof(s))) return;
+		if (!get_int_from_string(s, &depth_max)
+				|| depth_max < depth_min) return;
+		cmd_set_arg_number(cmd, "depth_max", depth_max);
+	} else if (depth_max < depth_min) {
+		return;
+	}
+
+	pit_stats(nsim, pittype, depth_min, depth_max);
 }
 
 

--- a/src/wizard.h
+++ b/src/wizard.h
@@ -71,7 +71,7 @@ void wiz_cheat_death(void);
 bool stats_are_enabled(void);
 void stats_collect(int nsim, int simtype);
 void disconnect_stats(int nsim, bool stop_on_disconnect);
-void pit_stats(int nsim, int pittype, int depth);
+void pit_stats(int nsim, int pittype, int depth_min, int depth_max);
 void stat_grid_counter(struct chunk *c, struct grid_counter_pred *gpreds,
 	int n_gpred, struct neighbor_counter_pred *npreds, int n_npred);
 void stat_grid_counter_simple(struct chunk *c, struct grid_counts counts[3]);


### PR DESCRIPTION
The number of simulations is now the number of simulations to perform at each depth.  The results written to the message window, when looping over multiple depths, are the sum of the histograms at each depth.  The histograms at each depth and the sum over depth of those histgrams are written to the file.  Shorten the messages written to the message window:  what was "Type: Animals, Number: 310." is now "Type Animals: 310.".