### PR TITLE
SDL2: add hooks in sdlpui_control to facilitate tracing

### DIFF
--- a/src/sdl2/pui-ctrl.c
+++ b/src/sdl2/pui-ctrl.c
@@ -22,6 +22,7 @@
 #include "pui-misc.h"
 
 
+static const char *get_image_type_name(const struct sdlpui_control *c);
 static void render_image(struct sdlpui_control *c, struct sdlpui_dialog *d,
 		struct sdlpui_window *w, SDL_Renderer *r);
 static void resize_image(struct sdlpui_control *c, struct sdlpui_dialog *d,
@@ -31,6 +32,8 @@ static void query_image_natural_size(struct sdlpui_control *c,
 		int *width, int *height);
 static void cleanup_image(struct sdlpui_control *c);
 
+static const char *get_label_type_name(const struct sdlpui_control *c);
+static const char *get_label_caption(const struct sdlpui_control *c);
 static void change_label_caption(struct sdlpui_control *c,
 		struct sdlpui_dialog *d, struct sdlpui_window *w,
 		const char *new_caption);
@@ -43,6 +46,8 @@ static void query_label_natural_size(struct sdlpui_control *c,
 		int *width, int *height);
 static void cleanup_label(struct sdlpui_control *c);
 
+static const char *get_pb_type_name(const struct sdlpui_control *c);
+static const char *get_pb_caption(const struct sdlpui_control *c);
 static void change_pb_caption(struct sdlpui_control *c,
 		struct sdlpui_dialog *d, struct sdlpui_window *w,
 		const char *new_caption);
@@ -86,6 +91,8 @@ static SDL_bool handle_mb_mousemove(struct sdlpui_control *c,
 static SDL_bool handle_mb_mousewheel(struct sdlpui_control *c,
 		struct sdlpui_dialog *d, struct sdlpui_window *w,
 		const struct SDL_MouseWheelEvent *e);
+static const char *get_mb_type_name(const struct sdlpui_control *c);
+static const char *get_mb_caption(const struct sdlpui_control *c);
 static void change_mb_caption(struct sdlpui_control *c,
 		struct sdlpui_dialog *d, struct sdlpui_window *w,
 		const char *new_caption);
@@ -142,6 +149,8 @@ static const struct sdlpui_control_funcs image_funcs = {
 	NULL,
 	NULL,
 	NULL,
+	get_image_type_name,
+	NULL,
 	NULL,
 	render_image,
 	NULL,
@@ -172,6 +181,8 @@ static const struct sdlpui_control_funcs label_funcs = {
 	NULL,
 	NULL,
 	NULL,
+	get_label_type_name,
+	get_label_caption,
 	change_label_caption,
 	render_label,
 	NULL,
@@ -202,6 +213,8 @@ const struct sdlpui_control_funcs push_button_funcs = {
 	sdlpui_control_handle_mouseclick,
 	sdlpui_control_handle_mousemove,
 	NULL,
+	get_pb_type_name,
+	get_pb_caption,
 	change_pb_caption,
 	render_pb,
 	respond_default_pb,
@@ -232,6 +245,8 @@ static const struct sdlpui_control_funcs menu_button_funcs = {
 	sdlpui_control_handle_mouseclick,
 	handle_mb_mousemove,
 	handle_mb_mousewheel,
+	get_mb_type_name,
+	get_mb_caption,
 	change_mb_caption,
 	render_mb,
 	respond_default_mb,
@@ -255,6 +270,12 @@ static const struct sdlpui_control_funcs menu_button_funcs = {
 };
 
 
+static const char *get_image_type_name(const struct sdlpui_control *c)
+{
+	return "image";
+}
+
+
 static void render_image(struct sdlpui_control *c, struct sdlpui_dialog *d,
 		struct sdlpui_window *w, SDL_Renderer *r)
 {
@@ -262,8 +283,8 @@ static void render_image(struct sdlpui_control *c, struct sdlpui_dialog *d,
 
 	SDL_assert(c->type_code == SDLPUI_CTRL_IMAGE && c->priv);
 	ip = c->priv;
-	SDLPUI_RENDER_TRACER("image", c, "(none)", c->rect, ip->image_rect,
-		d->texture);
+	SDLPUI_RENDER_TRACER((*c->ftb->get_type_name)(c), c, "(none)",
+		c->rect, ip->image_rect, d->texture);
 
 	if (ip->image_rect.w > 0 && ip->image_rect.h > 0) {
 		SDL_Rect dst_r = ip->image_rect;
@@ -398,6 +419,22 @@ static void cleanup_image(struct sdlpui_control *c)
 }
 
 
+static const char *get_label_type_name(const struct sdlpui_control *c)
+{
+	return "label";
+}
+
+
+static const char *get_label_caption(const struct sdlpui_control *c)
+{
+	struct sdlpui_label *lp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_LABEL && c->priv);
+	lp = c->priv;
+	return lp->caption;
+}
+
+
 static void change_label_caption(struct sdlpui_control *c,
 		struct sdlpui_dialog *d, struct sdlpui_window *w,
 		const char *new_caption)
@@ -423,8 +460,9 @@ static void render_label(struct sdlpui_control *c, struct sdlpui_dialog *d,
 
 	SDL_assert(c->type_code == SDLPUI_CTRL_LABEL && c->priv);
 	lp = c->priv;
-	SDLPUI_RENDER_TRACER("label", c, lp->caption, c->rect,
-		lp->caption_rect, d->texture);
+	SDLPUI_RENDER_TRACER((*c->ftb->get_type_name)(c), c,
+		(*c->ftb->get_caption)(c), c->rect, lp->caption_rect,
+		d->texture);
 
 	if (lp->caption_rect.w > 0 && lp->caption_rect.h > 0) {
 		SDL_Rect dst_r = lp->caption_rect;
@@ -439,7 +477,8 @@ static void render_label(struct sdlpui_control *c, struct sdlpui_dialog *d,
 			dst_r.x += d->rect.x;
 			dst_r.y += d->rect.y;
 		}
-		sdlpui_render_utf8_line(r, font, fg, &dst_r, lp->caption);
+		sdlpui_render_utf8_line(r, font, fg, &dst_r,
+			(*c->ftb->get_caption)(c));
 	}
 }
 
@@ -454,7 +493,7 @@ static void resize_label(struct sdlpui_control *c, struct sdlpui_dialog *d,
 	SDL_assert(c->type_code == SDLPUI_CTRL_LABEL && c->priv);
 	lp = c->priv;
 
-	sdlpui_get_utf8_metrics(font, lp->caption, &sw, &sh);
+	sdlpui_get_utf8_metrics(font, (*c->ftb->get_caption)(c), &sw, &sh);
 	border = 2 * SDLPUI_DEFAULT_CTRL_BORDER;
 	nw = sw + border;
 	nh = sh + border;
@@ -506,12 +545,8 @@ static void query_label_natural_size(struct sdlpui_control *c,
 		int *width, int *height)
 {
 	TTF_Font *font = sdlpui_get_ttf(w);
-	struct sdlpui_label *lp;
 
-	SDL_assert(c->type_code == SDLPUI_CTRL_LABEL && c->priv);
-	lp = c->priv;
-
-	sdlpui_get_utf8_metrics(font, lp->caption, width, height);
+	sdlpui_get_utf8_metrics(font, (*c->ftb->get_caption)(c), width, height);
 	*width += SDLPUI_DEFAULT_CTRL_BORDER * 2;
 	*height += SDLPUI_DEFAULT_CTRL_BORDER * 2;
 }
@@ -525,6 +560,22 @@ static void cleanup_label(struct sdlpui_control *c)
 	lp = c->priv;
 	SDL_free(lp->caption);
 	SDL_free(lp);
+}
+
+
+static const char *get_pb_type_name(const struct sdlpui_control *c)
+{
+	return "push button";
+}
+
+
+static const char *get_pb_caption(const struct sdlpui_control *c)
+{
+	struct sdlpui_label *pbp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+	pbp = c->priv;
+	return pbp->caption;
 }
 
 
@@ -556,8 +607,9 @@ static void render_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
 
 	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
 	pbp = c->priv;
-	SDLPUI_RENDER_TRACER("push button", c, pbp->caption, c->rect,
-		pbp->caption_rect, d->texture);
+	SDLPUI_RENDER_TRACER((*c->ftb->get_type_name)(c), c,
+		(*c->ftb->get_caption)(c), c->rect, pbp->caption_rect,
+		d->texture);
 
 	/*
 	 * Always draw a border.  There's one pixel between these to leave
@@ -619,7 +671,8 @@ static void render_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
 			dst_r.x += d->rect.x;
 			dst_r.y += d->rect.y;
 		}
-		sdlpui_render_utf8_line(r, font, fg, &dst_r, pbp->caption);
+		sdlpui_render_utf8_line(r, font, fg, &dst_r,
+			(*c->ftb->get_caption)(c));
 	}
 
 	if (pbp->disabled) {
@@ -648,14 +701,15 @@ static void respond_default_pb(struct sdlpui_control *c,
 	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
 	pbp = c->priv;
 	if (!pbp->disabled && pbp->callback) {
-		SDLPUI_EVENT_TRACER("push button", c, pbp->caption,
-			"default action invoked");
+		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
+			(*c->ftb->get_caption)(c), "default action invoked");
 		(pbp->callback)(c, d, w);
 	} else {
-		SDLPUI_EVENT_TRACER("push button", c, pbp->caption,
-			(pbp->disabled) ?
-				((pbp->callback) ? "default action suppressed; disable yes, callback available" : "default action suppressed; disable yes, callback unavailable") :
-				((pbp->callback) ? "default action suppressed; disable no, callback available" : "default action suppressed; disable no, callback unavailable"));
+		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
+			(*c->ftb->get_caption)(c),
+			(pbp->disabled)
+			? ((pbp->callback) ? "default action suppressed; disable yes, callback available" : "default action suppressed; disable yes, callback unavailable")
+			: ((pbp->callback) ? "default action suppressed; disable no, callback available" : "default action suppressed; disable no, callback unavailable"));
 	}
 }
 
@@ -669,8 +723,8 @@ static void gain_key_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
 	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
 	pbp = c->priv;
 	if (!pbp->has_key) {
-		SDLPUI_EVENT_TRACER("push button", c, pbp->caption,
-			"gained key focus");
+		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
+			(*c->ftb->get_caption)(c), "gains key focus");
 		pbp->has_key = SDL_TRUE;
 		d->dirty = SDL_TRUE;
 		sdlpui_signal_redraw(w);
@@ -687,8 +741,8 @@ static void lose_key_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
 	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
 	pbp = c->priv;
 	if (pbp->has_key) {
-		SDLPUI_EVENT_TRACER("push button", c, pbp->caption,
-			"lost key focus");
+		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
+			(*c->ftb->get_caption)(c), "loses key focus");
 		pbp->has_key = SDL_FALSE;
 		d->dirty = SDL_TRUE;
 		sdlpui_signal_redraw(w);
@@ -705,8 +759,8 @@ static void gain_mouse_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
 	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
 	pbp = c->priv;
 	if (!pbp->has_mouse) {
-		SDLPUI_EVENT_TRACER("push button", c, pbp->caption,
-			"gained mouse focus");
+		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
+			(*c->ftb->get_caption)(c), "gains mouse focus");
 		pbp->has_mouse = SDL_TRUE;
 		d->dirty = SDL_TRUE;
 		sdlpui_signal_redraw(w);
@@ -723,8 +777,8 @@ static void lose_mouse_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
 	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
 	pbp = c->priv;
 	if (pbp->has_mouse) {
-		SDLPUI_EVENT_TRACER("push button", c, pbp->caption,
-			"lost mouse focus");
+		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
+			(*c->ftb->get_caption)(c), "loses mouse focus");
 		pbp->has_mouse = SDL_FALSE;
 		d->dirty = SDL_TRUE;
 		sdlpui_signal_redraw(w);
@@ -783,7 +837,7 @@ static void resize_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
 	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
 	pbp = c->priv;
 
-	sdlpui_get_utf8_metrics(font, pbp->caption, &sw, &sh);
+	sdlpui_get_utf8_metrics(font, (*c->ftb->get_caption)(c), &sw, &sh);
 	border = 2 * (SDLPUI_DEFAULT_CTRL_BORDER + 2);
 	nw = sw + border;
 	nh = sh + border;
@@ -835,12 +889,8 @@ static void query_pb_natural_size(struct sdlpui_control *c,
 		int *height)
 {
 	TTF_Font *font = sdlpui_get_ttf(w);
-	struct sdlpui_push_button *pbp;
 
-	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
-	pbp = c->priv;
-
-	sdlpui_get_utf8_metrics(font, pbp->caption, width, height);
+	sdlpui_get_utf8_metrics(font, (*c->ftb->get_caption)(c), width, height);
 	*width += (SDLPUI_DEFAULT_CTRL_BORDER + 2) * 2;
 	*height += (SDLPUI_DEFAULT_CTRL_BORDER + 2) * 2;
 }
@@ -919,8 +969,8 @@ static void help_mb_popup_submenu(struct sdlpui_control *c,
 	mbp = c->priv;
 	SDL_assert(mbp->subtype_code == SDLPUI_MB_SUBMENU);
 
-	SDLPUI_EVENT_TRACER("menu submenu button", c, mbp->caption,
-		"popping up child menu");
+	SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
+		(*c->ftb->get_caption)(c), "popping up child menu");
 
 	ul_x_win = d->rect.x + c->rect.x;
 	ul_y_win = d->rect.y + c->rect.y;
@@ -990,71 +1040,33 @@ static SDL_bool handle_mb_mousemove(struct sdlpui_control *c,
 			}
 			if (old != mbp->has_mouse) {
 				if (!mbp->has_mouse) {
-#ifdef SDLPUI_TRACE_EVENTS
-					size_t ecap_sz =
-						SDL_strlen(mbp->caption) + 16;
-					char *ecap = SDL_malloc(ecap_sz);
-
-					(void)SDL_snprintf(ecap, ecap_sz,
-						mbp->caption,
-						mbp->v.ranged_int.curr);
-					SDLPUI_EVENT_TRACER("menu ranged int",
-						c, ecap, "lost mouse focus");
-					SDL_free(ecap);
-#endif
+					SDLPUI_EVENT_TRACER(
+						(*c->ftb->get_type_name)(c),
+						c, (*c->ftb->get_caption)(c),
+						"loses mouse focus");
 					d->c_mouse = NULL;
 				} else if (!old) {
-#ifdef SDLPUI_TRACE_EVENTS
-					size_t ecap_sz =
-						SDL_strlen(mbp->caption) + 16;
-					char *ecap = SDL_malloc(ecap_sz);
-
-					(void)SDL_snprintf(ecap, ecap_sz,
-						mbp->caption,
-						mbp->v.ranged_int.curr);
-					SDLPUI_EVENT_TRACER("menu ranged int",
-						c, ecap, "gained mouse focus");
-					SDL_free(ecap);
-#endif
+					SDLPUI_EVENT_TRACER(
+						(*c->ftb->get_type_name)(c),
+						c, (*c->ftb->get_caption)(c),
+						"gains mouse focus");
 					d->c_mouse = c;
 				}
 				/* Have keyboard focus follow the mouse. */
 				if (mbp->has_key != mbp->has_mouse) {
 					if (!mbp->has_mouse) {
-#ifdef SDLPUI_TRACE_EVENTS
-						size_t ecap_sz =
-							SDL_strlen(mbp->caption)
-							+ 16;
-						char *ecap =
-							SDL_malloc(ecap_sz);
-
-						(void)SDL_snprintf(ecap,
-							ecap_sz, mbp->caption,
-							mbp->v.ranged_int.curr);
 						SDLPUI_EVENT_TRACER(
-							"menu ranged int",
-							c, ecap,
-							"lost key focus");
-						SDL_free(ecap);
-#endif
+							(*c->ftb->get_type_name)(c),
+							c,
+							(*c->ftb->get_caption)(c),
+							"loses key focus");
 						d->c_key = NULL;
 					} else if (!mbp->has_key) {
-#ifdef SDLPUI_TRACE_EVENTS
-						size_t ecap_sz =
-							SDL_strlen(mbp->caption)
-							+ 16;
-						char *ecap =
-							SDL_malloc(ecap_sz);
-
-						(void)SDL_snprintf(ecap,
-							ecap_sz, mbp->caption,
-							mbp->v.ranged_int.curr);
 						SDLPUI_EVENT_TRACER(
-							"menu ranged int",
-							c, ecap,
-							"gained key focus");
-						SDL_free(ecap);
-#endif
+							(*c->ftb->get_type_name)(c),
+							c,
+							(*c->ftb->get_caption)(c),
+							"gains key focus");
 						d->c_key = c;
 					}
 					mbp->has_key = mbp->has_mouse;
@@ -1112,36 +1124,78 @@ static SDL_bool handle_mb_mousewheel(struct sdlpui_control *c,
 		result = mbp->v.ranged_int.max;
 	}
 	if (mbp->v.ranged_int.curr != result) {
-#ifdef SDLPUI_TRACE_EVENTS
-		size_t ecap_sz = SDL_strlen(mbp->caption) + 16;
-		char *ecap = SDL_malloc(ecap_sz);
-
-		(void)SDL_snprintf(ecap, ecap_sz, mbp->caption,
-			mbp->v.ranged_int.curr);
-		SDLPUI_EVENT_TRACER("menu ranged int", c, ecap,
-			"value changed by mouse wheel");
-		SDL_free(ecap);
-#endif
+		if (mbp->v.ranged_int.expanded_caption) {
+			SDL_free(mbp->v.ranged_int.expanded_caption);
+			mbp->v.ranged_int.expanded_caption = NULL;
+		}
 		mbp->v.ranged_int.old = mbp->v.ranged_int.curr;
 		mbp->v.ranged_int.curr = (int)result;
+		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
+			(*c->ftb->get_caption)(c),
+			"value changed by mouse wheel");
 		d->dirty = SDL_TRUE;
 		sdlpui_signal_redraw(w);
 		if (mbp->callback) {
 			(*mbp->callback)(c, d, w);
 		}
 	} else {
-#ifdef SDLPUI_TRACE_EVENTS
-		size_t ecap_sz = SDL_strlen(mbp->caption) + 16;
-		char *ecap = SDL_malloc(ecap_sz);
-
-		(void)SDL_snprintf(ecap, ecap_sz, mbp->caption,
-			mbp->v.ranged_int.curr);
-		SDLPUI_EVENT_TRACER("menu ranged int", c, ecap,
+		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
+			(*c->ftb->get_caption)(c),
 			"value left as is by mouse wheel");
-		SDL_free(ecap);
-#endif
 	}
 	return SDL_TRUE;
+}
+
+
+static const char *get_mb_type_name(const struct sdlpui_control *c)
+{
+	struct sdlpui_menu_button *mbp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+	mbp = c->priv;
+	switch (mbp->subtype_code) {
+	case SDLPUI_MB_INVALID:
+		return "menu invalid entry";
+
+	case SDLPUI_MB_NONE:
+		return "menu button";
+
+	case SDLPUI_MB_INDICATOR:
+		return "menu indicator";
+
+	case SDLPUI_MB_RANGED_INT:
+		return "menu ranged int";
+
+	case SDLPUI_MB_SUBMENU:
+		return "menu submenu button";
+
+	case SDLPUI_MB_TOGGLE:
+		return "menu toggle";
+
+	default:
+		return "menu unknown entry";
+	}
+}
+
+
+static const char *get_mb_caption(const struct sdlpui_control *c)
+{
+	struct sdlpui_menu_button *mbp;
+
+	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+	mbp = c->priv;
+	if (mbp->subtype_code != SDLPUI_MB_RANGED_INT) {
+		return mbp->caption;
+	}
+	if (!mbp->v.ranged_int.expanded_caption) {
+		size_t ecap_sz = SDL_strlen(mbp->caption) + 16;
+
+		mbp->v.ranged_int.expanded_caption = SDL_malloc(ecap_sz);
+		(void)SDL_snprintf(mbp->v.ranged_int.expanded_caption,
+			ecap_sz, mbp->caption, mbp->v.ranged_int.curr);
+
+	}
+	return mbp->v.ranged_int.expanded_caption;
 }
 
 
@@ -1155,6 +1209,11 @@ static void change_mb_caption(struct sdlpui_control *c,
 	mbp = c->priv;
 	SDL_free(mbp->caption);
 	mbp->caption = SDL_strdup(new_caption);
+	if (mbp->subtype_code == SDLPUI_MB_RANGED_INT
+			&& mbp->v.ranged_int.expanded_caption) {
+		SDL_free(mbp->v.ranged_int.expanded_caption);
+		mbp->v.ranged_int.expanded_caption = NULL;
+	}
 	resize_mb(c, d, w, c->rect.w, c->rect.h);
 	d->dirty = SDL_TRUE;
 	sdlpui_signal_redraw(w);
@@ -1172,8 +1231,9 @@ static void render_mb(struct sdlpui_control *c,
 
 	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
 	mbp = c->priv;
-	SDLPUI_RENDER_TRACER("menu button", c, mbp->caption, c->rect,
-		mbp->caption_rect, d->texture);
+	SDLPUI_RENDER_TRACER((*c->ftb->get_type_name)(c), c,
+		(*c->ftb->get_caption)(c), c->rect, mbp->caption_rect,
+		d->texture);
 
 	SDL_SetRenderDrawColor(r, fg->r, fg->g, fg->b, fg->a);
 
@@ -1185,19 +1245,8 @@ static void render_mb(struct sdlpui_control *c,
 			dst_r.x += d->rect.x;
 			dst_r.y += d->rect.y;
 		}
-		if (mbp->subtype_code != SDLPUI_MB_RANGED_INT) {
-			sdlpui_render_utf8_line(r, font, fg, &dst_r,
-				mbp->caption);
-		} else {
-			/* Fill in the current value in the caption. */
-			size_t ecap_sz = SDL_strlen(mbp->caption) + 16;
-			char *ecap = SDL_malloc(ecap_sz);
-
-			(void)SDL_snprintf(ecap, ecap_sz, mbp->caption,
-				mbp->v.ranged_int.curr);
-			sdlpui_render_utf8_line(r, font, fg, &dst_r, ecap);
-			SDL_free(ecap);
-		}
+		sdlpui_render_utf8_line(r, font, fg, &dst_r,
+			(*c->ftb->get_caption)(c));
 
 		if ((mbp->subtype_code == SDLPUI_MB_TOGGLE
 				|| mbp->subtype_code == SDLPUI_MB_INDICATOR)
@@ -1378,8 +1427,9 @@ static void respond_default_mb(struct sdlpui_control *c,
 			}
 			help_mb_popup_submenu(c, d, w);
 		} else {
-			SDLPUI_EVENT_TRACER("menu submenu button", c,
-				mbp->caption, "child menu already displayed");
+			SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
+				(*c->ftb->get_caption)(c),
+				"child menu already displayed");
 		}
 		/* Give the first button in the child menu keyboard focus. */
 		if (mbp->v.submenu.child->ftb->goto_first_control) {
@@ -1411,37 +1461,27 @@ static void respond_default_mb(struct sdlpui_control *c,
 			newi = mbp->v.ranged_int.max;
 		}
 		if (newi == mbp->v.ranged_int.curr) {
-#ifdef SDLPUI_TRACE_EVENTS
-			size_t ecap_sz = SDL_strlen(mbp->caption) + 16;
-			char *ecap = SDL_malloc(ecap_sz);
-
-			(void)SDL_snprintf(ecap, ecap_sz, mbp->caption,
-				mbp->v.ranged_int.curr);
-			SDLPUI_EVENT_TRACER("menu ranged int", c, ecap,
+			SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
+				(*c->ftb->get_caption)(c),
 				"left unchanged by default response");
-			SDL_free(ecap);
-#endif
 			return;
 		}
-#ifdef SDLPUI_TRACE_EVENTS
-		{
-			size_t ecap_sz = SDL_strlen(mbp->caption) + 16;
-			char *ecap = SDL_malloc(ecap_sz);
-
-			(void)SDL_snprintf(ecap, ecap_sz, mbp->caption, newi);
-			SDLPUI_EVENT_TRACER("menu ranged int", c, ecap,
-				"changed by default response");
-			SDL_free(ecap);
+		if (mbp->v.ranged_int.expanded_caption) {
+			SDL_free(mbp->v.ranged_int.expanded_caption);
+			mbp->v.ranged_int.expanded_caption = NULL;
 		}
-#endif
 		mbp->v.ranged_int.old = mbp->v.ranged_int.curr;
 		mbp->v.ranged_int.curr = newi;
+		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
+			(*c->ftb->get_caption)(c),
+			"changed by default response");
 		d->dirty = SDL_TRUE;
 		sdlpui_signal_redraw(w);
 		break;
 
 	case SDLPUI_MB_TOGGLE:
-		SDLPUI_EVENT_TRACER("menu toggle", c, mbp->caption,
+		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
+			(*c->ftb->get_caption)(c),
 			"changed by default response");
 		mbp->v.toggled = !mbp->v.toggled;
 		d->dirty = SDL_TRUE;
@@ -1467,8 +1507,8 @@ static void gain_key_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
 	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
 	mbp = c->priv;
 
-	SDLPUI_EVENT_TRACER("menu entry", c, mbp->caption,
-		"gained key focus");
+	SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
+		(*c->ftb->get_caption)(c), "gains key focus");
 	old = mbp->has_key;
 	if (mbp->subtype_code == SDLPUI_MB_RANGED_INT) {
 		if (comp_ind < 0) {
@@ -1502,8 +1542,8 @@ static void lose_key_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
 	mbp = c->priv;
 
 	if (mbp->has_key) {
-		SDLPUI_EVENT_TRACER("menu entry", c, mbp->caption,
-			"lost key focus");
+		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
+			(*c->ftb->get_caption)(c), "loses key focus");
 		mbp->has_key = 0;
 		d->dirty = SDL_TRUE;
 		sdlpui_signal_redraw(w);
@@ -1514,8 +1554,8 @@ static void lose_key_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
 	 */
 	if (mbp->subtype_code == SDLPUI_MB_SUBMENU && mbp->v.submenu.child
 			&& (!new_d || !sdlpui_is_descendant_dialog(d, new_d))) {
-		SDLPUI_EVENT_TRACER("submenu entry", c, mbp->caption,
-			"popping down submenu");
+		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
+			(*c->ftb->get_caption)(c), "popping down submenu");
 		sdlpui_popdown_dialog(mbp->v.submenu.child, w, SDL_FALSE);
 		mbp->v.submenu.child = NULL;
 	}
@@ -1531,8 +1571,8 @@ static void gain_mouse_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
 	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
 	mbp = c->priv;
 
-	SDLPUI_EVENT_TRACER("menu entry", c, mbp->caption,
-		"gained mouse focus");
+	SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
+		(*c->ftb->get_caption)(c), "gains mouse focus");
 	old = mbp->has_mouse;
 	if (mbp->subtype_code == SDLPUI_MB_RANGED_INT) {
 		if (comp_ind < 0) {
@@ -1567,8 +1607,8 @@ static void lose_mouse_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
 	mbp = c->priv;
 
 	if (mbp->has_mouse) {
-		SDLPUI_EVENT_TRACER("menu entry", c, mbp->caption,
-			"lost mouse focus");
+		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
+			(*c->ftb->get_caption)(c), "loses mouse focus");
 		mbp->has_mouse = 0;
 		d->dirty = SDL_TRUE;
 		sdlpui_signal_redraw(w);
@@ -1579,8 +1619,8 @@ static void lose_mouse_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
 	 */
 	if (mbp->subtype_code == SDLPUI_MB_SUBMENU && mbp->v.submenu.child
 			&& (!new_d || !sdlpui_is_descendant_dialog(d, new_d))) {
-		SDLPUI_EVENT_TRACER("submenu entry", c, mbp->caption,
-			"popping down submenu");
+		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
+			(*c->ftb->get_caption)(c), "popping down submenu");
 		sdlpui_popdown_dialog(mbp->v.submenu.child, w, SDL_FALSE);
 		mbp->v.submenu.child = NULL;
 	}
@@ -1611,7 +1651,8 @@ static void arm_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
 	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
 	mbp = c->priv;
 
-	SDLPUI_EVENT_TRACER("menu entry", c, mbp->caption, "arming");
+	SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
+		(*c->ftb->get_caption)(c), "arming");
 	old = mbp->armed;
 	if (mbp->subtype_code != SDLPUI_MB_RANGED_INT) {
 		mbp->armed = 1;
@@ -1641,7 +1682,8 @@ static void disarm_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
 	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
 	mbp = c->priv;
 
-	SDLPUI_EVENT_TRACER("menu entry", c, mbp->caption, "disarming");
+	SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
+		(*c->ftb->get_caption)(c), "disarming");
 	old = mbp->armed;
 	if (mbp->subtype_code != SDLPUI_MB_RANGED_INT
 			|| hint == SDLPUI_ACTION_HINT_NONE) {
@@ -1931,6 +1973,10 @@ static void cleanup_mb(struct sdlpui_control *c)
 	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
 	mbp = c->priv;
 	SDL_free(mbp->caption);
+	if (mbp->subtype_code == SDLPUI_MB_RANGED_INT
+			&& mbp->v.ranged_int.expanded_caption) {
+		SDL_free(mbp->v.ranged_int.expanded_caption);
+	}
 	SDL_free(mbp);
 }
 
@@ -2074,8 +2120,11 @@ SDL_bool sdlpui_control_handle_key(struct sdlpui_control *c,
 			}
 			if (mods == KMOD_NONE) {
 				if (c->ftb->respond_default) {
-					SDLPUI_EVENT_TRACER("control", c,
-						"(not extracted)",
+					SDLPUI_EVENT_TRACER(
+						(*c->ftb->get_type_name)(c), c,
+						(c->ftb->get_caption)
+						? (*c->ftb->get_caption)(c)
+						: "(none)",
 						"invoking default reponse");
 					(*c->ftb->respond_default)(c, d, w,
 						SDLPUI_ACTION_HINT_KEY);
@@ -2124,8 +2173,10 @@ SDL_bool sdlpui_control_handle_mouseclick(struct sdlpui_control *c,
 					SDLPUI_ACTION_HINT_MOUSE);
 			}
 			if (c->ftb->respond_default) {
-				SDLPUI_EVENT_TRACER("control", c,
-					"(not extracted)",
+				SDLPUI_EVENT_TRACER(
+					(*c->ftb->get_type_name)(c), c,
+					(c->ftb->get_caption)
+					? (*c->ftb->get_caption)(c) : "(none)",
 					"invoking default response");
 				(*c->ftb->respond_default)(c, d, w,
 					SDLPUI_ACTION_HINT_MOUSE);
@@ -2182,7 +2233,9 @@ void sdlpui_invoke_dialog_default_action(struct sdlpui_control *c,
 		struct sdlpui_dialog *d, struct sdlpui_window *w)
 {
 	if (d->ftb->respond_default) {
-		SDLPUI_EVENT_TRACER("control", c, "(not extracted)",
+		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
+			(c->ftb->get_caption) ? (*c->ftb->get_caption)(c)
+			: "(none)",
 			"invoking containing dialog's default action");
 		(*d->ftb->respond_default)(d, w);
 	}
@@ -2432,6 +2485,7 @@ void sdlpui_create_menu_ranged_int(struct sdlpui_control *c,
 	mbp->armed = 0;
 	mbp->disabled = (disabled) ? SDL_TRUE : SDL_FALSE;
 	mbp->subtype_code = SDLPUI_MB_RANGED_INT;
+	mbp->v.ranged_int.expanded_caption = NULL;
 	mbp->v.ranged_int.min = min_value;
 	mbp->v.ranged_int.max = max_value;
 	mbp->v.ranged_int.curr = curr_value;

--- a/src/sdl2/pui-ctrl.h
+++ b/src/sdl2/pui-ctrl.h
@@ -139,6 +139,16 @@ struct sdlpui_control_funcs {
 		struct sdlpui_dialog *d, struct sdlpui_window *w,
 		const SDL_MouseWheelEvent *e);
 	/**
+	 * Return the name for the type of a specific control.  May not be
+	 * NULL.
+	 */
+	const char *(*get_type_name)(const struct sdlpui_control *c);
+	/**
+	 * Return the caption for the control.  May be NULL.  In that case,
+	 * tracing statements use "(none)" when displaying the caption.
+	 */
+	const char *(*get_caption)(const struct sdlpui_control *c);
+	/**
 	 * Change the caption for the control.  May be NULL if the control
 	 * does not have a caption or otherwise does not want
 	 * sdlpui_change_caption() to work with the control.  Does resize
@@ -379,7 +389,10 @@ struct sdlpui_menu_button {
 				different look */
 	enum sdlpui_menu_button_type subtype_code;
 	union {
-		struct { int min, max, curr, old; } ranged_int;
+		struct {
+			char *expanded_caption;
+			int min, max, curr, old;
+		} ranged_int;
 		struct {
 			struct sdlpui_dialog *(*creator)(
 				struct sdlpui_control*,

--- a/src/sdl2/pui-dlg.c
+++ b/src/sdl2/pui-dlg.c
@@ -198,8 +198,11 @@ static SDL_bool handle_simple_menu_key(struct sdlpui_dialog *d,
 				}
 				if (mods == KMOD_NONE
 						&& c->ftb->respond_default) {
-					SDLPUI_EVENT_TRACER("control", c,
-						"(not extracted)",
+					SDLPUI_EVENT_TRACER(
+						(*c->ftb->get_type_name)(c), c,
+						(c->ftb->get_caption)
+						? (*c->ftb->get_caption)(c)
+						: "(none)",
 						"invoking default response");
 					(*c->ftb->respond_default)(c, d, w,
 						SDLPUI_ACTION_HINT_KEY);
@@ -347,8 +350,10 @@ static SDL_bool handle_simple_menu_textin(struct sdlpui_dialog *d,
 		 */
 		if (c) {
 			if (c->ftb->respond_default) {
-				SDLPUI_EVENT_TRACER("control", c,
-					"(not extracted)",
+				SDLPUI_EVENT_TRACER(
+					(*c->ftb->get_type_name)(c), c,
+					(c->ftb->get_caption)
+					? (*c->ftb->get_caption)(c) : "(none)",
 					"invoking default response");
 				(*c->ftb->respond_default)(c, d, w,
 					SDLPUI_ACTION_HINT_KEY);
@@ -1551,13 +1556,9 @@ SDL_bool sdlpui_dialog_handle_mousemove(struct sdlpui_dialog *d,
 		NULL;
 	if (c) {
 		if (c_mouse && c_mouse->ftb->lose_mouse) {
-			SDLPUI_EVENT_TRACER("control", d->c_mouse,
-				"(not extracted)", "loses mouse focus");
 			(*c_mouse->ftb->lose_mouse)(c_mouse, d, w, c, d);
 		}
 		if (c->ftb->gain_mouse) {
-			SDLPUI_EVENT_TRACER("control", c, "(not extracted)",
-				"gains mouse focus");
 			(*c->ftb->gain_mouse)(c, d, w, comp_ind);
 		}
 		d->c_mouse = c;
@@ -1565,14 +1566,10 @@ SDL_bool sdlpui_dialog_handle_mousemove(struct sdlpui_dialog *d,
 		/* Have keyboard focus follow the mouse. */
 		if (d->c_key != c) {
 			if (d->c_key && d->c_key->ftb->lose_key) {
-				SDLPUI_EVENT_TRACER("control", d->c_key,
-					"(not extracted)", "loses key focus");
 				(*d->c_key->ftb->lose_key)(d->c_key, d, w, c,
 					d);
 			}
 			if (c && c->ftb->gain_key) {
-				SDLPUI_EVENT_TRACER("control", c,
-					"(not extracted)", "gains key focus");
 				(c->ftb->gain_key)(c, d, w, comp_ind);
 			}
 			d->c_key = c;
@@ -1581,10 +1578,7 @@ SDL_bool sdlpui_dialog_handle_mousemove(struct sdlpui_dialog *d,
 	if (c || sdlpui_is_in_dialog(d, e->x, e->y)) {
 		if (!c) {
 			if (c_mouse) {
-				if (c_mouse && c_mouse->ftb->lose_mouse) {
-					SDLPUI_EVENT_TRACER("control",
-						c_mouse, "(not extracted)",
-						"loses mouse focus");
+				if (c_mouse->ftb->lose_mouse) {
 					(*c_mouse->ftb->lose_mouse)(
 						c_mouse, d, w, NULL, d);
 				}
@@ -1592,10 +1586,7 @@ SDL_bool sdlpui_dialog_handle_mousemove(struct sdlpui_dialog *d,
 			}
 			/* Have keyboard focus follow the mouse. */
 			if (d->c_key) {
-				if (d->c_key && d->c_key->ftb->lose_key) {
-					SDLPUI_EVENT_TRACER("control",
-						d->c_key, "(not extracted)",
-						"loses key focus");
+				if (d->c_key->ftb->lose_key) {
 					(*d->c_key->ftb->lose_key)(
 						d->c_key, d, w, NULL, d);
 				}


### PR DESCRIPTION
Remove some tracing statements in the dialog handling which duplicate ones in the controls.