### PR TITLE
Adjust some code flagged by gcc's static analysis option, -fanalyze

### DIFF
--- a/src/effect-handler-general.c
+++ b/src/effect-handler-general.c
@@ -2720,6 +2720,11 @@ bool effect_handler_TELEPORT_TO(effect_handler_context_t *context)
 		/* Monster being teleported */
 		start = t_mon->grid;
 	} else if (context->subtype) {
+		if (!mon) {
+			msg("Bug: TELEPORT_TO:SELF effect used that is not "
+				"cast by a monster.");
+			return true;
+		}
 		/* Monster teleporting to the player */
 		start = mon->grid;
 	} else {

--- a/src/generate.c
+++ b/src/generate.c
@@ -813,8 +813,12 @@ static bool labyrinth_check(int depth)
 static const struct cave_profile *choose_profile(struct player *p)
 {
 	const struct cave_profile *profile = NULL;
-	int moria_alloc = find_cave_profile("moria")->alloc;
-	int labyrinth_alloc = find_cave_profile("labyrinth")->alloc;
+	const struct cave_profile *moria_profile = find_cave_profile("moria");
+	const struct cave_profile *labyrinth_profile =
+		find_cave_profile("labyrinth");
+	int moria_alloc = (moria_profile) ? moria_profile->alloc : 0;
+	int labyrinth_alloc = (labyrinth_profile) ?
+		labyrinth_profile->alloc : 0;
 
 	/* A bit of a hack, but worth it for now NRM */
 	if (p->noscore & NOSCORE_JUMPING) {
@@ -839,10 +843,10 @@ static const struct cave_profile *choose_profile(struct player *p)
 		profile = find_cave_profile("classic");
 	} else if (labyrinth_check(p->depth) &&
 			(labyrinth_alloc > 0 || labyrinth_alloc == -1)) {
-		profile = find_cave_profile("labyrinth");
+		profile = labyrinth_profile;
 	} else if ((p->depth >= 10) && (p->depth < 40) && one_in_(40) &&
 			(moria_alloc > 0 || moria_alloc == -1)) {
-		profile = find_cave_profile("moria");
+		profile = moria_profile;
 	} else {
 		int total_alloc = 0;
 		size_t i;

--- a/src/load.c
+++ b/src/load.c
@@ -1624,7 +1624,7 @@ int rd_chunks(void)
 
 	rd_u16b(&chunk_max);
 	for (j = 0; j < chunk_max; j++) {
-		struct chunk *c;
+		struct chunk *c = NULL;
 
 		/* Read the dungeon */
 		if (rd_dungeon_aux(&c))

--- a/src/obj-desc.c
+++ b/src/obj-desc.c
@@ -276,7 +276,7 @@ size_t obj_desc_name_format(char *buf, size_t max, size_t end,
 					(int) (endmark - plural), plural);
 
 			fmt = endmark;
-		} else if (*fmt == '#') {
+		} else if (*fmt == '#' && modstr) {
 			/* Add modstr, with pluralisation if relevant */
 			end = obj_desc_name_format(buf, max, end, modstr, NULL,	pluralise);
 		}

--- a/src/obj-info.c
+++ b/src/obj-info.c
@@ -2391,15 +2391,30 @@ textblock *object_info_ego(struct ego_item *ego)
 {
 	struct object_kind *kind = NULL;
 	struct object obj = OBJECT_NULL, known_obj = OBJECT_NULL;
-	size_t i;
 	textblock *result;
 
-	for (i = 0; i < z_info->k_max; i++) {
-		kind = &k_info[i];
-		if (!kind->name)
-			continue;
-		if (i == ego->poss_items->kidx)
-			break;
+	if (ego->poss_items) {
+		size_t i;
+
+		for (i = 0; i < z_info->k_max; i++) {
+			kind = &k_info[i];
+			if (!kind->name)
+				continue;
+			if (i == ego->poss_items->kidx)
+				break;
+		}
+	}
+	if (!kind) {
+		result = textblock_new();
+		if (ego->poss_items) {
+			textblock_append(result, "Bug: the array of kinds of "
+				"objects no longer contains the first kind "
+				"that can have this ego.");
+		} else {
+			textblock_append(result,
+				"This ego does not appear on any items.");
+		}
+		return result;
 	}
 
 	obj.kind = kind;

--- a/src/obj-properties.c
+++ b/src/obj-properties.c
@@ -94,6 +94,17 @@ void flag_message(int flag, char *name)
 	size_t end = 0;
 
 	/* See if we have a message */
+	if (!prop) {
+		if (flag < 0 || flag >= OF_MAX) {
+			msg("Bug: invalid flag index, %d, passed to "
+				"flag_message().", flag);
+		} else {
+			msg("Bug: flag '%s' (index %d) noticed but has "
+				"no entry in object_property.txt.",
+				list_obj_flag_names[flag], flag);
+		}
+		return;
+	}
 	if (!prop->msg) return;
 	in_cursor = prop->msg;
 

--- a/src/obj-util.c
+++ b/src/obj-util.c
@@ -546,9 +546,11 @@ const struct artifact *lookup_artifact_name(const char *name)
  */
 struct ego_item *lookup_ego_item(const char *name, int tval, int sval)
 {
+	struct object_kind *kind = lookup_kind(tval, sval);
 	int i;
 
 	/* Look for it */
+	if (!kind) return NULL;
 	for (i = 0; i < z_info->e_max; i++) {
 		struct ego_item *ego = &e_info[i];
 		struct poss_item *poss_item = ego->poss_items;
@@ -559,7 +561,6 @@ struct ego_item *lookup_ego_item(const char *name, int tval, int sval)
 
 		/* Check tval and sval */
 		while (poss_item) {
-			struct object_kind *kind = lookup_kind(tval, sval);
 			if (kind->kidx == poss_item->kidx) {
 				return ego;
 			}

--- a/src/project.c
+++ b/src/project.c
@@ -616,7 +616,7 @@ bool project(struct source origin, int rad, struct loc finish,
 	bool player_sees_grid[256];
 
 	/* Precalculated damage values for each distance. */
-	int *dam_at_dist = malloc((z_info->max_range + 1) * sizeof(*dam_at_dist));
+	int *dam_at_dist = mem_alloc((z_info->max_range + 1) * sizeof(*dam_at_dist));
 
 	/* Flush any pending output */
 	handle_stuff(player);
@@ -999,7 +999,7 @@ bool project(struct source origin, int rad, struct loc finish,
 						  flg & PROJECT_SELF)) {
 				notice = true;
 				if (player->is_dead) {
-					free(dam_at_dist);
+					mem_free(dam_at_dist);
 					return notice;
 				}
 				break;
@@ -1026,7 +1026,7 @@ bool project(struct source origin, int rad, struct loc finish,
 	/* Update stuff if needed */
 	if (player->upkeep->update) update_stuff(player);
 
-	free(dam_at_dist);
+	mem_free(dam_at_dist);
 
 	/* Return "something was noticed" */
 	return (notice);

--- a/src/store.c
+++ b/src/store.c
@@ -2013,7 +2013,7 @@ void do_cmd_stash(struct command *cmd)
 		return;
 
 	/* Check we are somewhere we can stash items. */
-	if (store->feat != FEAT_HOME) {
+	if (!store || store->feat != FEAT_HOME) {
 		msg("You are not in your home.");
 		return;
 	}

--- a/src/ui-effect.c
+++ b/src/ui-effect.c
@@ -82,8 +82,10 @@ static struct menu *effect_menu_new(struct effect *effect, int count,
 		++ms_count;
 		effect = effect_next(effect);
 	}
-	/* Set the sentinel element. */
-	ms[ms_count] = NULL;
+	if (count > 0) {
+		/* Set the sentinel element. */
+		ms[ms_count] = NULL;
+	}
 
 	menu_setpriv(m, ms_count, ms);
 

--- a/src/ui-store.c
+++ b/src/ui-store.c
@@ -120,9 +120,9 @@ struct store_context {
 /* Return a random hint from the global hints list */
 static const char *random_hint(void)
 {
-	struct hint *v, *r = NULL;
+	struct hint *v, *r = hints;
 	int n;
-	for (v = hints, n = 1; v; v = v->next, n++)
+	for (v = hints->next, n = 2; v; v = v->next, n++)
 		if (one_in_(n))
 			r = v;
 	return r->hint;
@@ -153,7 +153,7 @@ static void prt_welcome(const struct owner *proprietor)
 	/* Truncate the name */
 	short_name[j] = '\0';
 
-	if (one_in_(3)) {
+	if (hints && one_in_(3)) {
 		size_t i = randint0(N_ELEMENTS(comment_hint));
 		msg(comment_hint[i], random_hint());
 	} else if (player->lev > 5) {


### PR DESCRIPTION
Instances that could be triggered with modified data files:

1. Issue a message rather than crash if a TELEPORT_TO:SELF effect does not originate from a monster.
2. Do not crash in generate.c's choose_profile() if the labyrinth or moria profiles are not defined in dungeon_profile.txt.
3. Do not crash in obj_desc_name_format() if the name of an object kind or the text for a flavor includes '#'.
4. Do not crash when trying to display a storekeeper's hint and hints.txt has no uncommented "H:" lines.

Mistaken code though not readily triggerable:

1. Dynamic allocation in project() used malloc().  Use mem_alloc() instead for consistent handling of out-of-memory conditions.
2. Tolerate failed object kind lookup in lookup_ego_item() rather than crash.
3. Avoid comparison with an uninitialized value when loading a save file and the chunk list contains a chunk named "arena".
4. Tolerate a zero-sized list in effect_menu_new() rather than crash.

Not known to be triggerable in the current code but change to be more robust:

1. Issue an appropriate message rather than crash if asked to display ego details for an ego that can not be applied to any objects or whose list of applicable objects is inconsistent with what is in the object kind array.
2. Issue an appropriate message rather than crash if an object flag is noticed (flag_message() is called) but the index of the flag is invalid or the flag was not configured in object_property.txt.
3. Issue a message rather than crash if do_cmd_stash() is called when the player is not on a store.