### PR TITLE
fix(ux): message when leaving dtrap area

### DIFF
--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -1143,15 +1143,18 @@ void move_player(int dir, bool disarm)
 		if (old_dtrap != new_dtrap)
 			player->upkeep->redraw |= (PR_DTRAP);
 
-		/* Disturb player if the player is about to leave the area */
-		if (player->upkeep->running
-				&& !player->upkeep->running_firststep
-				&& old_dtrap && !new_dtrap) {
-			disturb(player);
-			/* No move made so no energy spent. */
-			player->upkeep->energy_use = 0;
-			return;
-		}
+		/* Leaving a detected-trap area */
+        if (!player->upkeep->running_firststep && old_dtrap && !new_dtrap) {
+            if (player->upkeep->running) {
+                msg("You are leaving an area previously checked for traps.");
+                disturb(player);
+                player->upkeep->energy_use = 0;
+                return;
+            } else {
+                /* Optional info message for walking */
+                msg("You are leaving an area previously checked for traps.");
+            }
+        }
 
 		/*
 		 * If not confused, allow check before moving into damaging


### PR DESCRIPTION
Auto-exploring with 'p' stopped unexpectedly when leaving a trap-detected area. Previously, the player was silently disturbed, requiring a manual step and key press to continue.

This PR adds a feedback message whenever the player is disturbed while leaving a trap-detected area. To improve consistency, the message is shown both when running and when walking.

Closes #6398