### PR TITLE
workflows: remove release-flags jobs

### DIFF
--- a/.github/workflows/mac.yaml
+++ b/.github/workflows/mac.yaml
@@ -18,17 +18,6 @@ jobs:
           cd src
           env OPT="-Werror" make -f Makefile.osx -j$(sysctl -n hw.ncpu)
 
-  release-flags:
-    runs-on: macos-latest
-    steps:
-      - name: Clone Project
-        uses: actions/checkout@v4
-
-      - name: Build with Flags Used for Release
-        run: |
-          cd src
-          env OPT="-Werror -O2 -DNDEBUG" make -f Makefile.osx -j$(sysctl -n hw.ncpu)
-
   cmake-curses:
     runs-on: macos-latest
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -335,7 +335,8 @@ jobs:
         id: create_windows_archive
         run: |
           cmake -S . -B build -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS_RELEASE="-O2" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_FLAGS_RELEASE="-O2 -DNDEBUG -Werror" \
             -DSUPPORT_WINDOWS_FRONTEND=ON \
             -DSUPPORT_BUNDLED_PNG=ON \
             -DCMAKE_TOOLCHAIN_FILE=toolchains/linux-i686-mingw32-cross.cmake
@@ -409,7 +410,7 @@ jobs:
         id: create_mac_archive
         run: |
           cd src
-          env OPT="-O2 -DNDEBUG" make -f Makefile.osx -j$(sysctl -n hw.ncpu) dist
+          env OPT="-O2 -DNDEBUG -Werror" make -f Makefile.osx -j$(sysctl -n hw.ncpu) dist
           archive_prefix=${{ steps.store_config.outputs.name }}-${{ steps.store_config.outputs.version }}-osx
           echo "archive_file=${archive_prefix}.dmg" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -37,20 +37,3 @@ jobs:
             -DCMAKE_TOOLCHAIN_FILE=../toolchains/linux-i686-mingw32-cross.cmake \
             ..
           ninja -j$(nproc)
-
-  release-flags:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Build Dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install gcc-mingw-w64 automake autoconf make
-
-      - name: Clone Project
-        uses: actions/checkout@v4
-
-      - name: Build with Flags Used for Release
-        run: |
-          ./autogen.sh
-          env CFLAGS="-O2" ./configure --enable-release --enable-win --build=i686-pc-linux-gnu --host=i686-w64-mingw32
-          env CFLAGS="-Werror" make -j$(nproc)


### PR DESCRIPTION
They are redundant as everything from release.yaml except for publishing a release is now run on a pull request.  Add -Werror to CFLAGS for the macOS and Windows builds in release.yaml as that was done in the release-flags jobs.  Add -DNDEBUG to CFLAGS for the Windows build.yaml to address a regression introduced when switching from autoconf to CMake in release.yaml.