### PR TITLE
SDL2: rework quitting while the game is not at a command prompt

### DIFF
--- a/src/main-sdl2.c
+++ b/src/main-sdl2.c
@@ -464,6 +464,13 @@ struct my_app {
 	/** Width and height on screen for the default font */
 	int def_font_w, def_font_h;
 	/**
+	 * one if the player requested an exit while the game was not at a
+	 * command prompt; any non-zero value other than one when ready to
+	 * save the game at exit but the game may prompt for additional input;
+	 * zero in all other cases
+	 */
+	int quit_when_ready;
+	/**
 	 * true if KC_MOD_KEYPAD will be sent for numeric keypad keys at the
 	 * expense of not handling some keyboard layouts properly
 	 */
@@ -540,7 +547,7 @@ static bool is_close_to(int a, int b, unsigned range);
 static void handle_window_closed(struct my_app *a,
 		struct sdlpui_window *window);
 static void refresh_angband_terms(struct my_app *a);
-static void handle_quit(void);
+static void handle_quit(struct my_app *a, bool forced);
 static void wait_anykey(struct my_app *a);
 static void keyboard_event_to_angband_key(const SDL_KeyboardEvent *key,
 		bool kp_as_mod, keycode_t *ch, uint8_t *mods);
@@ -2611,7 +2618,7 @@ static void handle_menu_quit(struct sdlpui_control *ctrl,
 		struct sdlpui_dialog *dlg, struct sdlpui_window *window)
 {
 	sdlpui_popdown_dialog(dlg, window, true);
-	handle_quit();
+	handle_quit(window->app, false);
 }
 
 static void handle_menu_tile_set(struct sdlpui_control *ctrl,
@@ -3570,7 +3577,7 @@ static void handle_window_closed(struct my_app *a, struct sdlpui_window *window)
 	assert(window != NULL);
 
 	if (window->index == MAIN_WINDOW) {
-		handle_quit();
+		handle_quit(a, false);
 	} else {
 		for (size_t i = 0; i < N_ELEMENTS(window->subwindows); i++) {
 			struct subwindow *subwindow = window->subwindows[i];
@@ -4547,7 +4554,7 @@ static void wait_anykey(struct my_app *a)
 				SDL_FlushEvent(SDL_MOUSEMOTION);
 				break;
 			case SDL_QUIT:
-				handle_quit();
+				handle_quit(a, false);
 				break;
 			case SDL_RENDER_TARGETS_RESET:
 				recreate_textures(a, false);
@@ -4562,13 +4569,59 @@ static void wait_anykey(struct my_app *a)
 	}
 }
 
-static void handle_quit(void)
+static void handle_quit(struct my_app *a, bool forced)
 {
-	/* XXX copied from main-sdl.c */
-	if (character_generated && inkey_flag) {
-		/* no idea what that does :) */
+	if (character_generated) {
+		/*
+		 * Want to be at a command prompt so the game's state is
+		 * ready to save.  If not at a command prompt and not forcing
+		 * an exit, mark as ready to quit: term_xtra_event() will use
+		 * that to either call back to here when it is safe to save or
+		 * send escapes to the game to satisfy its requests for input.
+		 */
+		if (!inkey_flag && !forced) {
+			a->quit_when_ready = 1;
+			return;
+		}
+
+		/* Drop pending messages. */
 		msg_flag = false;
-		save_game();
+		a->quit_when_ready = 2;
+		/*
+		 * If not forcing an exit, allow the player to abort the exit
+		 * if there is trouble saving the game.
+		 */
+		if (!forced && !save_game_checked()) {
+			SDL_MessageBoxButtonData buttons[2] = {
+				{
+					0, 0, "Yes"
+				},
+				{
+					SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT
+					| SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT,
+					1,
+					"No"
+				}
+			};
+			SDL_MessageBoxData dialog;
+			int button_pressed = 1;
+
+			dialog.flags = SDL_MESSAGEBOX_ERROR
+				| SDL_MESSAGEBOX_BUTTONS_LEFT_TO_RIGHT;
+			dialog.window = a->windows[0].window;
+			dialog.title = "Confirm Quitting";
+			dialog.message = "Saving failed.  Really quit?";
+			dialog.numbuttons = 2;
+			dialog.buttons = buttons;
+			dialog.colorScheme = NULL;
+
+			(void)SDL_ShowMessageBox(&dialog, &button_pressed);
+			if (button_pressed != 0) {
+				a->quit_when_ready = 0;
+				return;
+			}
+		}
+		close_game(false);
 	}
 
 	quit(NULL);
@@ -4617,7 +4670,7 @@ static bool get_event(struct my_app *a)
 			recreate_textures(a, true);
 			return false;
 		case SDL_QUIT:
-			handle_quit();
+			handle_quit(a, false);
 			return false;
 		default:
 			return false;
@@ -4667,6 +4720,23 @@ static errr term_xtra_event(int v)
 	assert(subwindow != NULL);
 
 	redraw_all_windows(subwindow->app, true);
+
+	if (subwindow->app->quit_when_ready) {
+		if (inkey_flag && subwindow->app->quit_when_ready == 1) {
+			/*
+			 * The game is at a command prompt and has a
+			 * consistent state so it is safe to save and exit.
+			 */
+			handle_quit(subwindow->app, false);
+		} else {
+			/*
+			 * Send an escape to satisfy whatever the game is
+			 * asking for.
+			 */
+			Term_keypress(ESCAPE, 0);
+		}
+		return 0;
+	}
 
 	if (v) {
 		while (true) {
@@ -7253,6 +7323,7 @@ static void init_globals(struct my_app *a)
 
 	a->w_mouse = NULL;
 	a->w_key = NULL;
+	a->quit_when_ready = 0;
 	a->kp_as_mod = true;
 	a->controller = NULL;
 	num_joysticks = SDL_NumJoysticks();


### PR DESCRIPTION
Addresses https://github.com/angband/angband/issues/6459 for SDL2.  While saving and exiting, call close_game() to prevent the memory leaks mentioned in https://github.com/angband/angband/pull/6460 .