### PR TITLE
borg: fix some old code and reduce ammo priority 

### DIFF
--- a/src/borg/borg-caution.c
+++ b/src/borg/borg-caution.c
@@ -1966,13 +1966,14 @@ bool borg_caution(void)
 
     /* Use "recall" to flee if possible */
     if (borg.goal.fleeing && !borg.goal.fleeing_munchkin
-        && !borg.goal.fleeing_to_town && borg.trait[BI_CDEPTH] >= 1
-        && (borg_recall())) {
-        /* Note */
-        borg_note("# Fleeing the level (recall)");
+        && !borg.goal.fleeing_to_town && borg.trait[BI_CDEPTH] >= 1) {
+        if (borg_recall()) {
+            /* Note */
+            borg_note("# Fleeing the level (recall)");
 
-        /* Success */
-        return true;
+            /* Success */
+            return true;
+        }
     }
 
     /* If I am waiting for recall,and in danger, buy time with

--- a/src/borg/borg-fight-attack.c
+++ b/src/borg/borg-fight-attack.c
@@ -2919,8 +2919,6 @@ static int borg_attack_aux_wand_bolt_unknown(int dam, int typ)
         /* No charges */
         if (!borg_items[i].pval)
             continue;
-        if (strstr(borg_items[i].desc, "empty"))
-            continue;
 
         /* Select this wand */
         b_i = i;

--- a/src/borg/borg-io.c
+++ b/src/borg/borg-io.c
@@ -336,12 +336,12 @@ errr borg_keypress(keycode_t k)
 /*
  * Add a keypress to the history of what has been passed back to the game
  */
-void save_keypress_history(struct keypress *kp)
+struct keypress save_keypress_history(struct keypress kp)
 {
     /* Note the keypress */
     if (borg_cfg[BORG_VERBOSE]) {
-        if (kp->type == EVT_KBRD) {
-            keycode_t k = kp->code;
+        if (kp.type == EVT_KBRD) {
+            keycode_t k = kp.code;
             if (k >= 32 && k <= 126) {
                 borg_note(format("& Key <%c> (0x%02lX)", (char)k, (unsigned long)k));
             } else {
@@ -353,20 +353,21 @@ void save_keypress_history(struct keypress *kp)
                     borg_note(format("& Key <0x%02lX>", (unsigned long)k));
             }
         } else {
-            borg_note(format("& non-Keyboard <0x%02X>", kp->type));
+            borg_note(format("& non-Keyboard <0x%02X>", kp.type));
         }
-
     }
 
     /* Store the char, advance the queue */
-    borg_key_history[borg_key_history_head].code = kp->code;
-    borg_key_history[borg_key_history_head++].type = kp->type;
+    borg_key_history[borg_key_history_head].code = kp.code;
+    borg_key_history[borg_key_history_head++].type = kp.type;
 
     /* on full array, keep the last 100 */
     if (borg_key_history_head == KEY_SIZE) {
         memcpy(borg_key_history, &borg_key_history[KEY_SIZE - 101], sizeof(struct keypress) * 100);
         borg_key_history_head = 100;
     }
+
+    return kp;
 }
 
 

--- a/src/borg/borg-io.h
+++ b/src/borg/borg-io.h
@@ -65,7 +65,7 @@ extern errr borg_keypresses(const char *str);
 /*
  * Add a keypresses to history
  */
-extern void save_keypress_history(struct keypress *k);
+extern struct keypress save_keypress_history(struct keypress kp);
 
 /*
  * Dump keypress history

--- a/src/borg/borg-item-analyze.c
+++ b/src/borg/borg-item-analyze.c
@@ -596,8 +596,6 @@ void borg_item_analyze(
         /* if seen {empty} assume pval 0 */
         if (!item->aware && !o->pval)
             item->pval = 0;
-        if (strstr(borg_get_note(item), "empty"))
-            item->pval = 0;
     }
 
     /* Kind index -- Only if we are aware of its kind */

--- a/src/borg/borg-item-use.c
+++ b/src/borg/borg-item-use.c
@@ -1202,9 +1202,6 @@ bool borg_recharging(void)
         if (!item->ident || !item->aware)
             continue;
 
-        if (item->note && strstr(item->note, "empty"))
-            continue;
-
         /* assume we can't charge it. */
         charge = false;
 
@@ -1250,10 +1247,6 @@ bool borg_recharging(void)
 
             /* Recharge the item */
             borg_keypress(all_letters_nohjkl[i]);
-
-            /* Remove the {empty} if present */
-            if (item->note && strstr(item->note, "empty"))
-                borg_deinscribe(i);
 
             /* Success */
             return true;

--- a/src/borg/borg-junk.c
+++ b/src/borg/borg-junk.c
@@ -305,8 +305,7 @@ bool borg_drop_junk(void)
          * ie. 5 Staffs of Teleportation (2 charges).
          * Only 2 charges in 5 staves means top 3 are empty.
          */
-        if ((item->tval == TV_STAFF || item->tval == TV_WAND)
-            && (item->aware || (item->note && strstr(item->note, "empty")))) {
+        if ((item->tval == TV_STAFF || item->tval == TV_WAND) && item->aware) {
             if (item->iqty > item->pval)
                 value = 0L;
         }

--- a/src/borg/borg-power.c
+++ b/src/borg/borg-power.c
@@ -1596,14 +1596,14 @@ static int32_t borg_power_inventory(void)
         || borg.trait[BI_CLASS] == CLASS_WARRIOR) {
         k = 0;
         for (; k < 40 && k < borg.trait[BI_AMISSILES]; k++)
-            value += 1000L;
+            value += 100L;
         if (borg.trait[BI_STR] > 15 && borg.trait[BI_STR] <= 18) {
             for (; k < 80 && k < borg.trait[BI_AMISSILES]; k++)
-                value += 100L;
+                value += 10L;
         }
         if (borg.trait[BI_STR] > 18) {
             for (; k < 180 && k < borg.trait[BI_AMISSILES]; k++)
-                value += 80L;
+                value += 8L;
         }
 
         /* penalize use of too many quiver slots */
@@ -1613,10 +1613,10 @@ static int32_t borg_power_inventory(void)
     } else {
         k = 0;
         for (; k < 20 && k < borg.trait[BI_AMISSILES]; k++)
-            value += 1000L;
+            value += 100L;
         if (borg.trait[BI_STR] > 15) {
             for (; k < 50 && k < borg.trait[BI_AMISSILES]; k++)
-                value += 100L;
+                value += 10L;
         }
         /* Don't carry too many */
         if (borg.trait[BI_STR] <= 15 && borg.trait[BI_AMISSILES] > 20)

--- a/src/borg/borg-think-dungeon-util.c
+++ b/src/borg/borg-think-dungeon-util.c
@@ -184,8 +184,9 @@ bool borg_think_dungeon_light(void)
             return true;
 
         /* Can I recall out with a spell */
-        if (!borg.goal.recalling && borg_recall())
-            return true;
+        if (!borg.goal.recalling)
+            if (borg_recall()) 
+                return true;
 
         /* Test for stairs */
         if (!OPT(player, birth_force_descend)) {
@@ -920,15 +921,19 @@ bool borg_leave_level(bool bored)
 
             /* Recall if going to town */
             if (borg.goal.rising && ((borg_time_town + (borg_t - borg_began)) > 200)
-                && (borg.trait[BI_CDEPTH] >= 5) && borg_recall()) {
-                borg_note("# Recalling to town (goal rising)");
-                return true;
+                && (borg.trait[BI_CDEPTH] >= 5)) {
+                if (borg_recall()) {
+                    borg_note("# Recalling to town (goal rising)");
+                    return true;
+                }
             }
 
             /* Recall if needing to Restock */
-            if (need_restock && borg.trait[BI_CDEPTH] >= 5 && borg_recall()) {
-                borg_note("# Recalling to town (need to restock)");
-                return true;
+            if (need_restock && borg.trait[BI_CDEPTH] >= 5) {
+                if (borg_recall()) {
+                    borg_note("# Recalling to town (need to restock)");
+                    return true;
+                }
             }
         }
 

--- a/src/borg/borg-think-dungeon.c
+++ b/src/borg/borg-think-dungeon.c
@@ -2290,12 +2290,15 @@ bool borg_think_dungeon(void)
     }
 
     /* Recall to town */
-    if (borg.trait[BI_CDEPTH] && (borg_recall())) {
-        /* Note */
-        borg_note("# Recalling (twitchy)");
+    if (borg.trait[BI_CDEPTH]) {
+        if (borg_recall()) {
 
-        /* Success */
-        return true;
+            /* Note */
+            borg_note("# Recalling (twitchy)");
+
+            /* Success */
+            return true;
+        }
     }
 
     /* Reset multiple factors to jumpstart the borg */

--- a/src/borg/borg-think-store.c
+++ b/src/borg/borg-think-store.c
@@ -287,7 +287,7 @@ bool borg_think_store(void)
 {
     /* HACK: Prevent clock wrapping */
     if (borg_t >= 20000 && borg_t <= 20010) {
-        /* Clear Possible errors */
+        /* Clear Possible errors and leave the store */
         borg_keypress(ESCAPE);
         borg_keypress(ESCAPE);
         borg_keypress(ESCAPE);
@@ -296,6 +296,7 @@ bool borg_think_store(void)
         /* Re-examine inven and equip */
         borg_do_inven = true;
         borg_do_equip = true;
+        return true;
     }
 
     /* update all my equipment and swap items */
@@ -303,10 +304,6 @@ bool borg_think_store(void)
     borg_do_equip = true;
     borg_notice(true);
 
-#if 0
-    /* Stamp the shop with a time stamp */
-    borg_shops[shop_num].when = borg_t;
-#endif
 
     /* Wear "optimal" equipment */
     if (borg_best_stuff())

--- a/src/borg/borg-think.c
+++ b/src/borg/borg-think.c
@@ -158,9 +158,6 @@ bool borg_think(void)
 
         /* Cheat the "equip" screen */
         borg_cheat_equip();
-
-        /* Done */
-        return false;
     }
 
     /* Cheat */
@@ -173,9 +170,6 @@ bool borg_think(void)
 
         /* Do a quick cheat of the shops */
         borg_cheat_store();
-
-        /* Done */
-        return false;
     }
 
     /* save the items.  safe_items, from here on, should never be changed, */
@@ -225,11 +219,11 @@ bool borg_think(void)
         return true;
     }
 
-    /* Parse "equip" mode */
+    /* Parse equipment mode */
+    /* this shouldn't happen because we now pull equipment information */
+    /* directly from the game */
     if ((0 == borg_what_text(0, 0, 10, &t_a, buf))
         && (streq(buf, "(Equipment) "))) {
-        /* Parse the "equip" screen */
-        /* borg_parse_equip(); */
 
         /* Leave this mode */
         borg_keypress(ESCAPE);
@@ -238,11 +232,11 @@ bool borg_think(void)
         return true;
     }
 
-    /* Parse "inven" mode */
+    /* Parse Inventory mode */
+    /* this shouldn't happen because we now pull inventory information */
+    /* directly from the game */
     if ((0 == borg_what_text(0, 0, 10, &t_a, buf))
         && (streq(buf, "(Inventory) "))) {
-        /* Parse the "inven" screen */
-        /* borg_parse_inven(); */
 
         /* Leave this mode */
         borg_keypress(ESCAPE);
@@ -251,7 +245,9 @@ bool borg_think(void)
         return true;
     }
 
-    /* Parse "inven" mode */
+    /* Parse worn equipment mode */
+    /* this shouldn't happen because we now pull worn equipment information */
+    /* directly from the game */
     if ((0 == borg_what_text(0, 0, 6, &t_a, buf)) && (streq(buf, "Wear o"))) {
         /* Leave this mode */
         borg_keypress(ESCAPE);
@@ -266,15 +262,11 @@ bool borg_think(void)
         borg_do_spell = false;
     }
 
-
     /* Check for "browse" mode */
+    /* this shouldn't happen because we now pull spell information */
+    /* directly from the game */
     if ((0 == borg_what_text(COL_SPELL, ROW_SPELL, -12, &t_a, buf))
         && (streq(buf, "Lv Mana Fail"))) {
-        /* Parse the "spell" screen */
-        /* borg_parse_spell(borg_do_spell_aux); */
-
-        /* Advance to the next book */
-        /* borg_do_spell_aux++; */
 
         /* Leave that mode */
         borg_keypress(ESCAPE);
@@ -308,6 +300,8 @@ bool borg_think(void)
             reincarnate_borg();
 
             borg_flush();
+
+            return false;
 #endif /* bablos */
         }
     }

--- a/src/borg/borg-trait.c
+++ b/src/borg/borg-trait.c
@@ -2982,6 +2982,12 @@ void borg_notice_player(void)
     /* Assume experience is fine */
     borg.trait[BI_ISFIXEXP] = false;
 
+    /* Access depth Cheat */
+    borg.trait[BI_CDEPTH] = player->depth;
+
+    /* Access max depth Cheat */
+    borg.trait[BI_MAXDEPTH] = player->max_depth;
+
     /* Note "Exp" vs "EXP" and am I lower than level 50*/
     if (player->exp < player->max_exp) {
         /* fix it if in town */
@@ -3125,12 +3131,6 @@ void borg_notice_player(void)
             = player->stat_cur[STAT_STR + i] < player->stat_max[STAT_STR + i];
         borg.trait[BI_CSTR + i] = player->stat_cur[STAT_STR + i];
     }
-
-    /* Access depth Cheat */
-    borg.trait[BI_CDEPTH] = player->depth;
-
-    /* Access max depth Cheat */
-    borg.trait[BI_MAXDEPTH] = player->max_depth;
 
     /* Track if Sauron is dead Cheat */
     borg.trait[BI_SAURON_DEAD] = borg_race_death[borg_sauron_id];

--- a/src/borg/borg.c
+++ b/src/borg/borg.c
@@ -178,6 +178,19 @@ uint16_t borg_step = 0;
 struct borg_save_init borg_init_save;
 
 
+static struct keypress internal_borg_inkey(int flush_first);
+
+/*
+ * **START HERE FOR BORG PROCESSING**
+ *
+ * This routine is what captures control from Angband and feeds back keystrokes
+ * It wraps the main keypress routine to enable capture of the keys generated
+ */
+static struct keypress borg_inkey_hack(int flush_first)
+{
+    return save_keypress_history(internal_borg_inkey(flush_first));
+}
+
 /*
  * This function lets the Borg "steal" control from the user.
  *
@@ -512,16 +525,6 @@ static struct keypress internal_borg_inkey(int flush_first)
 
     key.code = ESCAPE;
     return key;
-}
-
-/* wrapper around keypress capture */
-static struct keypress borg_inkey_hack(int flush_first)
-{
-    struct keypress k = internal_borg_inkey(flush_first);
-
-    save_keypress_history(&k);
-
-    return k;
 }
 
 

--- a/src/borg/borg.txt
+++ b/src/borg/borg.txt
@@ -646,7 +646,7 @@ Power
 	condition(value(activation, stinking_cloud)): reward(524 * value(activation, stinking_cloud));
 	condition(value(activation, cold_ball50)): reward(596 * value(activation, cold_ball50));
 	condition(value(activation, cold_ball100)): reward(700 * value(activation, cold_ball100));
-	condition(value(activation, fire_bolt72)): reward(572 * value(activation, fire_bolt72));
+	condition(value(activation, fire_ball72)): reward(572 * value(activation, fire_ball72));
 	condition(value(activation, cold_bolt2)): reward(554 * value(activation, cold_bolt2));
 	condition(value(activation, fire_ball)): reward(644 * value(activation, fire_ball));
 	condition(value(activation, dispel_evil)): reward((500 + (10 + (value(trait, clevel) *5)/ 2)) * value(activation, dispel_evil));
@@ -904,13 +904,13 @@ Power
 	condition(value(trait, amt recharge) and value(trait, max depth) < 99): reward(5000);
 
 # missles
-	value(trait, amt missiles): range(1, 40): condition(value(class, warrior) or value(class, ranger)): reward(1000);
-	value(trait, amt missiles): range(41, 80): condition((value(class, warrior) or value(class, ranger)) and value(trait, str) > 15 and value(trait, str) <= 18): reward(100);
-	value(trait, amt missiles): range(81, 180): condition((value(class, warrior) or value(class, ranger)) and value(trait, str) > 18): reward(80);
+	value(trait, amt missiles): range(1, 40): condition(value(class, warrior) or value(class, ranger)): reward(100);
+	value(trait, amt missiles): range(41, 80): condition((value(class, warrior) or value(class, ranger)) and value(trait, str) > 15 and value(trait, str) <= 18): reward(10);
+	value(trait, amt missiles): range(81, 180): condition((value(class, warrior) or value(class, ranger)) and value(trait, str) > 18): reward(8);
 	value(trait, quiver slots): range(5, 10): condition(value(class, warrior) or value(class, ranger)): reward(-10000);
 
-	value(trait, amt missiles): range(1, 20): condition(!value(class, warrior) and !value(class, ranger)): reward(1000);
-	value(trait, amt missiles): range(21, 50): condition((!value(class, warrior) and !value(class, ranger)) and value(trait, str) > 15): reward(100);
+	value(trait, amt missiles): range(1, 20): condition(!value(class, warrior) and !value(class, ranger)): reward(100);
+	value(trait, amt missiles): range(21, 50): condition((!value(class, warrior) and !value(class, ranger)) and value(trait, str) > 15): reward(10);
 	condition((!value(class, warrior) and !value(class, ranger)) and value(trait, str) <= 15 and value(trait, amt missiles) > 20): reward(-1000);
 	value(trait, quiver slots): range(3, 10): condition(!value(class, warrior) and !value(class, ranger)): reward(-10000);
 


### PR DESCRIPTION
Ammo priority reduced because slings were not switched to bows as often as they should have.
"empty" inscription no longer used so checks for it are removed.
clean up some function calls in if statements that were hard to read.
fix a borg.txt typo