### PR TITLE
First pass at changing the handling of the fatal signals

### DIFF
--- a/src/ui-game.c
+++ b/src/ui-game.c
@@ -515,7 +515,7 @@ size_t cmd_list_lookup_by_name(const char *name)
 void textui_process_command(void)
 {
 	int count = 0;
-	bool done = true;
+	bool done = true, saved;
 	ui_event e = textui_get_command(&count);
 	struct cmd_info *cmd = NULL;
 	unsigned char key = '\0';
@@ -524,22 +524,19 @@ void textui_process_command(void)
 	switch (e.type) {
 		case EVT_DISCONNECT:
 			/*
-			 * If the front end provides a way to confirm with
-			 * the player, try to save before exiting, and if that
-			 * fails, check with the player whether to proceed with
-			 * the exit or to proceed with the game and cancel
-			 * disconnecting the UI.
+			 * Try to save before exiting.  If the front end
+			 * provides a way to confirm with the player, check
+			 * with the player whether to proceed with the exit
+			 * when the save fails or to proceed with the game and
+			 * cancel disconnecting the UI.
 			 */
-			if (disconnect_denier_hook) {
-				bool saved;
-
-				signals_protect(true);
-				saved = save_game_checked();
-				signals_protect(false);
-				if (!saved && (*disconnect_denier_hook)()) {
-					terms_disconnecting = 0;
-					return;
-				}
+			signals_protect(true);
+			saved = save_game_checked();
+			signals_protect(false);
+			if (!saved && disconnect_denier_hook
+					&& (*disconnect_denier_hook)()) {
+				terms_disconnecting = 0;
+				return;
 			}
 			textui_quit();
 			return;

--- a/src/ui-input.c
+++ b/src/ui-input.c
@@ -160,9 +160,6 @@ struct keypress(*inkey_hack)(int flush_first) = NULL;
  * function, so that the various "main-xxx.c" files can assume that input
  * is only requested (via "Term_inkey()") when "angband_term[0]" is active.
  *
- * Mega-Hack -- This function is used as the entry point for clearing the
- * "signal_count" variable, and of the "character_saved" variable.
- *
  * Mega-Hack -- Note the use of "inkey_hack" to allow the "Borg" to steal
  * control of the keyboard from the user.
  */
@@ -275,9 +272,6 @@ ui_event inkey_ex(void)
 
 			/* Mega-Hack -- reset saved flag */
 			character_saved = false;
-
-			/* Mega-Hack -- reset signal counter */
-			signal_count = 0;
 
 			/* Only once */
 			done = true;
@@ -1887,10 +1881,14 @@ ui_event textui_get_command(int *count)
 
 	const struct keypress *act = NULL;
 
-
-
 	/* Get command */
 	while (1) {
+		/*
+		 * Reset the signal count.  Since we are prompting for a
+		 * command, the game has the opportunity to exit normally.
+		 */
+		signal_count = 0;
+
 		/* No flush needed */
 		msg_flag = false;
 

--- a/src/ui-signals.c
+++ b/src/ui-signals.c
@@ -81,6 +81,14 @@ static void handle_signal_suspend(int sig)
 #endif /* ifdef SIGTSTP */
 
 
+static void exit_on_signal(int sig, const char *msg)
+{
+	plog(msg);
+	(void)install_handler(sig, SIG_DFL);
+	raise(sig);
+}
+
+
 /**
  * Handle signals -- simple (interrupt and quit)
  *
@@ -98,12 +106,26 @@ static void handle_signal_suspend(int sig)
 static void handle_signal_simple(int sig)
 {
 	/* Protect errno from library calls in signal handler */
-	int save_errno = errno;
+	int save_errno;
 	/*
 	 * Use own buffer to avoid interactions with the static variables
-	 * used to implement vformat() (and thus quit_fmt() and format()).
+	 * used to implement vformat() (and thus format()).
 	 */
 	char msg[48];
+
+	/* Make an attempt at a normal exit. */
+	terms_disconnecting = 1;
+
+	/*
+	 * Escalate the response if the player is impatient or the game is
+	 * genuinely stuck and has received multiple signals.
+	 */
+	++signal_count;
+	if (signal_count < 4) {
+		return;
+	}
+
+	save_errno = errno;
 
 #ifndef HAVE_SIGACTION
 	/* Disable handler */
@@ -113,11 +135,11 @@ static void handle_signal_simple(int sig)
 	/* Construct the exit message in case it is needed */
 	(void)strnfmt(msg, sizeof(msg), "Exiting on signal %d!", sig);
 
-	/* Nothing to save, just quit */
-	if (!character_generated || character_saved) quit(msg);
-
-	/* Count the signals */
-	signal_count++;
+	/* Nothing to save; exit on the given signal */
+	if (!character_generated || character_saved) {
+		exit_on_signal(sig, msg);
+		return;
+	}
 
 	/*
 	 * Terminate dead characters; quit without saving (non-setgid
@@ -130,9 +152,10 @@ static void handle_signal_simple(int sig)
 
 		close_game(false);
 
-		/* Quit */
-		quit(msg);
-	} else if (signal_count >= 5) {
+		exit_on_signal(sig, msg);
+		return;
+	}
+	if (signal_count >= 5) {
 #ifdef SETGID
 		/* Cause of "death" */
 		my_strcpy(player->died_from, "Interrupting", sizeof(player->died_from));
@@ -147,9 +170,10 @@ static void handle_signal_simple(int sig)
 		close_game(false);
 #endif
 
-		/* Quit */
-		quit(msg);
-	} else if (signal_count >= 4) {
+		exit_on_signal(sig, msg);
+		return;
+	}
+	if (signal_count >= 4) {
 		/*
 		 * Remember where the cursor was so it can be restored after
 		 * the message is displayed.
@@ -177,9 +201,6 @@ static void handle_signal_simple(int sig)
 
 		/* Flush */
 		Term_fresh();
-	} else if (signal_count >= 2) {
-		/* Make a noise */
-		Term_xtra(TERM_XTRA_NOISE, 0);
 	}
 
 #ifndef HAVE_SIGACTION
@@ -199,7 +220,7 @@ static void handle_signal_abort(int sig)
 {
 	/*
 	 * Use own buffer to avoid interactions with the static variables
-	 * used to implement vformat() (and thus quit_fmt() and format()).
+	 * used to implement vformat() (and thus format()).
 	 */
 	char msg[48];
 
@@ -211,8 +232,11 @@ static void handle_signal_abort(int sig)
 	/* Construct the exit message */
 	(void)strnfmt(msg, sizeof(msg), "Exiting on signal %d!", sig);
 
-	/* Nothing to save, just quit */
-	if (!character_generated || character_saved) quit(msg);
+	/* Nothing to save, exit on the signal */
+	if (!character_generated || character_saved) {
+		exit_on_signal(sig, msg);
+		return;
+	}
 
 	/* Clear the bottom line */
 	Term_erase(0, 23, 255);
@@ -243,8 +267,7 @@ static void handle_signal_abort(int sig)
 	/* Flush output */
 	Term_fresh();
 
-	/* Quit */
-	quit(msg);
+	exit_on_signal(sig, msg);
 }
 
 


### PR DESCRIPTION
For handle_signal_simple() (currently the handler for SIGINT and SIQUIT), try for a normal exit before escalating.  Reset the count that tracks whether to escalate the response when prompting for a game command rather than in inkey_ex().  To make the normal exit more useful, always try to save when prompting for a game command returns EVT_DISCONNECT.

When the handler for the fatal signal would call quit(), instead make the game exit on the signal:  that better communicates to the parent process what happened and avoids the use of quit(), which is not async-signal safe.  It does mean that the Curses front end will not try to restore the terminal when the game exits on a fatal signal.

Related to https://github.com/angband/angband/issues/6586 .