### PR TITLE
gcu:  remove dependence on term.h

### DIFF
--- a/src/main-gcu.c
+++ b/src/main-gcu.c
@@ -49,8 +49,6 @@
 # include <curses.h>
 #endif
 
-#include <term.h>
-
 #undef term
 
 /**
@@ -100,12 +98,6 @@ static struct termios  norm_termios;
 static struct termios  game_termios;
 
 #endif
-
-/**
- * The TERM environment variable; used for terminal capabilities.
- */
-static char *termtype;
-static bool loaded_terminfo;
 
 /**
  * Simple rectangle type
@@ -1289,10 +1281,6 @@ static void hook_quit(const char *str) {
  */
 errr init_gcu(int argc, char **argv) {
 	int i;
-
-	/* Initialize info about terminal capabilities */
-	termtype = getenv("TERM");
-	loaded_terminfo = termtype && tgetent(0, termtype) == 1;
 
 	/* Parse args */
 	for (i = 1; i < argc; i++) {


### PR DESCRIPTION
Prior changes, https://github.com/angband/angband/commit/2f0de2a857fe3db7ef493254f01028bc2efa097b and https://github.com/angband/angband/commit/53ab89f6e7c7f28e8204a7363010e5c7078613f9 , removed most of the code using it leaving one instance to load terminal information (which is not used anywhere else).  Helps compatibility with PDCurses which does not have term.h.