### PR TITLE
Nintendo DS: use the value of PROGNAME for NAME with the blocksds toolchain

### DIFF
--- a/src/Makefile.blocksds
+++ b/src/Makefile.blocksds
@@ -22,7 +22,7 @@ export ZFILES           :=      $(ZFILES)
 # User config
 # ===========
 
-NAME			:= angband
+NAME			:= $(PROGNAME)
 
 GAME_TITLE		:= Angband
 GAME_DESCRIPTION	:= Dungeon exploration


### PR DESCRIPTION
Backported from FAangband.