### PR TITLE
Include player/digging unit test when building with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -867,6 +867,7 @@ SET(ANGBAND_TEST_CASE_SOURCES
     player/birth.c
     player/calc-inventory.c
     player/combine-pack.c
+    player/digging.c
     player/history.c
     player/inven-carry-num.c
     player/inven-wield.c


### PR DESCRIPTION
Inadvertently omitted in 2eadcc2b0250b2d4c1e4b16385f6b13ad5011d98 .