### PR TITLE
In the classic level generation, reject the level if it has less than 2 rooms

### DIFF
--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -1254,6 +1254,14 @@ struct chunk *classic_gen(struct player *p, int min_height, int min_width,
 	mem_free(blocks_tried);
 	mem_free(dun->room_map);
 
+	if (built < 2) {
+		uncreate_artifacts(c);
+		wipe_mon_list(c, p);
+		cave_free(c);
+		*p_error = "less than two rooms created";
+		return NULL;
+	}
+
 	/* Generate permanent walls around the edge of the generated area */
 	draw_rectangle(c, 0, 0, c->height - 1, c->width - 1, 
 		FEAT_PERM, SQUARE_NONE, true);


### PR DESCRIPTION
In practice, that prevents a crash in the tunneling step if changes to dungeon_profile.txt, vault.txt, or room_template.txt make it impossible to add rooms.