### PR TITLE
Add check_break() to help keep the game responsive during long calculations

### DIFF
--- a/src/game-input.c
+++ b/src/game-input.c
@@ -40,6 +40,7 @@ bool (*get_item_hook)(struct object **choice, const char *pmt, const char *str,
 bool (*get_curse_hook)(int *choice, struct object *obj, char *dice_string);
 int (*get_effect_from_list_hook)(const char* prompt,
 	struct effect *effect, int count, bool allow_random);
+bool (*check_break_hook)(bool user_event, int messaging);
 bool (*confirm_debug_hook)(void);
 void (*get_panel_hook)(int *min_y, int *min_x, int *max_y, int *max_x);
 bool (*panel_contains_hook)(unsigned int y, unsigned int x);
@@ -336,4 +337,31 @@ void view_ability_menu(struct player_ability *ability_list,
 	/* Ask the UI for it */
 	if (view_abilities_hook)
 		view_abilities_hook(ability_list, num_abilities);
+}
+
+/**
+ * Keep the user interface responsive during extended calculations.
+ *
+ * \param user_event will, if true, allow some input events to signal a break
+ * while discarding all other input events.  Which input events signal a break
+ * is at the discretion of the UI layer.  When false, pending input events are
+ * transferred to the UI layer's event queue.
+ * \param messaging will, if one and user_event is true, cause a message to
+ * be displayed about how the player can request a break for the calculations.
+ * If two, clears the message displayed with check_break(true, 1) and
+ * immediately returns false without checking for a break.
+ * \return true if a break was requested (either user_event is true and the
+ * player generated a necessary event or another mechanism, like an asynchronous
+ * signal, window manager, or a front end's interface around the game, requested
+ * a break.
+ *
+ * The default implementation does nothing and returns false.  A UI layer's
+ * implementation, via check_break_hook, should do the minimum possible to keep
+ * the UI responsive to events and asynchronous signals that have deferred
+ * processing without waiting for an event or signal.
+ */
+bool check_break(bool user_event, int messaging)
+{
+	return (check_break_hook)
+		? check_break_hook(user_event, messaging) : false;
 }

--- a/src/game-input.h
+++ b/src/game-input.h
@@ -66,6 +66,7 @@ extern bool (*panel_contains_hook)(unsigned int y, unsigned int x);
 extern bool (*map_is_visible_hook)(void);
 extern void (*view_abilities_hook)(struct player_ability *ability_list,
 								   int num_abilities);
+extern bool (*check_break_hook)(bool user_event, int messaging);
 
 bool get_string(const char *prompt, char *buf, size_t len);
 int get_quantity(const char *prompt, int max);
@@ -92,5 +93,6 @@ bool panel_contains(unsigned int y, unsigned int x);
 bool map_is_visible(void);
 void view_ability_menu(struct player_ability *ability_list,
 						 int num_abilities);
+bool check_break(bool user_event, int messaging);
 
 #endif /* INCLUDED_GAME_INPUT_H */

--- a/src/generate.c
+++ b/src/generate.c
@@ -1117,6 +1117,12 @@ static struct chunk *cave_generate(struct player *p, int height, int width)
 		int y, x;
 		struct dun_data dun_body;
 
+		/*
+		 * Can not break out (need to generate a level), but keep the
+		 * user interface responsive.
+		 */
+		(void)check_break(false, 0);
+
 		error = NULL;
 
 		/* Mark the dungeon as being unready (to avoid artifact loss, etc) */

--- a/src/mon-move.c
+++ b/src/mon-move.c
@@ -24,6 +24,7 @@
 
 #include "angband.h"
 #include "cave.h"
+#include "game-input.h"
 #include "game-world.h"
 #include "init.h"
 #include "monster.h"
@@ -1950,6 +1951,13 @@ void process_monsters(int minimum_energy)
 			/* Process timed effects - skip turn if necessary */
 			if (process_monster_timed(mon))
 				continue;
+
+			/*
+			 * Cannot break (only want to do so when it is the
+			 * player's turn to act), but keep the user interface
+			 * responsive.
+			 */
+			(void)check_break(false, 0);
 
 			/* Set this monster to be the current actor */
 			cave->mon_current = i;

--- a/src/ui-input.c
+++ b/src/ui-input.c
@@ -1741,6 +1741,53 @@ static bool textui_get_point(struct loc *grid)
 }
 
 /**
+ * Keep the textui responsive during extended calculations.
+ *
+ * \param user_event will, if true, allow ESCAPE or a click with the second
+ * mouse button to request a break.  When user_event is true, any pending
+ * events, up to the first ESCAPE or click with the second mouse button will
+ * be discarded.  When user_event is false, input events are simply added to
+ * the input event queue.
+ * \param messaging will, if one and user_event is true, display a message that
+ * ESCAPE or a click with the second mouse button will request a break.  If two,
+ * clears the message displayed with textui_check_break(true, 1) and immediately
+ * returns false, without checking for a break.
+ * \return true if user_event is true and an ESCAPE or click with the second
+ * mouse button was received or if something happened such that Term_inkey()
+ * produces EVT_DISCONNECT events.
+ */
+static bool textui_check_break(bool user_event, int messaging)
+{
+	ui_event ch;
+	bool result;
+
+	if (messaging == 2) {
+		prt("", 0, 0);
+		return false;
+	}
+	if (user_event && messaging == 1) {
+		prt("To break out, press Escape or click the second mouse "
+			"button.", 0, 0);
+		Term_fresh();
+	}
+	result = false;
+	while (!Term_inkey(&ch, false, user_event)) {
+		if (ch.type == EVT_DISCONNECT) {
+			result = true;
+			break;
+		}
+		if (user_event && ((ch.type == EVT_KBRD
+				&& ch.key.code == ESCAPE)
+				|| (ch.type == EVT_MOUSE
+				&& ch.mouse.button == 2))) {
+			result = true;
+			break;
+		}
+	}
+	return result;
+}
+
+/**
  * Initialise the UI hooks to give input asked for by the game
  */
 void textui_input_init(void)
@@ -1761,6 +1808,7 @@ void textui_input_init(void)
 	panel_contains_hook = textui_panel_contains;
 	map_is_visible_hook = textui_map_is_visible;
 	view_abilities_hook = textui_view_ability_menu;
+	check_break_hook = textui_check_break;
 }
 
 

--- a/src/wiz-stats.c
+++ b/src/wiz-stats.c
@@ -28,6 +28,7 @@
 #include "cave.h"
 #include "cmds.h"
 #include "effects.h"
+#include "game-input.h"
 #include "generate.h"
 #include "init.h"
 #include "mon-make.h"
@@ -1496,22 +1497,33 @@ static void revive_uniques(void)
 static void diving_stats(void)
 {
 	int depth;
+	bool running;
 
 	/* Iterate through levels */
-	for (depth = 0; depth < MAX_LVL; depth += 5) {
-		player->depth = depth;
-		if (player->depth == 0) player->depth = 1;
+	event_signal(EVENT_MESSAGE_FLUSH);
+	running = !check_break(true, 1);
+	for (depth = 0; depth < MAX_LVL && running; depth += 5) {
+		player->depth = (depth == 0) ? 1 : depth;
 
 		/* Do many iterations of each level */
-		for (iter = 0; iter < tries; iter++)
-		     stats_collect_level();
+		for (iter = 0; iter < tries; iter++) {
+			if (check_break(true, 0)) {
+				running = false;
+				break;
+			}
+			stats_collect_level();
+		}
 
 		/* Print the output to the file */
-		print_stats(depth);
+		if (running) {
+			print_stats(depth);
+		}
 
 		/* Show the level to check on status */
 		do_cmd_redraw();
 	}
+
+	(void)check_break(true, 2);
 }
 
 /**
@@ -1521,9 +1533,12 @@ static void diving_stats(void)
 static void clearing_stats(void)
 {
 	int depth;
+	bool running;
 
 	/* Do many iterations of the game */
-	for (iter = 0; iter < tries; iter++) {
+	event_signal(EVENT_MESSAGE_FLUSH);
+	running = !check_break(true, 1);
+	for (iter = 0; iter < tries && running; iter++) {
 		/* Move all artifacts to uncreated */
 		uncreate_all_artifacts();
 
@@ -1531,7 +1546,7 @@ static void clearing_stats(void)
 		revive_uniques();
 
 		/* Do randart regen */
-		if ((regen) && (iter<tries)) {
+		if (regen) {
 			/* Get seed */
 			int seed_randart = randint0(0x10000000);
 
@@ -1548,20 +1563,28 @@ static void clearing_stats(void)
 
 		/* Do game iterations */
 		for (depth = 1 ; depth < MAX_LVL; depth++) {
-			/* Debug 
-			msg_format("Attempting level %d",depth); */
+			if (check_break(true, 0)) {
+				running = false;
+				break;
+			}
 
 			/* Move player to that depth */
 			player->depth = depth;
 
 			/* Get stats */
 			stats_collect_level();
-
-			/* Debug
-			msg_format("Finished level %d,depth"); */
 		}
 
-		msg("Iteration %d complete",iter);
+		if (running) {
+			if (iter == 0) {
+				(void)check_break(true, 2);
+			}
+			msg("Iteration %d complete", iter);
+		}
+	}
+
+	if (!running && iter == 0) {
+		(void)check_break(true, 2);
 	}
 
 	/* Restore original artifacts */
@@ -1799,6 +1822,7 @@ void pit_stats(int nsim, int pittype, int depth_min, int depth_max)
 	char path[1024];
 	ang_file *pitfile;
 	int depth, p;
+	bool running;
 
 	/* Initialize hist */
 	hist = mem_alloc(z_info->pit_max * sizeof(*hist));
@@ -1864,7 +1888,9 @@ void pit_stats(int nsim, int pittype, int depth_min, int depth_max)
 		pitfile = NULL;
 	}
 
-	for (depth = depth_min; depth <= depth_max; ++depth) {
+	event_signal(EVENT_MESSAGE_FLUSH);
+	running = !check_break(true, 1);
+	for (depth = depth_min; depth <= depth_max && running; ++depth) {
 		int j;
 
 		for (p = 0; p < z_info->pit_max; ++p) {
@@ -1876,6 +1902,10 @@ void pit_stats(int nsim, int pittype, int depth_min, int depth_max)
 			int pit_idx = 0;
 			int pit_dist = 999;
 
+			if (check_break(true, 0)) {
+				running = false;
+				break;
+			}
 			for (i = 0; i < z_info->pit_max; i++) {
 				int offset, dist;
 				const struct pit_profile *pit = &pit_info[i];
@@ -1896,7 +1926,7 @@ void pit_stats(int nsim, int pittype, int depth_min, int depth_max)
 			hist[pit_idx]++;
 		}
 
-		if (pitfile) {
+		if (pitfile && running) {
 			(void)file_putf(pitfile, "%d", depth);
 			for (p = 0; p < z_info->pit_max; ++p) {
 				const struct pit_profile *pit = &pit_info[p];
@@ -1909,13 +1939,14 @@ void pit_stats(int nsim, int pittype, int depth_min, int depth_max)
 			(void)file_putf(pitfile, "\n");
 		}
 
-		if (sum_hist) {
+		if (sum_hist && running) {
 			for (p = 0; p < z_info->pit_max; ++p) {
 				sum_hist[p] += hist[p];
 			}
 		}
 	}
 
+	(void)check_break(true, 2);
 	for (p = 0; p < z_info->pit_max; ++p) {
 		const struct pit_profile *pit = &pit_info[p];
 
@@ -2899,6 +2930,7 @@ void disconnect_stats(int nsim, bool stop_on_disconnect)
 	ang_file *disfile;
 	struct cgen_stats gs;
 	ang_file *gstfile;
+	bool running;
 
 	path_build(path, sizeof(path), ANGBAND_DIR_USER, "disconnect.html");
 	disfile = file_open(path, MODE_WRITE, FTYPE_TEXT);
@@ -2916,7 +2948,9 @@ void disconnect_stats(int nsim, bool stop_on_disconnect)
 	 */
 	initialize_generation_stats(&gs);
 
-	for (i = 1; i <= nsim; i++) {
+	event_signal(EVENT_MESSAGE_FLUSH);
+	running = !check_break(true, 1);
+	for (i = 1; i <= nsim && running; i++) {
 		/* Assume no disconnected areas */
 		bool has_dsc = false;
 		/* Assume you can't get to the down staircase */
@@ -3048,15 +3082,20 @@ void disconnect_stats(int nsim, bool stop_on_disconnect)
 				dump_level_body(disfile, label, cave,
 					cave_dist);
 			}
-			if (stop_on_disconnect) i = nsim;
+			if (stop_on_disconnect) running = false;
 		}
 
 		/* Free arrays */
 		for (y = 0; y < cave->height; y++)
 			mem_free(cave_dist[y]);
 		mem_free(cave_dist);
+
+		if (check_break(true, 0)) {
+			running = false;
+		}
 	}
 
+	(void)check_break(true, 2);
 	msg("Total levels with bad starts: %ld", bad_starts);
 	msg("Total levels with disconnected areas: %ld",dsc_area);
 	msg("Total levels isolated from stairs: %ld",dsc_from_stairs);


### PR DESCRIPTION
Use that within the debugging commands, 'D', 'P', and 'S' where it will allow player input to break out from the calculations.  Also use it in process_monsters() and cave_generate(), but there player input does not cause a break out from the calculations.  Resolves https://github.com/angband/angband/issues/6606 .