### PR TITLE
X11: avoid using uninitialized data after memory allocation failure

### DIFF
--- a/src/main-x11.c
+++ b/src/main-x11.c
@@ -772,8 +772,10 @@ static errr Infowin_set_name(const char *name)
 	char *bp = buf;
 	my_strcpy(buf, name, sizeof(buf));
 	st = XStringListToTextProperty(&bp, 1, &tp);
-	if (st) XSetWMName(Metadpy->dpy, Infowin->win, &tp);
-	XFree(tp.value);
+	if (st) {
+		XSetWMName(Metadpy->dpy, Infowin->win, &tp);
+		XFree(tp.value);
+	}
 	return (0);
 }
 


### PR DESCRIPTION
From the reference manual for XStringListToTextProperty(), the elements of the XTextProperty* argument are not modified when the function returns zero.