### PR TITLE
Fix terminal resize overflow

### DIFF
--- a/src/win/win-term.h
+++ b/src/win/win-term.h
@@ -60,8 +60,8 @@ struct _term_data
 
 	uint keys;
 
-	uint8_t rows;
-	uint8_t cols;
+	uint16_t rows;
+	uint16_t cols;
 
 	uint pos_x;
 	uint pos_y;


### PR DESCRIPTION
When we resized the sub window with the map overview beyond about 2000 pixels, the term_data->cols overflowed because it was stored in an 8-bit integer. Resolves [issue 6373](https://github.com/angband/angband/issues/6373).