### PR TITLE
Add EVT_DISCONNECT

### DIFF
--- a/src/borg/borg.c
+++ b/src/borg/borg.c
@@ -441,18 +441,22 @@ static struct keypress internal_borg_inkey(int flush_first)
     if (borg.trait[BI_CDEPTH] >= 1)
         borg.in_shop = false;
 
-    if (!borg.in_shop && (ch_evt.type & EVT_KBRD) && ch_evt.key.code > 0
-        && ch_evt.key.code != 10) {
+    if (!borg.in_shop && (((ch_evt.type & EVT_KBRD) && ch_evt.key.code > 0
+        && ch_evt.key.code != 10) || ch_evt.type == EVT_DISCONNECT)) {
         /* Oops */
-        if (ch_evt.key.code >= 32 && ch_evt.key.code <= 126) {
-            borg_note(format("# User key press <%lu><%c>",
-                (unsigned long)ch_evt.key.code, (char)ch_evt.key.code));
+        if (ch_evt.type == EVT_DISCONNECT) {
+            borg_oops("terminal disconnect abort");
         } else {
-            borg_note(format("# User key press <%lu>",
-                (unsigned long)ch_evt.key.code));
+            if (ch_evt.key.code >= 32 && ch_evt.key.code <= 126) {
+                borg_note(format("# User key press <%lu><%c>",
+                    (unsigned long)ch_evt.key.code, (char)ch_evt.key.code));
+            } else {
+                borg_note(format("# User key press <%lu>",
+                    (unsigned long)ch_evt.key.code));
+            }
+            borg_note(format("# Key type was <%d><%c>", ch_evt.type, ch_evt.type));
+            borg_oops("user abort");
         }
-        borg_note(format("# Key type was <%d><%c>", ch_evt.type, ch_evt.type));
-        borg_oops("user abort");
 
         key.code = ESCAPE;
         return key;

--- a/src/h-basic.h
+++ b/src/h-basic.h
@@ -103,7 +103,7 @@
 #include <errno.h>
 #include <limits.h>
 #include <assert.h>
-
+#include <signal.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -107,13 +107,11 @@ enum
 @end
 
 /**
- * Delay handling of pre-emptive "quit" event; one if the player requests
- * an exit and the game is not at a command prompt (or have not verified the
- * state of that prompt); any non-zero value other than one when ready to
- * save the game at exit but the game may request additional input; zero in
- * all other cases
+ * Remember that we are quitting so that when a window closes, it is treated
+ * as a result of quitting rather than something that has to be remembered
+ * in the preferences.
  */
-static int quit_when_ready = 0;
+static int quitting = 0;
 
 /** Set to indicate the game is over and we can quit without delay */
 static BOOL game_is_finished = NO;
@@ -3796,7 +3794,7 @@ static int compare_nsrect_yorigin_greater(const void *ap, const void *bp)
      * If closing only because the application is terminating, don't update
      * the visible state for when the application is relaunched.
      */
-    if (! quit_when_ready) {
+    if (!quitting) {
 	[self saveWindowVisibleToDefaults: NO];
     }
 }
@@ -4545,8 +4543,8 @@ static errr Term_xtra_cocoa(int n, int v)
 				       inMode:NSDefaultRunLoopMode
 				       dequeue:YES];
 			if (event) send_event(event);
-		    } while (event);
-		} while ([date timeIntervalSinceNow] >= 0);
+		    } while (event && !quitting);
+		} while ([date timeIntervalSinceNow] >= 0 && !quitting);
 	    }
 	    break;
 
@@ -4957,52 +4955,19 @@ static void wakeup_event_loop(void)
 }
 
 
-/**
- * Respond to user interface events which either request an immediate exit
- * (forced is YES) or a possible exit subject to requesting more input
- * from the user (forced is NO).
- */
-static void handle_quit(BOOL forced)
+static bool cocoa_deny_disconnect(void)
 {
-    if (character_generated) {
-        /*
-         * Want to be at a command prompt so the game's state is ready
-         * to save.  If not at a command prompt and not forcing an
-         * exit mark it as ready to quit:  check_events() will use that
-         * to either call back here or send escapes to the game to
-         * satisfy its requests for input.
-         */
-        if (!inkey_flag && !forced) {
-            quit_when_ready = 1;
-            return;
-        }
+    NSAlert *alert = [[NSAlert alloc] init];
 
-        /* Drop pending messages */
-        msg_flag = false;
-        quit_when_ready = 2;
-
-        /*
-         * If not forcing an exit, allow the player to abort the
-         * exit if there is trouble saving the game.
-         */
-        if (!forced && !save_game_checked()) {
-            NSAlert *alert = [[NSAlert alloc] init];
-
-            alert.messageText = @"Confirm Quitting";
-            alert.informativeText = @"Saving failed.  Really quit?";
-            [alert addButtonWithTitle:@"No"];
-            [alert addButtonWithTitle:@"Yes"];
-            if ([alert runModal] != NSAlertSecondButtonReturn) {
-                quit_when_ready = 0;
-                return;
-            }
-        }
-
-        record_current_savefile();
-        close_game(true);
+    alert.messageText = @"Confirm Quitting";
+    alert.informativeText = @"Saving failed.  Really quit?";
+    [alert addButtonWithTitle:@"No"];
+    [alert addButtonWithTitle:@"Yes"];
+    if ([alert runModal] != NSAlertSecondButtonReturn) {
+        quitting = 0;
+        return true;
     }
-
-    quit(NULL);
+    return false;
 }
 
 
@@ -5267,31 +5232,19 @@ static BOOL check_events(int wait)
 	NSEvent* event;
 
 	for (;;) {
-	    if (quit_when_ready) {
-		if (inkey_flag && quit_when_ready == 1) {
-		    /*
-		     * The game is at a command prompt and has a consistent
-		     * state so it is safe to save and quit.
-		     */
-		    handle_quit(NO);
-		} else {
-		    /*
-		     * Send an escape to satisfy whatever the game is asking
-		     * for.
-		     */
-		    Term_keypress(ESCAPE, 0);
-		}
-		result = NO;
-		break;
-	    }
-
 	    event = [NSApp nextEventMatchingMask:-1 untilDate:endDate
 			       inMode:NSDefaultRunLoopMode dequeue:YES];
 	    if (!event) {
 		result = NO;
 		break;
 	    }
-	    if (send_event(event)) break;
+	    if (send_event(event)) {
+		break;
+	    }
+	    if (quitting) {
+		result = NO;
+		break;
+	    }
 	}
     }
 
@@ -5881,6 +5834,12 @@ static void cocoa_reinit(void)
 	/* Hook into file saving dialogue routine */
 	get_file = cocoa_get_file;
 
+	/*
+	 * Allow for player intervention if saving the game fails while the
+	 * UI is disconnecting from the game.
+	 */
+	disconnect_denier_hook = cocoa_deny_disconnect;
+
 	/* Initialize file paths */
 	prepare_paths_and_directories();
 
@@ -6289,25 +6248,22 @@ static void cocoa_reinit(void)
 
 - (NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication *)sender
 {
+    quitting = 1;
     if (!player->upkeep->playing || game_is_finished)
     {
-        quit_when_ready = 1;
         return NSTerminateNow;
     }
-    else
-    {
-        /*
-         * Post an escape event so that we can return from our get-key-event
-         * function
-         */
-        wakeup_event_loop();
-        quit_when_ready = 1;
-        /*
-         * Must return Cancel, not Later, because we need to get out of the
-         * run loop and back to Angband's loop
-         */
-        return NSTerminateCancel;
-    }
+    terms_disconnecting = 1;
+    /*
+     * Post an escape event so that we can return from our get-key-event
+     * function
+     */
+    wakeup_event_loop();
+    /*
+     * Must return Cancel, not Later, because we need to get out of the
+     * run loop and back to Angband's loop
+     */
+    return NSTerminateCancel;
 }
 
 /**

--- a/src/main-gcu.c
+++ b/src/main-gcu.c
@@ -795,8 +795,9 @@ static errr Term_xtra_gcu_event(int v) {
 		halfdelay(2);
 		i = getch();
 		while (i == ERR) {
-			i = getch();
+			if (terms_disconnecting) return 1;
 			idle_update();
+			i = getch();
 		}
 		cbreak();
 	} else {

--- a/src/main-nds.c
+++ b/src/main-nds.c
@@ -740,9 +740,9 @@ int main(int argc, char *argv[])
 
 	/* Wait for response */
 	pause_line(Term);
-
-	/* Play the game */
-	play_game(GAME_LOAD);
+	if (!terms_disconnecting) {
+		play_game(GAME_LOAD);
+	}
 
 	/* Free resources */
 	textui_cleanup();

--- a/src/main-sdl.c
+++ b/src/main-sdl.c
@@ -144,13 +144,6 @@ static int overdraw_max = 0;
 
 static char *sdl_settings_file;
 
-/**
- * One if the player requests an exit and the game is not at a command prompt;
- * any non-zero value other than one when ready to save the game at exit but
- * the game may request additional input; zero in all other cases
- */
-static int quit_when_ready = 0;
-
 /* Default point size for scalable fonts */
 #define DEFAULT_POINT_SIZE (10)
 /* Minimum allowed point size for scalable fonts */
@@ -1252,45 +1245,10 @@ static void hook_quit(const char *str)
 		string_free(FontList[i]);
 }
 
-/**
- * Respond to user interface events which either request an immediate
- * exit (forced is true) or a possible exit subject to requesting more
- * input from the user(forced is false).
- */
-static void handle_quit(bool forced)
+static bool sdl_deny_disconnect(void)
 {
-	if (character_generated) {
-		/*
-		 * Want to be at a command prompt so the game's state is ready
-		 * to save.  If not at a command prompt and not forcing an
-		 * exit, mark as ready to quit:  Term_extra_sdl_event() will
-		 * use that to either call back to here when it is safe to
-		 * save or send escapes to the game to satisfy its requests
-		 * for input.
-		 */
-		if (!inkey_flag && !forced) {
-			quit_when_ready = 1;
-			return;
-		}
-
-		/* Drop pending messages. */
-		msg_flag = false;
-		quit_when_ready = 2;
-		/*
-		 * If not forcing an exit, allow the player to abort the
-		 * exit if there is trouble saving the game.
-		 */
-		if (!forced && !save_game_checked()
-				&& SimpleConfirm("Saving failed.  Really quit?",
-				NULL, NULL, false) == 1) {
-			quit_when_ready = 0;
-			return;
-		}
-		close_game(false);
-	}
-
-	save_prefs();
-	quit(NULL);
+	return SimpleConfirm("Saving failed.  Really quit?", NULL, NULL,
+		false) == 1;
 }
 
 static void BringToTop(void)
@@ -1504,7 +1462,7 @@ static void RemovePopUp(void)
 
 static void QuitActivate(sdl_Button *sender)
 {
-	handle_quit(false);
+	terms_disconnecting = 1;
 }
 
 static void SetStatusButtons(void)
@@ -4811,7 +4769,7 @@ static errr sdl_HandleEvent(SDL_Event *event)
 		/* Shut down the game */
 		case SDL_QUIT:
 		{
-			handle_quit(false);
+			terms_disconnecting = 1;
 			break;
 		}
 
@@ -5008,32 +4966,19 @@ static errr Term_xtra_sdl_clear(void)
 }
 
 /**
- * Process at least one event
+ * Handle game core's request for input events, waiting for them if v is not
+ * zero.
  */
 static errr Term_xtra_sdl_event(int v)
 {
 	SDL_Event event;
 	errr error = 0;
 
-	/* Wait or check for an event with special casing when exiting */
-	if (quit_when_ready) {
-		if (inkey_flag && quit_when_ready == 1) {
-			/*
-			 * The game is at a command prompt and has a
-			 * consistent state so it is safe to quit and exit.
-			 */
-			handle_quit(false);
-		} else {
-			/*
-			 * Send an escape to satisfy whatever the game is
-			 * asking for.
-			 */
-			Term_keypress(ESCAPE, 0);
-		}
-	} else if (v) {
+	if (v) {
 		/* Wait in 0.02s increments while updating animations every 0.2s */
 		int i = 0;
 		while (!SDL_PollEvent(&event)) {
+			if (terms_disconnecting) return 0;
 			if (i == 0) idle_update();
 			usleep(20000);
 			i = (i + 1) % 10;
@@ -6123,8 +6068,14 @@ int init_sdl(int argc, char *argv[])
 	/* Prepare some more windows(!) */
 	init_morewindows();
 
-	/* Activate  quit hook */
+	/* Activate quit hook */
 	quit_aux = hook_quit;
+
+	/*
+	 * Allow for player intervention if saving the game fails while the UI
+	 * is disconnecting from the game.
+	 */
+	disconnect_denier_hook = sdl_deny_disconnect;
 
 	/* Paranoia */
 	return (0);

--- a/src/main-sdl2.c
+++ b/src/main-sdl2.c
@@ -464,13 +464,6 @@ struct my_app {
 	/** Width and height on screen for the default font */
 	int def_font_w, def_font_h;
 	/**
-	 * one if the player requested an exit while the game was not at a
-	 * command prompt; any non-zero value other than one when ready to
-	 * save the game at exit but the game may prompt for additional input;
-	 * zero in all other cases
-	 */
-	int quit_when_ready;
-	/**
 	 * true if KC_MOD_KEYPAD will be sent for numeric keypad keys at the
 	 * expense of not handling some keyboard layouts properly
 	 */
@@ -547,7 +540,6 @@ static bool is_close_to(int a, int b, unsigned range);
 static void handle_window_closed(struct my_app *a,
 		struct sdlpui_window *window);
 static void refresh_angband_terms(struct my_app *a);
-static void handle_quit(struct my_app *a, bool forced);
 static void wait_anykey(struct my_app *a);
 static void keyboard_event_to_angband_key(const SDL_KeyboardEvent *key,
 		bool kp_as_mod, keycode_t *ch, uint8_t *mods);
@@ -2636,7 +2628,7 @@ static void handle_menu_quit(struct sdlpui_control *ctrl,
 		struct sdlpui_dialog *dlg, struct sdlpui_window *window)
 {
 	sdlpui_popdown_dialog(dlg, window, SDL_TRUE);
-	handle_quit(window->app, false);
+	terms_disconnecting = 1;
 }
 
 static void handle_menu_tile_set(struct sdlpui_control *ctrl,
@@ -3591,7 +3583,7 @@ static void handle_window_closed(struct my_app *a, struct sdlpui_window *window)
 	assert(window != NULL);
 
 	if (window->index == MAIN_WINDOW) {
-		handle_quit(a, false);
+		terms_disconnecting = 1;
 	} else {
 		for (size_t i = 0; i < N_ELEMENTS(window->subwindows); i++) {
 			struct subwindow *subwindow = window->subwindows[i];
@@ -4568,7 +4560,7 @@ static void wait_anykey(struct my_app *a)
 				SDL_FlushEvent(SDL_MOUSEMOTION);
 				break;
 			case SDL_QUIT:
-				handle_quit(a, false);
+				terms_disconnecting = 1;
 				break;
 			case SDL_RENDER_TARGETS_RESET:
 				recreate_textures(a, false);
@@ -4581,64 +4573,6 @@ static void wait_anykey(struct my_app *a)
 				return;
 		}
 	}
-}
-
-static void handle_quit(struct my_app *a, bool forced)
-{
-	if (character_generated) {
-		/*
-		 * Want to be at a command prompt so the game's state is
-		 * ready to save.  If not at a command prompt and not forcing
-		 * an exit, mark as ready to quit: term_xtra_event() will use
-		 * that to either call back to here when it is safe to save or
-		 * send escapes to the game to satisfy its requests for input.
-		 */
-		if (!inkey_flag && !forced) {
-			a->quit_when_ready = 1;
-			return;
-		}
-
-		/* Drop pending messages. */
-		msg_flag = false;
-		a->quit_when_ready = 2;
-		/*
-		 * If not forcing an exit, allow the player to abort the exit
-		 * if there is trouble saving the game.
-		 */
-		if (!forced && !save_game_checked()) {
-			SDL_MessageBoxButtonData buttons[2] = {
-				{
-					0, 0, "Yes"
-				},
-				{
-					SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT
-					| SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT,
-					1,
-					"No"
-				}
-			};
-			SDL_MessageBoxData dialog;
-			int button_pressed = 1;
-
-			dialog.flags = SDL_MESSAGEBOX_ERROR
-				| SDL_MESSAGEBOX_BUTTONS_LEFT_TO_RIGHT;
-			dialog.window = a->windows[0].window;
-			dialog.title = "Confirm Quitting";
-			dialog.message = "Saving failed.  Really quit?";
-			dialog.numbuttons = 2;
-			dialog.buttons = buttons;
-			dialog.colorScheme = NULL;
-
-			(void)SDL_ShowMessageBox(&dialog, &button_pressed);
-			if (button_pressed != 0) {
-				a->quit_when_ready = 0;
-				return;
-			}
-		}
-		close_game(false);
-	}
-
-	quit(NULL);
 }
 
 static bool get_event(struct my_app *a)
@@ -4684,7 +4618,7 @@ static bool get_event(struct my_app *a)
 			recreate_textures(a, true);
 			return false;
 		case SDL_QUIT:
-			handle_quit(a, false);
+			terms_disconnecting = 1;
 			return false;
 		default:
 			return false;
@@ -4735,27 +4669,13 @@ static errr term_xtra_event(int v)
 
 	redraw_all_windows(subwindow->app, true);
 
-	if (subwindow->app->quit_when_ready) {
-		if (inkey_flag && subwindow->app->quit_when_ready == 1) {
-			/*
-			 * The game is at a command prompt and has a
-			 * consistent state so it is safe to save and exit.
-			 */
-			handle_quit(subwindow->app, false);
-		} else {
-			/*
-			 * Send an escape to satisfy whatever the game is
-			 * asking for.
-			 */
-			Term_keypress(ESCAPE, 0);
-		}
-		return 0;
-	}
-
 	if (v) {
 		while (true) {
 			for (int i = 0; i < DEFAULT_IDLE_UPDATE_PERIOD; i++) {
 				if (get_event(subwindow->app)) {
+					return 0;
+				}
+				if (terms_disconnecting) {
 					return 0;
 				}
 				SDL_Delay(subwindow->window->delay);
@@ -7160,6 +7080,33 @@ static void quit_hook(const char *s)
 	quit_systems();
 }
 
+static bool sdl2_deny_disconnect(void)
+{
+	SDL_MessageBoxButtonData buttons[2] = {
+		{ 0, 0, "Yes" },
+		{
+			SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT
+			| SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT,
+			1,
+			"No"
+		}
+	};
+	SDL_MessageBoxData dialog;
+	int button_pressed = 1;
+
+	dialog.flags = SDL_MESSAGEBOX_ERROR
+		| SDL_MESSAGEBOX_BUTTONS_LEFT_TO_RIGHT;
+	dialog.window = g_app.windows[0].window;
+	dialog.title = "Confirm Quitting";
+	dialog.message = "Saving failed.  Really quit?";
+	dialog.numbuttons = 2;
+	dialog.buttons = buttons;
+	dialog.colorScheme = NULL;
+
+	(void)SDL_ShowMessageBox(&dialog, &button_pressed);
+	return button_pressed != 0;
+}
+
 static void init_systems(void)
 {
 #if defined(SDLPUI_TRACE_EVENTS) || defined(SDLPUI_TRACE_RENDER)
@@ -7211,6 +7158,12 @@ errr init_sdl2(int argc, char **argv)
 	}
 
 	quit_aux = quit_hook;
+
+	/*
+	 * Allow for player intervention is saving the game fails while the UI
+	 * is disconnecting from the game.
+	 */
+	disconnect_denier_hook = sdl2_deny_disconnect;
 
 	/* Dump details about SDL that do not require SDL_Init(). */
 	if (g_app.print_sdl_details) {
@@ -7338,7 +7291,6 @@ static void init_globals(struct my_app *a)
 
 	a->w_mouse = NULL;
 	a->w_key = NULL;
-	a->quit_when_ready = 0;
 	a->kp_as_mod = true;
 	a->controller = NULL;
 	num_joysticks = SDL_NumJoysticks();

--- a/src/main-x11.c
+++ b/src/main-x11.c
@@ -1627,18 +1627,6 @@ static int term_windows_open;
 
 
 /**
- * Track progress towards quitting when the window manager requests closing the
- * main window.  Will be zero when no close request for the main window has
- * been received.  Will be one if a close request has been received, but either
- * the game is not yet ready to save or have not determined the status of the
- * game.  Will be a non-zero value other than one if a close request has been
- * received and the game is ready to save.
- */
-static int quit_when_ready = 0;
-
-
-
-/**
  * Remove a window and all the associated data.
  *
  * \param ind is the index of the window to remove.
@@ -1669,41 +1657,6 @@ static void nuke_window(int ind)
 		(void)term_nuke(t);
 		t->key_queue = NULL;
 	}
-}
-
-
-
-/**
- * Handle exiting the game due to events not triggered by the game's core.
- */
-static void handle_quit(void)
-{
-	if (character_generated) {
-		/*
-		 * Want to be at a command prompt so the game's state is ready
-		 * to save.  If not at a command prompt, mark as ready to quit:
-		 * CheckEvent() will use that to either call back to here when
-		 * it is safe to save or send escapes to the game to satisfy
-		 * its requests for input.
-		 */
-		if (!inkey_flag) {
-			quit_when_ready = 1;
-			return;
-		}
-
-		/* Drop pending messages. */
-		msg_flag = false;
-		quit_when_ready = 2;
-
-		/*
-		 * Other front ends (SDL, SDL2) try to explicitly save here,
-		 * and if that is not successful, confirm with the player
-		 * whether to proceed with quitting.  For now, skip that for
-		 * X11:  use the implicit save done within close_game().
-		 */
-		close_game(false);
-	}
-	quit(NULL);
 }
 
 
@@ -1852,29 +1805,13 @@ static errr CheckEvent(bool wait)
 	int i;
 	int window = 0;
 
-	if (quit_when_ready) {
-		if (inkey_flag && quit_when_ready == 1) {
-			/*
-			 * The game is at a command prompt and has a consistent
-			 * state so it is safe to save and exit.
-			 */
-			handle_quit();
-		} else {
-			/*
-			 * Send an escape to satisfy whatever the game is
-			 * asking for.
-			 */
-			Term_keypress(ESCAPE, 0);
-		}
-		return 0;
-	}
-
 	/* Do not wait unless requested */
 	if (!wait && !XPending(Metadpy->dpy)) return (1);
 
 	/* Wait in 0.02s increments while updating animations every 0.2s */
 	i = 0;
 	while (!XPending(Metadpy->dpy)) {
+		if (terms_disconnecting) return 1;
 		if (i == 0) idle_update();
 		usleep(20000);
 		i = (i + 1) % 10;
@@ -2049,9 +1986,7 @@ static errr CheckEvent(bool wait)
 					== Metadpy->wm_delete_msg) {
 				/* Requested close for window */
 				if (window == 0) {
-					if (!quit_when_ready) {
-						handle_quit();
-					}
+					terms_disconnecting = 1;
 				} else {
 					nuke_window(window);
 				}
@@ -2203,7 +2138,7 @@ static errr Term_xtra_x11(int n, int v)
 		case TERM_XTRA_EVENT: return (CheckEvent(v));
 
 		/* Flush the events XXX */
-		case TERM_XTRA_FLUSH: while (!quit_when_ready && !CheckEvent(false)); return (0);
+		case TERM_XTRA_FLUSH: while (!CheckEvent(false)); return (0);
 
 		/* Handle change in the "level" */
 		case TERM_XTRA_LEVEL: return (Term_xtra_x11_level(v));

--- a/src/main.c
+++ b/src/main.c
@@ -64,35 +64,35 @@
 static const struct module modules[] =
 {
 #ifdef USE_X11
-	{ "x11", help_x11, init_x11 },
+	{ "x11", help_x11, init_x11, false },
 #endif /* USE_X11 */
 
 #ifdef USE_SDL
-	{ "sdl", help_sdl, init_sdl },
+	{ "sdl", help_sdl, init_sdl, false },
 #endif /* USE_SDL */
 
 #ifdef USE_SDL2
-	{ "sdl2", help_sdl2, init_sdl2 },
+	{ "sdl2", help_sdl2, init_sdl2, false },
 #endif /* USE_SDL2 */
 
 #ifdef USE_GCU
-	{ "gcu", help_gcu, init_gcu },
+	{ "gcu", help_gcu, init_gcu, true },
 #endif /* USE_GCU */
 
 #ifdef USE_TEST
-	{ "test", help_test, init_test },
+	{ "test", help_test, init_test, false },
 #endif /* !USE_TEST */
 
 #ifdef USE_STATS
-	{ "stats", help_stats, init_stats },
+	{ "stats", help_stats, init_stats, false },
 #endif /* USE_STATS */
 
 #ifdef USE_SPOIL
-	{ "spoil", help_spoil, init_spoil },
+	{ "spoil", help_spoil, init_spoil, false },
 #endif
 
 #ifdef USE_IBM
-	{ "ibm", help_ibm, init_ibm },
+	{ "ibm", help_ibm, init_ibm, false },
 #endif /* USE_IBM */
 };
 
@@ -545,7 +545,7 @@ int main(int argc, char *argv[])
 	if (!done) quit("Unable to prepare any 'display module'!");
 
 	/* Catch nasty signals */
-	signals_init();
+	signals_init(modules[i].hup_disconnects);
 
 	/* Set up the command hook */
 	cmd_get_hook = textui_get_cmd;
@@ -576,10 +576,11 @@ int main(int argc, char *argv[])
 
 	/* Wait for response */
 	pause_line(Term);
-
-	/* Play the game */
-	play_game((select_game) ?
-		GAME_SELECT : ((new_game) ? GAME_NEW : GAME_LOAD));
+	if (!terms_disconnecting) {
+		/* Play the game */
+		play_game((select_game) ?
+			GAME_SELECT : ((new_game) ? GAME_NEW : GAME_LOAD));
+	}
 
 	/* Quit */
 	quit(NULL);

--- a/src/main.h
+++ b/src/main.h
@@ -68,6 +68,15 @@ struct module
 	const char *name;
 	const char *help;
 	errr (*init)(int argc, char **argv);
+	/**
+	 * If true, SIGHUP triggers the UI to disconnect from the game and
+	 * the game to exit.  In that case, the front end should either use
+	 * NULL for ui-input.h's disconnect_denier_hook (that is the default)
+	 * or have the hook it registers be able to deal with the case that
+	 * the communication channel with the player has indeed been lost.
+	 * If false, SIGHUP is ignored.
+	 */
+	bool hup_disconnects;
 };
 
 #endif /* INCLUDED_MAIN_H */

--- a/src/ui-birth.c
+++ b/src/ui-birth.c
@@ -118,7 +118,8 @@ static enum birth_stage textui_birth_quickstart(void)
 		if (ke.code == 'N' || ke.code == 'n') {
 			cmdq_push(CMD_BIRTH_RESET);
 			next = BIRTH_RACE_CHOICE;
-		} else if (ke.code == KTRL('X')) {
+		} else if (ke.code == KTRL('X')
+				|| (ke.code == ESCAPE && terms_disconnecting)) {
 			quit(NULL);
 		} else if ( !arg_force_name && (ke.code == 'C' || ke.code == 'c')) {
 			next = BIRTH_NAME_CHOICE;
@@ -804,6 +805,9 @@ static enum birth_stage menu_question(enum birth_stage current,
 		   use of "back" (left arrow key or equivalent) to step back in 
 		   the proces as well as "escape". */
 		if (cx.type == EVT_ESCAPE) {
+			if (terms_disconnecting) {
+				quit(NULL);
+			}
 			next = BIRTH_BACK;
 		} else if (cx.type == EVT_SELECT) {
 			if (current == BIRTH_ROLLER_CHOICE) {
@@ -901,29 +905,15 @@ static enum birth_stage roller_command(bool first_call)
 	/* Prompt for it */
 	prt(prompt, Term->hgt - 1, Term->wid / 2 - promptlen / 2);
 	
-	/*
-	 * Get the response.  Emulate what inkey_does() without coercing mouse
-	 * events to look like keystrokes.
-	 */
-	while (1) {
-		in = inkey_ex();
-		if (in.type == EVT_KBRD || in.type == EVT_MOUSE) {
-			break;
-		}
-		if (in.type == EVT_BUTTON) {
-			in.type = EVT_KBRD;
-			break;
-		}
-		if (in.type == EVT_ESCAPE) {
-			in = (ui_event){ .key = { .type = EVT_KBRD, .code = ESCAPE, .mods = 0 } };
-			break;
-		}
-	}
+	/* Get the response. */
+	in = inkey_m();
 
 	/* Analyse the command */
 	if (in.type == EVT_KBRD) {
 		if (in.key.code == ESCAPE) {
-			action = ACT_CTX_BIRTH_ROLL_ESCAPE;
+			action = (terms_disconnecting)
+				? ACT_CTX_BIRTH_ROLL_QUIT
+				: ACT_CTX_BIRTH_ROLL_ESCAPE;
 		} else if (in.key.code == KC_ENTER) {
 			action = ACT_CTX_BIRTH_ROLL_ACCEPT;
 		} else if (in.key.code == ' ' || in.key.code == 'r') {
@@ -1132,30 +1122,17 @@ static enum birth_stage point_based_command(void)
 	/* Place cursor just after cost of current stat */
 	Term_gotoxy(COSTS_COL + 4, COSTS_ROW + stat);
 
-	/*
-	 * Get input.  Emulate what inkey() does without coercing mouse events
-	 * to look like keystrokes.
-	 */
-	while (1) {
-		in = inkey_ex();
-		if (in.type == EVT_KBRD || in.type == EVT_MOUSE) {
-			break;
-		}
-		if (in.type == EVT_BUTTON) {
-			in.type = EVT_KBRD;
-		}
-		if (in.type == EVT_ESCAPE) {
-			in = (ui_event){ .key = { .type = EVT_KBRD, .code = ESCAPE, .mods = 0 } };
-			break;
-		}
-	}
+	/* Get input. */
+	in = inkey_m();
 
 	/* Figure out what to do. */
 	if (in.type == EVT_KBRD) {
 		if (in.key.code == KTRL('X')) {
 			action = ACT_CTX_BIRTH_PTS_QUIT;
 		} else if (in.key.code == ESCAPE) {
-			action = ACT_CTX_BIRTH_PTS_ESCAPE;
+			action = (terms_disconnecting)
+				? ACT_CTX_BIRTH_PTS_QUIT
+				: ACT_CTX_BIRTH_PTS_ESCAPE;
 		} else if (in.key.code == 'r' || in.key.code == 'R') {
 			action = ACT_CTX_BIRTH_PTS_RESET;
 		} else if (in.key.code == KC_ENTER) {
@@ -1535,6 +1512,9 @@ static enum birth_stage get_history_command(void)
 	if (ke.code == KTRL('X')) {
 		quit(NULL);
 	} else if (ke.code == ESCAPE) {
+		if (terms_disconnecting) {
+			quit(NULL);
+		}
 		next = BIRTH_BACK;
 	} else if (ke.code == 'N' || ke.code == 'n') {
 		char history[240];
@@ -1542,6 +1522,9 @@ static enum birth_stage get_history_command(void)
 
 		switch (edit_text(history, sizeof(history))) {
 			case -1:
+				if (terms_disconnecting) {
+					quit(NULL);
+				}
 				next = BIRTH_BACK;
 				break;
 			case 0:
@@ -1579,6 +1562,9 @@ static enum birth_stage get_confirm_command(void)
 	} else if (ke.code == KTRL('X')) {
 		quit(NULL);
 	} else if (ke.code == ESCAPE) {
+		if (terms_disconnecting) {
+			quit(NULL);
+		}
 		next = BIRTH_BACK;
 	} else {
 		cmdq_push(CMD_ACCEPT_CHARACTER);

--- a/src/ui-death.c
+++ b/src/ui-death.c
@@ -410,6 +410,11 @@ void death_screen(void)
 		{
 			done = get_check("Do you want to quit? ");
 		}
+		else if (e.type == EVT_ESCAPE)
+		{
+			if (terms_disconnecting) break;
+			done = get_check("Do you want to quit? ");
+		}
 	}
 
 	menu_free(death_menu);

--- a/src/ui-equip-cmp.c
+++ b/src/ui-equip-cmp.c
@@ -334,7 +334,6 @@ void equip_cmp_display(void)
 	}
 
 	while (istate != EQUIP_CMP_MENU_DONE) {
-		ui_event in;
 		int wid, hgt;
 
 		assert(istate >= 0 && istate < (int)N_ELEMENTS(states));
@@ -367,26 +366,8 @@ void equip_cmp_display(void)
 		Term_get_size(&wid, &hgt);
 		prt(states[istate].prompt, hgt - 1, 0);
 
-		/*
-		 * Emulate what inkey() would do without coercing mouse events
-		 * into keystrokes.
-		 */
-		while (1) {
-			in = inkey_ex();
-			if (in.type == EVT_KBRD || in.type == EVT_MOUSE) {
-				break;
-			}
-			if (in.type == EVT_BUTTON) {
-				in.type = EVT_KBRD;
-				break;
-			}
-			if (in.type == EVT_ESCAPE) {
-				in = (ui_event){ .key = { .type = EVT_KBRD, .code = ESCAPE, .mods = 0 } };
-				break;
-			}
-		}
-		istate = (*states[istate].inputfunc)(in, istate, the_summary,
-			player);
+		istate = (*states[istate].inputfunc)(inkey_m(), istate,
+			the_summary, player);
 	}
 
 	screen_load();

--- a/src/ui-event.h
+++ b/src/ui-event.h
@@ -36,7 +36,9 @@ typedef enum
 	EVT_ESCAPE	= 0x0010,	/* Get out of this menu */
 	EVT_MOVE	= 0x0020,	/* Menu movement */
 	EVT_SELECT	= 0x0040,	/* Menu selection */
-	EVT_SWITCH	= 0x0080	/* Menu switch */
+	EVT_SWITCH	= 0x0080,	/* Menu switch */
+
+	EVT_DISCONNECT	= 0x0100,	/* UI is disconnecting */
 } ui_event_type;
 
 

--- a/src/ui-game.c
+++ b/src/ui-game.c
@@ -522,6 +522,21 @@ void textui_process_command(void)
 	int mode = OPT(player, rogue_like_commands) ? KEYMAP_MODE_ROGUE : KEYMAP_MODE_ORIG;
 
 	switch (e.type) {
+		case EVT_DISCONNECT:
+			/*
+			 * If the front end provides a way to confirm with
+			 * the player, try to save before exiting, and if that
+			 * fails, check with the player whether to proceed with
+			 * the exit or to proceed with the game and cancel
+			 * disconnecting the UI.
+			 */
+			if (disconnect_denier_hook && !save_game_checked()
+					&& (*disconnect_denier_hook)()) {
+				terms_disconnecting = 0;
+				return;
+			}
+			textui_quit();
+			return;
 		case EVT_RESIZE: do_cmd_redraw(); return;
 		case EVT_MOUSE: textui_process_click(e); return;
 		case EVT_BUTTON:
@@ -1129,11 +1144,13 @@ void close_game(bool prompt_failed_save)
 	/* Handle death or life */
 	if (player->is_dead) {
 		death_knowledge(player);
-		death_screen();
+		if (Term->mapped_flag && !terms_disconnecting) {
+			death_screen();
+		}
 
 		/* Save dead player */
 		while (prompting && !savefile_save(savefile)) {
-			if (!prompt_failed_save
+			if (!prompt_failed_save || terms_disconnecting
 					|| !get_check("Saving failed.  Try again? ")) {
 				prompting = false;
 				msg("death save failed!");
@@ -1143,13 +1160,13 @@ void close_game(bool prompt_failed_save)
 	} else {
 		/* Save the game */
 		while (prompting && !save_game_checked()) {
-			if (!prompt_failed_save
+			if (!prompt_failed_save || terms_disconnecting
 					|| !get_check("Saving failed.  Try again? ")) {
 				prompting = false;
 			}
 		}
 
-		if (Term->mapped_flag) {
+		if (Term->mapped_flag && !terms_disconnecting) {
 			struct keypress ch;
 
 			prt("Press Return (or Escape).", 0, 40);

--- a/src/ui-input.c
+++ b/src/ui-input.c
@@ -53,6 +53,8 @@ static bool inkey_xtra;
 uint32_t inkey_scan;		/* See the "inkey()" function */
 bool inkey_flag;		/* See the "inkey()" function */
 
+bool (*disconnect_denier_hook)(void) = NULL;
+
 /**
  * Flush all pending input.
  *
@@ -316,9 +318,11 @@ void anykey(void)
 {
 	ui_event ke = EVENT_EMPTY;
   
-	/* Only accept a keypress or mouse click */
-	while (ke.type != EVT_MOUSE && ke.type != EVT_KBRD)
+	/* Only accept a keypress, mouse click, or disconnect */
+	while (ke.type != EVT_MOUSE && ke.type != EVT_KBRD
+			&& ke.type != EVT_DISCONNECT) {
 		ke = inkey_ex();
+	}
 }
 
 /**
@@ -328,22 +332,26 @@ struct keypress inkey(void)
 {
 	ui_event ke = { .key = KEYPRESS_NULL };
 
-	while (ke.type != EVT_ESCAPE && ke.type != EVT_KBRD &&
-		   ke.type != EVT_MOUSE && ke.type != EVT_BUTTON)
+	while (ke.type != EVT_ESCAPE && ke.type != EVT_KBRD
+			&& ke.type != EVT_MOUSE && ke.type != EVT_BUTTON
+			&& ke.type != EVT_DISCONNECT) {
 		ke = inkey_ex();
+	}
 
 	/* Make the event a keypress */
-    if (ke.type == EVT_ESCAPE) {
-        ke = (ui_event){ .key = { .type = EVT_KBRD, .code = ESCAPE, .mods = 0 } };
-    } else if (ke.type == EVT_MOUSE) {
-        ke = (ui_event){ .key = { 
-            .type = EVT_KBRD,
-            .code = (ke.mouse.button == 1 ? '\n' : ESCAPE),
-            .mods = 0 
-        } };
-    } else if (ke.type == EVT_BUTTON) {
-        ke.key.type = EVT_KBRD;
-    }
+	if (ke.type == EVT_ESCAPE || ke.type == EVT_DISCONNECT) {
+		ke = (ui_event){ .key = {
+			.type = EVT_KBRD,
+			.code = ESCAPE,
+			.mods = 0 } };
+	} else if (ke.type == EVT_MOUSE) {
+		ke = (ui_event){ .key = {
+			.type = EVT_KBRD,
+			.code = (ke.mouse.button == 1 ? '\n' : ESCAPE),
+			.mods = 0 } };
+	} else if (ke.type == EVT_BUTTON) {
+		ke.key.type = EVT_KBRD;
+	}
 
 	return ke.key;
 }
@@ -356,17 +364,26 @@ ui_event inkey_m(void)
 {
 	ui_event ke = { .key = KEYPRESS_NULL };
 
-	/* Only accept a keypress */
-	while (ke.type != EVT_ESCAPE && ke.type != EVT_KBRD	&&
-		   ke.type != EVT_MOUSE  && ke.type != EVT_BUTTON)
+	/*
+	 * Only accept something that can be converted to a key or mouse press
+	 */
+	while (ke.type != EVT_ESCAPE && ke.type != EVT_KBRD
+			&& ke.type != EVT_MOUSE && ke.type != EVT_BUTTON
+			&& ke.type != EVT_DISCONNECT) {
 		ke = inkey_ex();
-	if (ke.type == EVT_ESCAPE) {
-		ke = (ui_event){ .key = { .type = EVT_KBRD, .code = ESCAPE, .mods = 0 } };
+	}
+
+	if (ke.type == EVT_ESCAPE || ke.type == EVT_DISCONNECT) {
+		ke = (ui_event){ .key = {
+			.type = EVT_KBRD,
+			.code = ESCAPE,
+			.mods = 0 }
+		};
 	} else if (ke.type == EVT_BUTTON) {
 		ke.key.type = EVT_KBRD;
 	}
 
-  return ke;
+	return ke;
 }
 
 
@@ -974,29 +991,13 @@ bool askfor_aux_ext(char *buf, size_t len,
 
 	/* Process input */
 	while (!done) {
-		ui_event in = { .key = KEYPRESS_NULL };
+		ui_event in;
 
 		/* Place cursor */
 		Term_gotoxy(x + k, y);
 
-		/*
-		 * Get input.  Emulate what inkey() does without the coercing
-		 * mouse events to look like keystrokes.
-		 */
-		while (1) {
-			in = inkey_ex();
-			if (in.type == EVT_KBRD || in.type == EVT_MOUSE) {
-				break;
-			}
-			if (in.type == EVT_BUTTON) {
-				in.key.type = EVT_KBRD;
-				break;
-			}
-			if (in.type == EVT_ESCAPE) {
-				in = (ui_event){.key = {.type = EVT_KBRD, .code = ESCAPE, .mods = 0}};
-				break;
-			}
-		}
+		/* Get input. */
+		in = inkey_m();
 
 		/* Pass on to the appropriate handler. */
 		if (in.type == EVT_KBRD) {
@@ -1518,6 +1519,13 @@ static bool textui_get_rep_dir(int *dp, bool allow_5)
 			ke = inkey_ex();
 		}
 
+		if (ke.type == EVT_ESCAPE || ke.type == EVT_DISCONNECT) {
+			/* Clear the prompt */
+			prt("", 0, 0);
+
+			return false;
+		}
+
 		/* Check mouse coordinates, or get keypresses until a dir is chosen */
 		if (ke.type == EVT_MOUSE) {
 			if (ke.mouse.button == 1) {
@@ -1853,6 +1861,9 @@ ui_event textui_get_command(int *count)
 			Term_set_cursor(false);
 		}
 
+		if (ke.type == EVT_DISCONNECT) {
+			break;
+		}
 		if (ke.type == EVT_KBRD) {
 			bool keymap_ok = true;
 			switch (ke.key.code) {

--- a/src/ui-input.h
+++ b/src/ui-input.h
@@ -84,6 +84,18 @@ extern bool inkey_flag;
 extern uint8_t lazymove_delay;
 extern bool msg_flag;
 
+/**
+ * If exiting a game because the UI is disconnecting and this hook is not
+ * NULL, an attempt to save the game will be done before close_game() is
+ * called.   If that save attempt is not successful, the hook function will
+ * be called.  If it returns true, disconnecting will be canceled and the
+ * game will proceed.  Otherwise, the game exits.  Because this hook is
+ * called while the UI is disconnecting, collecting any input from the
+ * player should be done independently of Term_inkey() and the functions in
+ * game-input.h or ui-input.h.
+ */
+extern bool (*disconnect_denier_hook)(void);
+
 void flush(game_event_type unused, game_event_data *data, void *user);
 ui_event inkey_ex(void);
 void anykey(void);

--- a/src/ui-knowledge.c
+++ b/src/ui-knowledge.c
@@ -974,10 +974,11 @@ static void display_knowledge(const char *title, int *obj_list, int o_count,
 		if (!tile_picker && !glyph_picker) {
 			ui_event ke0 = EVENT_EMPTY;
 
-			if (ke.type == EVT_MOUSE)
+			if (ke.type == EVT_MOUSE) {
 				menu_handle_mouse(active_menu, &ke, &ke0);
-			else if (ke.type == EVT_KBRD)
+			} else if (ke.type == EVT_KBRD) {
 				menu_handle_keypress(active_menu, &ke, &ke0);
+			}
 
 			if (ke0.type != EVT_NONE)
 				ke = ke0;
@@ -1029,6 +1030,7 @@ static void display_knowledge(const char *title, int *obj_list, int o_count,
 			}
 
 			case EVT_ESCAPE:
+			case EVT_DISCONNECT:
 			{
 				if (panel == 1)
 					do_swap = true;
@@ -3172,6 +3174,7 @@ static void do_cmd_knowledge_shapechange(const char *name, int row)
 				break;
 
 			case EVT_ESCAPE:
+			case EVT_DISCONNECT:
 				displaying = false;
 				break;
 
@@ -3919,6 +3922,8 @@ void do_cmd_messages(void)
 					i = (i >= 20) ? (i - 20) : 0;
 					break;
 			}
+		} else if (ke.type == EVT_ESCAPE || ke.type == EVT_DISCONNECT) {
+			more = false;
 		}
 
 		/* Find the next item */

--- a/src/ui-menu.c
+++ b/src/ui-menu.c
@@ -810,6 +810,8 @@ ui_event menu_select(struct menu *menu, int notify, bool popup)
 			menu_calc_size(menu);
 			if (menu->row_funcs->resize)
 				menu->row_funcs->resize(menu);
+		} else if (in.type == EVT_DISCONNECT) {
+			in.type = EVT_ESCAPE;
 		}
 
 		/* Redraw menu here if cursor has moved */

--- a/src/ui-options.c
+++ b/src/ui-options.c
@@ -511,6 +511,8 @@ static void do_cmd_options_win(const char *name, int row)
 				x = (x + ddx[d] + 8) % ANGBAND_TERM_MAX;
 				y = (y + ddy[d] + 16) % PW_MAX_FLAGS;
 			}
+		} else if (ke.type == EVT_ESCAPE || ke.type == EVT_DISCONNECT) {
+			break;
 		}
 	}
 
@@ -651,7 +653,8 @@ static void ui_keymap_create(const char *title, int row)
 
 		kp = inkey();
 
-		if (kp.code == '=') {
+		if (kp.code == '=' || (kp.code == ESCAPE
+				&& terms_disconnecting)) {
 			done = true;
 			continue;
 		}

--- a/src/ui-player.c
+++ b/src/ui-player.c
@@ -1238,9 +1238,9 @@ void do_cmd_change_name(void)
 		Term_putstr(2, 23, -1, COLOUR_WHITE, p);
 
 		/* Query */
-		ke = inkey_ex();
+		ke = inkey_m();
 
-		if ((ke.type == EVT_KBRD)||(ke.type == EVT_BUTTON)) {
+		if (ke.type == EVT_KBRD) {
 			switch (ke.key.code) {
 				case ESCAPE: more = false; break;
 				case 'c': {

--- a/src/ui-signals.c
+++ b/src/ui-signals.c
@@ -49,6 +49,17 @@ static Signal_Handler_t wrap_signal(int sig, Signal_Handler_t handler)
 static Signal_Handler_t (*signal_aux)(int, Signal_Handler_t) = wrap_signal;
 
 
+#ifdef SIGHUP
+/**
+ * Handle signals -- disconnect in an orderly fashion
+ */
+static void handle_signal_disconnect(int sig)
+{
+	terms_disconnecting = 1;
+}
+#endif
+
+
 #ifdef SIGTSTP
 /**
  * Handle signals -- suspend
@@ -285,11 +296,14 @@ void signals_handle_tstp(void)
 /**
  * Prepare to handle the relevant signals
  */
-void signals_init(void)
+void signals_init(bool hup_disconnects)
 {
 
 #ifdef SIGHUP
-	(void)(*signal_aux)(SIGHUP, SIG_IGN);
+	(void)(*signal_aux)(SIGHUP,
+		(hup_disconnects) ? handle_signal_disconnect : SIG_IGN);
+#else
+	(void)hup_disconnects;
 #endif
 
 
@@ -390,8 +404,9 @@ void signals_handle_tstp(void)
 /**
  * Do nothing
  */
-void signals_init(void)
+void signals_init(bool hup_disconnects)
 {
+	(void)hup_disconnects;
 }
 
 #endif	/* !WINDOWS */

--- a/src/ui-signals.h
+++ b/src/ui-signals.h
@@ -23,6 +23,6 @@ extern int16_t signal_count;
 
 void signals_ignore_tstp(void);
 void signals_handle_tstp(void);
-void signals_init(void);
+void signals_init(bool hup_disconnects);
 
 #endif /* INCLUDED_UI_SIGNALS_H */

--- a/src/ui-term.c
+++ b/src/ui-term.c
@@ -299,6 +299,7 @@ char angband_term_name[ANGBAND_TERM_MAX][16] =
 };
 
 uint32_t window_flag[ANGBAND_TERM_MAX];
+volatile sig_atomic_t terms_disconnecting = 0;
 
 int row_top_map[SIDEBAR_MAX] = {1, 4, 1};
 int row_bottom_map[SIDEBAR_MAX] = {1, 0, 0};
@@ -2654,18 +2655,23 @@ errr Term_event_push(const ui_event *ke)
 }
 
 
-
-
-
 /**
- * Check for a pending keypress on the key queue.
+ * Check for a pending event on the active terminal's input queue.
  *
- * Store the keypress, if any, in "ch", and return "0".
+ * Store the event, if any, in "ch", and return "0".
  * Otherwise store "zero" in "ch", and return "1".
  *
- * Wait for a keypress if "wait" is true.
+ * If terms_disconnecting is nonzero, the returned value is "0".  This
+ * function will never wait in that case or request more input events
+ * from the underlying terminal driver.  When disconnecting, ch->type will be
+ * set to EVT_DISCONNECT if there is no pending input in the terminal's queue.
  *
- * Remove the keypress if "take" is true.
+ * If "wait" is true, terms_disconnecting is zero, and the terminal has no
+ * queued input events, more input events will be requested from the
+ * underlying terminal driver and this function will wait until there is
+ * something in the terminal's input queue.
+ *
+ * Remove the input event if "take" is true.
  */
 errr Term_inkey(ui_event *ch, bool wait, bool take)
 {
@@ -2673,36 +2679,47 @@ errr Term_inkey(ui_event *ch, bool wait, bool take)
 	memset(ch, 0, sizeof *ch);
 
 	/* Get bored */
-	if (!Term->never_bored)
+	if (!Term->never_bored && !terms_disconnecting) {
 		/* Process random events */
 		Term_xtra(TERM_XTRA_BORED, 0);
+	}
 
-	/* Wait or not */
-	if (wait)
-		/* Process pending events while necessary */
-		while (Term->key_head == Term->key_tail)
-			/* Process events (wait for one) */
-			Term_xtra(TERM_XTRA_EVENT, true);
-	else
-		/* Process pending events if necessary */
-		if (Term->key_head == Term->key_tail)
+	if (Term->key_head == Term->key_tail) {
+		if (wait) {
+			do {
+				if (terms_disconnecting) {
+					ch->type = EVT_DISCONNECT;
+					return 0;
+				}
+
+				/* Process events (wait for one) */
+				Term_xtra(TERM_XTRA_EVENT, true);
+			} while (Term->key_head == Term->key_tail);
+		} else {
+			if (terms_disconnecting) {
+				ch->type = EVT_DISCONNECT;
+				return 0;
+			}
+
 			/* Process events (do not wait) */
 			Term_xtra(TERM_XTRA_EVENT, false);
 
-	/* No keys are ready */
-	if (Term->key_head == Term->key_tail) return (1);
+			/* No keys are ready */
+			if (Term->key_head == Term->key_tail) return 1;
+		}
+	}
 
 	/* Extract the next keypress */
 	(*ch) = Term->key_queue[Term->key_tail];
 
-	/* sketchy key loggin */
+	/* sketchy key logging */
 	log_keypress(*ch);
 
 	/* If requested, advance the queue, wrap around if necessary */
 	if (take && (++Term->key_tail == Term->key_size)) Term->key_tail = 0;
 
 	/* Success */
-	return (0);
+	return 0;
 }
 
 

--- a/src/ui-term.h
+++ b/src/ui-term.h
@@ -352,6 +352,11 @@ extern bool smlcurs;
 extern term *angband_term[ANGBAND_TERM_MAX];
 extern char angband_term_name[ANGBAND_TERM_MAX][16];
 extern uint32_t window_flag[ANGBAND_TERM_MAX];
+/**
+ * Flags whether the terminals are in a "disconnecting" state.  Modifies the
+ * behavior of Term_inkey().
+ */
+extern volatile sig_atomic_t terms_disconnecting;
 
 /**
  * The main "screen"


### PR DESCRIPTION
Term_inkey(), inkey_ex(), and textui_get_command() will return it if the terminals are ~~terminal is~~ in the process of disconnecting.  Callers of those functions should ensure they make progress toward the game exiting (by breaking out of a loop requesting input or, when there's nothing more to break out of, ensuring that textui_quit() is called if there's an active character or quit() is called when there is not an active character.  inkey() and inkey_m() will convert EVT_DISCONNECT to a keypress with ESCAPE as the code.  menu_select() will convert EVT_DISCONNECT to EVT_ESCAPE.  If you want to distinguish between an escape or disconnect with those functions (most likely because you are requesting input from the birth or death screens), terms_disconnecting, declared in ui-term.h, ~~Term->disconnecting~~ will be nonzero on a disconnect or, for inkey() and inkey_m(), use inkey_ex() instead.  anykey() and pause_line() will return if a disconnect is detected.

~~Add a function, Term_set_disconnecting_all() in ui-term.h, to set or clear the disconnecting state of all active terminals.~~

To set all terminals to a disconnecting state, set terms_disconnecting, declared in ui-term.h, to a non-zero value.  Set it to zero, its initial value, to cancel the disconnecting state.

For front ends using main.c, allow them to specify whether SIGHUP should be ignored or should trigger disconnecting the terminals.  For all such front ends except curses, ignore SIGHUP.  Resolves https://github.com/angband/angband/issues/6558 .

Change the macOS, SDL, SDL2, and X11 front ends to use the disconnect mechanism rather than the individual solutions they had for handling out-of-band exit requests.  Prevents an infinite loop, present prior to 4.2.6 for the macOS front end and present in post-4.2.6 prereleases for the SDL, SDL2, and X11 front ends, if the out-of-band exit request comes while the player is creating a keymap and entering the action for that keymap.  The macOS, SDL, and SDL2 front ends make use of a new hook, disconnect_denier_hook in ui-input.h, so that the player can abort the exit/disconnect when saving the game fails.