### PR TITLE
borg: fix waiting for a monster to approach

### DIFF
--- a/src/borg/borg-reincarnate.c
+++ b/src/borg/borg-reincarnate.c
@@ -460,6 +460,9 @@ void reincarnate_borg(void)
     /* Assume not ignoring monsters */
     borg.goal.ignoring = false;
 
+    /* and not waiting */
+    borg.goal.waiting = false;
+
     flavor_init();
 
     /** Roll up a new character **/

--- a/src/borg/borg-trait.h
+++ b/src/borg/borg-trait.h
@@ -356,6 +356,7 @@ struct goals {
     bool fleeing_to_town; /* Fleeing the level to town */
     bool ignoring; /* ignoring monsters */
     bool less; /* return to, but don't use, the next up stairs */
+    bool waiting; /* waiting for an approaching monster */
 
     int recalling; /* waiting for recall, guessing turns left */
     int descending; /* waiting for deep descent */


### PR DESCRIPTION
the borg was waiting for a monster to approach forever (see https://angband.live/forums/forum/angband/vanilla/10687-borg-bugs-and-feature-requests?p=257902#post257902).  Added a check for the monster being afraid or confused or stunned and made sure the borg didn't wait twice.  If the first wait didn't work, waiting again won't help.  This seems to force him to go after things that aren't approaching. 

I also got rid of some trailing whitespace just because it was easiest to install a mod that did that automatically. 
