### PR TITLE
Plug leak of monster's shape name if it specifies a monster base

### DIFF
--- a/src/mon-init.c
+++ b/src/mon-init.c
@@ -1855,6 +1855,8 @@ static errr finish_parse_monster(struct parser *p) {
 		}
 		for (s = race->shapes; s; s = s->next) {
 			if (s->base) {
+				string_free(s->name);
+				s->name = NULL;
 				continue;
 			}
 			s->race = lookup_monster(s->name);
@@ -1873,6 +1875,7 @@ static errr finish_parse_monster(struct parser *p) {
 					race->name);
 			}
 			string_free(s->name);
+			s->name = NULL;
 		}
 	}
 


### PR DESCRIPTION
That is a regression due to https://github.com/angband/angband/commit/c58b64535b92a1e3b4be3771667e00f8285e4a74 .