### PR TITLE
docs:  rearrange compiling instructions

### DIFF
--- a/docs/hacking/cmake.rst
+++ b/docs/hacking/cmake.rst
@@ -1,0 +1,266 @@
+===========
+CMake Hints
+===========
+
+To keep things simpler, :doc:`compiling` uses CMake in a standardized way:
+``cmake [options] -B build`` to configure the build and
+``cmake --build build [options]`` to perform the build.  Both are run in the
+top-level directory of the sources which is where CMakeLists.txt is.  Here, we
+will provide hints about ways you can use CMake to match how you want to build
+the game.
+
+CMake's command line syntax is documented at `cmake(1) <https://cmake.org/cmake/help/latest/manual/cmake.1.html>`_.
+CMake does have interactive interfaces which are not used here or in
+:doc:`compiling`.  If one of those is more to your liking, information about
+them are at `ccmake(1) <https://cmake.org/cmake/help/latest/manual/ccmake.1.html>`_
+and `cmake-gui(1) <https://cmake.org/cmake/help/latest/manual/cmake-gui.1.html>`_.
+For information about using CMake and Visual Studio, see
+`Microsoft's introduction <https://learn.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=msvc-170>`_.
+
+Configuring the Build
+=====================
+
+Setting the Build and Source Directories
+----------------------------------------
+
+Since CMake 3.13, the location of the build directories and the source
+directories can be specified with the ``-B`` and ``-S`` options when
+configuring the build: ``cmake [options] -B path-to-build [-S path-to-source]``.
+In :doc:`compiling`, CMake is run where the game's CMakeLists.txt is located
+and the build's products are placed in the build subdirectory, so the
+configuration step looks like ``cmake [options] -B build``.  If you want to
+run CMake in a different location or place the build products in a different
+location, feel free to make use the full range of what the ``-B`` and ``-S``
+options allow.
+
+An alternate way to perform the configuration step, supported by all versions
+of CMake, is to run the configuration step in the top-level directory of where
+the build's products will be placed and specify the path to the directory
+containing the relevant CMakeLists.txt file as the last argument:
+``cmake [options] path-to-source``.  So on a system that looks like Unix, these
+commands function similarly to the ``cmake [options] -B build`` used in
+:doc:`compiling`::
+
+    mkdir build && cd build
+    cmake [options] ..
+
+Choosing the Underlying Build Tool
+----------------------------------
+
+CMake supports a variety of native build tools:  make, ninja, ....  In
+CMake's parlance, one selects a "generator" when configuring the build, and
+CMake uses that to set up the build directories for a native build tool.  In
+:doc:`compiling`, most examples used the default generator.  Running
+``cmake --help`` will display the generators that are available and which is
+the default.
+
+One reason to choose a generator other than the default is performance.  On
+systems where the ``Unix Makefiles`` generator is the default, you might prefer
+to use the ``Ninja`` generator because ninja is faster than make.  Another
+reason is that the native build tool corresponding to the default generator
+is not installed but you do have access to another build tool supported by
+another generator.
+
+When configuring the build, you can specify the generator by with
+``-G name-of-generator``.  In :doc:`compiling`, that was used in some places
+to use the generator for ninja::
+
+    cmake -G Ninja -B build
+    cmake --build build
+
+On Windows if you prefer to use Visual Studio rather than something
+like MSYS2 or Cygwin, you might install CMake and then use something like
+this from Cmd.exe's command line to build the game and build and run the
+unit tests from the top-level directory of the game's source files::
+
+    call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars32.bat"
+    cmake -G "Visual Studio 17 2022" -A Win32 -DSUPPORT_WINDOWS_FRONTEND=ON -DSUPPORT_BUNDLED_PNG=ON -B build
+    cmake --build build 
+    cmake --build build -t allunittests
+
+Of course, you would have to adjust the path to vcvars32.bat and, perhaps, the
+name of the generator to be compatible with the version of Visual Studio you
+have installed.
+
+Adjusting the Configuration with Environment Variables
+------------------------------------------------------
+
+CMake's documentation on environment variables that influence how a build is
+configured is at `cmake-env-variables(7) <https://cmake.org/cmake/help/latest/manual/cmake-env-variables.7.html#manual:cmake-env-variables(7)>`_.
+The environment variables likely to be of use when configuring the build for the
+game are ``CMAKE_BUILD_TYPE``, ``CMAKE_GENERATOR``, ``CC`` (the C compiler to
+use), ``CFLAGS`` (options to pass to the C compiler), ``LDFLAGS`` (options to
+pass when linking), ``RC`` (the compiler for resource files; only relevant if
+building the Windows front end), and ``RCFLAGS`` (options to pass when
+compiling resource files; only relevant if building the Windows front end).
+In :doc:`compiling`, the example commands do not use environment variables but
+specify everything with command line options (``-G name`` to set the generator,
+``-DCMAKE_BUILD_TYPE=...`` to set the build type, and ``-DCMAKE_C_FLAGS=...``
+to set options for the C compiler).
+
+Determining What Variables To Set
+---------------------------------
+
+Running ``cmake --help-variable-list`` will list CMake's variables which have
+documentation and running ``cmake --help-variable x`` will display the
+documentation for the variable x.  Those do not provide any information about
+the variables specific to the game's CMakeLists.txt.  For those, running
+``cmake -N -LH path-to-build`` (i.e. running ``cmake -N -LH  .`` in the build
+directory) after you have already configured a build will display a brief
+description and current setting for those variables.
+
+Debugging the Configuration Process
+-----------------------------------
+
+In some cases, CMake compiles or runs stuff during configuration to test what
+works.  When such a test fails and it is unclear from CMake's output what
+exactly went wrong, rerunning the configuration step with ``--debug-trycompile``
+in the options will leave the temporary directories CMake creates for the tests
+in place.  Then it is possible to inspect the commands that were involved the
+test and rerun them outside of CMake to better determine what went wrong.
+
+Performing the Build
+====================
+
+Using the Native Build Tool Rather Than CMake
+---------------------------------------------
+
+The instructions in :doc:`compiling` use ``cmake --build path-to-build [options]``
+to perform the build.  You could also use native build tool directly.  For
+instance, rather than ``cmake --build ./build -t allunittests``, you could
+change directories to ``./build`` and run ``make allunittests`` if make is the
+native build tool or run ``ninja allunittests`` if ninja is the native build
+tool.
+
+Parallel Builds
+---------------
+
+To speed up the build by running independent portions simultaneously, use
+``cmake --build path-to-build -j n [options]``
+
+where n is the maximum number of jobs to run in parallel.  That requires CMake
+3.12 or later.  When you know the native build tools option for parallel builds,
+you can use that instead.  With GNU Make, use ``make -j n [options]``.  With
+ninja, use ``ninja -j n [options]``.  Rather than specifying a fixed number
+for n, it can be useful to get the number of processor available on the
+machine.  For instance, on Linux use::
+
+    -j $(nproc)
+
+On macOS use::
+
+    -j $(sysctl -n hw.activecpu)
+
+On PowerShell use::
+
+    -j ${env:NUMBER_OF_PROCESSORS}
+
+Useful Targets
+--------------
+
+Targets that are likely to be useful with the ``-t`` option to
+``cmake --build`` or as an argument to make or ninja:
+
+all
+    This is the default target, used when no other targets are specified.  It
+    will compile the game and, if BUILD_DOC was turned on when the build was
+    configured, the user manual.  This target is common to all CMake projects.
+
+alltests
+    Performs all the actions of the allunittests target.  If not cross-compiling
+    and the test front end has been configured, builds the game, if necessary,
+    and runs tests/run-test from the source directory.  This target is specific
+    to the game's CMakeLists.txt.
+
+allunittests
+    If not cross-compiling or an emulator is available, builds, if necessary,
+    all of the unit tests from src/tests in the source directory and then
+    runs all of those tests.  This target is specific to the game's
+    CMakeLists.txt.
+
+clean
+    Removes build intermediates.   Another way to do that is by running,
+    ``cmake --build path-to-build --clean-first [options]`` when you also want
+    to build something immediately after cleaning up the intermediates.  This
+    target is common to all CMake projects.
+
+coverage
+    Reports how well the tests performed by the ``alltests`` target cover the
+    code.  Peforms the actions of the ``resetcoverage`` target to remove any
+    prior coverage information.  Then performs the actions of the ``alltests``
+    target.  Finally, generates the coverage reports by performing the actions
+    of the ``reportcoverage`` target.  This target is specific to the game's
+    CMakeLists.txt and is only available if SUPPORT_COVERAGE was turned on when
+    the build was configured.
+
+install
+    Builds the game, if necessary, and installs it at the location set when
+    build was configured.  Useful if the build was configured with
+    SHARED_INSTALL or READONLY_INSTALL turned on.  For builds configured
+    with SC_INSTALL turned on (which is the default), there is an alternative
+    that makes it easier to control where the game is installed:  build without
+    any target specified and run
+    ``cmake --install path-to-build-directory --prefix desired-installation-location``.
+    This target is common to all CMake projects.
+
+OurManual
+    Builds the user manual.  This target is specific to the game's
+    CMakeLists.txt and is only available if BUILD_DOC was turned on when the
+    build was configured.
+
+print-executable-name
+    Writes ``our-executable-name=x`` to standard output where x is the file
+    name (no directory information) of the game's executable.  This target is
+    specific to the game's CMakeLists.txt.
+
+print-project-name
+    Writes ``our-project-name=x`` to standard output where x is what is
+    set as the project's name by calling project() in CMakeLists.txt.  This
+    target is specific to the game's CMakeLists.txt.
+
+reportcoverage
+    Using the current accumulated coverage data, generate a coverage report
+    for each source file (each such report has a .gcov extension) and a summary,
+    generated by src/gen-coverage in the source directories, across all source
+    files.  That summary is written to standard output.  This target is
+    specific to the game's CMakeLists.txt and is only available if
+    SUPPORT_COVERAGE was turned on when the build was configured.
+
+resetcoverage
+    Clears any accumulated coverage data and any prior coverage report for each
+    source file.  This target is specific to the game's CMakeLists.txt and is
+    only available if SUPPORT_COVERAGE was turned on when the build was
+    configured.
+
+run-unittest-*x*
+    Builds, if necessary, a specific unit test and runs that test (if
+    cross-compiling and an emulator is not available, running will not work).
+    *x* is the name of the unit test's source file within the source directory
+    with the leading ``src/tests`` and trailing ``.c`` removed, and each ``/``
+    converted to a ``-``.  For instance, the target ``run-unittest-parse-parse``
+    would build and run the tests in src/tests/parse/parse.c.  This target is
+    specific to the game's CMakeLists.txt.
+
+Changing Configurations
+=======================
+
+You can continue to reuse a build directory as you make changes to the source
+code, including adding, moving, or removing files, and then rebuild.  However,
+if you want to change the configuration of the build, you will need to
+configure a new build.  That could be done in a different directory.  If you
+want to use a build directory with the same name as what you were using, you
+could use the ``--fresh`` option to CMake when reconfiguring (requires CMake
+3.24 or later) or remove that directory and all of its contents
+(i.e.  ``rm -rf path-to-build`` on Unix) and have the configuration step
+regenerate that directory.
+
+End Products
+============
+
+The game's CMakeLists.txt puts the game's executable and the lib directory it
+depends on in the subdirectory, ``game``, of the build directory.  That avoids
+trouble on MSYS2 (the game's DLLs interfere with the MinGW compiler) and
+separates the game from the other intermediates generated during the build.
+
+The compiled user's manual for the game will be in the subdirectory,
+``manual-output/html``, of the build directory.

--- a/docs/hacking/compiling.rst
+++ b/docs/hacking/compiling.rst
@@ -9,6 +9,584 @@ listed are to be run from top-level directory of the Angband source files.
 .. contents:: Contents
    :local:
 
+Linux / other UNIX with CMake
+-----------------------------
+
+The compilation process with CMake requires version 3.7 or later and the
+commands used here require 3.13 or later.  For alternate ways of writing the
+CMake commands that follow, including ways to be compatible with versions prior
+to 3.13, see :doc:`cmake`.
+
+By default the compilation process uses the X11 front end unless one or more of
+the other graphical front ends are selected.  The graphical front ends are:
+GCU, SDL, SDL2 and X11.  All of the following generate a self-contained
+directory, ``build/game``, that you can move elsewhere or rename.  To run the
+result, change directories to ``build/game`` or whatever you renamed it to) and
+run ``./angband``.
+
+To build Angband with the X11 front end::
+
+    cmake -B build
+    cmake --build build
+
+If you want to build the X11 front end while building one of the other
+graphical front ends, the option to pass to CMake is
+``-DSUPPORT_X11_FRONTEND=ON``.
+
+To build Angband with the SDL front end::
+
+    cmake -DSUPPORT_SDL_FRONTEND=ON -B build
+    cmake --build build
+
+To build Angband with the SDL2 front end::
+
+    cmake -DSUPPORT_SDL2_FRONTEND=ON -B build
+    cmake --build build
+
+To build Angband with the GCU front end::
+
+    cmake -DSUPPORT_GCU_FRONTEND=ON -B build
+    cmake --build build
+
+You can build support for more than one of the graphical front ends by setting
+all the desired SUPPORT_*_FRONTEND options when running CMake (the exception to
+this are the SDL and SDL2 which can not be built at the same time).  If you
+want the executable to have support for sound, pass ``-DSUPPORT_SDL_SOUND=ON``
+or ``-DSUPPORT_SDL2_SOUND=ON`` to CMake (as with the SDL and SDL2 front ends,
+you can't build support for both SDL and SDL2 sound; it is also not possible to
+build the SDL front end with SDL2 sound or the SDL2 front end with SDL sound).
+
+There are options to not build a self-contained installation and, instead,
+organize the files for a typical Linux or Unix layout.  One such option
+installs the executable as setgid so the high score and save files can be
+stored in a centralized location for multiple users.  To enable that option,
+pass ``-DSHARED_INSTALL=ON`` to CMake.  To specify the group used for the setgid
+executable, pass ``-DINSTALL_GROUP_ID=xxx`` to CMake where you replace xxx with
+the name or number of the group to use.  If you do not set the group, the games
+group will be used.  Another option creates a read-only installation with any
+variable state, including the high score and save files, stored on a per-user
+basis in the user's own directories.  To enable that option, pass
+``-DREADONLY_INSTALL=ON`` to CMake.  With either SHARED_INSTALL or
+READONLY_INSTALL, you will need to run ``cmake --build build -t install`` after
+the other steps for compiling with CMake.  As an example, this would build a
+shared installation with an executable that is setgid for the games group::
+
+    cmake -DSHARED_INSTALL=ON -DSUPPORT_GCU_FRONTEND=ON -B build
+    cmake --build build
+    sudo cmake --build build -t install
+
+Turning on both SHARED_INSTALL and READONLY_INSTALL is not supported and will
+cause CMake to exit with an error.  Turning either SHARED_INSTALL or
+READONLY_INSTALL when SUPPORT_WINDOWS_FRONTEND is on is also not supported
+and will cause CMake to exit with an error.  To customize where the shared
+and read-only installations place files, pass -DCMAKE_INSTALL_PREFIX=prefix
+to install all the files within the given prefix (i.e. using
+``-DCMAKE_INSTALL_PREFIX=/opt/Angband-4.2`` would place all the files within
+/opt/Angband-4.2 or its subdirectories).  For finer-grained placement of the
+files within the given prefix, you could also set CMAKE_INSTALL_BINDIR
+(for the subdirectory of prefix where the executable will be placed; by
+default that is bin), CMAKE_INSTALL_DATAROOTDIR (for the subdirectory of
+prefix to hold read-only data not configured for the site; by default that is
+share), CMAKE_INSTALL_SYSCONFDIR (for the subdrectory of prefix to hold data
+configured for the site; by default that is etc), and
+CMAKE_INSTALL_SHAREDSTATEDIR (for the subdirectory of prefix to hold writable
+persistent state; by default that is com).  Because paths to the data are
+hardwired in the executable, setting the destination directory when performing
+the build (i.e. by setting DESTDIR) is not supported and will not work in
+general:  set the destination when configuring the build by setting the
+variables mentioned above.
+
+Debug build
+~~~~~~~~~~~
+
+To build the game for easier source-level debugging and with the address and
+undefined behavior sanitizers included, use this when configuring the build
+with CMake (of course, you can specify front ends and other options by putting
+them before ``-B build``)::
+
+    cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF \
+        -DCMAKE_C_FLAGS="-fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer" \
+        -B build
+
+Test cases
+~~~~~~~~~~
+
+To compile and run the unit tests and run the run-tests script while using
+CMake, do the following::
+
+    cmake -DSUPPORT_TEST_FRONTEND=ON -B build
+    cmake --build build -t alltests
+
+If you only want the unit tests while using CMake, it is a little simpler::
+
+    cmake -B build
+    cmake --build build -t allunittests
+
+To compile, as necessary, and run a single unit test, use the target,
+run-unittest-*something* where *something*, is the name of the test in src/tests
+with the leading ``src/tests`` and trailing ``.c`` dropped and any forward
+slashes converted to hyphens.  So, if you have configured the build and only
+want to run the tests in src/tests/object/pile.c, you can do that with::
+
+    cmake --build build -t run-unittest-object-pile
+
+There is some support for measuring how well the test cases cover the code.
+If you have perl and either gcc and gcov or clang and llvm-cov, then you
+can configure code coverage support by including ``-DSUPPORT_COVERAGE=ON``
+in the options to CMake when configuring the build.  That adds three targets for
+manipulating coverage results.  The ``reportcoverage`` target generates per-file
+coverage reports (.gcov files in the directory where you are building) using
+the current accumulated coverage data and then writes a summary of those
+reports to standard output.  The gen-coverage Perl script in the src directory
+is used to generate the summary.  The ``resetcoverage`` target removes the
+accumulated coverage data (.gcda files) and any per-file coverage reports.
+The ``coverage`` target is equivalent to building the ``resetcoverage``,
+``alltests``, and ``reportcoverage`` targets in that order.  So if you wanted
+to determine how well the unit tests cover the code, this would configure the
+build and generate the necessary coverage reports::
+
+    cmake -DSUPPORT_COVERAGE=ON -B build
+    cmake --build build -t coverage
+
+Statistics build
+~~~~~~~~~~~~~~~~
+
+To get the statistic front end and support for the debugging commands related
+to statistics, include ``-DSUPPORT_STATS_FRONTEND=ON`` in the options to CMake
+when configuring the build.  That requires the sqlite3 headers and libraries.
+On Debian and Ubuntu, the libsqlite3-dev package and its dependencies provides
+that.  If you only want the debugging commands related to statistics, include
+``-DSUPPORT_STATS_BACKEND=ON`` in the options to CMake when configuring the
+build and either do nothing for ``SUPPORT_STATS_FRONTEND`` or explicitly turn
+it off by also including ``-DSUPPORT_STATS_FRONTEND=OFF`` in the options.
+
+Linux / other UNIX with autotools
+---------------------------------
+
+Some sets of source code (e.g. downloads from Rephial.org) will contain a
+"configure" script in the root directory of the unpacked files, while other
+filesets (e.g. the "Source code (tar.gz)" links on the Releases pages or a
+cloned git repository) will not contain the "configure" script.
+
+If the code you download does not contain the "configure" script, then you
+will first need to run the following command to create that script::
+
+    ./autogen.sh
+
+autogen.sh requires autoconf, autoheader, and aclocal to be installed.  On
+Debian and Ubuntu, those are in the autoconf and automake packages.
+
+To see a list of the useful options and variables that influence what
+configure does, run::
+
+    ./configure --help
+
+To build Angband to be run in-place, run this::
+
+    ./configure --with-no-install [other options as needed]
+    make
+
+That'll create an executable in the src directory.  You can run it from the
+same directory where you ran make with::
+
+    src/angband
+
+To see what command line options are accepted, use::
+
+    src/angband -?
+
+Note that some of Angband's makefiles (src/Makefile and src/tests/Makefile are
+the primary offenders) may assume features present in GNU make.  If the default
+make on your system is not GNU make, you'll likely have to replace instances
+of make in the quoted commands with whatever will run GNU make.  On OpenBSD,
+for instance, that is gmake (which can be installed by running
+``pkg_add gmake``).
+
+On systems where there's several C compilers, ./configure may choose the
+wrong one.  One example of that is on OpenBSD 6.9 when building Angband with
+SDL2:  ./configure chooses gcc but the installed version of gcc can't handle
+the SDL2 header files that are installed via pkg_add.  To override ./configure's
+default selection of the compiler, use::
+
+    ./configure [the appropriate configure options] CC=the_good_compiler
+
+Replace the_good_compiler in that command with the command for running the
+compiler that you want.  For OpenBSD 6.9 when compiling with SDL2, you'd
+replace the_good_compiler with cc or clang.
+
+To build Angband to be installed in some other location, run this::
+
+    ./configure --prefix /path/to [other options as needed]
+    make
+    make install
+
+On some BSDs, you may need to copy install-sh into lib/ and various
+subdirectories of lib/ in order to install correctly.
+
+Debug build
+~~~~~~~~~~~
+
+**WARNING** this build is intended primarily for debugging purposes. It might have a somewhat slower performance, higher memory requirements and panic saves don't always work (in case of a crash there is a higher chance of losing progress).
+
+When debugging crashes it can be very useful to get more information about *what exactly* went wrong. There are many tools that can detect common issues and provide useful information. Two such tools that are best used together are AddressSanitizer (ASan) and UndefinedBehaviorSanitizer (UBSan). To use them you'll need to enable them when compiling angband::
+
+    ./configure [options]
+    SANITIZE_FLAGS="-fsanitize=undefined -fsanitize=address" make
+
+Note that compiling with these tools will require installing additional dependencies: libubsan libasan (names of the packages might be different in your distribution).
+
+Test cases
+~~~~~~~~~~
+
+To compile and run the unit tests if you used ./configure --with-no-install,
+do this::
+
+    make tests
+
+If you want to rerun just one part, say monster/attack, of the unit tests,
+that's most easily done by directly running from the top-level directory::
+
+    src/tests/monster/attack.exe
+
+Older versions put the test executables in src/tests/bin.  With those
+versions, the line above would be::
+
+    src/tests/bin/monster/attack
+
+There's a separate set of tests that use scripts to control a character in
+the full game.  To run those tests, you'll need to enable the test module
+when running configure and then run the run-tests script in the top-level
+directory::
+
+    ./configure --with-no-install --enable-test
+    make
+    ./run-tests
+
+There is some support for measuring how well the test cases cover the code.
+If you have gcc, gcov, and perl, you can run this in src directory after
+running configure::
+
+    make coverage
+
+That cleans the directories (removing object files, intermediates generated
+for code coverage, and coverage reports), rebuilds the game with code coverage
+profiling enabled, runs the unit tests, generates coverage reports for
+individual source files (.gcov files in the src directory), and then writes a
+summary of those reports to standard output.  The gen-coverage Perl script in
+the src directory is used to generate the summary.
+
+Statistics build
+~~~~~~~~~~~~~~~~
+
+To get the statistics front end and support for the debugging commands related
+to statistics (see the descriptions for ``S``, ``D``, and ``P`` in
+:ref:`DebugDungeon`), include ``--enable-stats`` in the options to configure.
+For that to work, you'll need to have sqlite3's headers and libraries
+installed (on Debian and Ubuntu, the libsqlite3-dev package and its
+dependencies provides those).
+
+Windows native build
+--------------------
+
+Using MSYS2 (with MinGW64) and CMake
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Install the dependencies by::
+
+    pacman -S make mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja
+
+Additional dependency for the native Windows client is::
+
+    pacman -S mingw-w64-x86_64-libpng
+
+The additional dependency for ncurses is::
+
+    pacman -S mingw-w64-x86_64-ncurses
+
+Additional dependencies for the SDL2 client are::
+
+    pacman -S mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_image \
+        mingw-w64-x86_64-SDL2_ttf mingw-w64-x86_64-SDL2_mixer
+
+Then run the following to compile for native Windows::
+
+    cmake -G Ninja -DSUPPORT_WINDOWS_FRONTEND=ON \
+        -DSUPPORT_STATIC_LINKING=ON \
+        -B build
+    cmake --build build
+
+For ncurses, do::
+
+    cmake -G Ninja -DSUPPORT_GCU_FRONTEND=ON \
+        -DSUPPORT_STATIC_LINKING=ON \
+        -B build
+    cmake --build build
+
+For SDL2, do::
+
+    cmake -G Ninja -DSUPPORT_SDL2_FRONTEND=ON \
+        -DSUPPORT_SDL2_SOUND=ON \
+        -DSUPPORT_STATIC_LINKING=ON \
+        -B build
+    cmake --build build
+
+Once built, go to build/game/ subdirectory and start angband by::
+
+    cd build/game
+    ./angband.exe
+
+Using MinGW
+~~~~~~~~~~~
+
+This build uses autotools, so it is very similar to builds on Linux or Unix with
+autotools.  Open the MinGW shell (MSYS) by running msys.bat.
+
+If your source files are from rephial.org, from a "Source code" link on the
+github releases page, or from cloning the git repository, you'll first need to
+run this to create the configure script::
+
+        ./autogen.sh
+
+That is not necessary for source files that are from the github releases page
+but not from a "Source code" link on that page.
+
+Then run these commands::
+
+        ./configure --enable-win
+        make install
+
+The last step only works with relative recent versions.  For older ones, use
+"make" rather than "make install" and copy src/angband.exe,
+src/win/dll/libpng12.dll, and src/win/dll/zlib1.dll to the top-level directory.
+
+Using Cygwin with MinGW and CMake
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use this option if you want to build a native Windows executable that
+can run with or without Cygwin.
+
+Use the Cygwin setup.exe to install cmake, ninja, and mingw64-i686-gcc-core.
+Build with::
+
+    cmake -G Ninja \
+        -DCMAKE_C_COMPILER=/usr/bin/i686-w64-mingw32-gcc \
+        -DCMAKE_RC_COMPILER=/usr/bin/i686-w64-mingw32-windres \
+        -DSUPPORT_WINDOWS_FRONTEND=ON \
+        -DSUPPORT_BUNDLED_PNG=ON \
+        -B build
+    cmake --build build
+
+Run with::
+
+    cd build/game
+    ./angband.exe
+
+If you want to build the Unix version of Angband that uses X11 or
+Curses and run it under Cygwin, then follow the Linux/Unix instructions.
+
+Using Cygwin with MinGW and autotools
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use this option if you want to build a native Windows executable that
+can run with or without Cygwin.
+
+Use the Cygwin setup.exe to install autoconf, automake, make, and
+mingw64-i686-gcc-core.  Build with::
+
+    ./autogen.sh
+    ./configure --enable-win --host=i686-w64-mingw32
+    make install
+
+And run::
+
+    ./angband.exe
+
+If you want to build the Unix version of Angband that uses X11 or
+Curses and run it under Cygwin, then follow the Linux/Unix instructions.
+
+Using eclipse (Indigo) on Windows (with MinGW)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* For eclipse with EGit, select File | Import..., Git | Projects from Git, Next >
+* Clone your/the upstream repo, or Add your existing cloned repo, Next >
+* Select "Use the New Projects Wizard", Finish
+* In the New Project Wizard, select C/C++ | Makefile Project with Existing Code, Next >
+* Give the project a name (Angband),
+  * navigate to the repo you cloned in "Existing Code Location",
+  * Select "C", but not "C++"
+  * Choose "MinGW GCC" Toolchain, Finish
+* Once the project is set up, r-click | Properties
+* Go to C/C++ Build | Toolchain Editor, select "Gnu Make Builder" instead of "CDT Internal Builder"
+* go to C/C++ Build, uncheck "Generate Makefiles automatically"
+
+You still need to run ./autogen.sh, if your source files are from a
+"Source code" link on the github releases page or from cloning the
+git repository, and ./configure manually, outside eclipse (see above)
+
+Using Visual Studio
+~~~~~~~~~~~~~~~~~~~
+
+Blue Baron has detailed instructions for setting this up at:
+
+    src/win/angband_visual_studio_step_by_step.txt
+
+Debug build
+~~~~~~~~~~~
+
+To compile with the address and undefined behavior sanitizer on Windows,
+similar to what's done for the debugging build on Linux, you need MSYS2 CLANG64
+since other shells and compilers do not properly support those sanitizers
+at the time this was written.
+
+Run::
+
+    C:/msys64/clang64.exe
+
+Install dependencies and build with::
+
+    pacman -S \
+        mingw-w64-clang-x86_64-clang \
+        mingw-w64-clang-x86_64-compiler-rt \
+        mingw-w64-clang-x86_64-cmake \
+        mingw-w64-clang-x86_64-ninja \
+        mingw-w64-clang-x86_64-libpng \
+        winpty
+    cmake -G Ninja \
+        -DCMAKE_C_FLAGS="-fsanitize=address -fsanitize=undefined" \
+        -B build
+    cmake --build build
+
+Run the tests or the game from winpty because Windows won't printf to an MSYS2
+terminal::
+
+    winpty cmake --build build -t alltests
+    cd build/game
+    winpty ./angband.exe
+
+We also still need the path from the MSYS2 shell so that it can find the
+required DLLs (libclang_rt.asan_dynamic-x86_64.dll and libc++.dll), although
+we can also copy those.
+
+Statistics build
+~~~~~~~~~~~~~~~~
+
+The Windows front end bypasses main.c and can not use the statistics front end.
+It is possible to enable the debugging commands related to statistics (see
+the descriptions for ``S``, ``D``, and ``P`` in :ref:`DebugDungeon`).  With
+CMake, you can do that by including ``-DSUPPORT_STATS_BACKEND=ON`` in the
+options when configuring the build.  With other build tools, set the compiler
+flags so tha the USE_STATS preprocessor macro is set.  With configure, that can
+be done by including ``CFLAGS=-DUSE_STATS`` in the options to configure.
+
+Cross-building for Windows with MinGW and CMake
+-----------------------------------------------
+
+Many developers (as well as the auto-builder) build Angband for Windows using
+MinGW on Linux. This requires that the necessary MinGW packages are all
+installed.  CMake's documentation for cross-compiling is available
+`here <https://cmake.org/cmake/help/book/mastering-cmake/chapter/Cross%20Compiling%20With%20CMake.html>`__.
+``toolchains/linux-i686-mingw32-cross.cmake`` is an example of a toolchain file
+set up to build for Windows using MinGW as it is installed on recent versions
+of Debian and Ubuntu (tool names prefixed with ``i686-w64-mingw32-`` and
+relevant files placed within ``/usr/i686-w64-mingw32``).  If your installation
+is not compatible with that, create a copy of that toolchain file, edit the
+names or paths in it to match what your installation expects, and use that
+copy instead of ``toolchains/linux-i686-mingw32-cross.cmake`` in the example
+below.
+
+To perform the build::
+
+    cmake \
+        -DCMAKE_TOOLCHAIN_FILE=toolchains/linux-i686-mingw32-cross.cmake \
+        -DSUPPORT_BUNDLED_PNG=ON \
+        -B build
+    cmake --build build
+
+That will leave an angband.exe and the needed .dll files in the sub directory
+build/game/.  That executable can be run with wine::
+
+    cd build/game
+    wine angband.exe
+
+To include support for the debugging statistics commands, include
+``-DSUPPORT_STATS_BACKEND=ON`` in the options to CMake when configuring the
+build.
+
+If wine is installed and mentioned as the ``CMAKE_CROSSCOMPILING_EMULATOR`` in
+the toolchain file, the unit test cases can be run from CMake with
+``cmake --build build -t allunitests`` or for a particular unit test, something
+like ``cmake --build build -t run-unittest-player-birth``.
+
+Cross-building for Windows with MinGW and autotools
+---------------------------------------------------
+
+This type of build is very similar to a native build on Linux or Unix using
+autotools.  The key difference is setting up to cross-compile and the use
+of ``--enable-win`` when running configure.
+
+If your source files are from rephial.org, from a "Source code" link on the
+github releases page, or from cloning the git repository, you'll first need to
+run this to create the configure script::
+
+    ./autogen.sh
+
+That is not necessary for source files that are from the github releases page
+but not from a "Source code" link on that page.
+
+Then configure the cross-compilation and perform the compilation itself::
+
+    ./configure --enable-win --build=i686-pc-linux-gnu --host=i686-w64-mingw32
+    make install
+
+You may need to change the --build and --host options there to match your
+system.  MinGW installs commands like ``i686-w64-mingw32-gcc``. The value of
+--host should be that same command with the ``-gcc`` removed. Instead of i686
+you may see i686, amd64, etc. The value of --build should be the host you are
+building on (see http://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.68/html_node/Specifying-Target-Triplets.html#Specifying%20Names
+for gory details of how these triplets are arrived at).  The ``make install``
+step only works with relatively recent versions.  For older ones, use this
+instead of the last step::
+
+    make
+    cp src/angband.exe .
+    cp src/win/dll/*.dll .
+
+To run the result, you can use wine like this::
+
+    wine angband.exe
+
+Since the Windows front end bypasses main.c, it is not possible to use the
+statistics front end.  To compile in support for the debugging statistics
+commands, set configure to include ``-DUSE_STATS`` in CFLAGS::
+
+    ./configure --enable-win --build=i686-pc-linux-gnu --host=i686-w64-mingw32 \
+        CFLAGS=-DUSE_STATS
+    make install
+
+The test cases can be built, with ``make tests``, but when that target tries
+to run the test cases, that will fail as src/tests/run-tests is not set up to
+run the individual test cases in an emulator like wine.  You can run those
+test cases manually.  For instance, this::
+
+    wine src/tests/game/mage.exe
+
+would run the tests from src/tests/game/mage.c or this::
+
+    for t in src/tests/*/*.exe ; do
+        wine $t
+    done
+
+would run all of the unit tests.
+
+TODO: except for recent versions (after Angband 4.2.3) you likely need to
+manually disable curses (add --disable-curses to the options passed to
+configure), or the host curses installation will be found causing the build
+process to fail when linking angband.exe (the error message will likely be
+"cannot find -lncursesw" and "cannot find -ltinfo").  Most of the --with or
+--enable options for configure are not appropriate when using --enable-win.
+The ones that are okay are --with-private-dirs (on by default),
+--with-gamedata-in-lib (has no effect), and --enable-release.
+
 macOS
 -----
 
@@ -96,7 +674,7 @@ Statistics build
 The Mac front end bypasses main.c and can not use the statistics front end.
 It is possible to enable the debugging commands related to statistics (see
 the descriptions for ``S``, ``D``, and ``P`` in :ref:`DebugDungeon`).  To do so,
-include "-DUSE_STATS" in the setting for OPT passed to make.  The equivalent
+include ``-DUSE_STATS`` in the setting for OPT passed to make.  The equivalent
 of the standard build with those debugging commands enabled would be::
 
     cd src
@@ -105,544 +683,6 @@ of the standard build with those debugging commands enabled would be::
 If you had already built everything without statistics enabled, you would need
 to run either "rm wiz-stats.o" or "make -f Makefile.osx clean" immediately
 after running "cd src".
-
-Linux / other UNIX
-------------------
-
-Native builds
-~~~~~~~~~~~~~
-
-Linux builds using autotools. There are several different front ends that you
-can optionally build (GCU, SDL, SDL2, and X11) using arguments to configure
-such as --enable-sdl, --disable-x11, etc. Each front end has different
-dependencies (e.g. ncurses, SDL libraries, etc).
-
-Some sets of source code (e.g. downloads from Rephial.org) will contain a
-"configure" script in the root directory of the unpacked files, while other
-filesets (e.g. the "Source code (tar.gz)" links on the Releases pages)
-will not contain the "configure" script.
-
-If the code you download doesn't contain the "configure" script, then you'll
-first need to run the following command to create that script::
-
-    ./autogen.sh
-
-To build Angband to be run in-place, then run this::
-
-    ./configure --with-no-install [other options as needed]
-    make
-
-That'll create an executable in the src directory.  You can run it from the
-same directory where you ran make with::
-
-    src/angband
-
-To see what command line options are accepted, use::
-
-    src/angband -?
-
-Note that some of Angband's makefiles (src/Makefile and src/tests/Makefile are
-the primary offenders) assume features present in GNU make.  If the default
-make on your system is not GNU make, you'll likely have to replace instances
-of make in the quoted commands with whatever will run GNU make.  On OpenBSD,
-for instance, that is gmake (which can be installed by running "pkg_add gmake").
-
-On systems where there's several C compilers, ./configure may choose the
-wrong one.  One example of that is on OpenBSD 6.9 when building Angband with
-SDL2:  ./configure chooses gcc but the installed version of gcc can't handle
-the SDL2 header files that are installed via pkg_add.  To override ./configure's
-default selection of the compiler, use::
-
-    env CC=the_good_compiler ./configure [the appropriate configure options]
-
-Replace the_good_compiler in that command with the command for running the
-compiler that you want.  For OpenBSD 6.9 when compiling with SDL2, you'd
-replace the_good_compiler with cc or clang.
-
-To build Angband to be installed in some other location, run this::
-
-    ./configure --prefix /path/to [other options as needed]
-    make
-    make install
-
-On some BSDs, you may need to copy install-sh into lib/ and various
-subdirectories of lib/ in order to install correctly.
-
-Compilation with CMake
-~~~~~~~~~~~~~~~~~~~~~~
-
-The compilation process with CMake requires a version greater than 3,
-by default the compilation process uses the X11 front end unless
-one or more of the other graphical front ends are selected. The graphical front
-ends are: GCU, SDL, SDL2 and X11.  All of the following generate a
-self-contained directory, build/game, that you can move elsewhere or rename.  To
-run the result, change directories to build/game or whatever you renamed it to) and
-run ./angband .
-
-To build Angband with the X11 front end::
-
-    mkdir build && cd build
-    cmake ..
-    make
-
-If you want to build the X11 front end while building one of the other
-graphical front ends, the option to pass to cmake is -DSUPPORT_X11_FRONTEND=ON .
-
-To build Angband with the SDL front end::
-
-    mkdir build && cd build
-    cmake -DSUPPORT_SDL_FRONTEND=ON ..
-    make
-
-To build Angband with the SDL2 front end::
-
-    mkdir build && cd build
-    cmake -DSUPPORT_SDL2_FRONTEND=ON ..
-    make
-
-To build Angband with the GCU front end::
-
-    mkdir build && cd build
-    cmake -DSUPPORT_GCU_FRONTEND=ON ..
-    make
-
-You can build support for more than one of the graphical front ends by setting
-all the desired SUPPORT_*_FRONTEND options when running cmake (the exception to
-this are the SDL and SDL2 which can not be built at the same time).  If you
-want the executable to have support for sound, pass -DSUPPORT_SDL_SOUND=ON or
--DSUPPORT_SDL2_SOUND=ON to cmake (as with the SDL and SDL2 front ends, you
-can't build support for both SDL and SDL2 sound; it is also not possible to
-build the SDL front end with SDL2 sound or the SDL2 front end with SDL sound).
-
-There are options to not build a self-contained installation and, instead,
-organize the files for a typical Linux or Unix layout.  One such option
-installs the executable as setgid so the high score and save files can be
-stored in a centralized location for multiple users.  To enable that option,
-pass -DSHARED_INSTALL=ON to cmake.  To specify the group used for the setgid
-executable, pass -DINSTALL_GROUP_ID=xxx to cmake where you replace xxx with
-the name or number of the group to use.  If you do not set the group, the games
-group will be used.  Another option creates a read-only installation with any
-variable state, including the high score and save files, stored on a per-user
-basis in the user's own directories.  To enable that option, pass
--DREADONLY_INSTALL=ON to cmake.  With either SHARED_INSTALL or READONLY_INSTALL,
-you will need to run 'make install' after the other steps for compiling with
-CMake.  As an example, this would build a shared installation with an
-executable that is setgid for the games group::
-
-    mkdir build && cd build
-    cmake -DSHARED_INSTALL=ON -DSUPPORT_GCU_FRONTEND=ON ..
-    make
-    sudo make install
-
-Turning on both SHARED_INSTALL and READONLY_INSTALL is not supported and will
-cause cmake to exit with an error.  Turning either SHARED_INSTALL or
-READONLY_INSTALL when SUPPORT_WINDOWS_FRONTEND is on is also not supported
-and will cause cmake to exit with an error.  To customize where the shared
-and read-only installations place files, pass -DCMAKE_INSTALL_PREFIX=prefix
-to install all the files within the given prefix (i.e. using
--DCMAKE_INSTALL_PREFIX=/opt/Angband-4.2.3 would place all the files within
-/opt/Angband-4.2.3 or its subdirectories).  For finer-grained placement
-of the files within the given prefix, you could also set CMAKE_INSTALL_BINDIR
-(for the subdirectory of prefix where the executable will be placed; by
-default that is bin), CMAKE_INSTALL_DATAROOTDIR (for the subdirectory of
-prefix to hold read-only data not configured for the site; by default that is
-share), CMAKE_INSTALL_SYSCONFDIR (for the subdrectory of prefix to hold data
-configured for the site; by default that is etc), and
-CMAKE_INSTALL_SHAREDSTATEDIR (for the subdirectory of prefix to hold writable
-persistent state; by default that is com).  Because paths to the data are
-hardwired in the executable, setting the destination directory when running
-make (i.e. by setting DESTDIR) is not supported and will not work in general:
-set the destination when running cmake by setting the variables mentioned above.
-
-Speeding up CMake with Ninja and multiple cores
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-For faster builds, you can switch from the default Makefile generator to Ninja,
-which is optimized for parallel compilation.  Instead of::
-
-    mkdir build && cd build
-    cmake ..
-    make
-
-you can do::
-
-    mkdir build && cd build
-    cmake -G Ninja ..
-    ninja -j16
-
-The option `-j16` tells Ninja to use 16 cores. It’s best to set this to the
-number of CPU cores available on your machine.  On Linux, you can do that
-automatically with `ninja -j$(nproc)`.  On macOS, use
-`ninja -j$(sysctl -n hw.ncpu)`.  In PowerShell, use
-`ninja -j${env:NUMBER_OF_PROCESSORS}`.
-
-This can also be done with Make (`make -j$(nproc)`), but Ninja is often faster.
-
-Instead of `ninja -j$(nproc)`, you can also use::
-
-    cmake --build . -- -j$(nproc)
-
-which works regardless of the generator used (Ninja, Makefiles, etc.).
-
-Cross-building for Windows with Mingw
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Many developers (as well as the auto-builder) build Angband for Windows using
-Mingw on Linux. This requires that the necessary Mingw packages are all
-installed.
-
-A build using Mingw cross-compiler is possible with CMake.
-
-To perform the build::
-
-    mkdir build && cd build
-    cmake -G Ninja \
-        -DCMAKE_TOOLCHAIN_FILE=../toolchains/linux-i686-mingw32-cross.cmake \
-        -DSUPPORT_BUNDLED_PNG=ON \
-        ..
-    ninja
-
-That will leave an angband.exe and the needed .dll files in the sub directory
-game/.  That executable can be run with wine::
-
-    cd game
-    wine angband.exe
-
-The unit test cases can also be run from cmake.
-
-This type of build can also use autotools to make the overall procedure very
-similar to that for a native build.  The key difference is setting up to
-cross-compile when running configure.
-
-If your source files are from rephial.org, from a "Source code" link on the
-github releases page, or from cloning the git repository, you'll first need to
-run this to create the configure script::
-
-    ./autogen.sh
-
-That is not necessary for source files that are from the github releases page
-but not from a "Source code" link on that page.
-
-Then configure the cross-compilation and perform the compilation itself::
-
-    ./configure --enable-win --build=i686-pc-linux-gnu --host=i686-w64-mingw32
-    make install
-
-You may need to change the --build and --host options there to match your
-system. Mingw installs commands like 'i686-w64-mingw32-gcc'. The value of --host
-should be that same command with the '-gcc' removed. Instead of i686 you may
-see i686, amd64, etc. The value of --build should be the host you're building
-on (see http://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.68/html_node/Specifying-Target-Triplets.html#Specifying%20Names for
-gory details of how these triplets are arrived at).  The 'make install' step
-only works with very recent version.  For older ones, use this instead of the
-last step::
-
-    make
-    cp src/angband.exe .
-    cp src/win/dll/*.dll .
-
-To run the result, you can use wine like this::
-
-    wine angband.exe
-
-TODO: except for recent versions (after Angband 4.2.3) you likely need to
-manually disable curses (add --disable-curses to the options passed to
-configure), or the host curses installation will be found causing the build
-process to fail when linking angband.exe (the error message will likely be
-"cannot find -lncursesw" and "cannot find -ltinfo").  Most of the --with or
---enable options for configure are not appropriate when using --enable-win.
-The ones that are okay are --with-private-dirs (on by default),
---with-gamedata-in-lib (has no effect), and --enable-release.
-
-Debug build
-~~~~~~~~~~~
-
-**WARNING** this build is intended primarily for debugging purposes. It might have a somewhat slower performance, higher memory requirements and panic saves don't always work (in case of a crash there is a higher chance of losing progress).
-
-When debugging crashes it can be very useful to get more information about *what exactly* went wrong. There are many tools that can detect common issues and provide useful information. Two such tools that are best used together are AddressSanitizer (ASan) and UndefinedBehaviorSanitizer (UBSan). To use them you'll need to enable them when compiling angband::
-
-    ./configure [options]
-    SANITIZE_FLAGS="-fsanitize=undefined -fsanitize=address" make
-
-Note that compiling with these tools will require installing additional dependencies: libubsan libasan (names of the packages might be different in your distribution).
-
-Test cases
-~~~~~~~~~~
-
-To compile and run the unit tests and run the run-tests script while using
-CMake, do the following::
-
-    mkdir build && cd build
-    cmake -DSUPPORT_TEST_FRONTEND=ON ..
-    make alltests
-
-If you only want the unit tests while using CMake, it's a little simpler::
-
-    mkdir build && cd build
-    cmake ..
-    make allunittests
-
-To compile and run the unit tests if you used ./configure --with-no-install,
-do this::
-
-    make tests
-
-If you want to rerun just one part, say monster/attack, of the unit tests,
-that's most easily done by directly running from the top-level directory::
-
-    src/tests/monster/attack.exe
-
-Previous versions put the test executables in src/tests/bin.  With those
-versions, the line above would be::
-
-    src/tests/bin/monster/attack
-
-There's a separate set of tests that use scripts to control a character in
-the full game.  To run those tests, you'll need to enable the test module
-when running configure and then run the run-tests script in the top-level
-directory::
-
-    ./configure --with-no-install --enable-test
-    make
-    ./run-tests
-
-There is some support for measuring how well the test cases cover the code.
-If you use configure and have gcc, gcov, and perl, you can run this in src
-directory after running configure::
-
-    make coverage
-
-That cleans the directories (removing object files, intermediates generated
-for code coverage, and coverage reports), rebuilds the game with code coverage
-profiling enabled, runs the unit tests, generates coverage reports for
-individual source files (.gcov files in the src directory), and then writes a
-summary of those reports to standard output.  The gen-coverage Perl script in
-the src directory is what is used to generate the summary.
-
-If you use CMake, have perl, and have either gcc and gcov or clang and
-llvm-cov, then you can configure code coverage support by including
--DSUPPORT_COVERAGE=ON in the options to cmake.  That adds three targets for
-manipulating coverage results.  "make reportcoverage" generates per-file
-coverage reports (.gcov files in the directory where you are building) using
-the current accumulated coverage data and then writes a summary of those
-reports to standard output.  The gen-coverage Perl script in the src directory
-is what is used to generate the summary.  "make resetcoverage" removes the
-accumulated coverage data (.gcda files) and any per-file coverage reports.
-"make coverage" is equivalent to "make resetcoverage; make alltests;
-make reportcverage":  clear accumulated coverage information, run the unit
-tests (and, if -DSUPPORT_TEST_FRONTEND=ON was supplied to cmake, the end-to-end
-tests), and then report the coverage results.
-
-Statistics build
-~~~~~~~~~~~~~~~~
-
-If building directly for Linux/Unix using configure, you can get the statistics
-front end and support for the debugging commands related to statistics (see
-the descriptions for ``S``, ``D``, and ``P`` in :ref:`DebugDungeon`) by
-including --enable-stats in the options to configure.  For that to work, you'll
-need to have sqlite3's headers and libraries installed (on Debian and Ubuntu,
-the libsqlite3-dev package and its dependencies provides those).   If using
-CMake, pass -DSUPPORT_STATS_FRONTEND=ON to cmake to get the statistics front
-end and support for the debugging commands related to statistics; like builds
-with configure that use --enable-stats, that requires sqlite3.  With CMake, you
-also have an the option to only include support for the debugging commands
-related to statistics:  pass -DSUPPORT_STATS_BACKEND=ON to cmake and either do
-nothing for SUPPORT_STATS_FRONTEND or explicitly turn it off by passing
--DSUPPORT_STATS_FRONTEND=OFF to cmake.
-
-When cross-compiling for Windows, the statistics front end is not useful
-(the Windows front end bypasses main.c and can not use the statistics front
-end).  With configure, you could include support for debugging commands
-related to statistics by setting CFLAGS to include -DUSE_STATS::
-
-    ./configure [your cross-compiling options] --enable-win CFLAGS=-DUSE_STATS
-
-Windows
--------
-
-Using MinGW
-~~~~~~~~~~~
-
-This build now also uses autotools, so should be very similar to the Linux
-build. Open the MinGW shell (MSYS) by running msys.bat.
-
-If your source files are from rephial.org, from a "Source code" link on the
-github releases page, or from cloning the git repository, you'll first need to
-run this to create the configure script::
-
-        ./autogen.sh
-
-That is not necessary for source files that are from the github releases page
-but not from a "Source code" link on that page.
-
-Then run these commands::
-
-        ./configure --enable-win
-        make install
-
-The last step only works with very recent versions.  For older ones, use
-"make" rather than "make install" and copy src/angband.exe,
-src/win/dll/libpng12.dll, and src/win/dll/zlib1.dll to the top-level directory.
-
-Using Cygwin (with MinGW)
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Use this option if you want to build a native Windows executable that
-can run with or without Cygwin.
-
-Use the Cygwin setup.exe to install cmake, ninja, and mingw64-i686-gcc-core.
-Build with::
-
-    mkdir build && cd build
-    cmake -G Ninja \
-        -DCMAKE_C_COMPILER=/usr/bin/i686-w64-mingw32-gcc \
-        -DCMAKE_RC_COMPILER=/usr/bin/i686-w64-mingw32-windres \
-        -DSUPPORT_WINDOWS_FRONTEND=ON \
-        -DSUPPORT_BUNDLED_PNG=ON \
-        ..
-    ninja
-
-Run with::
-
-    cd game
-    ./angband.exe
-
-Alternatively you can use autotools, for which we need the autoconf,
-automake, make, and mingw64-i686-gcc-core::
-
-    ./autogen.sh
-    ./configure --enable-win --host=i686-w64-mingw32
-    make install
-
-And run::
-
-    ./angband.exe
-
-If you want to build the Unix version of Angband that uses X11 or
-Curses and run it under Cygwin, then follow the native build
-instructions.
-
-Using MSYS2 (with MinGW64)
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Install the dependencies by::
-
-    pacman -S make mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja
-
-Additional dependency for the native Windows client is::
-
-    pacman -S mingw-w64-x86_64-libpng
-
-The additional dependency for ncurses is::
-
-    pacman -S mingw-w64-x86_64-ncurses
-
-Additional dependencies for the SDL2 client are::
-
-    pacman -S mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_image \
-        mingw-w64-x86_64-SDL2_ttf mingw-w64-x86_64-SDL2_mixer
-
-Then run the following to compile for native Windows::
-
-    cmake -G Ninja -DSUPPORT_WINDOWS_FRONTEND=ON \
-        -DSUPPORT_STATIC_LINKING=ON \
-        ..
-    ninja
-
-For ncurses, do::
-
-    mkdir build && cd build
-    cmake -G Ninja -DSUPPORT_GCU_FRONTEND=ON \
-        -DSUPPORT_STATIC_LINKING=ON \
-        ..
-    ninja
-
-For SDL2, do::
-
-    cmake -G Ninja -DSUPPORT_SDL2_FRONTEND=ON \
-        -DSUPPORT_SDL2_SOUND=ON \
-        -DSUPPORT_STATIC_LINKING=ON \
-        ..
-    ninja
-
-Once built, go to game/ subdirectory and start angband by::
-
-    cd game
-    ./angband
-
-Using eclipse (Indigo) on Windows (with MinGW)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-* For eclipse with EGit, select File | Import..., Git | Projects from Git, Next >
-* Clone your/the upstream repo, or Add your existing cloned repo, Next >
-* Select "Use the New Projects Wizard", Finish
-* In the New Project Wizard, select C/C++ | Makefile Project with Existing Code, Next >
-* Give the project a name (Angband),
-  * navigate to the repo you cloned in "Existing Code Location",
-  * Select "C", but not "C++"
-  * Choose "MinGW GCC" Toolchain, Finish
-* Once the project is set up, r-click | Properties
-* Go to C/C++ Build | Toolchain Editor, select "Gnu Make Builder" instead of "CDT Internal Builder"
-* go to C/C++ Build, uncheck "Generate Makefiles automatically"
-
-You still need to run ./autogen.sh, if your source files are from a
-"Source code" link on the github releases page or from cloning the
-git repository, and ./configure manually, outside eclipse (see above)
-
-Using Visual Studio
-~~~~~~~~~~~~~~~~~~~
-
-Blue Baron has detailed instructions for setting this up at:
-
-    src/win/angband_visual_studio_step_by_step.txt
-
-Debug build
-~~~~~~~~~~~
-
-To compile with the address and undefined behavior sanitizer on Windows,
-similar to what's done for the debugging build on Linux, you need MSYS2 CLANG64
-since other shells and compilers do not properly support those sanitizers
-at the time this was written.
-
-Run::
-
-    C:/msys64/clang64.exe
-
-Install dependencies and build with::
-
-    pacman -S \
-        mingw-w64-clang-x86_64-clang \
-        mingw-w64-clang-x86_64-compiler-rt \
-        mingw-w64-clang-x86_64-cmake \
-        mingw-w64-clang-x86_64-ninja \
-        mingw-w64-clang-x86_64-libpng \
-        winpty
-    mkdir build && cd build
-    cmake -G Ninja \
-        -DCMAKE_C_FLAGS="-fsanitize=address -fsanitize=undefined" \
-        ..
-    ninja
-
-Run the tests or the game from winpty because Windows won't printf to an MSYS2
-terminal::
-
-    winpty ninja alltests
-    cd game
-    winpty ./angband.exe
-
-We also still need the path from the MSYS2 shell so that it can find the
-required DLLs (libclang_rt.asan_dynamic-x86_64.dll and libc++.dll), although
-we can also copy those.
-
-Statistics build
-~~~~~~~~~~~~~~~~
-
-The Windows front end bypasses main.c and can not use the statistics front end.
-It is possible to enable the debugging commands related to statistics (see
-the descriptions for ``S``, ``D``, and ``P`` in :ref:`DebugDungeon`).  To do
-so, set your compiler options so that the USE_STATS preprocessor macro is set.
-When using mingw (either stand-alone or as part of Cygwin) and configure,
-include CFLAGS=-DUSE_STATS in the options to configure to do that.
 
 Nintendo DS / Nintendo 3DS
 --------------------------
@@ -719,6 +759,7 @@ To create the angband.zip distribution, run::
 
 User Documentation
 ------------------
+
 To convert the user manual from restructured text to the desired output
 format, you'll need Sphinx ( https://www.sphinx-doc.org/en/master/ )
 and, unless you change the theme in the documentation configuration, the
@@ -729,37 +770,49 @@ can be installed via pip using::
 
 ).
 
-If you are using configure, you can tell it to build the manual in HTML by
-including ``--with-sphinx`` in the options to configure.  If you want to
-override the default theme, specify the theme's name in the DOC_HTML_THEME
-variable.  For instance, running this at the top level of the distribution::
+With CMake
+~~~~~~~~~~
+
+To build the documentation with CMake, ensure the prerequisites, described
+above, are installed and include ``-DBUILD_DOC=ON`` in the options to CMake
+when configuring the build.  If you want to override the default theme,
+specify the theme's name in the DOC_HTML_THEME variable.  For instance, running
+this at the top level of the distribution::
+
+    cmake -DBUILD_DOC=ON -DDOC_HTML_THEME=alabaster -B build
+    cmake --build build -t OurManual
+
+would configure the build to include the documentation, using Sphinx's builtin
+alabaster theme, and then build the documentation.  The generated user manual
+will be in the subdirectory, ``manual-output/html``, in the build directory.
+So with the example commmands above, the user manual is in
+``build/manual-output/html``.
+
+With autotools
+~~~~~~~~~~~~~~
+
+To build the documentation with autotools, ensure the prerequisites, described
+above, are installed and include ``--with-sphinx`` in the options to configure.
+If you want to override the default theme, specify the theme's name in the
+DOC_HTML_THEME variable.  For instance, running this at the top level of the
+distribution::
 
     ./configure --with-no-install --with-sphinx DOC_HTML_THEME=alabaster
+    make manual
 
-would use one of the themes always included with Sphinx and avoid the need
-to install the sphinx-better-theme.  When running make or ``make manual``
-after configure has been set up to generate the user manual, the result
-will appear in docs/_build/html.
+would configure the build to include the documentation, using Sphinx's builtin
+alabaster theme, and then build the documentation.  The generated user manual
+will be in docs/_build/html.
 
-If you are using CMake, you can tell it to build the manual in HTML by including
-``-DBUILD_DOC=ON``  in the options to CMake.  If you want to override the
-default theme, specify the theme's name in the DOC_HTML_THEME variable.  For
-instance running this at the top level of the distribution::
-
-    mkdir build
-    cd build
-    cmake -DBUILD_DOC=ON -DDOC_HTML_THEME=alabaster ..
-
-would behave much like the earlier example using configure.  After building
-with CMake (i.e. ``cmake --build .`` or ``cmake --build . -t OurManual``), the
-generated user manual will be in manual-output-html in the build directory.
+Without CMake and autotools
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To build the user manual without configure or CMake, make sure sphinx-build
-is in your path and then run::
+is in your path, change directories to the docs subdirectory of the top-level
+directory in the source files, and then run::
 
     make html
 
-in the docs subdirectory of the top-level directory in the source files.
 That will generate a _build/html directory with the result of the conversion;
 _build/html/index.html is the top-level help with links to everything else.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,6 +45,7 @@ Angband is a very complex game, and it may be difficult to grasp everything at f
 
    hacking/modifying
    hacking/compiling
+   hacking/cmake
    hacking/debug
    hacking/how-it-works
    hacking/metadoc


### PR DESCRIPTION
Put the Linux/Unix instructions for native builds first, Windows second (first native builds followed by cross-compiling builds), and then macOS.  For previous sections that covered autotools and CMake, typically split those into two, with a section for CMake first followed by a section for autotools.  Split off some details about CMake into a separate file, cmake.rst.  Resolves https://github.com/angband/angband/issues/6578 .