### PR TITLE
macOS: put call to setTerm() last in the terminal initialization hook

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -2084,7 +2084,7 @@ static BOOL initialized = NO;
 
 - (void)requestRedraw
 {
-    if (! self->terminal) return;
+    if (!self->terminal || !self->terminal->mapped_flag) return;
     
     term *old = Term;
     
@@ -4222,12 +4222,6 @@ static void Term_init_cocoa(term *t)
 	if (autosaveName) [window setFrameAutosaveName:autosaveName];
 
 	/*
-	 * Tell it about its term. Do this after we've sized it so that the
-	 * sizing doesn't trigger redrawing and such.
-	 */
-	[context setTerm:t];
-
-	/*
 	 * Only order front if it's the first term. Other terms will be ordered
 	 * front from AngbandUpdateWindowVisibility(). This is to work around a
 	 * problem where Angband aggressively tells us to initialize terms that
@@ -4238,8 +4232,11 @@ static void Term_init_cocoa(term *t)
 
 	NSEnableScreenUpdates();
 
-	/* Set "mapped" flag */
-	t->mapped_flag = true;
+	/*
+	 * Tell it about its term. Do this after we've sized it so that the
+	 * sizing doesn't trigger redrawing and such.
+	 */
+	[context setTerm:t];
     }
 }
 


### PR DESCRIPTION
Ported from sil-q's https://github.com/sil-quirk/sil-q/pull/137 .  See the comments on https://github.com/sil-quirk/sil-q/issues/121 for the case of infinite recursion at startup it fixes.  So far, there's been no report of similar problems with Vanilla Angband.