### PR TITLE
When called from get_aim_dir(), do not allow targeting to start pathfinding

### DIFF
--- a/src/cmd-wizard.c
+++ b/src/cmd-wizard.c
@@ -1923,7 +1923,7 @@ void do_cmd_wiz_push_object(struct command *cmd)
 	struct loc grid;
 
 	if (cmd_get_arg_point(cmd, "point", &grid) != CMD_OK) {
-		if (!target_set_interactive(TARGET_KILL, -1, -1)) return;
+		if (!target_set_interactive(TARGET_KILL, -1, -1, false)) return;
 		target_get(&grid);
 		cmd_set_arg_point(cmd, "point", grid);
 	}
@@ -2728,7 +2728,7 @@ void do_cmd_wiz_teleport_to(struct command *cmd)
 
 	if (cmd_get_arg_point(cmd, "point", &grid) != CMD_OK) {
 		/* Use the targeting function. */
-		if (!target_set_interactive(TARGET_LOOK, -1, -1)) return;
+		if (!target_set_interactive(TARGET_LOOK, -1, -1, false)) return;
 
 		/* Grab the target coordinates. */
 		target_get(&grid);

--- a/src/ui-context.c
+++ b/src/ui-context.c
@@ -396,7 +396,7 @@ int context_menu_player(int mx, int my)
 			break;
 
 		case MENU_VALUE_LOOK:
-			if (target_set_interactive(TARGET_LOOK, player->grid.x, player->grid.y))
+			if (target_set_interactive(TARGET_LOOK, player->grid.x, player->grid.y, true))
 				msg("Target Selected.");
 			break;
 
@@ -599,7 +599,7 @@ int context_menu_cave(struct chunk *c, int y, int x, int adjacent, int mx,
 	switch (selected) {
 		case MENU_VALUE_LOOK:
 			/* Look at the spot */
-			if (target_set_interactive(TARGET_LOOK, x, y)) {
+			if (target_set_interactive(TARGET_LOOK, x, y, true)) {
 				msg("Target Selected.");
 			}
 			break;
@@ -1061,7 +1061,7 @@ void textui_process_click(ui_event e)
 									  motion_dir(player->grid, loc(x, y)));
 			} else if (e.mouse.mods & KC_MOD_ALT) {
 				/* alt-click - look */
-				if (target_set_interactive(TARGET_LOOK, x, y)) {
+				if (target_set_interactive(TARGET_LOOK, x, y, true)) {
 					msg("Target Selected.");
 				}
 			} else {

--- a/src/ui-input.c
+++ b/src/ui-input.c
@@ -1646,8 +1646,9 @@ static bool textui_get_aim_dir(int *dp)
 
 		if (ke.type == EVT_MOUSE) {
 			if (ke.mouse.button == 1) {
-				if (target_set_interactive(TARGET_KILL, KEY_GRID_X(ke),
-										   KEY_GRID_Y(ke)))
+				if (target_set_interactive(TARGET_KILL,
+						KEY_GRID_X(ke), KEY_GRID_Y(ke),
+						false))
 					dir = 5;
 			} else if (ke.mouse.button == 2) {
 				break;
@@ -1655,7 +1656,8 @@ static bool textui_get_aim_dir(int *dp)
 		} else if (ke.type == EVT_KBRD) {
 			if (ke.key.code == '*') {
 				/* Set new target, use target if legal */
-				if (target_set_interactive(TARGET_KILL, -1, -1))
+				if (target_set_interactive(TARGET_KILL, -1, -1,
+						false))
 					dir = 5;
 			} else if (ke.key.code == '\'') {
 				/* Set to closest target */

--- a/src/ui-knowledge.c
+++ b/src/ui-knowledge.c
@@ -4057,7 +4057,7 @@ void do_cmd_quiver(void)
 void do_cmd_look(void)
 {
 	/* Look around */
-	if (target_set_interactive(TARGET_LOOK, -1, -1))
+	if (target_set_interactive(TARGET_LOOK, -1, -1, true))
 	{
 		msg("Target Selected.");
 	}

--- a/src/ui-target.h
+++ b/src/ui-target.h
@@ -34,13 +34,6 @@
 #define KEY_GRID_X(K) \
 	((int) (((K.mouse.x - COL_MAP) / tile_width) + Term->offset_x))
 
-
-/**
- * Height of the help screen; any higher than 4 will overlap the health
- * bar which we want to keep in targeting mode.
- */
-#define HELP_HEIGHT 3
-
 /**
  * Size of the array that is used for object names during targeting.
  */
@@ -48,9 +41,8 @@
 
 int target_dir(struct keypress ch);
 int target_dir_allow(struct keypress ch, bool allow_5, bool allow_esc);
-void target_display_help(bool monster, bool object, bool free);
 void textui_target(void);
 void textui_target_closest(void);
-bool target_set_interactive(int mode, int x, int y);
+bool target_set_interactive(int mode, int x, int y, bool allow_pathfinding);
 
 #endif /* UI_TARGET_H */


### PR DESCRIPTION
Do allow that when called to implement the look and targeting commands or to implement looking in the context menus.  Changes the prototype for target_display_help().  As that function is only used in ui-target.c, limit the visibility of that function and the related HELP_HEIGHT to ui-target.c.