### PR TITLE
SDL2: trigger redraw when stepping focus through composite menu item

### DIFF
--- a/src/sdl2/pui-dlg.c
+++ b/src/sdl2/pui-dlg.c
@@ -506,6 +506,8 @@ static void step_simple_menu_control(struct sdlpui_dialog *d,
 	SDL_assert(c >= p->controls && c < p->controls + p->number);
 
 	if (c->ftb->step_within && (*c->ftb->step_within)(c, forward)) {
+		d->dirty = true;
+		sdlpui_signal_redraw(w);
 		return;
 	}
 


### PR DESCRIPTION
The only composite controls that currently appear in menus are the ranged int buttons for setting a scalable font's size.