### PR TITLE
workflows: better compatibility with Node.js 24

### DIFF
--- a/.github/workflows/cygwin.yaml
+++ b/.github/workflows/cygwin.yaml
@@ -21,7 +21,7 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
           
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build (MinGW32 cross, inside Cygwin)
         shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
@@ -73,7 +73,7 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
           
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build & Test (MinGW32 cross, inside Cygwin)
         shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -19,7 +19,7 @@ jobs:
       # with an arbitrary number of commits.  Only get the part of the
       # repository that affects building the documentation.
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           sparse-checkout: |
@@ -56,7 +56,7 @@ jobs:
           fi
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.DOC_ARTIFACT }}
           path: ${{ env.DOC_ARTIFACT_PATH }}

--- a/.github/workflows/dos.yaml
+++ b/.github/workflows/dos.yaml
@@ -17,7 +17,7 @@ jobs:
           sudo apt-get install make dosbox-x
 
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build
         run: |

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -16,7 +16,7 @@ jobs:
           sudo apt-get install gcc cmake ninja-build libx11-dev 
 
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build with Ninja
         run: |
@@ -36,7 +36,7 @@ jobs:
           sudo apt-get install gcc cmake ninja-build libx11-dev
 
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build with Ninja
         run: |
@@ -55,7 +55,7 @@ jobs:
           sudo apt-get install gcc cmake ninja-build libncursesw5-dev
 
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build with Ninja
         run: |
@@ -74,7 +74,7 @@ jobs:
           sudo apt-get install gcc cmake ninja-build libsdl-image1.2-dev libsdl-ttf2.0-dev libsdl-mixer1.2-dev
 
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build with Ninja
         run: |
@@ -93,7 +93,7 @@ jobs:
           sudo apt-get install gcc cmake ninja-build libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev
 
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build with CMake/Ninja
         run: |
@@ -112,7 +112,7 @@ jobs:
           sudo apt-get install gcc make libsqlite3-dev libsdl1.2-dev libsdl-mixer1.2-dev cmake ninja-build
 
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Turn on sound and the test front end so more of the basic
       # infrastructure is compiled.
@@ -138,7 +138,7 @@ jobs:
           sudo apt-get install gcc autoconf automake make libsqlite3-dev libsdl1.2-dev libsdl-mixer1.2-dev
 
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Turn on sound and the test front end so more of the basic
       # infrastructure is compiled.
@@ -158,7 +158,7 @@ jobs:
           sudo apt-get install gcc make libncursesw5-dev libx11-dev libsdl-image1.2-dev libsdl-ttf2.0-dev libsdl-mixer1.2-dev libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev libsqlite3-dev
 
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build
         run: |

--- a/.github/workflows/mac.yaml
+++ b/.github/workflows/mac.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build
         run: |
@@ -26,7 +26,7 @@ jobs:
           brew install ncurses
 
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure (CMake)
         run: |
@@ -48,7 +48,7 @@ jobs:
           brew install automake
 
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build
         run: |

--- a/.github/workflows/msbuild.yaml
+++ b/.github/workflows/msbuild.yaml
@@ -14,10 +14,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build
         run: |

--- a/.github/workflows/msys2.yaml
+++ b/.github/workflows/msys2.yaml
@@ -26,7 +26,7 @@ jobs:
             mingw-w64-x86_64-ncurses
 
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build with CMake/Ninja
         run: |
@@ -58,7 +58,7 @@ jobs:
             mingw-w64-x86_64-SDL2_mixer
 
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build with CMake/Ninja including sound and static linking
         run: |
@@ -88,7 +88,7 @@ jobs:
             mingw-w64-i686-gcc
 
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build
         run: |
@@ -116,7 +116,7 @@ jobs:
             mingw-w64-i686-libpng
 
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure with CMake/Ninja and static linking
         run: |
@@ -159,7 +159,7 @@ jobs:
             mingw-w64-x86_64-libpng
 
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure with CMake/Ninja
         run: |
@@ -203,7 +203,7 @@ jobs:
             mingw-w64-clang-x86_64-libpng
 
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build with ASAN/UBSAN
         run: |

--- a/.github/workflows/nintendo.yaml
+++ b/.github/workflows/nintendo.yaml
@@ -13,7 +13,7 @@ jobs:
     container: devkitpro/devkitarm
     steps:
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Extract Names from Makefile
         id: get_names
@@ -73,7 +73,7 @@ jobs:
     container: skylyrac/blocksds:slim-latest
     steps:
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build
         shell: bash
@@ -88,7 +88,7 @@ jobs:
 #    container: devkitpro/devkitarm
 #    steps:
 #      - name: Clone Project
-#        uses: actions/checkout@v4
+#        uses: actions/checkout@v6
 
 #      - name: Build
 #        shell: bash

--- a/.github/workflows/nmake.yaml
+++ b/.github/workflows/nmake.yaml
@@ -13,12 +13,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Add nmake and compiler to PATH
-        uses: TheMrMilchmann/setup-msvc-dev@v3
+        uses: TheMrMilchmann/setup-msvc-dev@v4
         with:
           arch: x86
 
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,7 +68,7 @@ jobs:
       # Need commit history and tags for scripts/version.sh to work as expected
       # so use 0 for fetch-depth.
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -118,7 +118,7 @@ jobs:
           echo draft= '${{ steps.get_release_vars.outputs.draft }}' >> $CONFIG_ARTIFACT_PATH
 
       - name: Upload Artifact for Use by Dependent Steps
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.CONFIG_ARTIFACT }}
           path: ${{ env.CONFIG_ARTIFACT_PATH }}
@@ -133,7 +133,7 @@ jobs:
       # dependencies as that step does some writing to the current directory
       # and cloning the project wipes the current directory.
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -178,7 +178,7 @@ jobs:
             -C build manual-output/html
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.DOC_ARTIFACT }}
           path: ${{ env.DOC_ARTIFACT_PATH }}
@@ -190,7 +190,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Artifact with Configuration Information
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.CONFIG_ARTIFACT }}
 
@@ -212,7 +212,7 @@ jobs:
       # Need commit history and tags for scripts/version.sh to work as expected
       # so use 0 for fetch-depth.
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -256,14 +256,14 @@ jobs:
           echo archive_path= '${{ steps.create_source_archive.outputs.archive_file }}' > $SRC_ARTIFACT_PATH
 
       - name: Upload Artifact with Source Archive Path
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.SRC_ARTIFACT }}
           path: ${{ env.SRC_ARTIFACT_PATH }}
           retention-days: 1
 
       - name: Upload Source Archive as Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.SRC_ARCHIVE_ARTIFACT }}
           path: ${{ steps.create_source_archive.outputs.archive_file }}
@@ -275,7 +275,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Download Artifact with Configuration Information
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.CONFIG_ARTIFACT }}
 
@@ -297,12 +297,12 @@ jobs:
       # Need commit history and tags for scripts/version.sh to work as expected
       # so use 0 for fetch-depth.
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Download Artifact with Converted Documents
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.DOC_ARTIFACT }}
 
@@ -351,14 +351,14 @@ jobs:
           echo archive_path= '${{ steps.create_windows_archive.outputs.archive_file }}' > $WIN_ARTIFACT_PATH
 
       - name: Upload Artifact with Windows Archive Path
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.WIN_ARTIFACT }}
           path: ${{ env.WIN_ARTIFACT_PATH }}
           retention-days: 1
 
       - name: Upload Windows Archive as Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.WIN_ARCHIVE_ARTIFACT }}
           path: ${{ steps.create_windows_archive.outputs.archive_file }}
@@ -370,7 +370,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Download Artifact with Configuration Information
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.CONFIG_ARTIFACT }}
 
@@ -387,12 +387,12 @@ jobs:
       # Need commit history and tags for scripts/version.sh to work as expected
       # so use 0 for fetch-depth.
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Download Artifact with Converted Documents
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.DOC_ARTIFACT }}
 
@@ -419,14 +419,14 @@ jobs:
           echo archive_path= '${{ steps.create_mac_archive.outputs.archive_file }}' > $MAC_ARTIFACT_PATH
 
       - name: Upload Artifact with Mac Archive Path
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.MAC_ARTIFACT }}
           path: ${{ env.MAC_ARTIFACT_PATH }}
           retention-days: 1
 
       - name: Upload Mac Archive as Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.MAC_ARCHIVE_ARTIFACT }}
           path: ${{ steps.create_mac_archive.outputs.archive_file }}
@@ -439,7 +439,7 @@ jobs:
     container: devkitpro/devkitarm
     steps:
       - name: Download Artifact with Configuration Information
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.CONFIG_ARTIFACT }}
 
@@ -454,12 +454,12 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Download Artifact with Converted Documents
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.DOC_ARTIFACT }}
 
@@ -532,14 +532,14 @@ jobs:
           echo archive_path= '${{ steps.create_nintendo_3ds_archive.outputs.archive_file }}' > $NIN_3DS_ARTIFACT_PATH
 
       - name: Upload Artifact with Nintendo 3DS Archive Path
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.NIN_3DS_ARTIFACT }}
           path: ${{ env.NIN_3DS_ARTIFACT_PATH }}
           retention-days: 1
 
       - name: Upload Nintendo 3DS Archive as Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.NIN_3DS_ARCHIVE_ARTIFACT }}
           path: ${{ steps.create_nintendo_3ds_archive.outputs.archive_file }}
@@ -552,7 +552,7 @@ jobs:
     container: skylyrac/blocksds:slim-latest
     steps:
       - name: Download Artifact with Configuration Information
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.CONFIG_ARTIFACT }}
 
@@ -567,12 +567,12 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Download Artifact with Converted Documents
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.DOC_ARTIFACT }}
 
@@ -602,14 +602,14 @@ jobs:
           echo archive_path= '${{ steps.create_nintendo_ds_archive.outputs.archive_file }}' > $NIN_DS_ARTIFACT_PATH
 
       - name: Upload Artifact with Nintendo DS Archive Path
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.NIN_DS_ARTIFACT }}
           path: ${{ env.NIN_DS_ARTIFACT_PATH }}
           retention-days: 1
 
       - name: Upload Nintendo DS Archive as Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.NIN_DS_ARCHIVE_ARTIFACT }}
           path: ${{ steps.create_nintendo_ds_archive.outputs.archive_file }}
@@ -622,7 +622,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Artifact with Configuration Information
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.CONFIG_ARTIFACT }}
 
@@ -637,7 +637,7 @@ jobs:
           echo "draft=$draft" >> $GITHUB_OUTPUT
 
       - name: Download Artifact with Source Archive Path
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.SRC_ARTIFACT }}
 
@@ -648,12 +648,12 @@ jobs:
           echo "archive_path=$archive_path" >> $GITHUB_OUTPUT
 
       - name: Download Artifact with Source Archive
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.SRC_ARCHIVE_ARTIFACT }}
 
       - name: Download Artifact with Windows Archive Path
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.WIN_ARTIFACT }}
 
@@ -664,12 +664,12 @@ jobs:
           echo "archive_path=$archive_path" >> $GITHUB_OUTPUT
 
       - name: Download Artifact with Windows Archive
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.WIN_ARCHIVE_ARTIFACT }}
 
       - name: Download Artifact with Mac Archive Path
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.MAC_ARTIFACT }}
 
@@ -680,12 +680,12 @@ jobs:
           echo "archive_path=$archive_path" >> $GITHUB_OUTPUT
 
       - name: Download Artifact with Mac Archive
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.MAC_ARCHIVE_ARTIFACT }}
 
       - name: Download Artifact with Nintendo 3DS Archive Path
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.NIN_3DS_ARTIFACT }}
 
@@ -696,12 +696,12 @@ jobs:
           echo "archive_path=$archive_path" >> $GITHUB_OUTPUT
 
       - name: Download Artifact with Nintendo 3DS Archive
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.NIN_3DS_ARCHIVE_ARTIFACT }}
 
       - name: Download Artifact with Nintendo DS Archive Path
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.NIN_DS_ARTIFACT }}
 
@@ -712,7 +712,7 @@ jobs:
           echo "archive_path=$archive_path" >> $GITHUB_OUTPUT
 
       - name: Download Artifact with Nintendo DS Archive
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.NIN_DS_ARCHIVE_ARTIFACT }}
 

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -16,7 +16,7 @@ jobs:
           sudo apt-get install gcc-mingw-w64 automake autoconf make cmake ninja-build
 
       - name: Clone Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build
         id: autotools_build


### PR DESCRIPTION
Some actions still use Node.js 20:  egor-tensin/setup-cygwin in cygwin.yaml, microsoft/setup-msbuild in msbuild.yaml,  msys2/setup-msys2 in msys2.yaml, and softprops/action-gh-release in release.yaml.