### PR TITLE
Alter binary searches to avoid the possiblity of integer overflow

### DIFF
--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -277,7 +277,7 @@ static struct loc choose_random_entrance(struct chunk *c, int ridx,
 					mem_free(accum);
 					return dun->ent[ridx][low];
 				}
-				mid = (low + high) / 2;
+				mid = low + (high - low) / 2;
 				if (accum[mid] <= chosen) {
 					low = mid;
 				} else {

--- a/src/obj-make.c
+++ b/src/obj-make.c
@@ -324,7 +324,7 @@ static int binary_search_probtable(const uint32_t *tbl, int n, uint32_t p)
 			assert(tbl[ilow] <= p && tbl[ihigh] > p);
 			return ilow;
 		}
-		imid = (ilow + ihigh) / 2;
+		imid = ilow + (ihigh - ilow) / 2;
 		if (tbl[imid] <= p) {
 			ilow = imid;
 		} else {

--- a/src/sdl2/pui-dlg.c
+++ b/src/sdl2/pui-dlg.c
@@ -630,7 +630,7 @@ static struct sdlpui_control *find_simple_menu_control_containing(
 			}
 			return p->v_ctrls[ilo];
 		}
-		imid = (ilo + ihi) / 2;
+		imid = ilo + (ihi - ilo) / 2;
 		if (p->vertical) {
 			if (p->v_ctrls[imid]->rect.y > y) {
 				ihi = imid;

--- a/src/sdl2/pui-misc.c
+++ b/src/sdl2/pui-misc.c
@@ -201,7 +201,7 @@ Uint32 sdlpui_register_code(const char *name)
 			break;
 		}
 
-		imid = (ilo + ihi) / 2;
+		imid = ilo + (ihi - ilo) / 2;
 		cmp = strcmp(my_registry.entries[imid].name, name);
 		if (cmp == 0) {
 			code = my_registry.entries[imid].code;

--- a/src/ui-entry.c
+++ b/src/ui-entry.c
@@ -1167,7 +1167,7 @@ static int ui_entry_search(const char *name, int *ind)
 			*ind = ilow;
 			return 0;
 		}
-		imid = (ilow + ihigh) / 2;
+		imid = ilow + (ihigh - ilow) / 2;
 		cmp = strcmp(entries[imid]->name, name);
 		if (cmp == 0) {
 			*ind = imid;
@@ -1257,7 +1257,7 @@ static int ui_entry_search_categories(const struct ui_entry *entry,
 			*ind = ilow;
 			return 0;
 		}
-		imid = (ilow + ihigh) / 2;
+		imid = ilow + (ihigh - ilow) / 2;
 		cmp = strcmp(entry->categories[imid].name, name);
 		if (cmp == 0) {
 			*ind = imid;
@@ -1390,7 +1390,7 @@ static int search_embryo_categories(const struct embryonic_ui_entry *embryo,
 			*ind = ilow;
 			return 0;
 		}
-		imid = (ilow + ihigh) / 2;
+		imid = ilow + (ihigh - ilow) / 2;
 		cmp = strcmp(embryo->categories[imid].name, name);
 		if (cmp == 0) {
 			*ind = imid;


### PR DESCRIPTION
Some searches (in gen-chunk.c, main-sdl2.c, ui-entry-combiner.c, z-rand.c, and z-util.c) have been left as is because the range of the search precludes the chance of overflow.