### PR TITLE
CMake: add code coverage support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,11 @@ find_package(Sphinx)
 CMAKE_DEPENDENT_OPTION(BUILD_DOC "Build the documentation" OFF "Sphinx_FOUND" OFF)
 SET(DOC_HTML_THEME "" CACHE STRING "If set and not an empty string, it is the builtin Sphinx HTML theme to use in place of the default theme in conf.py (currently the better theme).")
 
+# Allow the user to enable code coverage if the system supports it.
+INCLUDE(src/cmake/modules/CheckCoverage.cmake)
+CHECK_COVERAGE(Coverage_FOUND)
+CMAKE_DEPENDENT_OPTION(SUPPORT_COVERAGE "Compile for reporting code coverage" OFF "Coverage_FOUND" OFF)
+
 IF ((SUPPORT_NCURSES_FRONTEND) AND (NOT SUPPORT_GCU_FRONTEND))
     SET(SUPPORT_GCU_FRONTEND ON)
 ENDIF()
@@ -374,12 +379,19 @@ IF(SUPPORT_BORG)
     ENDIF()
 ENDIF()
 
+IF(SUPPORT_COVERAGE)
+    CONFIGURE_TARGET_FOR_COVERAGE(OurCoreLib)
+ENDIF()
+
 IF(SUPPORT_SDL_SOUND OR SUPPORT_SDL2_SOUND)
     ADD_LIBRARY(OurSoundSupportLib OBJECT
             src/snd-sdl.c
     )
     SET_TARGET_PROPERTIES(OurSoundSupportLib PROPERTIES C_STANDARD 99)
     SET(SOUND_SUPPORT_LIB OurSoundSupportLib)
+    IF(SUPPORT_COVERAGE)
+        CONFIGURE_TARGET_FOR_COVERAGE(OurSoundSupportLib)
+    ENDIF()
 ELSE()
     SET(SOUND_SUPPORT_LIB "")
 ENDIF()
@@ -477,6 +489,10 @@ ENDIF()
 IF(SUPPORT_TEST_FRONTEND)
     INCLUDE(src/cmake/macros/TEST_Frontend.cmake)
     CONFIGURE_TEST_FRONTEND(OurExecutable)
+ENDIF()
+
+IF(SUPPORT_COVERAGE)
+    CONFIGURE_TARGET_FOR_COVERAGE(OurExecutable)
 ENDIF()
 
 # Set the build ID.
@@ -900,6 +916,10 @@ IF((NOT CMAKE_CROSSCOMPILING) AND SUPPORT_TEST_FRONTEND)
 ELSE()
     ADD_CUSTOM_TARGET(alltests)
 ENDIF()
+IF(SUPPORT_COVERAGE)
+    ADD_COVERAGE_TARGETS(resetcoverage reportcoverage coverage
+        COMBINED_SUBTARGETS alltests)
+ENDIF()
 
 # For unit tests, use a working directory so the data files can be found.
 # This complements how DEFAULT_CONFIG_PATH, DEFAULT_LIB_PATH, DEFAULT_DATA_PATH,
@@ -934,7 +954,7 @@ IF((READONLY_INSTALL) OR (SHARED_INSTALL))
     TARGET_COMPILE_DEFINITIONS(OurUnitTestLib PRIVATE -D TEST_OVERRIDE_PATHS)
 ENDIF()
 IF(SUPPORT_WINDOWS_FRONTEND)
-   CONFIGURE_WINDOWS_FRONTEND(OurUnitTestLib YES)
+    CONFIGURE_WINDOWS_FRONTEND(OurUnitTestLib YES)
 ENDIF()
 
 # Set up targets for exercising the unit tests (from src/tests in the source
@@ -980,16 +1000,19 @@ FOREACH(ANGBAND_TEST_CASE_SOURCE ${ANGBAND_TEST_CASE_SOURCES})
         CONFIGURE_SDL2_SOUND(${ANGBAND_TEST_CASE_NAME} NO)
     ENDIF()
     IF(SUPPORT_WINDOWS_FRONTEND)
-       CONFIGURE_WINDOWS_FRONTEND(${ANGBAND_TEST_CASE_NAME} YES)
-       # Guarantee that it is not marked as having a WinMain entry point
-       # regardless of the setting of CMAKE_WIN32_EXECUTABLE.
-       SET_TARGET_PROPERTIES(${ANGBAND_TEST_CASE_NAME} PROPERTIES
-           WIN32_EXECUTABLE OFF)
-       IF(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
-           # Despite the guarantee above, the Visual Studio generator still
-           # needs this to avoid a linker error about missing WinMain.
-           TARGET_LINK_OPTIONS(${ANGBAND_TEST_CASE_NAME} PRIVATE "/SUBSYSTEM:CONSOLE")
-       ENDIF()
+        CONFIGURE_WINDOWS_FRONTEND(${ANGBAND_TEST_CASE_NAME} YES)
+        # Guarantee that it is not marked as having a WinMain entry point
+        # regardless of the setting of CMAKE_WIN32_EXECUTABLE.
+        SET_TARGET_PROPERTIES(${ANGBAND_TEST_CASE_NAME} PROPERTIES
+            WIN32_EXECUTABLE OFF)
+        IF(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+            # Despite the guarantee above, the Visual Studio generator still
+            # needs this to avoid a linker error about missing WinMain.
+            TARGET_LINK_OPTIONS(${ANGBAND_TEST_CASE_NAME} PRIVATE "/SUBSYSTEM:CONSOLE")
+        ENDIF()
+    ENDIF()
+    IF(SUPPORT_COVERAGE)
+        CONFIGURE_TARGET_FOR_COVERAGE(${ANGBAND_TEST_CASE_NAME} LINKONLY)
     ENDIF()
     # Very few of the test cases use the math library, but it is easier to
     # have all use it.

--- a/docs/hacking/compiling.rst
+++ b/docs/hacking/compiling.rst
@@ -405,6 +405,33 @@ If you only want the unit tests while using CMake, it's a little simpler::
     cmake ..
     make allunittests
 
+There is some support for measuring how well the test cases cover the code.
+If you use configure and have gcc, gcov, and perl, you can run this in src
+directory after running configure::
+
+    make coverage
+
+That cleans the directories (removing object files, intermediates generated
+for code coverage, and coverage reports), rebuilds the game with code coverage
+profiling enabled, runs the unit tests, generates coverage reports for
+individual source files (*.gcov in the src directory), and then writes a
+summary of those reports to standard output.  The gen-coverage Perl script in
+the src directory is what is used to generate the summary.
+
+If you use CMake, have perl, and have either gcc and gcov or clang and
+llvm-cov, then you can configure code coverage support by including
+-DSUPPORT_COVERAGE=ON in the options to cmake.  That adds three targets for
+manipulating coverage results.  "make reportcoverage" generates per-file
+coverage reports (*.gcov in the directory where you are building) using
+the current accumulated coverage data and then writes a summary of those
+reports to standard output.  The gen-coverage Perl script in the src directory
+is what is used to generate the summary.  "make resetcoverage" removes the
+accumulated coverage data (*.gcda files) and any per-file coverage reports.
+"make coverage" is equivalent to "make resetcoverage; make alltests;
+make reportcverage":  clear accumulated coverage information, run the unit
+tests (and, if -DSUPPORT_TEST_FRONTEND=ON was supplied to cmake, the end-to-end
+tests), and then report the coverage results.
+
 Statistics build
 ~~~~~~~~~~~~~~~~
 

--- a/src/cmake/modules/CheckCoverage.cmake
+++ b/src/cmake/modules/CheckCoverage.cmake
@@ -1,0 +1,284 @@
+# Define check_coverage(), configure_target_for_coverage(), and
+# add_coverage_targets().
+
+# Determine if the compiler and other available tools will support generating
+# code coverage information.
+#
+# check_coverage(
+#     <variable>
+# )
+#
+# Will set an internal cache variable whose name is <variable> to a boolean
+# value indicating whether or not code coverage is available.
+#
+# The following non-internal cache variables affect how this function
+# operates:
+#
+# LLVM_COV_PATH is how to invoke LLVM's llvm-cov tool.
+# GCOV_PATH is how to invoke gcov.
+#
+# Sets these internal cache variables for use by
+# configure_target_for_coverage() and add_coverage_rules():
+#
+# COVERAGE_C_COMPILER_FLAGS is the C compiler flags necessary for code
+# coverage.
+# COVERAGE_C_LINKER_FLAGS is the C compiler as linker flags necessary for
+# code coverage.
+# COVERAGE_C_LIBS is the libraries necesary to link with compiled C code
+# for code coverage.
+# COVERAGE_C_IMPLEMENTATION is the code name for how code coverage is
+# implemented.  It is either GCC+GCOV (gcc with gcov to produce reports),
+# CLANG+GCOV (clang with its gcov emulation mode; use "llvm-cov gcov" to
+# produce reports), or NONE (we do not know how to generate code coverage
+# on this system).
+#
+# Limitations:
+# Assumes C as the language.
+# Does nothing for layering other reporting tools (gcovr, fastcov, lcov, ...)
+#     on top of what gcov or llvm-cov provide but does use the src/gen-coverage
+#     Perl script from CMAKE_CURRENT_SOURCE_DIR when reporting on gcov results
+#     (either from gcc or clang).
+# Does not give the option to use clang's source coverage mode (
+#     https://clang.llvm.org/docs/SourceBasedCodeCoverage.html ).
+#
+FUNCTION(check_coverage _VARIABLE)
+    # Parse the arguments.
+    CMAKE_PARSE_ARGUMENTS(_IN "" "" "" ${ARGN})
+    IF(DEFINED _IN_UNPARSED_ARGUMENTS)
+        MESSAGE(FATAL_ERROR "check_coverage() was called with one or more unrecognized arguments: ${_IN_UNPARSED_ARGUMENTS}")
+    ENDIF()
+
+    # We know how to work with gcc or clang (only in its gcov coverage mode).
+    INCLUDE(CheckCCompilerFlag)
+    INCLUDE(CheckLinkerFlag)
+    IF("${CMAKE_C_COMPILER_ID}" MATCHES "(Apple)?[Cc]lang")
+        FIND_PROGRAM(LLVM_COV_PATH llvm-cov
+            DOC "LLVM's tool to emit coverage information, llvm-cov")
+        SET(CMAKE_REQUIRED_LINK_OPTIONS "--coverage")
+        CHECK_C_COMPILER_FLAG(--coverage HAVE_c_coverage)
+        SET(CMAKE_REQUIRED_LINK_OPTIONS "--fprofile-arcs -ftest-coverage")
+        CHECK_C_COMPILER_FLAG(-fprofile-arcs HAVE_c_fprofile_arcs)
+        CHECK_C_COMPILER_FLAG(-ftest-coverage HAVE_c_ftest_coverage)
+        IF((LLVM_COV_PATH) AND ((HAVE_c_coverage) OR ((HAVE_c_fprofile_arcs) AND (HAVE_c_ftest_coverage))))
+            SET(_COVERAGE_C_COMPILER_FLAGS)
+            IF(HAVE_c_coverage)
+                LIST(APPEND _COVERAGE_C_COMPILER_FLAGS --coverage)
+            ELSE()
+                LIST(APPEND _COVERAGE_C_COMPILER_FLAGS -fprofile-arcs -ftest-coverage)
+            ENDIF()
+            SET("${_VARIABLE}" YES CACHE INTERNAL
+                 "System supports code coverage")
+            SET(COVERAGE_C_COMPILER_FLAGS ${_COVERAGE_C_COMPILER_FLAGS}
+                CACHE INTERNAL "C compiler flags for code coverage")
+            SET(COVERAGE_C_LINKER_FLAGS ${_COVERAGE_C_COMPILER_FLAGS}
+                CACHE INTERNAL
+                "C compiler as linker flags for code coverage")
+            SET(COVERAGE_C_LIBS "" CACHE INTERNAL
+                "Libraries for C code coverage")
+            SET(COVERAGE_C_IMPLEMENTATION "CLANG+GCOV" CACHE INTERNAL
+                "Code coverage implementation")
+            RETURN()
+        ENDIF()
+    ELSEIF("${CMAKE_C_COMPILER_ID}" MATCHES "GNU")
+        FIND_PROGRAM(GCOV_PATH gcov)
+        CHECK_LINKER_FLAG(C -lgcov HAVE_linker_c_lgcov)
+        IF((GCOV_PATH) AND (HAVE_linker_c_lgcov))
+            SET(CMAKE_REQUIRED_LIBRARIES "gcov")
+            CHECK_C_COMPILER_FLAG(--coverage HAVE_c_coverage)
+            CHECK_C_COMPILER_FLAG(-fprofile-arcs HAVE_c_fprofile_arcs)
+            CHECK_C_COMPILER_FLAG(-ftest-coverage HAVE_c_ftest_coverage)
+            IF((HAVE_c_coverage) OR ((HAVE_c_fprofile_arcs) AND (HAVE_c_ftest_coverage)))
+                SET(_COVERAGE_C_COMPILER_FLAGS)
+                IF(HAVE_c_coverage)
+                    LIST(APPEND _COVERAGE_C_COMPILER_FLAGS --coverage)
+                ELSE()
+                    LIST(APPEND _COVERAGE_C_COMPILER_FLAGS -fprofile-arcs -ftest-coverage)
+                ENDIF()
+                CHECK_C_COMPILER_FLAG(-fprofile-abs-path HAVE_c_fprofile_abs_path)
+                IF(HAVE_c_fprofile_abs_path)
+                    LIST(APPEND _COVERAGE_C_COMPILER_FLAGS -fprofile-abs-path)
+                ENDIF()
+                SET("${_VARIABLE}" YES CACHE INTERNAL
+                    "System supports code coverage")
+                SET(COVERAGE_C_COMPILER_FLAGS ${_COVERAGE_C_COMPILER_FLAGS}
+                    CACHE INTERNAL "C compiler flags for code coverage")
+                SET(COVERAGE_C_LINKER_FLAGS "" CACHE INTERNAL
+                    "C compiler as linker flags for code coverage")
+                SET(COVERAGE_C_LIBS "gcov" CACHE INTERNAL
+                    "Libraries for C code coverage")
+                SET(COVERAGE_C_IMPLEMENTATION "GCC+GCOV" CACHE INTERNAL
+                    "Code coverage implementation")
+                RETURN()
+            ENDIF()
+        ENDIF()
+    ENDIF()
+    SET("${_VARIABLE}" NO CACHE INTERNAL "System supports code coverage")
+    SET(COVERAGE_C_COMPILER_FLAGS "" CACHE INTERNAL
+        "C compiler flags for code coverage")
+    SET(COVERAGE_C_LINKER_FLAGS "" CACHE INTERNAL
+        "C compiler as linker flags for code coverage")
+    SET(COVERAGE_C_LIBS "" CACHE INTERNAL "Libraries for C code coverage")
+    SET(COVERAGE_C_IMPLEMENTATION "NONE" CACHE INTERNAL
+        "Code coverage implementation")
+ENDFUNCTION()
+
+
+# Configure a target so it is compiled (optional) and linked with code coverage.
+#
+# configure_target_for_coverage(
+#     <target>
+#     [LINKONLY]
+# )
+#
+# <target> is the name of a target created by a command such as add_executable()
+#     or add_library() and must not be an ALIAS target.
+# LINKONLY specifies that the targets will only link in code coverage:  any
+#     code that is directly compiled (i.e. not through a dependency of the
+#     target) for the target will be excluded from code coverage.
+#
+FUNCTION(configure_target_for_coverage _TARGET)
+    # Parse the arguments.
+    SET(_OPTIONS LINKONLY)
+    SET(_ONE_VALUE_ARGS)
+    SET(_MULT_VALUE_ARGS)
+    CMAKE_PARSE_ARGUMENTS(_IN "${_OPTIONS}" "${_ONE_VALUE_ARGS}" "${_MULT_VALUE_ARGS}" ${ARGN})
+    IF(DEFINED _IN_UNPARSED_ARGUMENTS)
+        MESSAGE(FATAL_ERROR "configure_target_for_coverage() was called with one or more unrecognized arguments: ${_IN_UNPARSED_ARGUMENTS}")
+    ENDIF()
+    IF((NOT _IN_LINKONLY) AND (DEFINED COVERAGE_C_COMPILER_FLAGS) AND (NOT (COVERAGE_C_COMPILER_FLAGS STREQUAL "")))
+        TARGET_COMPILE_OPTIONS(${_TARGET} PRIVATE
+            $<$<COMPILE_LANGUAGE:C>:${COVERAGE_C_COMPILER_FLAGS}>)
+    ENDIF()
+    GET_TARGET_PROPERTY(_TARGET_TYPE ${_TARGET} TYPE)
+    IF((NOT (_TARGET_TYPE STREQUAL "STATIC_LIBRARY")) AND (NOT (_TARGET_TYPE STREQUAL "OBJECT_LIBRARY")))
+        IF((DEFINED COVERAGE_C_LINKER_FLAGS) AND (NOT (COVERAGE_C_LINKER_FLAGS STREQUAL "")))
+            TARGET_LINK_OPTIONS(${_TARGET} PUBLIC ${COVERAGE_C_LINKER_FLAGS})
+        ENDIF()
+    ENDIF()
+    IF((DEFINED COVERAGE_C_LIBS) AND (NOT (COVERAGE_C_LIBS STREQUAL "")))
+        TARGET_LINK_LIBRARIES(${_TARGET} PUBLIC ${COVERAGE_C_LIBS})
+    ENDIF()
+ENDFUNCTION()
+
+
+# Define targets to reset accumulated coverage data, report on the accumulated
+# coverage data, and a convenience target to reset accumulated coverage data,
+# perform one or more operations to accumulate coverage data, and then
+# report the coverage results.
+#
+# add_coverage_targets(
+#     <reset_target>
+#     <report_target>
+#     <combined_target>
+#     [COMBINED_SUBTARGETS <target1> ...]
+# )
+#
+# <reset_target> is the name to use for the target to reset accumulated coverage
+#     data.
+# <report_target> is the name to use for the target to report on the accumulated
+#     coverage data.
+# <combined_target> is the name to use for the target that resets the
+#     accumulated coverage data, performs one or more operations to accumulate
+#     coverage data, and then report the coverage results.
+# COMBINED_SUBTARGETS specifies the names of one or more targets that the
+#     combined target will invoke to accumulate coverage data.
+#
+# Limitations
+# The commands for the custom targets assume a Unix-like shell environment
+# and namely the ability to use pipes and the find, rm, sed, tr, and xargs
+# utilities.
+# The way files are found for reporting coverage does not handle file names
+# that contain newlines (do not use -print0 since do not have a way to
+# portably have sed handle the null-delimited file names when it converts
+# .gcda extensions to .o).
+#
+FUNCTION(add_coverage_targets _RESET_TARGET _REPORT_TARGET _COMBINED_TARGET)
+    # Parse the arguments.
+    SET(_OPTIONS)
+    SET(_ONE_VALUE_ARGS)
+    SET(
+        _MULT_VALUE_ARGS
+        COMBINED_SUBTARGETS
+    )
+    CMAKE_PARSE_ARGUMENTS(_IN "${_OPTIONS}" "${_ONE_VALUE_ARGS}" "${_MULT_VALUE_ARGS}" ${ARGN})
+    IF(DEFINED _IN_UNPARSED_ARGUMENTS)
+        MESSAGE(FATAL_ERROR "add_coverage_targets() was called with one or more unrecognized arguments: ${_IN_UNPARSED_ARGUMENTS}")
+    ENDIF()
+
+    # Use VERBATIM so CMake does the quoting/escaping necessary necessary
+    # to handle tool-specific characters.  Still need to apply some
+    # quoting/escaping for CMake:
+    #     1) Double quote variable expansions that have to be presented to the
+    #        tool as one piece, even if the variable expands to something with
+    #        whitespace.
+    #     2) Backslash escape parenthesis used in find commands so CMake does
+    #        not parse them.
+    #     3) Backslash escape dollar signs in sed commands so CMake does not
+    #        parse them.
+    #     4) When a backslash is needed in the command, use a double backslash.
+    IF(DEFINED COVERAGE_C_IMPLEMENTATION)
+        IF((COVERAGE_C_IMPLEMENTATION STREQUAL "GCC+GCOV") OR (COVERAGE_C_IMPLEMENTATION STREQUAL "CLANG+GCOV"))
+            ADD_CUSTOM_TARGET(${_RESET_TARGET}
+                COMMAND find "${CMAKE_CURRENT_BINARY_DIR}" \( -name *.gcda -o -name *.gcov \) -print0 | xargs -0 rm -f
+                VERBATIM)
+        ELSE()
+            ADD_CUSTOM_TARGET(${_RESET_TARGET})
+        ENDIF()
+    ELSE()
+        ADD_CUSTOM_TARGET(${_RESET_TARGET})
+    ENDIF()
+
+    IF(DEFINED COVERAGE_C_IMPLEMENTATION)
+        IF(COVERAGE_C_IMPLEMENTATION STREQUAL "GCC+GCOV")
+            ADD_CUSTOM_TARGET(${_REPORT_TARGET}
+                COMMAND find "${CMAKE_CURRENT_BINARY_DIR}" -name *.gcda -print | sed s/\\.gcda\$/.o/ | tr \\n \\0 | xargs -0 "${GCOV_PATH}" -p
+                COMMAND find "${CMAKE_CURRENT_BINARY_DIR}" -name *.gcov -print0 | xargs -0 "${CMAKE_CURRENT_SOURCE_DIR}/src/gen-coverage"
+                VERBATIM)
+        ELSEIF(COVERAGE_C_IMPLEMENTATION STREQUAL "CLANG+GCOV")
+            ADD_CUSTOM_TARGET(${_REPORT_TARGET}
+                COMMAND find "${CMAKE_CURRENT_BINARY_DIR}" -name *.gcda -print | sed s/\\.gcda\$/.o/ | tr \\n \\0 | xargs -0 "${LLVM_COV_PATH}" gcov -p
+                COMMAND find "${CMAKE_CURRENT_BINARY_DIR}" -name *.gcov -print0 | xargs -0 "${CMAKE_CURRENT_SOURCE_DIR}/src/gen-coverage"
+                VERBATIM)
+        ELSE()
+            ADD_CUSTOM_TARGET(${_REPORT_TARGET})
+        ENDIF()
+    ELSE()
+        ADD_CUSTOM_TARGET(${_REPORT_TARGET})
+    ENDIF()
+
+    IF(DEFINED COVERAGE_C_IMPLEMENTATION)
+        IF(DEFINED _IN_COMBINED_SUBTARGETS)
+            STRING(REPLACE ";" " " _SUBTARGETS_STR "${_IN_COMBINED_SUBTARGETS}")
+            IF(COVERAGE_C_IMPLEMENTATION STREQUAL "GCC+GCOV")
+                ADD_CUSTOM_TARGET(${_COMBINED_TARGET}
+                    COMMAND find "${CMAKE_CURRENT_BINARY_DIR}" \( -name *.gcda -o -name *.gcov \) -print0 | xargs -0 rm -f
+                    COMMAND "${CMAKE_COMMAND}" --build "${CMAKE_CURRENT_BINARY_DIR}" -t ${_SUBTARGETS_STR}
+                    COMMAND find "${CMAKE_CURRENT_BINARY_DIR}" -name *.gcda -print | sed s/\\.gcda\$/.o/ | tr \\n \\0 | xargs -0 "${GCOV_PATH}" -p
+                    COMMAND find "${CMAKE_CURRENT_BINARY_DIR}" -name *.gcov -print0 | xargs -0 "${CMAKE_CURRENT_SOURCE_DIR}/src/gen-coverage"
+                    VERBATIM)
+            ELSEIF(COVERAGE_C_IMPLEMENTATION STREQUAL "CLANG+GCOV")
+                ADD_CUSTOM_TARGET(${_COMBINED_TARGET}
+                    COMMAND find "${CMAKE_CURRENT_BINARY_DIR}" \( -name *.gcda -o -name *.gcov \) -print0 | xargs -0 rm -f
+                    COMMAND "${CMAKE_COMMAND}" --build "${CMAKE_CURRENT_BINARY_DIR}" -t ${_SUBTARGETS_STR}
+                    COMMAND find "${CMAKE_CURRENT_BINARY_DIR}" -name *.gcda -print | sed s/\\.gcda\$/.o/ | tr \\n \\0 | xargs -0 "${LLVM_COV_PATH}" gcov -p
+                    COMMAND find "${CMAKE_CURRENT_BINARY_DIR}" -name *.gcov -print0 | xargs -0 "${CMAKE_CURRENT_SOURCE_DIR}/src/gen-coverage"
+                    VERBATIM)
+            ELSE()
+                ADD_CUSTOM_TARGET(${_COMBINED_TARGET})
+            ENDIF()
+        ELSE()
+            # Since no targets to generate coverage data were specified,
+            # the combined target devolves to be the same as the reset one.
+            IF((COVERAGE_C_IMPLEMENTATION STREQUAL "GCC+GCOV")
+                    OR (COVERAGE_C_IMPLEMENTATION STREQUAL "CLANG+GCOV"))
+                ADD_CUSTOM_TARGET(${_COMBINED_TARGET}
+                    COMMAND find "${CMAKE_CURRENT_BINARY_DIR}" \( -name *.gcda -o -name *.gcov \) -print0 | xargs -0 rm -f
+                    VERBATIM)
+            ELSE()
+                ADD_CUSTOM_TARGET(${_COMBINED_TARGET})
+            ENDIF()
+        ENDIF()
+    ELSE()
+        ADD_CUSTOM_TARGET(${_COMBINED_TARGET})
+    ENDIF()
+ENDFUNCTION()

--- a/src/gen-coverage
+++ b/src/gen-coverage
@@ -8,7 +8,6 @@ my $cov = 0;
 my @fs = ();
 foreach my $fn (@ARGV) {
 	my $fh;
-	$fn =~ s!/!#!g;
 	open($fh, '<', $fn) or (warn "cannot open $fn: $!" and next);
 	my $fcov = 0;
 	my $ftot = 0;


### PR DESCRIPTION
Changes src/gen-coverage to use the arguments without modification.  That does not appear to affect "make coverage" with builds using configure and is necessary when that script is used with builds from CMake.

Add a bit of documentation in the compiling instructions for how to access the code coverage information on Linux/Unix.