### PR TITLE
stats frontend:  avoid crash during cleanup

### DIFF
--- a/src/main-stats.c
+++ b/src/main-stats.c
@@ -1797,7 +1797,6 @@ static errr run_stats(void)
 		mem_free(a_info_save);
 	}
 	free_stats_memory();
-	cleanup_angband();
 	if (!quiet) printf("Done!\n");
 	quit(NULL);
 	exit(0);


### PR DESCRIPTION
That is a post-4.2.6 regression introduced by f3bf5ac4ee9699a726ae4e52a3308508fc78be10 .