### PR TITLE
Use PY_MAX_LEVEL for exp display instead of hardcoded 50

### DIFF
--- a/src/ui-display.c
+++ b/src/ui-display.c
@@ -226,13 +226,13 @@ static void prt_level(int row, int col)
 static void prt_exp(int row, int col)
 {
 	char out_val[32];
-	bool lev50 = (player->lev == 50);
+	bool lev_max = (player->lev == PY_MAX_LEVEL);
 
 	long xp = (long)player->exp;
 
 
 	/* Calculate XP for next level */
-	if (!lev50)
+	if (!lev_max)
 		xp = (long)(player_exp[player->lev - 1] * player->expfact / 100L) -
 			player->exp;
 
@@ -241,10 +241,10 @@ static void prt_exp(int row, int col)
 
 
 	if (player->exp >= player->max_exp) {
-		put_str((lev50 ? "EXP" : "NXT"), row, col);
+		put_str((lev_max ? "EXP" : "NXT"), row, col);
 		c_put_str(COLOUR_L_GREEN, out_val, row, col + 4);
 	} else {
-		put_str((lev50 ? "Exp" : "Nxt"), row, col);
+		put_str((lev_max ? "Exp" : "Nxt"), row, col);
 		c_put_str(COLOUR_YELLOW, out_val, row, col + 4);
 	}
 }


### PR DESCRIPTION
Replaces hardcoded player level checks with the 'PY_MAX_LEVEL' constant in the experience display logic in 'ui-display.c'.

Currently, 'prt_exp()' uses the literal '50' to determine if a player has reached the maximum level. Using 'PY_MAX_LEVEL' instead improves code maintainability and ensures the UI correctly reflects the maximum level if it's ever changed in 'player.h'.