### PR TITLE
SDL2: correct tab order for menu shortcuts dialog

### DIFF
--- a/src/main-sdl2.c
+++ b/src/main-sdl2.c
@@ -1631,7 +1631,7 @@ static void step_shortcut_editor_control(struct sdlpui_dialog *d,
 		if (c == &pse->change_buttons[i]) {
 			new_c = (forward) ? &pse->clear_buttons[i] :
 				((i > 0) ? &pse->clear_buttons[i - 1] :
-				&pse->close_button);
+				&pse->reset_button);
 			break;
 		} else if (c == &pse->clear_buttons[i]) {
 			new_c = (forward) ? ((i < MAX_WINDOWS - 1) ?


### PR DESCRIPTION
Without this change, stepping backwards through the controls with Shift-Tab skipped the "Reset" button.