### PR TITLE
configure:  rewrite ncurses detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -298,18 +298,9 @@ AS_IF([test "$enable_curses" = "yes"],
 		AC_DEFINE(USE_GCU, 1, [Define to 1 if using the Curses frontend.])
 		CPPFLAGS="${CPPFLAGS} ${NCURSES_CFLAGS}"
 		LIBS="${LIBS} ${NCURSES_LIBS}"
-		MAINFILES="${MAINFILES} \$(GCUMAINFILES)"],
-		[AC_CHECK_LIB([ncursesw], [initscr], [
-			AC_DEFINE(USE_NCURSES, 1, [Define to 1 if NCurses is found.])
-			AC_DEFINE(USE_GCU, 1, [Define to 1 if using the Curses frontend.])
-			AC_DEFINE(_XOPEN_SOURCE_EXTENDED, 1, [Defined for systems that guard ncurses decls with _XOPEN_SOURCE_EXTENDED])
-			with_curses=yes
-			LIBS="${LIBS} -lncursesw"
-			MAINFILES="${MAINFILES} \$(GCUMAINFILES)"
-		])
-		AC_SEARCH_LIBS([keypad], [tinfow tinfo])])])
-
-AC_CHECK_FUNCS([mvwaddnwstr use_default_colors can_change_color])
+		MAINFILES="${MAINFILES} \$(GCUMAINFILES)"
+		AC_SEARCH_LIBS([keypad], [tinfow tinfo])
+		AC_CHECK_FUNCS([use_default_colors])])])
 
 dnl X11 checking
 with_x11=no


### PR DESCRIPTION
Most of the changes are in AM_PATH_NCURSESW.  When cross-compiling, perform compiling/linking sanity check rather than doing no checks.  Suggested by Helmut Grohne in https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1121264 .  Tighten both compiling/linking and execution sanity checks by referencing symbols from ncurses.  Remove --with-ncurses-exec-prefix since it did nothing more than could be done with --with-ncurses-prefix.  Change --disable-ncursestest from doing nothing to disabling the execution sanity check.  If the config program is not present fall back to checking if ncurses.h and either an ncursesw or ncurses library can be found in the standard search paths.

Since AM_PATH_NCURSESW does more, remove much of logic related to ncurses detection in configure.ac.  Retain the check for the extension to curses, use_default_colors and the check if keypad needs additional libraries.