### PR TITLE
Add function prototypes to silence GCC warnings in main-ibm.c for DOS port

### DIFF
--- a/src/main-ibm.c
+++ b/src/main-ibm.c
@@ -315,6 +315,10 @@ static uint8_t ext_color_map[32] = {
 	8   /* Shade -> Light Dark */
 };
 
+int Term_iswprint_ibm(wint_t);
+wchar_t *Term_wcschr_ibm(const wchar_t *, wchar_t);
+size_t Term_wcslen_ibm(const wchar_t *);
+
 /*
  * Activate the "ibm_color_complex" palette information.
  *


### PR DESCRIPTION
GCC warnings are treated as errors and this blocks the DJGPP build.  Add function prototypes to silence warnings in main-ibm.c.