### PR TITLE
Only prevent exploring ('p', '<', or '>') when obvious monster is in view

### DIFF
--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -1407,8 +1407,6 @@ void do_cmd_run(struct command *cmd)
  */
 void do_cmd_navigate_down(struct command *cmd)
 {
-	int visible_monster_count = 0;
-
 	/* cancel if confused */
 	if (player->timed[TMD_CONFUSED]) {
 		msg("You cannot explore while confused.");
@@ -1427,24 +1425,7 @@ void do_cmd_navigate_down(struct command *cmd)
 
 
 	/* Screen for visible monsters */
-	for (int y = 0; y < cave->height; y++) {
-		for (int x = 0; x < cave->width; x++) {
-			struct loc grid = loc(x, y);
-
-			if (loc_eq(grid, player->grid)) continue;
-
-			if (square_isoccupied(cave, grid)) {
-				int m_idx = square(cave, grid)->mon;
-				struct monster *mon = cave_monster(cave, m_idx);
-				if (monster_is_obvious(mon)) {
-					visible_monster_count++;
-					break;
-				}
-			}
-		}
-	}
-
-	if (visible_monster_count > 0) {
+	if (player_has_monster_in_view(player)) {
 		msg("Something is here.");
 		return;
 	}
@@ -1471,7 +1452,6 @@ void do_cmd_navigate_down(struct command *cmd)
  */
 void do_cmd_navigate_up(struct command *cmd)
 {
-	int visible_monster_count = 0;
 	/* cancel if confused */
 	if (player->timed[TMD_CONFUSED]) {
 		msg("You cannot explore while confused.");
@@ -1490,24 +1470,7 @@ void do_cmd_navigate_up(struct command *cmd)
 
 
 	/* Screen for visible monsters */
-	for (int y = 0; y < cave->height; y++) {
-		for (int x = 0; x < cave->width; x++) {
-			struct loc grid = loc(x, y);
-
-			if (loc_eq(grid, player->grid)) continue;
-
-			if (square_isoccupied(cave, grid)) {
-				int m_idx = square(cave, grid)->mon;
-				struct monster *mon = cave_monster(cave, m_idx);
-				if (monster_is_obvious(mon)) {
-					visible_monster_count++;
-					break;
-				}
-			}
-		}
-	}
-
-	if (visible_monster_count > 0) {
+	if (player_has_monster_in_view(player)) {
 		msg("Something is here.");
 		return;
 	}
@@ -1534,8 +1497,6 @@ void do_cmd_navigate_up(struct command *cmd)
  */
 void do_cmd_explore(struct command *cmd)
 {
-	bool visible_monster = false;
-
 	/* Do nothing if autoexplore commands disabled. */
 	if (!OPT(player, autoexplore_commands)) {
 		return;
@@ -1559,24 +1520,7 @@ void do_cmd_explore(struct command *cmd)
 
 
 	/* Screen for visible monsters */
-	for (int y = 0; y < cave->height && !visible_monster; y++) {
-		for (int x = 0; x < cave->width; x++) {
-			struct loc grid = loc(x, y);
-
-			if (loc_eq(grid, player->grid)) continue;
-
-			if (square_isoccupied(cave, grid)) {
-				int m_idx = square(cave, grid)->mon;
-				struct monster *mon = cave_monster(cave, m_idx);
-				if (monster_is_obvious(mon)) {
-					visible_monster = true;
-					break; /* only breaks the inner loop */
-				}
-			}
-		}
-	}
-
-	if (visible_monster) {
+	if (player_has_monster_in_view(player)) {
 		msg("Something is here.");
 		return;
 	}

--- a/src/player-util.c
+++ b/src/player-util.c
@@ -23,6 +23,7 @@
 #include "game-world.h"
 #include "generate.h"
 #include "init.h"
+#include "mon-predicate.h"
 #include "obj-chest.h"
 #include "obj-gear.h"
 #include "obj-ignore.h"
@@ -1712,4 +1713,21 @@ void search(struct player *p)
 			}
 		}
 	}
+}
+
+/**
+ * Test if there are any monsters the player knows about in the field of view.
+ */
+bool player_has_monster_in_view(const struct player *p)
+{
+	int n = cave_monster_max(cave), i;
+
+	for (i = 1; i < n; ++i) {
+		const struct monster *mon = cave_monster(cave, i);
+
+		if (monster_is_obvious(mon) && monster_is_in_view(mon)) {
+			return true;
+		}
+	}
+	return false;
 }

--- a/src/player-util.h
+++ b/src/player-util.h
@@ -120,5 +120,6 @@ void player_handle_post_move(struct player *p, bool eval_trap,
 		bool is_involuntary);
 void disturb(struct player *p);
 void search(struct player *p);
+bool player_has_monster_in_view(const struct player *p);
 
 #endif /* !PLAYER_UTIL_H */


### PR DESCRIPTION
Resolves https://github.com/angband/angband/issues/6386 .