### PR TITLE
ci: add CMake + Ninja macOS curses build

### DIFF
--- a/.github/workflows/mac.yaml
+++ b/.github/workflows/mac.yaml
@@ -29,7 +29,25 @@ jobs:
           cd src
           env OPT="-Werror -O2 -DNDEBUG" make -f Makefile.osx -j$(sysctl -n hw.ncpu)
 
-  autoconf:
+  cmake-curses:
+    runs-on: macos-latest
+    steps:
+      - name: Install Build Dependencies
+        run: |
+          brew install ncurses
+
+      - name: Clone Project
+        uses: actions/checkout@v4
+
+      - name: Configure (CMake)
+        run: |
+          cmake -S . -B build -G Ninja -DSUPPORT_GCU_FRONTEND=ON
+
+      - name: Build
+        run: |
+          cmake --build build --parallel
+
+  autoconf-curses:
     runs-on: macos-latest
     steps:
       # Requires autoconf and automake; install those via homebrew (available
@@ -47,4 +65,4 @@ jobs:
         run: |
           ./autogen.sh
           ./configure --with-no-install --enable-curses --disable-ncursestest
-          make
+          make -j$(sysctl -n hw.ncpu)


### PR DESCRIPTION
Adds a GitHub Actions job to build Angband with CMake on macOS (curses frontend) alongside the existing CI.

Highlights:

- Uses modern CMake commands: `cmake -S . -B build` and `cmake --build build --parallel`, avoiding legacy `mkdir/cd` and direct `ninja` calls.
- Only `ncurses` is installed; `cmake` and `ninja` are already present on `macos-latest`.
- This job runs in parallel with autotools CI, providing CMake build coverage without replacing existing workflows.
