### PR TITLE
Hide autoexplore commands behind option

### DIFF
--- a/docs/option.rst
+++ b/docs/option.rst
@@ -36,6 +36,17 @@ Rogue-like commands ``rogue_like_commands``
   work better for you if use a keyboard which doesn't have a numeric
   keypad.
 
+.. _autoexplore-commands-option:
+.. index::
+   single: autoexplore; commands option
+
+Autoexplore commands ``autoexplore_commands``
+  Modifies how the commands to use staircases work: if not already at
+  the appropriate staircase, attempt to move to the nearest known
+  staircase of the appropriate kind. Adds a command, ``p``, in both
+  the original and "roguelike" command sets to move to the nearest
+  unexplored location.
+
 Use sound ``use_sound``
   Turns on sound effects, if your system supports them.
 

--- a/docs/playing.rst
+++ b/docs/playing.rst
@@ -111,7 +111,7 @@ Original Keyset Command Summary
 ``m``  Cast a spell                  ``M``  Display map of entire level
 ``n``  Repeat previous command       ``N``  (unused)
 ``o``  Open a door or chest          ``O``  (unused)
-``p``  Walk to unexplored location   ``P``  (unused)
+``p``  (normally unused; see note)   ``P``  (unused)
 ``q``  Quaff a potion                ``Q``  Kill character & quit
 ``r``  Read a scroll                 ``R``  Rest for a period
 ``s``  Steal (rogues only)           ``S``  See abilities
@@ -145,14 +145,27 @@ Original Keyset Command Summary
 ``'``  Target closest monster        ``^u`` (unused)
 ``"``  Enter a user pref command     ``^v`` (unused)
 ``,``  Stay still (with pickup)      ``^w`` (special - wizard mode)
-``<``  Go up/to up staircase         ``^x`` Save and quit
+``<``  Go up staircase (see note)    ``^x`` Save and quit
 ``.``  Run                           ``^y`` (unused)
-``>``  Go down/to down staircase     ``^z`` Borg commands (if available)
+``>``  Go down staircase (see note)  ``^z`` Borg commands (if available)
 ``\``  (special - bypass keymap)     ``~``  Check knowledge
  \`    (special - escape)            ``?``  Display help
 ``/``  Identify symbol
 ``|``  List contents of quiver
 ====== ============================= ====== ============================
+
+.. index::
+   single: autoexplore; original keyset
+
+Note that the ``<``, ``>``, and ``p`` commands are affected by the
+autoexplore_commands option (see
+:ref:`Autoexplore Commands Option <autoexplore-commands-option>`). When that
+option is off (that is the default), the commands act as described above.
+When that option is on, ``<`` or ``>`` will use the staircase at the player's
+location if it is the appropriate kind of staircase or will move to the
+nearest known staircase of the appropriate kind if the player is not already
+at that kind of staircase. ``p`` will move to the nearest unexplored location
+when the autoexplore_commands option is on.
 
 .. index::
    single: roguelike keyset
@@ -177,7 +190,7 @@ Roguelike Keyset Command Summary
  ``m``  Cast a spell                  ``M``  Display map of entire level
  ``n``  (walk - south east)           ``N``  (run - south east)
  ``o``  Open a door or chest          ``O``  Toggle ignore
- ``p``  Walk to unexplored location   ``P``  Browse a book
+ ``p``  (normally unused; see note)   ``P``  Browse a book
  ``q``  Quaff a potion                ``Q``  Kill character & quit
  ``r``  Read a scroll                 ``R``  Rest for a period
  ``s``  Steal (rogues only)           ``S``  See abilities
@@ -211,15 +224,28 @@ Roguelike Keyset Command Summary
  ``'``  Target closest monster        ``^u`` (alter - north east)
  ``"``  Enter a user pref command     ``^v`` Repeat previous command
  ``,``  Run                           ``^w`` (special - wizard mode)
- ``<``  Go up/to up staircase         ``^x`` Save and quit
+ ``<``  Go up staircase (see note)    ``^x`` Save and quit
  ``.``  Stay still (with pickup)      ``^y`` (alter - north west)
- ``>``  Go down/to down staircase     ``^z`` Borg commands (if available)
+ ``>``  Go down staircase (see note)  ``^z`` Borg commands (if available)
  ``\``  (special - bypass keymap)     ``~``  Check knowledge
   \`    (special - escape)            ``?``  Display help
  ``/``  Identify symbol
 ``TAB`` Fire default ammo at target
  ``|``  List contents of quiver
 ======= ============================= ====== ============================
+
+.. index::
+   single: autoexplore; roguelike keyset
+
+Note that the ``<``, ``>``, and ``p`` commands are affected by the
+autoexplore_commands option (see
+:ref:`Autoexplore Commands Option <autoexplore-commands-option>`). When that
+option is off (that is the default), the commands act as described above. When
+that option is on, ``<`` or ``>`` will use the staircase at the player's
+location if it is the appropriate kind of staircase or will move to the
+nearest known staircase of the appropriate kind if the player is not already
+at that kind of staircase. ``p`` will move to the nearest unexplored location
+when the autoexplore_commands option is on.
 
 Special Keys
 ============

--- a/lib/help/commands.txt
+++ b/lib/help/commands.txt
@@ -6,7 +6,14 @@ Original Keyset Command Summary
 the letter key with the control key also depressed.  You may also press
 and release ^ and then press and release the letter key to activate the
 same command in case your system intercepts the control plus key
-combination and does not pass it on.
+combination and does not pass it on.  The autoexplore_commands option
+modifies the '<', '>', and 'p' commands.  When that option is off (that
+is the default), the commands act as described below.  When that option
+is on, '<' or '>' will use the staircase at the player's location if it
+is the appropriate kind of staircase or will move to the nearest known
+staircase of the appropriate kind if the player is not already at that
+kind of staircase.  'p' will move to the nearest unexplored location
+when the autoexplore_commands option is on.
 
   a    Aim a wand                      A    Activate an object
   b    Browse a book                   B    -
@@ -23,7 +30,7 @@ combination and does not pass it on.
   m    Cast a spell                    M    Display map of entire level
   n    Repeat previous command         N    -
   o    Open a door or chest            O    -
-  p    Walk to unexplored location     P    -
+  p    - (see above)                   P    -
   q    Quaff a potion                  Q    Kill character & quit
   r    Read a scroll                   R    Rest for a period
   s    Steal from a monster (rogues)   S    See abilities
@@ -57,9 +64,9 @@ combination and does not pass it on.
   '    Target closest monster          ^u   -
   "    Enter a user pref command       ^v   -
   ,    Stay still (with pickup)        ^w   (special - wizard mode)
-  <    Go up/to next up staircase      ^x   Save and quit
+  <    Go up staircase (see above)     ^x   Save and quit
   .    Run                             ^y   -
-  >    Go down/to next down staircase  ^z   (special - borg command)
+  >    Go down staircase (see above)   ^z   (special - borg command)
   \    (special - bypass keymap)        ~   Check knowledge
   `    (special - escape)               ?   Display help
   /    Identify symbol

--- a/lib/help/r_comm.txt
+++ b/lib/help/r_comm.txt
@@ -6,7 +6,14 @@ Roguelike Keyset Command Summary
 the letter key with the control key also depressed.  You may also press
 and release ^ and then press and release the letter key to activate the
 same command in case your system intercepts the control plus key
-combination and does not pass it on.
+combination and does not pass it on.  The autoexplore_commands option
+modifies the '<', '>', and 'p' commands.  When that option is off (that
+is the default), the commands act as described below.  When that option
+is on, '<' or '>' will use the staircase at the player's location if it
+is the appropriate kind of staircase or will move to the nearest known
+staircase of the appropriate kind if the player is not already at that
+kind of staircase.  'p' will move to the nearest unexplored location
+when the autoexplore_commands option is on.
 
   a    Zap a rod (Activate)            A    Activate an object
   b    (walk - south west)             B    (run - south west)
@@ -23,7 +30,7 @@ combination and does not pass it on.
   m    Cast a spell                    M    Display map of entire level
   n    (walk - south east)             N    (run - south east)
   o    Open a door or chest            O    Toggle ignore
-  p    Walk to unexplored location     P    Browse a book
+  p    - (see above)                   P    Browse a book
   q    Quaff a potion                  Q    Kill character & quit
   r    Read a scroll                   R    Rest for a period
   s    Steal from a monster (rogues)   S    See abilities
@@ -57,9 +64,9 @@ combination and does not pass it on.
   '    Target closest monster          ^u   (alter - north east)
   "    Enter a user pref command       ^v   Repeat previous command
   ,    Run                             ^w   (special - wizard mode)
-  <    Go up/to next up staircase      ^x   Save and quit
+  <    Go up staircase (see above)     ^x   Save and quit
   .    Stay still (with pickup)        ^y   (alter - north west)
-  >    Go down/to next down staircase  ^z   (special - borg command)
+  >    Go down staircase (see above)   ^z   (special - borg command)
   \    (special - bypass keymap)       ~    Check knowledge
   `    (special - escape)              ?    Display help
   /    Identify symbol

--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -59,7 +59,11 @@ void do_cmd_go_up(struct command *cmd)
 
 	/* Verify stairs */
 	if (!square_isupstairs(cave, player->grid)) {
-		do_cmd_navigate_up(cmd);
+		if (OPT(player, autoexplore_commands)) {
+			do_cmd_navigate_up(cmd);
+		} else {
+			msg("I see no up staircase here.");
+		}
 		return;
 	}
 
@@ -100,7 +104,11 @@ void do_cmd_go_down(struct command *cmd)
 
 	/* Verify stairs */
 	if (!square_isdownstairs(cave, player->grid)) {
-		do_cmd_navigate_down(cmd);
+		if (OPT(player, autoexplore_commands)) {
+			do_cmd_navigate_down(cmd);
+		} else {
+			msg("I see no down staircase here.");
+		}
 		return;
 	}
 
@@ -1399,7 +1407,7 @@ void do_cmd_navigate_down(struct command *cmd)
 	/* cancel if confused */
 	if (player->timed[TMD_CONFUSED]) {
 		msg("You cannot explore while confused.");
-	   	return;
+		return;
 	}
 
 
@@ -1411,13 +1419,13 @@ void do_cmd_navigate_down(struct command *cmd)
 		player->upkeep->energy_use = z_info->move_energy;
 		return;
 	}
-	
+
 
 	/* Screen for visible monsters */
 	for (int y = 0; y < cave->height; y++) {
 		for (int x = 0; x < cave->width; x++) {
 			struct loc grid = loc(x, y);
-			
+
 			if (loc_eq(grid, player->grid)) continue;
 
 			if (square_isoccupied(cave, grid)) {
@@ -1462,7 +1470,7 @@ void do_cmd_navigate_up(struct command *cmd)
 	/* cancel if confused */
 	if (player->timed[TMD_CONFUSED]) {
 		msg("You cannot explore while confused.");
-	   	return;
+		return;
 	}
 
 
@@ -1474,7 +1482,7 @@ void do_cmd_navigate_up(struct command *cmd)
 		player->upkeep->energy_use = z_info->move_energy;
 		return;
 	}
-	
+
 
 	/* Screen for visible monsters */
 	for (int y = 0; y < cave->height; y++) {
@@ -1522,10 +1530,16 @@ void do_cmd_navigate_up(struct command *cmd)
 void do_cmd_explore(struct command *cmd)
 {
 	bool visible_monster = false;
+
+	/* Do nothing if autoexplore commands disabled. */
+	if (!OPT(player, autoexplore_commands)) {
+		return;
+	}
+
 	/* cancel if confused */
 	if (player->timed[TMD_CONFUSED]) {
 		msg("You cannot explore while confused.");
-	   	return;
+		return;
 	}
 
 
@@ -1537,13 +1551,13 @@ void do_cmd_explore(struct command *cmd)
 		player->upkeep->energy_use = z_info->move_energy;
 		return;
 	}
-	
+
 
 	/* Screen for visible monsters */
 	for (int y = 0; y < cave->height && !visible_monster; y++) {
 		for (int x = 0; x < cave->width; x++) {
 			struct loc grid = loc(x, y);
-			
+
 			if (loc_eq(grid, player->grid)) continue;
 
 			if (square_isoccupied(cave, grid)) {

--- a/src/list-options.h
+++ b/src/list-options.h
@@ -13,6 +13,8 @@ OP(none,                  "",
 SPECIAL, false)
 OP(rogue_like_commands,   "Use the roguelike command keyset",
 INTERFACE, false)
+OP(autoexplore_commands,  "Use autoexplore commands",
+INTERFACE, false)
 OP(use_sound,             "Use sound",
 INTERFACE, false)
 OP(show_damage,           "Show damage player deals to monsters",

--- a/src/ui-context.c
+++ b/src/ui-context.c
@@ -251,6 +251,7 @@ int context_menu_player(int mx, int my)
 	int selected;
 	char *labels;
 	bool allowed = true;
+	bool autoexplore = OPT(player, autoexplore_commands);
 	int mode = OPT(player, rogue_like_commands) ? KEYMAP_MODE_ROGUE : KEYMAP_MODE_ORIG;
 	unsigned char cmdkey;
 	struct object *obj;
@@ -270,12 +271,16 @@ int context_menu_player(int mx, int my)
 		ADD_LABEL("Cast", CMD_CAST, MN_ROW_VALID);
 	}
 
-	/* if player is on stairs add option to use them */
-	if (square_isupstairs(cave, player->grid)) {
+	/* if player is on stairs or autoexplore commands are enabled,
+		add option to use them */
+	if (square_isupstairs(cave, player->grid) || autoexplore) {
 		ADD_LABEL("Go Up", CMD_GO_UP, MN_ROW_VALID);
 	}
-	else if (square_isdownstairs(cave, player->grid)) {
+	if (square_isdownstairs(cave, player->grid) || autoexplore) {
 		ADD_LABEL("Go Down", CMD_GO_DOWN, MN_ROW_VALID);
+	}
+	if (autoexplore) {
+		ADD_LABEL("Explore", CMD_EXPLORE, MN_ROW_VALID);
 	}
 
 	/* Looking has different keys, but we don't have a way to look them up
@@ -337,6 +342,7 @@ int context_menu_player(int mx, int my)
 		case CMD_CAST:
 		case CMD_GO_UP:
 		case CMD_GO_DOWN:
+		case CMD_EXPLORE:
 		case CMD_PICKUP:
 			/* Only check for ^ inscriptions, since we don't have an object
 			 * selected (if we need one). */
@@ -376,6 +382,7 @@ int context_menu_player(int mx, int my)
 
 		case CMD_GO_UP:
 		case CMD_GO_DOWN:
+		case CMD_EXPLORE:
 		case CMD_PICKUP:
 			cmdq_push(selected);
 			break;


### PR DESCRIPTION
That option, autoexplore_commands, is off by default.  When that option is on, modify the player's context menu so the autoexplore commands are available.  Resolves https://github.com/angband/angband/issues/6324 .  Some discussion is here, https://angband.live/forums/forum/angband/development/252252-suggestion-re-navigating-to-the-nearest-staircase .