### PR TITLE
Fix: Preserve player resources (HP/SP) during pathfinding digging checks

### DIFF
--- a/src/player-path.c
+++ b/src/player-path.c
@@ -225,6 +225,7 @@ static int compute_rubble_penalty(struct player *p)
 	int digging_chances[DIGGING_MAX], num_digger = 1;
 	bool swapped_digger;
 	int penalty;
+	int16_t csp = p->csp, chp = p->chp;
 
 	if (best_digger != current_weapon && (!current_weapon
 			|| obj_can_takeoff(current_weapon))) {
@@ -276,6 +277,7 @@ static int compute_rubble_penalty(struct player *p)
 			penalty = INT_MAX;
 		}
 	}
+	p->csp = csp; p->chp = chp;
 
 	return convert_turn_penalty(penalty, p);
 }


### PR DESCRIPTION
The 'compute_rubble_penalty' function temporarily swaps the player's weapon 
to determine the digging penalty (e.g., when calculating an autoexplore path).

When the current weapon has HP/SP (or CON/INT) bonuses, current HP (chp), 
and SP (csp) are reset to the unequipped maximum, effectively draining 
users' resources whenever a path is calculated.

This patch fixes the issue by safely preserving the current resource values (csp, chp) 
before the temporary equip-swap and restoring them afterward.