### PR TITLE
borg: check for double recall

### DIFF
--- a/src/borg/borg-fight-attack.c
+++ b/src/borg/borg-fight-attack.c
@@ -2947,6 +2947,8 @@ static int borg_attack_aux_wand_bolt_unknown(int dam, int typ)
     /* Use target */
     borg_keypress('5');
 
+    borg.trying_unknown = true;
+
     /* Set our shooting flag */
     successful_target = -1;
 
@@ -3019,6 +3021,8 @@ static int borg_attack_aux_rod_bolt_unknown(int dam, int typ)
 
     /* Set our shooting flag */
     successful_target = -1;
+
+    borg.trying_unknown = true;
 
     /* Value */
     return b_n;

--- a/src/borg/borg-item-use.c
+++ b/src/borg/borg-item-use.c
@@ -139,6 +139,8 @@ bool borg_quaff_unknown(void)
     /* Clear "shop" goals. Inventory changed so goals need to be redone. */
     borg.goal.shop = borg.goal.ware = borg.goal.item = -1;
 
+    borg.trying_unknown = true;
+
     /* Success */
     return true;
 }
@@ -234,6 +236,8 @@ bool borg_read_unknown(void)
     /* Clear "shop" goals */
     borg.goal.shop = borg.goal.ware = borg.goal.item = -1;
 
+    borg.trying_unknown = true;
+
     /* Success */
     return true;
 }
@@ -307,6 +311,8 @@ bool borg_eat_unknown(void)
 
     /* Clear "shop" goals */
     borg.goal.shop = borg.goal.ware = borg.goal.item = -1;
+
+    borg.trying_unknown = true;
 
     /* Success */
     return true;
@@ -557,6 +563,8 @@ bool borg_use_unknown(void)
 
     /* In case it is ID staff, ESCAPE out. */
     borg_keypress(ESCAPE);
+
+    borg.trying_unknown = true;
 
     /* Success */
     return true;

--- a/src/borg/borg-messages-react.c
+++ b/src/borg/borg-messages-react.c
@@ -253,6 +253,16 @@ bool borg_react_prompted(const char* buf, struct keypress *key, int x, int y)
         return true;
     }
 
+    /* Word of Recall -- cancel */
+    if (x >= 25 && (prefix(buf, "Word of Recall is already"))) {
+        /* this shouldn't happen but can if the borg is "playing with" and unknown rod */
+        if (!borg.trying_unknown)
+            borg_oops("unexpected double Word of Recall");
+
+        /* no canceling it */
+        key->code = 'n';
+        return true;
+    }
 
     return false;
 }

--- a/src/borg/borg-think-dungeon.c
+++ b/src/borg/borg-think-dungeon.c
@@ -1198,6 +1198,9 @@ bool borg_think_dungeon(void)
         return true;
     }
 
+    /* no longer trying an unknown object */
+    borg.trying_unknown = false;
+
     /* if standing on something valueless, destroy it */
     if (borg_destroy_floor())
         return true;

--- a/src/borg/borg-trait.h
+++ b/src/borg/borg-trait.h
@@ -455,6 +455,9 @@ struct borg_struct {
     int16_t times_twitch; /* how often twitchy on this level */
     int16_t escapes; /* how often teleported on this level */
 
+    /* trying an unknown potion wand rod scroll etc */
+    bool trying_unknown;
+
     /* goals */
     struct goals goal;
 


### PR DESCRIPTION
added a check for using an unknown object as well because this shouldn't happen otherwise.