### PR TITLE
SDL2: correct cast when changing label of menu entry

### DIFF
--- a/src/sdl2/pui-ctrl.c
+++ b/src/sdl2/pui-ctrl.c
@@ -1143,7 +1143,7 @@ static void change_mb_caption(struct sdlpui_control *c,
 		struct sdlpui_dialog *d, struct sdlpui_window *w,
 		const char *new_caption)
 {
-	struct sdlpui_label *mbp;
+	struct sdlpui_menu_button *mbp;
 
 	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
 	mbp = c->priv;


### PR DESCRIPTION
Has no effect on what the player can see as the SDL2 front end does not change the label for a menu entry after it is created.