### PR TITLE
Do not necessarily stop at first parsing error from a data or pref file

### DIFF
--- a/src/datafile.c
+++ b/src/datafile.c
@@ -42,15 +42,6 @@ const char *parser_error_str[PARSE_ERROR_MAX] = {
  * Angband datafile parsing routines
  * ------------------------------------------------------------------------ */
 
-static void print_error(struct file_parser *fp, struct parser *p) {
-	struct parser_state s;
-	parser_getstate(p, &s);
-	msg("Parse error in %s line %d column %d: %s: %s", fp->name,
-	           s.line, s.col, s.msg, parser_error_str[s.error]);
-	event_signal(EVENT_MESSAGE_FLUSH);
-	quit_fmt("Parse error in %s line %d column %d.", fp->name, s.line, s.col);
-}
-
 errr run_parser(struct file_parser *fp) {
 	struct parser *p = fp->init();
 	errr r;
@@ -58,17 +49,13 @@ errr run_parser(struct file_parser *fp) {
 		return PARSE_ERROR_GENERIC;
 	}
 	r = fp->run(p);
-	if (r) {
-		print_error(fp, p);
-		return r;
-	}
-	r = fp->finish(p);
-	if (r) {
-		msg("Parser finish error in %s: %s", fp->name,
-			(r > 0 && r < PARSE_ERROR_MAX) ?
-			parser_error_str[r] : "unspecified error");
-		event_signal(EVENT_MESSAGE_FLUSH);
-		quit_fmt("Parser finish error in %s.", fp->name);
+	if (!r) {
+		r = fp->finish(p);
+		if (r) {
+			plog_fmt("Parser finish error in %s: %s", fp->name,
+				(r > 0 && r < PARSE_ERROR_MAX) ?
+				parser_error_str[r] : "unspecified error");
+		}
 	}
 	return r;
 }
@@ -76,6 +63,10 @@ errr run_parser(struct file_parser *fp) {
 /**
  * The basic file parsing function.  Attempt to load filename through
  * parser and perform a quit if the file is not found.
+ *
+ * \return PARSE_ERROR_NONE if no errors occurred.  Otherwise, return the
+ * PARSE_ERROR_* constant for the first error detected.  In that case,
+ * calling parser_getstate() will return the context of that error.
  */
 errr parse_file_quit_not_found(struct parser *p, const char *filename) {
 	errr parse_err = parse_file(p, filename);
@@ -88,12 +79,19 @@ errr parse_file_quit_not_found(struct parser *p, const char *filename) {
 
 /**
  * The basic file parsing function.
+ *
+ * \return PARSE_ERROR_NONE if no errors occurred.  Otherwise, return the
+ * PARSE_ERROR_* constant for the first error detected.  In that case,
+ * calling parser_getstate() will return the context of that error.
  */
 errr parse_file(struct parser *p, const char *filename) {
 	char path[1024];
 	char buf[1024];
+	char firstmsg[1024] = "";
 	ang_file *fh;
-	errr r = 0;
+	errr firste = 0;
+	unsigned int firstl = 0, firstc = 0;
+	int maxe = get_parser_error_limit(), counte = 0;
 
 	/* The player can put a customised file in the user directory */
 	path_build(path, sizeof(path), ANGBAND_DIR_USER, format("%s.txt",
@@ -113,12 +111,34 @@ errr parse_file(struct parser *p, const char *filename) {
 
 	/* Parse it */
 	while (file_getl(fh, buf, sizeof(buf))) {
-		r = parser_parse(p, buf);
-		if (r)
-			break;
+		errr r = parser_parse(p, buf);
+
+		if (r) {
+			struct parser_state s;
+
+			parser_getstate(p, &s);
+			if (!firste) {
+				firste = r;
+				firstl = s.line;
+				firstc = s.col;
+				my_strcpy(firstmsg, s.msg, sizeof(firstmsg));
+			}
+			plog_fmt("Parse error in %s line %d column %d: %s: %s",
+				path, s.line, s.col, s.msg,
+				parser_error_str[s.error]);
+			if (maxe) {
+				if (counte >= maxe - 1) {
+					break;
+				}
+				++counte;
+			}
+		}
 	}
 	file_close(fh);
-	return r;
+	if (firste) {
+		parser_setstate(p, firste, firstl, firstc, firstmsg);
+	}
+	return firste;
 }
 
 void cleanup_parser(struct file_parser *fp)

--- a/src/grafmode.c
+++ b/src/grafmode.c
@@ -167,43 +167,50 @@ static errr finish_parse_grafmode(struct parser *p) {
 static void print_error(const char *name, struct parser *p) {
 	struct parser_state s;
 	parser_getstate(p, &s);
-	msg("Parse error in %s line %d column %d: %s: %s", name,
+	plog_fmt("Parse error in %s line %d column %d: %s: %s", name,
 	           s.line, s.col, s.msg, parser_error_str[s.error]);
 	event_signal(EVENT_MESSAGE_FLUSH);
 }
 
 bool init_graphics_modes(void) {
-	char buf[1024];
-
+	char buf[1024], line[1024];
 	ang_file *f;
 	struct parser *p;
-	errr e = 0;
+	int maxe, counte;
+	bool result;
 
 	/* Build the filename */
 	path_build(buf, sizeof(buf), ANGBAND_DIR_TILES, "list.txt");
 
 	f = file_open(buf, MODE_READ, FTYPE_TEXT);
 	if (!f) {
-		msg("Cannot open '%s'.", buf);
+		plog_fmt("Cannot open '%s'.", buf);
 		finish_parse_grafmode(NULL);
-	} else {
-		char line[1024];
+		return true;
+	}
+	result = true;
+	maxe = get_parser_error_limit();
+	counte = 0;
+	p = init_parse_grafmode();
+	while (file_getl(f, line, sizeof(line))) {
+		errr e = parser_parse(p, line);
 
-		p = init_parse_grafmode();
-		while (file_getl(f, line, sizeof line)) {
-			e = parser_parse(p, line);
-			if (e != PARSE_ERROR_NONE) {
-				print_error(buf, p);
-				break;
+		if (e != PARSE_ERROR_NONE) {
+			result = false;
+			print_error(buf, p);
+			if (maxe) {
+				if (counte >= maxe - 1) {
+					break;
+				}
+				++counte;
 			}
 		}
-
-		finish_parse_grafmode(p);
-		file_close(f);
 	}
 
-	/* Result */
-	return e == PARSE_ERROR_NONE;
+	finish_parse_grafmode(p);
+	file_close(f);
+
+	return result;
 }
 
 void close_graphics_modes(void) {

--- a/src/init.c
+++ b/src/init.c
@@ -1004,19 +1004,25 @@ static int check_critical_levels(const struct critical_level *head)
 }
 
 static errr finish_parse_constants(struct parser *p) {
+	errr result = PARSE_ERROR_NONE;
+
 	z_info = parser_priv(p);
 	parser_destroy(p);
 	if (check_critical_levels(z_info->m_crit_level_head)) {
 		plog("The cutoffs for melee criticals in constants.txt are "
 			"not strictly increasing.");
-		return PARSE_ERROR_NON_SEQUENTIAL_RECORDS;
+		if (result == PARSE_ERROR_NONE) {
+			result = PARSE_ERROR_NON_SEQUENTIAL_RECORDS;
+		}
 	}
 	if (check_critical_levels(z_info->r_crit_level_head)) {
 		plog("The cutoffs for ranged criticals in constants.txt are "
 			"not strictly increasing.");
-		return PARSE_ERROR_NON_SEQUENTIAL_RECORDS;
+		if (result == PARSE_ERROR_NONE) {
+			result = PARSE_ERROR_NON_SEQUENTIAL_RECORDS;
+		}
 	}
-	return 0;
+	return result;
 }
 
 static void cleanup_critical_levels(struct critical_level *head)
@@ -1115,6 +1121,8 @@ static errr run_parse_world(struct parser *p) {
 
 static errr finish_parse_world(struct parser *p) {
 	struct level *level_check;
+	errr result = PARSE_ERROR_NONE;
+	int maxe = get_parser_error_limit(), counte = 0;
 
 	/* Check that all levels referred to exist */
 	for (level_check = world; level_check; level_check = level_check->next) {
@@ -1126,7 +1134,18 @@ static errr finish_parse_world(struct parser *p) {
 				level_find = level_find->next;
 			}
 			if (!level_find) {
-				quit_fmt("Invalid level reference %s", level_check->up);
+				if (result == PARSE_ERROR_NONE) {
+					result = PARSE_ERROR_INVALID_VALUE;
+				}
+				plog_fmt("Invalid up level reference, %s, "
+					"for level %s", level_check->up,
+					level_check->name);
+				if (maxe) {
+					if (counte >= maxe - 1) {
+						break;
+					}
+					++counte;
+				}
 			}
 		}
 
@@ -1137,13 +1156,24 @@ static errr finish_parse_world(struct parser *p) {
 				level_find = level_find->next;
 			}
 			if (!level_find) {
-				quit_fmt("Invalid level reference %s", level_check->down);
+				if (result == PARSE_ERROR_NONE) {
+					result = PARSE_ERROR_INVALID_VALUE;
+				}
+				plog_fmt("Invalid down level reference, %s, "
+					"for level %s", level_check->down,
+					level_check->name);
+				if (maxe) {
+					if (counte >= maxe - 1) {
+						break;
+					}
+					++counte;
+				}
 			}
 		}
 	}
 
 	parser_destroy(p);
-	return 0;
+	return result;
 }
 
 static void cleanup_world(void)
@@ -2491,6 +2521,9 @@ static errr run_parse_history(struct parser *p) {
 static errr finish_parse_history(struct parser *p) {
 	struct history_chart *c;
 	struct history_entry *e, *prev, *next;
+	errr result = PARSE_ERROR_NONE;
+	int maxe = get_parser_error_limit(), counte = 0;
+
 	histories = parser_priv(p);
 
 	/* Go fix up the entry successor pointers. We can't compute them at
@@ -2513,13 +2546,24 @@ static errr finish_parse_history(struct parser *p) {
 				continue;
 			e->succ = findchart(histories, e->isucc);
 			if (!e->succ) {
-				return -1;
+				if (result == PARSE_ERROR_NONE) {
+					result = PARSE_ERROR_INVALID_VALUE;
+				}
+				plog_fmt("No successor found for history "
+					"entry, '%s': requested successor "
+					"is %d", e->text, e->isucc);
+				if (maxe) {
+					if (counte >= maxe - 1) {
+						break;
+					}
+					++counte;
+				}
 			}
 		}
 	}
 
 	parser_destroy(p);
-	return 0;
+	return result;
 }
 
 static void cleanup_history(void)

--- a/src/load.c
+++ b/src/load.c
@@ -980,7 +980,9 @@ int rd_misc(void)
 		if (randart_file_exists()) {
 			cleanup_parser(&artifact_parser);
 			activate_randart_file();
-			run_parser(&randart_parser);
+			if (run_parser(&randart_parser)) {
+				quit("Could not parse random artifacts.");
+			}
 		} else {
 			do_randart(seed_randart, true);
 		}

--- a/src/main-sdl2.c
+++ b/src/main-sdl2.c
@@ -8044,27 +8044,37 @@ static bool read_config_file(struct my_app *a)
 	char line[1024];
 	ang_file *config = file_open(a->config_file, MODE_READ, FTYPE_TEXT);
 	struct parser *parser;
-	errr error = PARSE_ERROR_NONE;
+	int maxe, counte;
+	bool result;
 
 	if (config == NULL) {
 		/* not an error, its ok for a config file to not exist */
 		return false;
 	}
 
+	result = true;
+	maxe = get_parser_error_limit();
+	counte = 0;
 	parser = init_parse_config(a);
-
 	while (file_getl(config, line, sizeof(line))) {
-		error = parser_parse(parser, line);
+		errr error = parser_parse(parser, line);
+
 		if (error != PARSE_ERROR_NONE) {
+			result = false;
 			print_error(a->config_file, parser);
-			break;
+			if (maxe) {
+				if (counte >= maxe - 1) {
+					break;
+				}
+				++counte;
+			}
 		}
 	}
 
 	parser_destroy(parser);
 	file_close(config);
 
-	return error == PARSE_ERROR_NONE;
+	return result;
 }
 
 #endif /* USE_SDL2 */

--- a/src/main-spoil.c
+++ b/src/main-spoil.c
@@ -303,7 +303,10 @@ errr init_spoil(int argc, char *argv[]) {
 
 				if (result == 0) {
 					cleanup_parser(&artifact_parser);
-					run_parser(&randart_parser);
+					if (run_parser(&randart_parser)) {
+						quit("Could not parse random "
+							"artifacts.");
+					}
 					if (randart_name) {
 						file_delete(defname);
 					} else {

--- a/src/mon-init.c
+++ b/src/mon-init.c
@@ -1757,6 +1757,8 @@ static errr finish_parse_monster(struct parser *p) {
 	struct monster_race *r, *n;
 	size_t i;
 	int ridx;
+	errr result = PARSE_ERROR_NONE;
+	int maxe = get_parser_error_limit(), counte = 0;
 
 	/* Scan the list for the max id and max blows */
 	z_info->r_max = 0;
@@ -1836,18 +1838,39 @@ static errr finish_parse_monster(struct parser *p) {
 				f->race = lookup_monster(f->name);
 			}
 			if (!f->race) {
-				quit_fmt("Couldn't find friend named '%s' for monster '%s'",
-						 f->name, race->name);
+				if (result == PARSE_ERROR_NONE) {
+					result = PARSE_ERROR_INVALID_MONSTER;
+				}
+				if (maxe) {
+					if (counte >= maxe) {
+						break;
+					}
+					++counte;
+				}
+				plog_fmt("Could not find friend named '%s' "
+					"for monster '%s'", f->name,
+					race->name);
 			}
 			string_free(f->name);
 		}
 		for (s = race->shapes; s; s = s->next) {
-			if (!s->base) {
-				s->race = lookup_monster(s->name);
-				if (!s->race) {
-					quit_fmt("Couldn't find shape named '%s' for monster '%s'",
-							 s->name, race->name);
+			if (s->base) {
+				continue;
+			}
+			s->race = lookup_monster(s->name);
+			if (!s->race) {
+				if (result == PARSE_ERROR_NONE) {
+					result = PARSE_ERROR_INVALID_MONSTER;
 				}
+				if (maxe) {
+					if (counte >= maxe) {
+						break;
+					}
+					++counte;
+				}
+				plog_fmt("Could not find shape named '%s' "
+					"for monster '%s'", s->name,
+					race->name);
 			}
 			string_free(s->name);
 		}
@@ -1862,7 +1885,7 @@ static errr finish_parse_monster(struct parser *p) {
 	}
 
 	parser_destroy(p);
-	return 0;
+	return result;
 }
 
 static void cleanup_monster(void)

--- a/src/obj-init.c
+++ b/src/obj-init.c
@@ -435,9 +435,17 @@ static errr finish_parse_projection(struct parser *p) {
 	}
 
 	if (element_count + 1 < (int) N_ELEMENTS(element_names)) {
-		quit_fmt("Too few elements in projection.txt!");
+		parser_destroy(p);
+		plog_fmt("Too few elements in projection.txt!  Expected %d "
+			"and got %d.", (int)N_ELEMENTS(element_names),
+			element_count + 1);
+		return PARSE_ERROR_TOO_FEW_ENTRIES;
 	} else if (element_count + 1 > (int) N_ELEMENTS(element_names)) {
-		quit_fmt("Too many elements in projection.txt!");
+		parser_destroy(p);
+		plog_fmt("Too many elements in projection.txt!  Expected %d "
+			"and got %d.", (int)N_ELEMENTS(element_names),
+			element_count + 1);
+		return PARSE_ERROR_TOO_MANY_ENTRIES;
 	}
 
 	/* Allocate the direct access list and copy the data to it */
@@ -812,6 +820,7 @@ static errr finish_parse_slay(struct parser *p) {
 	slay = parser_priv(p);
 	while (slay) {
 		if (z_info->slay_max >= 254) {
+			plog("Cannot handle more than 254 slays in slay.txt.");
 			result = PARSE_ERROR_TOO_MANY_ENTRIES;
 			break;
 		}
@@ -984,6 +993,8 @@ static errr finish_parse_brand(struct parser *p) {
 	brand = parser_priv(p);
 	while (brand) {
 		if (z_info->brand_max >= 254) {
+			plog("Cannot handle more than 254 brands in "
+				"brand.txt.");
 			result = PARSE_ERROR_TOO_MANY_ENTRIES;
 			break;
 		}
@@ -1367,6 +1378,8 @@ static errr finish_parse_curse(struct parser *p) {
 	curse = parser_priv(p);
 	while (curse) {
 		if (z_info->curse_max >= 254) {
+			plog("Cannot handle more than 254 curses in "
+				"curse.txt.");
 			result = PARSE_ERROR_TOO_MANY_ENTRIES;
 			break;
 		}

--- a/src/obj-util.c
+++ b/src/obj-util.c
@@ -172,7 +172,9 @@ void flavor_init(void)
 			f->sval = SV_UNKNOWN;
 		}
 		cleanup_parser(&flavor_parser);
-		run_parser(&flavor_parser);
+		if (run_parser(&flavor_parser)) {
+			quit("Could not parse flavor.txt.");
+		}
 	}
 
 	if (OPT(player, birth_randarts))

--- a/src/option.c
+++ b/src/option.c
@@ -18,6 +18,7 @@
 #include "angband.h"
 #include "init.h"
 #include "option.h"
+#include "parser.h"
 #include "z-util.h"
 
 /**
@@ -35,6 +36,47 @@ static struct option_entry {
 	#include "list-options.h"
 	#undef OP
 };
+
+struct option_parser_context {
+	struct player_options *opts;
+	int page;
+};
+
+static enum parser_error parse_option(struct parser *p)
+{
+	struct option_parser_context *ctx = parser_priv(p);
+	const char *name, *yno;
+	int opt;
+
+	if (!ctx) {
+		return PARSE_ERROR_INTERNAL;
+	}
+
+	name = parser_getsym(p, "name");
+	opt = 0;
+	while (1) {
+		if (opt >= OPT_MAX) {
+			return PARSE_ERROR_INVALID_OPTION;
+		}
+		if (options[opt].type == ctx->page && options[opt].name
+				&& streq(name, options[opt].name)) {
+			break;
+		}
+		++opt;
+	}
+
+	yno = parser_getstr(p, "yno");
+	if (strncmp("yes", yno, 3) == 0 && contains_only_spaces(yno + 3)) {
+		ctx->opts->opt[opt] = true;
+		return PARSE_ERROR_NONE;
+	}
+	if (strncmp("no", yno, 2) == 0 && contains_only_spaces(yno + 2)) {
+		ctx->opts->opt[opt] = false;
+		return PARSE_ERROR_NONE;
+	}
+
+	return PARSE_ERROR_INVALID_VALUE;
+}
 
 /**
  * Given the option type, return a short name in all lower case.
@@ -224,110 +266,51 @@ bool options_save_custom(struct player_options *opts, int page)
  */
 bool options_restore_custom(struct player_options *opts, int page)
 {
-	const char *page_name = option_type_name(page);
 	char path[1024], buf[1024], file_name[80];
 	ang_file *f;
-	int linenum;
+	struct parser *p;
+	struct option_parser_context ctx;
+	int maxe, counte;
 
 	strnfmt(file_name, sizeof(file_name), "customized_%s_options.txt",
-		page_name);
+		option_type_name(page));
 	path_build(path, sizeof(path), ANGBAND_DIR_USER, file_name);
 	if (!file_exists(path)) {
 		options_restore_maintainer(opts, page);
 		return true;
 	}
 
-	/*
-	 * Could use run_parser(), but that exits the application if
-	 * there are syntax errors.  Therefore, use our own parsing.
-	 */
 	f = file_open(path, MODE_READ, FTYPE_TEXT);
 	if (!f) {
 		return false;
 	}
-	linenum = 1;
+	p = parser_new();
+	ctx.opts = opts;
+	ctx.page = page;
+	parser_setpriv(p, &ctx);
+	parser_reg(p, "option sym name str yno", parse_option);
+	maxe = get_parser_error_limit();
+	counte = 0;
 	while (file_getl(f, buf, sizeof(buf))) {
-		char *sub = strstr(buf, "option:"), *com;
-		int opt;
+		errr r = parser_parse(p, buf);
 
-		if (!sub) {
-			/*
-			 * If it isn't an option, it should be a comment or
-			 * whitespace.
-			 */
-			sub = strchr(buf, '#');
+		if (r) {
+			struct parser_state s;
 
-			if (sub) {
-				*sub = '\0';
-			}
-			if (!contains_only_spaces(buf)) {
-				msg("Line %d of the customized %s options is "
-					"not parseable.", linenum, page_name);
-			}
-			++linenum;
-			continue;
-		}
-
-		*sub = '\0';
-		/* Ignore if the "option:" is embedded in a comment. */
-		com = strchr(buf, '#');
-		if (com) {
-			*com = '\0';
-			if (!contains_only_spaces(buf)) {
-				msg("Line %d of the customized %s options is "
-					"not parseable.", linenum, page_name);
-			}
-			++linenum;
-			continue;
-		}
-		if (!contains_only_spaces(buf)) {
-			msg("Line %d of the customized %s options is not "
-					"parseable.", linenum, page_name);
-			++linenum;
-			continue;
-		}
-
-		/* Try to find the option. */
-		sub += 7;
-		opt = 0;
-		while (1) {
-			size_t lname;
-
-			if (opt >= OPT_MAX) {
-				msg("Unrecognized option at line %d of the "
-					"customized %s options.", linenum,
-					page_name);
-				break;
-			}
-			if (options[opt].type != page || !options[opt].name) {
-				++opt;
-				continue;
-			}
-			lname = strlen(options[opt].name);
-			if (strncmp(options[opt].name, sub, lname) == 0
-					&& sub[lname] == ':') {
-				if (strncmp("yes", sub + lname + 1, 3) == 0
-						&& contains_only_spaces(sub + lname + 4)) {
-					(*opts).opt[opt] = true;
-				} else if (strncmp("no", sub + lname + 1, 2) == 0
-						&& contains_only_spaces(sub + lname + 3)) {
-					(*opts).opt[opt] = false;
-				} else {
-					msg("Value at line %d of the "
-						"customized %s options is not "
-						"yes or no.", linenum,
-						page_name);
+			parser_getstate(p, &s);
+			plog_fmt("Parse error in %s line %d column %d: %s: %s",
+				path, s.line, s.col, s.msg,
+				parser_error_str[s.error]);
+			if (maxe) {
+				if (counte >= maxe - 1) {
+					break;
 				}
-				break;
+				++counte;
 			}
-			++opt;
 		}
-		++linenum;
 	}
-
-	if (!file_close(f)) {
-		return false;
-	}
+	parser_destroy(p);
+	(void)file_close(f);
 
 	return true;
 }

--- a/src/parser.c
+++ b/src/parser.c
@@ -27,6 +27,17 @@
 #include "z-virt.h"
 
 
+#ifndef PARSE_ERROR_LIMIT
+/**
+ * This is a compile-time limit on the number of error messages reported when
+ * parsing a file.  It can be overridden at runtime by setting the
+ * PARSE_ERROR_LIMIT environment variable to the desired limit as a positive
+ * decimal integer.  A limit of zero imposes no limit on the number of error
+ * messages.
+ */
+#define PARSE_ERROR_LIMIT (20)
+#endif
+
 /**
  * A parser has a list of hooks (which are run across new lines given to
  * parser_parse()) and a list of the set of named values for the current line.
@@ -610,8 +621,38 @@ int parser_getstate(struct parser *p, struct parser_state *s) {
 /**
  * Sets the parser's detailed error description and field number.
  */
-void parser_setstate(struct parser *p, unsigned int col, const char *msg) {
+void parser_setstate(struct parser *p, enum parser_error ecode,
+		unsigned int line, unsigned int col, const char *msg) {
+	p->error = ecode;
+	p->lineno = line;
 	p->colno = col;
 	my_strcpy(p->errmsg, msg, sizeof(p->errmsg));
 }
 
+/**
+ * Return the maximum number of error messages to display while parsing a file.
+ *
+ * If the maximum is zero, then there is no limit.
+ */
+int get_parser_error_limit(void)
+{
+	static int elimit = -1;
+
+	if (elimit < 0) {
+		const char *envlimit = getenv("PARSE_ERROR_LIMIT");
+		long llimit;
+		char *end;
+
+		if (envlimit && *envlimit
+				&& (llimit = strtol(envlimit, &end, 10)) >= 0
+				&& !*end) {
+			elimit = (llimit < INT_MAX) ? (int)llimit : INT_MAX;
+		} else {
+#if PARSE_ERROR_LIMIT < 0
+#error "PARSE_ERROR_LIMIT is negative."
+#endif
+			elimit = PARSE_ERROR_LIMIT;
+		}
+	}
+	return elimit;
+}

--- a/src/parser.h
+++ b/src/parser.h
@@ -63,6 +63,8 @@ extern unsigned int parser_getuint(struct parser *p, const char *name);
 extern struct random parser_getrand(struct parser *p, const char *name);
 extern wchar_t parser_getchar(struct parser *p, const char *name);
 extern int parser_getstate(struct parser *p, struct parser_state *s);
-extern void parser_setstate(struct parser *p, unsigned int col, const char *msg);
+extern void parser_setstate(struct parser *p, enum parser_error ecode,
+		unsigned int line, unsigned int col, const char *msg);
+extern int get_parser_error_limit(void);
 
 #endif /* !PARSER_H */

--- a/src/player-birth.c
+++ b/src/player-birth.c
@@ -1276,7 +1276,9 @@ void do_cmd_accept_character(struct command *cmd)
 	/* Restore the standard artifacts (randarts may have been loaded) */
 	cleanup_parser(&randart_parser);
 	deactivate_randart_file();
-	run_parser(&artifact_parser);
+	if (run_parser(&artifact_parser)) {
+		quit("Could not parse artifact.txt.");
+	}
 
 	/* Now only randomize the artifacts if required */
 	if (OPT(player, birth_randarts)) {

--- a/src/ui-entry.c
+++ b/src/ui-entry.c
@@ -1757,6 +1757,8 @@ static int hatch_embryo(struct embryonic_ui_entry *embryo)
 
 		/* Check that required fields are valid. */
 		if (embryo->entry->combiner_index == 0) {
+			plog_fmt("No combine directive specified for %s",
+				embryo->entry->name);
 			string_free(embryo->entry->name);
 			mem_free(embryo->entry->label);
 			mem_free(embryo->entry);
@@ -2263,7 +2265,7 @@ static errr run_parse_ui_entry(struct parser *p)
 		return result;
 	}
 	if (hatch_last_embryo(p)) {
-		return 1;
+		return PARSE_ERROR_INVALID_VALUE;
 	}
 	/*
 	 * Mark those as templates only so they'll never be directly displayed.
@@ -2277,11 +2279,13 @@ static errr run_parse_ui_entry(struct parser *p)
 
 static errr finish_parse_ui_entry(struct parser *p)
 {
-	errr result = 0;
+	errr result = PARSE_ERROR_NONE;
+	int maxe = get_parser_error_limit(), counte = 0;
 	int i;
 
 	if (hatch_last_embryo(p)) {
-		result = -1;
+		result = PARSE_ERROR_INVALID_VALUE;
+		counte = 1;
 	}
 	for (i = 0; i < n_entry; ++i) {
 		int j;
@@ -2302,10 +2306,39 @@ static errr finish_parse_ui_entry(struct parser *p)
 				if (n2 != (size_t)-1) {
 					entries[i]->nlabel = n;
 				} else {
-					result = -1;
+					entries[i]->label[0] = 0;
+					entries[i]->nlabel = 0;
+					if (result == PARSE_ERROR_NONE) {
+						result = PARSE_ERROR_INTERNAL;
+					}
+					plog_fmt("Internal error:  "
+						"text_mbstowcs() could not "
+						"convert an empty string "
+						"while transferring name to "
+						"label for '%s'",
+						entries[i]->name);
+					if (maxe) {
+						if (counte >= maxe - 1) {
+							break;
+						}
+						++counte;
+					}
 				}
 			} else {
-				result = -1;
+				entries[i]->label[0] = 0;
+				entries[i]->nlabel = 0;
+				if (result == PARSE_ERROR_NONE) {
+					result = PARSE_ERROR_INVALID_VALUE;
+				}
+				plog_fmt("Invalid text encoding detected "
+					"while transferring name to label "
+					"for '%s'", entries[i]->name);
+				if (maxe) {
+					if (counte >= maxe - 1) {
+						break;
+					}
+					++counte;
+				}
 			}
 		}
 		fill_out_shortened(entries[i]);

--- a/src/ui-prefs.c
+++ b/src/ui-prefs.c
@@ -1211,22 +1211,29 @@ static void print_error(const char *name, struct parser *p) {
  */
 static bool process_pref_file_named(const char *path, bool quiet, bool user) {
 	ang_file *f = file_open(path, MODE_READ, -1);
-	errr e = 0;
+	bool result = true;
 
 	if (!f) {
 		if (!quiet)
 			msg("Cannot open '%s'.", path);
-
-		e = PARSE_ERROR_INTERNAL; /* signal failure to callers */
+		result = false;
 	} else {
 		char line[1024];
+		int maxe = get_parser_error_limit(), counte = 0;
 
 		struct parser *p = init_parse_prefs(user);
 		while (file_getl(f, line, sizeof line)) {
-			e = parser_parse(p, line);
+			errr e = parser_parse(p, line);
+
 			if (e != PARSE_ERROR_NONE) {
+				result = false;
 				print_error(path, p);
-				break;
+				if (maxe) {
+					if (counte >= maxe - 1) {
+						break;
+					}
+					++counte;
+				}
 			}
 		}
 		finish_parse_prefs(p);
@@ -1236,8 +1243,7 @@ static bool process_pref_file_named(const char *path, bool quiet, bool user) {
 		parser_destroy(p);
 	}
 
-	/* Result */
-	return e == PARSE_ERROR_NONE;
+	return result;
 }
 
 

--- a/src/wiz-stats.c
+++ b/src/wiz-stats.c
@@ -1538,7 +1538,9 @@ static void clearing_stats(void)
 			/* Restore the standard artifacts */
 			cleanup_parser(&randart_parser);
 			deactivate_randart_file();
-			run_parser(&artifact_parser);
+			if (run_parser(&artifact_parser)) {
+				quit("Could not parse artifact.txt.");
+			}
 
 			/* regen randarts */
 			do_randart(seed_randart, false);
@@ -1567,10 +1569,14 @@ static void clearing_stats(void)
 		cleanup_parser(&randart_parser);
 		if (OPT(player, birth_randarts)) {
 			activate_randart_file();
-			run_parser(&randart_parser);
+			if (run_parser(&randart_parser)) {
+				quit("Could not parse random artifacts.");
+			}
 			deactivate_randart_file();
 		} else {
-			run_parser(&artifact_parser);
+			if (run_parser(&artifact_parser)) {
+				quit("Could not parse artifact.txt.");
+			}
 		}
 	}
 


### PR DESCRIPTION
Allow for recording up to n (default 20; configurable at compile time and run time) errors.  Has the limitation that parsing a line stops on the first error so it will not indicate multiple errors on the same line.  The finish step for parsing is only run if the body of the file parsed successfully so need to correct all the errors in the body before any errors can be reported by the finish step.

Has several side effects.  run_parser() will now return rather than call quit() when a parsing error occurrs.  In Vanilla, the cases where run_parser()'s return value was not checked were related to parsing randart, artifact or flavor files.  For parsing of data files and other configuration files, like lib/tiles/list.txt, read at startup, report errors through plog() rather than msg() as the latter is lost if the front end immediately exits without a character loaded.  The prototype for parser_setstate() has changed so the caller can alter everything needed for error reporting.