### PR TITLE
Fix message truncation

### DIFF
--- a/src/cmd-misc.c
+++ b/src/cmd-misc.c
@@ -89,7 +89,7 @@ void do_cmd_note(void)
 {
 	/* Allocate/Initialize strings to get and format user input. */
 	char tmp[70];
-	char note[90];
+	char note[114];
 	my_strcpy(tmp, "", sizeof(tmp));
 	my_strcpy(note, "", sizeof(note));
 

--- a/src/load.c
+++ b/src/load.c
@@ -1734,7 +1734,7 @@ int rd_history(void)
 		const struct artifact *art = NULL;
 		int aidx = 0;
 		char name[80];
-		char text[80];
+		char text[114];
 
 		for (j = 0; j < hist_size; j++)		
 			rd_byte(&type[j]);

--- a/src/player-history.h
+++ b/src/player-history.h
@@ -50,7 +50,7 @@ struct history_info {
 	int16_t clev;			/* Character level when this item was recorded */
 	uint8_t a_idx;			/* Artifact this item relates to */
 	int32_t turn;			/* Turn this item was recorded on */
-	char event[80];			/* The text of the item */
+	char event[114];		/* The text of the item */
 };
 
 void history_clear(struct player *p);

--- a/src/ui-history.c
+++ b/src/ui-history.c
@@ -40,7 +40,7 @@ void history_display(void)
 	struct history_info *history_list_local = NULL;
 	size_t max_item = history_get_list(player, &history_list_local);
 	int row, wid, hgt, page_size;
-	char buf[120];
+	char buf[121];
 	static size_t first_item = 0;
 	size_t i;
 	bool active = true;


### PR DESCRIPTION
Notes written to the screen log and player history can be truncated when using the /me or /say options.

The existing code doesn't seem to account for the increased size of the note when the player name is added to it.

To repro:  Use a long player name (e.g. "The Magnificent Malvolio") and the /say or /me option when creating a long note (e.g. "/say Quiet, Farmer Maggot, or I'll sell your dogs to the Black Market", or "/me grabs Farmer Maggot by the scruff of the neck and throws him away").  Watch for truncation in the main window, sub-windows showing the screen log, and in the player history.

These changes seem to resolve the truncation (in both the player log and in the screen log) described by the above repro steps.  I'll leave it to more experienced folks to decide whether this is an appropriate approach to the problems.