### PR TITLE
workflows: hw.activecpu better choice than hw.ncpu for macOS parallel builds

### DIFF
--- a/.github/workflows/mac.yaml
+++ b/.github/workflows/mac.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Build
         run: |
           cd src
-          env OPT="-Werror" make -f Makefile.osx -j$(sysctl -n hw.ncpu)
+          env OPT="-Werror" make -f Makefile.osx -j$(sysctl -n hw.activecpu)
 
   cmake-curses:
     runs-on: macos-latest
@@ -54,4 +54,4 @@ jobs:
         run: |
           ./autogen.sh
           ./configure --with-no-install --enable-curses --disable-ncursestest
-          make -j$(sysctl -n hw.ncpu)
+          make -j$(sysctl -n hw.activecpu)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -410,7 +410,7 @@ jobs:
         id: create_mac_archive
         run: |
           cd src
-          env OPT="-O2 -DNDEBUG -Werror" make -f Makefile.osx -j$(sysctl -n hw.ncpu) dist
+          env OPT="-O2 -DNDEBUG -Werror" make -f Makefile.osx -j$(sysctl -n hw.activecpu) dist
           archive_prefix=${{ steps.store_config.outputs.name }}-${{ steps.store_config.outputs.version }}-osx
           echo "archive_file=${archive_prefix}.dmg" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
sysctl(1) man page on macOS 26.3.1 says hw.ncpu is deprecated.  hw.physicalcpu would be another possibility.  More information is available at https://developer.apple.com/documentation/kernel/1387446-sysctlbyname/determining_system_capabilities .