### PR TITLE
SDL2: rework focus and visual feedback for menus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,6 +416,7 @@ add_executable(OurExecutable
         $<$<BOOL:${SUPPORT_SDL2_FRONTEND}>:src/main-sdl2.c>
         $<$<BOOL:${SUPPORT_SDL2_FRONTEND}>:src/sdl2/pui-ctrl.c>
         $<$<BOOL:${SUPPORT_SDL2_FRONTEND}>:src/sdl2/pui-dlg.c>
+        $<$<BOOL:${SUPPORT_SDL2_FRONTEND}>:src/sdl2/pui-foc.c>
         $<$<BOOL:${SUPPORT_SDL2_FRONTEND}>:src/sdl2/pui-misc.c>
         $<$<BOOL:${SUPPORT_WINDOWS_FRONTEND}>:${OUR_WINDOWS_RC}>
         $<$<BOOL:${SUPPORT_WINDOWS_FRONTEND}>:src/main-win.c>

--- a/src/Makefile.src
+++ b/src/Makefile.src
@@ -122,6 +122,7 @@ SDL2MAINFILES = \
 	main-sdl2.o \
 	sdl2/pui-ctrl.o \
 	sdl2/pui-dlg.o \
+	sdl2/pui-foc.o \
 	sdl2/pui-misc.o
 
 SDLMAINFILES = main-sdl.o

--- a/src/main-sdl2.c
+++ b/src/main-sdl2.c
@@ -22,6 +22,7 @@
 
 #include "sdl2/pui-ctrl.h"
 #include "sdl2/pui-dlg.h"
+#include "sdl2/pui-foc.h"
 #include "sdl2/pui-misc.h"
 #include "sdl2/pui-win.h"
 #include "SDL_image.h"
@@ -55,8 +56,9 @@
 /* that should be plenty... */
 #define MAX_WINDOWS 4
 
+/* Need the timer subsystem for momentary feedback about initiating an action */
 #define INIT_SDL_FLAGS \
-	(SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER)
+	(SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER | SDL_INIT_TIMER)
 #define INIT_IMG_FLAGS \
 	(IMG_INIT_PNG)
 
@@ -352,7 +354,7 @@ struct sdlpui_window {
 	struct window_config *config;
 
 	/** window has changed and must be redrawn */
-	bool dirty;
+	SDL_atomic_t dirty;
 	/**
 	 * when true, window is temporarily not in fullscreen mode because the
 	 * application was stopped
@@ -413,13 +415,6 @@ struct sdlpui_window {
 	 * window.  Both will be NULL if no menus/dialogs are active.
 	 */
 	struct sdlpui_dialog *d_head, *d_tail;
-
-	/**
-	 * These point to the dialog/menu that should receive mouse events or
-	 * keyboard events, respectively.  If NULL, events will be directed
-	 * to the game's core.
-	 */
-	struct sdlpui_dialog *d_mouse, *d_key;
 };
 
 struct font_info {
@@ -599,6 +594,21 @@ const SDL_Color *sdlpui_get_color(struct sdlpui_window *w, int role)
 		idx = COLOUR_SHADE;
 		break;
 
+	case SDLPUI_COLOR_MENU_ACTION_FEEDBACK:
+	case SDLPUI_COLOR_ACTION_FEEDBACK:
+		idx = COLOUR_BLUE;
+		break;
+
+	case SDLPUI_COLOR_MENU_ACTION_UNAVAIL:
+	case SDLPUI_COLOR_ACTION_UNAVAIL:
+		idx = COLOUR_RED;
+		break;
+
+	case SDLPUI_COLOR_MENU_ACTION_DRAG:
+	case SDLPUI_COLOR_ACTION_DRAG:
+		idx = COLOUR_YELLOW;
+		break;
+
 	default:
 		/*
 		 * Should not happen; assign a safe index in case assertions
@@ -615,7 +625,7 @@ const SDL_Color *sdlpui_get_color(struct sdlpui_window *w, int role)
 
 void sdlpui_signal_redraw(struct sdlpui_window *w)
 {
-	w->dirty = true;
+	(void)SDL_AtomicSet(&w->dirty, SDL_TRUE);
 }
 
 void sdlpui_dialog_push_to_top(struct sdlpui_window *w, struct sdlpui_dialog *d)
@@ -653,12 +663,6 @@ void sdlpui_dialog_push_to_top(struct sdlpui_window *w, struct sdlpui_dialog *d)
 
 void sdlpui_dialog_pop(struct sdlpui_window *w, struct sdlpui_dialog *d)
 {
-	if (w->d_mouse && w->d_mouse->id == d->id) {
-		w->d_mouse = NULL;
-	}
-	if (w->d_key && w->d_key->id == d->id) {
-		w->d_key = NULL;
-	}
 	if (d->next) {
 		d->next->prev = d->prev;
 	} else {
@@ -671,45 +675,7 @@ void sdlpui_dialog_pop(struct sdlpui_window *w, struct sdlpui_dialog *d)
 		SDL_assert(w->d_head && w->d_head->id == d->id);
 		w->d_head = d->next;
 	}
-	w->dirty = true;
-}
-
-void sdlpui_dialog_gain_key_focus(struct sdlpui_window *w,
-		struct sdlpui_dialog *d)
-{
-	w->d_key = d;
-}
-
-void sdlpui_dialog_yield_key_focus(struct sdlpui_window *w,
-		struct sdlpui_dialog *d)
-{
-	if (w->d_key && w->d_key->id == d->id) {
-		w->d_key = NULL;
-	}
-}
-
-void sdlpui_dialog_gain_mouse_focus(struct sdlpui_window *w,
-		struct sdlpui_dialog *d)
-{
-	w->d_mouse = d;
-}
-
-void sdlpui_dialog_yield_mouse_focus(struct sdlpui_window *w,
-		struct sdlpui_dialog *d)
-{
-	if (w->d_mouse && w->d_mouse->id == d->id) {
-		w->d_mouse = NULL;
-	}
-}
-
-struct sdlpui_dialog *sdlpui_dialog_with_key_focus(struct sdlpui_window *w)
-{
-	return w->d_key;
-}
-
-struct sdlpui_dialog *sdlpui_dialog_with_mouse_focus(struct sdlpui_window *w)
-{
-	return w->d_mouse;
+	sdlpui_signal_redraw(w);
 }
 
 void sdlpui_force_quit(void)
@@ -890,6 +856,8 @@ static void render_all(struct sdlpui_window *window)
 			SDL_RenderCopy(window->renderer, d->texture, NULL,
 				&d->rect);
 		} else if (d->ftb->render) {
+			/* Turn off the redraw flag in case it was set. */
+			(void)sdlpui_dialog_should_redraw(d);
 			(*d->ftb->render)(d, window);
 		}
 	}
@@ -910,7 +878,7 @@ static void render_status_bar(struct sdlpui_window *window)
 	struct sdlpui_dialog *d;
 
 	for (d = window->d_tail; d; d = d->prev) {
-		if (d->dirty) {
+		if (sdlpui_dialog_should_redraw(d)) {
 			if (d->ftb->render) {
 				(*d->ftb->render)(d, window);
 			}
@@ -977,10 +945,10 @@ static void render_window_while_menu_active(struct sdlpui_window *window)
 	 * over subwindows.
 	 */
 	for (d = window->d_tail; d; d = d->prev) {
-		if (d->ftb->render && (d->dirty || !d->texture)) {
+		if ((sdlpui_dialog_should_redraw(d) || !d->texture)
+				&& d->ftb->render) {
 			(*d->ftb->render)(d, window);
 		}
-		d->dirty = SDL_FALSE;
 		if (d->texture) {
 			SDL_SetRenderTarget(window->renderer, NULL);
 			SDL_RenderCopy(window->renderer, d->texture, NULL,
@@ -1018,11 +986,18 @@ static void redraw_window_while_menu_active(struct sdlpui_window *window)
 /** this function is mostly used while normally playing the game */
 static void redraw_window(struct sdlpui_window *window)
 {
-	if (window->move_state.moving || window->size_state.sizing
-			|| window->d_mouse || window->d_key) {
+	if (window->move_state.moving || window->size_state.sizing) {
 		redraw_window_while_menu_active(window);
 		return;
 	}
+
+	sdlpui_begin_focus_transaction();
+	if (sdlpui_any_dialog_with_focus()) {
+		sdlpui_end_focus_transaction();
+		redraw_window_while_menu_active(window);
+		return;
+	}
+	sdlpui_end_focus_transaction();
 
 	render_all(window);
 	SDL_RenderPresent(window->renderer);
@@ -1040,10 +1015,10 @@ static void redraw_all_windows(struct my_app *a, bool dirty)
 {
 	for (unsigned i = 0; i < MAX_WINDOWS; i++) {
 		struct sdlpui_window *window = get_window_direct(a, i);
-		if (window != NULL && (dirty ? window->dirty : true)) {
+		if (window != NULL && (SDL_AtomicCAS(&window->dirty,
+				SDL_TRUE, SDL_FALSE) || !dirty)) {
 			render_status_bar(window);
 			redraw_window(window);
-			window->dirty = false;
 		}
 	}
 }
@@ -1585,22 +1560,25 @@ static void render_shortcut_editor(struct sdlpui_dialog *d,
 	if (pse->reset_button.ftb->render) {
 		(*pse->reset_button.ftb->render)(&pse->reset_button, d, w, r);
 	}
-	d->dirty = SDL_FALSE;
 }
 
-static void goto_shortcut_editor_first_control(struct sdlpui_dialog *d,
-		struct sdlpui_window *w)
+static struct sdlpui_control* goto_shortcut_editor_first_control(
+		struct sdlpui_dialog *d, struct sdlpui_window *w)
 {
 	struct shortcut_editor_data *pse;
+	struct sdlpui_control *result;
 
 	SDL_assert(d->type_code == SHORTCUT_EDITOR_CODE && d->priv);
 	pse = d->priv;
-	SDL_assert(pse->change_buttons[0].ftb->gain_key);
-	SDL_assert(!d->c_key || d->c_key->id == pse->change_buttons[0].id);
-	(*pse->change_buttons[0].ftb->gain_key)(
-		&pse->change_buttons[0], d, w, 0);
-	d->c_key = &pse->change_buttons[0];
-	sdlpui_dialog_gain_key_focus(w, d);
+	result = &pse->change_buttons[0];
+	sdlpui_begin_focus_transaction();
+	if (!sdlpui_change_focus(result, 0, d, w, SDLPUI_ACTION_HINT_KEY,
+			SDL_FALSE)) {
+		result = NULL;
+	}
+	sdlpui_end_focus_transaction();
+
+	return result;
 }
 
 static void step_shortcut_editor_control(struct sdlpui_dialog *d,
@@ -1645,13 +1623,10 @@ static void step_shortcut_editor_control(struct sdlpui_dialog *d,
 		}
 		++i;
 	}
-	if (d->c_key && (!new_c || d->c_key->id != new_c->id) &&
-			d->c_key->ftb->lose_key) {
-		(*d->c_key->ftb->lose_key)(d->c_key, d, w, new_c, d);
-	}
-	SDL_assert(new_c->ftb->gain_key);
-	(*new_c->ftb->gain_key)(new_c, d, w, 0);
-	d->c_key = new_c;
+	sdlpui_begin_focus_transaction();
+	(void)sdlpui_change_focus(new_c, 0, d, w, SDLPUI_ACTION_HINT_KEY,
+		SDL_FALSE);
+	sdlpui_end_focus_transaction();
 }
 
 static struct sdlpui_control *find_shortcut_editor_control_containing(
@@ -1943,11 +1918,13 @@ static void cleanup_shortcut_editor(struct sdlpui_dialog *d)
 }
 
 static void handle_shortcut_change(struct sdlpui_control *c,
-		struct sdlpui_dialog *d, struct sdlpui_window *w)
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		enum sdlpui_action_hint hint)
 {
 	struct shortcut_editor_data *pse;
 	int tag = sdlpui_get_tag(c);
 
+	(void)hint;
 	SDL_assert(d->type_code == SHORTCUT_EDITOR_CODE && d->priv);
 	pse = d->priv;
 	SDL_assert(tag >= 0 && tag < MAX_WINDOWS);
@@ -1958,11 +1935,13 @@ static void handle_shortcut_change(struct sdlpui_control *c,
 }
 
 static void handle_shortcut_clear(struct sdlpui_control *c,
-		struct sdlpui_dialog *d, struct sdlpui_window *w)
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		enum sdlpui_action_hint hint)
 {
 	struct shortcut_editor_data *pse;
 	int tag = sdlpui_get_tag(c);
 
+	(void)hint;
 	SDL_assert(d->type_code == SHORTCUT_EDITOR_CODE && d->priv);
 	pse = d->priv;
 	SDL_assert(tag >= 0 && tag < MAX_WINDOWS);
@@ -1981,17 +1960,21 @@ static void handle_shortcut_clear(struct sdlpui_control *c,
 }
 
 static void handle_shortcut_editor_close(struct sdlpui_control *c,
-		struct sdlpui_dialog *d, struct sdlpui_window *w)
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		enum sdlpui_action_hint hint)
 {
+	(void)hint;
 	sdlpui_popdown_dialog(d, w, SDL_FALSE);
 }
 
 static void handle_shortcut_editor_reset(struct sdlpui_control *c,
-		struct sdlpui_dialog *d, struct sdlpui_window *w)
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		enum sdlpui_action_hint hint)
 {
 	struct shortcut_editor_data *pse;
 	int i;
 
+	(void)hint;
 	SDL_assert(d->type_code == SHORTCUT_EDITOR_CODE && d->priv);
 	pse = d->priv;
 	for (i = 0; i < MAX_WINDOWS; ++i) {
@@ -2116,14 +2099,12 @@ static void show_shortcut_editor(struct sdlpui_window *w, int x, int y)
 	w->shorte->next_r = NULL;
 	w->shorte->prev_r = NULL;
 	w->shorte->texture = NULL;
-	w->shorte->c_mouse = NULL;
-	w->shorte->c_key = NULL;
 	w->shorte->priv = pse;
 	w->shorte->id = id;
 	w->shorte->type_code = SHORTCUT_EDITOR_CODE;
 	w->shorte->tag = 0;
 	w->shorte->pinned = SDL_FALSE;
-	w->shorte->dirty = SDL_TRUE;
+	w->shorte->dirty.value = SDL_TRUE;
 	sdlpui_register_dialog(w->shorte);
 
 	(*w->shorte->ftb->query_natural_size)(w->shorte, w, &dw, &dh);
@@ -2174,8 +2155,7 @@ static void recreate_about_dialog_textures(struct sdlpui_dialog *d,
 				DEFAULT_ABOUT_ICON);
 			pi->image = load_image(w, path);
 
-			d->dirty = SDL_TRUE;
-			sdlpui_signal_redraw(w);
+			sdlpui_dialog_mark_for_redraw(d, w);
 			break;
 		}
 	}
@@ -2484,7 +2464,7 @@ static void signal_move_state(struct sdlpui_window *window)
 		SDL_assert(mb->subtype_code == SDLPUI_MB_TOGGLE);
 		mb->v.toggled = (window->move_state.active)
 			? SDL_TRUE : SDL_FALSE;
-		window->status_bar->dirty = SDL_TRUE;
+		sdlpui_dialog_mark_for_redraw(window->status_bar, window);
 	}
 
 	SDL_SetWindowGrab(window->window, was_active ? SDL_FALSE : SDL_TRUE);
@@ -2517,15 +2497,17 @@ static void signal_size_state(struct sdlpui_window *window)
 		SDL_assert(mb->subtype_code == SDLPUI_MB_TOGGLE);
 		mb->v.toggled = (window->size_state.active)
 			? SDL_TRUE : SDL_FALSE;
-		window->status_bar->dirty = SDL_TRUE;
+		sdlpui_dialog_mark_for_redraw(window->status_bar, window);
 	}
 
 	SDL_SetWindowGrab(window->window, was_active ? SDL_FALSE : SDL_TRUE);
 }
 
 static void handle_button_movesize(struct sdlpui_control *ctrl,
-		struct sdlpui_dialog *dlg, struct sdlpui_window *window)
+		struct sdlpui_dialog *dlg, struct sdlpui_window *window,
+		enum sdlpui_action_hint hint)
 {
+	(void)hint;
 	SDL_assert(ctrl->ftb->get_tag);
 	if ((*ctrl->ftb->get_tag)(ctrl) == 0) {
 		if (window->size_state.active) {
@@ -2543,20 +2525,24 @@ static void handle_button_movesize(struct sdlpui_control *ctrl,
 }
 
 static void handle_menu_shortcuts(struct sdlpui_control *ctrl,
-		struct sdlpui_dialog *dlg, struct sdlpui_window *window)
+		struct sdlpui_dialog *dlg, struct sdlpui_window *window,
+		enum sdlpui_action_hint hint)
 {
 	int x = dlg->rect.x + ctrl->rect.x, y = dlg->rect.y + ctrl->rect.y;
 
+	(void)hint;
 	sdlpui_popdown_dialog(dlg, window, SDL_TRUE);
 	show_shortcut_editor(window, x, y);
 }
 
 static void handle_menu_window(struct sdlpui_control *ctrl,
-		struct sdlpui_dialog *dlg, struct sdlpui_window *window)
+		struct sdlpui_dialog *dlg, struct sdlpui_window *window,
+		enum sdlpui_action_hint hint)
 {
 	int tag;
 	struct sdlpui_window *other;
 
+	(void)hint;
 	SDL_assert(ctrl->ftb->get_tag);
 	tag = (*ctrl->ftb->get_tag)(ctrl);
 	SDL_assert(tag >= 0);
@@ -2659,8 +2645,10 @@ static bool toggle_fullscreen(struct sdlpui_window *window)
 }
 
 static void handle_menu_fullscreen(struct sdlpui_control *ctrl,
-		struct sdlpui_dialog *dlg, struct sdlpui_window *window)
+		struct sdlpui_dialog *dlg, struct sdlpui_window *window,
+		enum sdlpui_action_hint hint)
 {
+	(void)hint;
 	sdlpui_popdown_dialog(dlg, window, SDL_TRUE);
 	if (!toggle_fullscreen(window)) {
 		SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_WARNING,
@@ -2671,39 +2659,48 @@ static void handle_menu_fullscreen(struct sdlpui_control *ctrl,
 }
 
 static void handle_menu_kp_mod(struct sdlpui_control *ctrl,
-		struct sdlpui_dialog *dlg, struct sdlpui_window *window)
+		struct sdlpui_dialog *dlg, struct sdlpui_window *window,
+		enum sdlpui_action_hint hint)
 {
+	(void)hint;
 	sdlpui_popdown_dialog(dlg, window, SDL_TRUE);
 	window->app->kp_as_mod = !window->app->kp_as_mod;
 }
 
 static void handle_menu_about(struct sdlpui_control *ctrl,
-		struct sdlpui_dialog *dlg, struct sdlpui_window *window)
+		struct sdlpui_dialog *dlg, struct sdlpui_window *window,
+		enum sdlpui_action_hint hint)
 {
 	int x = dlg->rect.x + ctrl->rect.x, y = dlg->rect.y + ctrl->rect.y;
 
+	(void)hint;
 	sdlpui_popdown_dialog(dlg, window, SDL_TRUE);
 	show_about(window, x, y);
 }
 
 static void handle_menu_sdl_details(struct sdlpui_control *ctrl,
-		struct sdlpui_dialog *dlg, struct sdlpui_window *window)
+		struct sdlpui_dialog *dlg, struct sdlpui_window *window,
+		enum sdlpui_action_hint hint)
 {
 	int x = dlg->rect.x + ctrl->rect.x, y = dlg->rect.y + ctrl->rect.y;
 
+	(void)hint;
 	sdlpui_popdown_dialog(dlg, window, SDL_TRUE);
 	show_sdl_details(window, x, y);
 }
 
 static void handle_menu_quit(struct sdlpui_control *ctrl,
-		struct sdlpui_dialog *dlg, struct sdlpui_window *window)
+		struct sdlpui_dialog *dlg, struct sdlpui_window *window,
+		enum sdlpui_action_hint hint)
 {
+	(void)hint;
 	sdlpui_popdown_dialog(dlg, window, SDL_TRUE);
 	terms_disconnecting = 1;
 }
 
 static void handle_menu_tile_set(struct sdlpui_control *ctrl,
-		struct sdlpui_dialog *dlg, struct sdlpui_window *window)
+		struct sdlpui_dialog *dlg, struct sdlpui_window *window,
+		enum sdlpui_action_hint hint)
 {
 	int new_id;
 
@@ -2720,7 +2717,10 @@ static void handle_menu_tile_set(struct sdlpui_control *ctrl,
 		mb = (struct sdlpui_menu_button*)ctrl->priv;
 		SDL_assert(mb->subtype_code == SDLPUI_MB_TOGGLE);
 		mb->v.toggled = SDL_TRUE;
-		dlg->dirty = SDL_TRUE;
+		sdlpui_begin_focus_transaction();
+		sdlpui_trigger_momentary_feedback(hint, SDL_FALSE);
+		sdlpui_end_focus_transaction();
+		sdlpui_dialog_mark_for_redraw(dlg, window);
 	} else {
 		/* Change the graphics mode.  Toggle off the old mode. */
 		int old_id = current_graphics_mode->grafID;
@@ -2740,7 +2740,7 @@ static void handle_menu_tile_set(struct sdlpui_control *ctrl,
 			SDL_assert(mb->subtype_code == SDLPUI_MB_TOGGLE);
 			if (mb->tag == old_id) {
 				mb->v.toggled = SDL_FALSE;
-				dlg->dirty = SDL_TRUE;
+				sdlpui_dialog_mark_for_redraw(dlg, window);
 				break;
 			}
 		}
@@ -2750,11 +2750,13 @@ static void handle_menu_tile_set(struct sdlpui_control *ctrl,
 }
 
 static void handle_menu_tile_size(struct sdlpui_control *ctrl,
-		struct sdlpui_dialog *dlg, struct sdlpui_window *window)
+		struct sdlpui_dialog *dlg, struct sdlpui_window *window,
+		enum sdlpui_action_hint hint)
 {
 	struct sdlpui_menu_button *mb;
 	int tag;
 
+	(void)hint;
 	SDL_assert(ctrl->type_code == SDLPUI_CTRL_MENU_BUTTON);
 	mb = (struct sdlpui_menu_button*)ctrl->priv;
 	SDL_assert(mb->subtype_code == SDLPUI_MB_RANGED_INT);
@@ -2856,12 +2858,14 @@ static struct sdlpui_dialog *handle_menu_tiles(struct sdlpui_control *ctrl,
 }
 
 static void handle_menu_pw(struct sdlpui_control *ctrl,
-		struct sdlpui_dialog *dlg, struct sdlpui_window *window)
+		struct sdlpui_dialog *dlg, struct sdlpui_window *window,
+		enum sdlpui_action_hint hint)
 {
 	int tag, subw_idx, flag_idx;
 	struct sdlpui_menu_button *mb;
 	uint32_t *new_flags;
 
+	(void)hint;
 	SDL_assert(ctrl->ftb->get_tag);
 	tag = (*ctrl->ftb->get_tag)(ctrl);
 	SDL_assert(tag >= 0);
@@ -2886,7 +2890,8 @@ static void handle_menu_pw(struct sdlpui_control *ctrl,
 }
 
 static void handle_menu_font_name(struct sdlpui_control *ctrl,
-		struct sdlpui_dialog *dlg, struct sdlpui_window *window)
+		struct sdlpui_dialog *dlg, struct sdlpui_window *window,
+		enum sdlpui_action_hint hint)
 {
 	int tag = sdlpui_get_tag(ctrl), index, old_index;
 	struct subwindow *subwindow;
@@ -2910,7 +2915,10 @@ static void handle_menu_font_name(struct sdlpui_control *ctrl,
 		mb = (struct sdlpui_menu_button*)ctrl->priv;
 		SDL_assert(mb->subtype_code == SDLPUI_MB_TOGGLE);
 		mb->v.toggled = SDL_TRUE;
-		dlg->dirty = SDL_TRUE;
+		sdlpui_begin_focus_transaction();
+		sdlpui_trigger_momentary_feedback(hint, SDL_FALSE);
+		sdlpui_end_focus_transaction();
+		sdlpui_dialog_mark_for_redraw(dlg, window);
 		return;
 	}
 
@@ -2936,7 +2944,8 @@ static void handle_menu_font_name(struct sdlpui_control *ctrl,
 				mb = (struct sdlpui_menu_button*)sm->controls[i].priv;
 				if (mb->tag == target_tag) {
 					mb->v.toggled = SDL_FALSE;
-					dlg->dirty = SDL_TRUE;
+					sdlpui_dialog_mark_for_redraw(dlg,
+						window);
 					searching = false;
 					break;
 				}
@@ -2977,18 +2986,20 @@ static void handle_menu_font_name(struct sdlpui_control *ctrl,
 		SDL_assert(mb->subtype_code == SDLPUI_MB_TOGGLE);
 		mb->disabled = SDL_TRUE;
 		mb->v.toggled = SDL_FALSE;
-		dlg->dirty = SDL_TRUE;
+		sdlpui_dialog_mark_for_redraw(dlg, window);
 	}
 }
 
 static void handle_menu_font_size(struct sdlpui_control *ctrl,
-		struct sdlpui_dialog *dlg, struct sdlpui_window *window)
+		struct sdlpui_dialog *dlg, struct sdlpui_window *window,
+		enum sdlpui_action_hint hint)
 {
 	int tag;
 	struct subwindow *subwindow;
 	struct sdlpui_menu_button *mb;
 	struct font_info *info;
 
+	(void)hint;
 	SDL_assert(ctrl->ftb->get_tag);
 	tag = (*ctrl->ftb->get_tag)(ctrl);
 	subwindow = get_subwindow_by_index(window, (unsigned int)tag, false);
@@ -3172,11 +3183,13 @@ static struct sdlpui_dialog *handle_menu_font(struct sdlpui_control *ctrl,
 }
 
 static void handle_menu_borders(struct sdlpui_control *ctrl,
-		struct sdlpui_dialog *dlg, struct sdlpui_window *window)
+		struct sdlpui_dialog *dlg, struct sdlpui_window *window,
+		enum sdlpui_action_hint hint)
 {
 	int tag;
 	struct subwindow *subwindow;
 
+	(void)hint;
 	SDL_assert(ctrl->ftb->get_tag);
 	tag = (*ctrl->ftb->get_tag)(ctrl);
 	SDL_assert(tag >= 0);
@@ -3187,7 +3200,8 @@ static void handle_menu_borders(struct sdlpui_control *ctrl,
 }
 
 static void handle_menu_subwindow_alpha(struct sdlpui_control *ctrl,
-		struct sdlpui_dialog *dlg, struct sdlpui_window *window)
+		struct sdlpui_dialog *dlg, struct sdlpui_window *window,
+		enum sdlpui_action_hint hint)
 {
 	int tag;
 	struct subwindow *subwindow;
@@ -3212,7 +3226,10 @@ static void handle_menu_subwindow_alpha(struct sdlpui_control *ctrl,
 		mb = (struct sdlpui_menu_button*)ctrl->priv;
 		SDL_assert(mb->subtype_code == SDLPUI_MB_TOGGLE);
 		mb->v.toggled = SDL_TRUE;
-		dlg->dirty = SDL_TRUE;
+		sdlpui_begin_focus_transaction();
+		sdlpui_trigger_momentary_feedback(hint, SDL_FALSE);
+		sdlpui_end_focus_transaction();
+		sdlpui_dialog_mark_for_redraw(dlg, window);
 		return;
 	}
 	/* Toggle off the previous setting. */
@@ -3229,7 +3246,7 @@ static void handle_menu_subwindow_alpha(struct sdlpui_control *ctrl,
 		if (is_close_to(alpha, subwindow->color.a,
 				DEFAULT_ALPHA_STEP / 2)) {
 			mb->v.toggled = SDL_FALSE;
-			dlg->dirty = SDL_TRUE;
+			sdlpui_dialog_mark_for_redraw(dlg, window);
 			break;
 		}
 	}
@@ -3278,11 +3295,13 @@ static struct sdlpui_dialog *handle_menu_alpha(struct sdlpui_control *ctrl,
 }
 
 static void handle_menu_top(struct sdlpui_control *ctrl,
-		struct sdlpui_dialog *dlg, struct sdlpui_window *window)
+		struct sdlpui_dialog *dlg, struct sdlpui_window *window,
+		enum sdlpui_action_hint hint)
 {
 	int tag;
 	struct subwindow *subwindow;
 
+	(void)hint;
 	SDL_assert(ctrl->ftb->get_tag);
 	tag = (*ctrl->ftb->get_tag)(ctrl);
 	SDL_assert(tag >= 0);
@@ -3699,14 +3718,11 @@ static void handle_window_focus(struct my_app *a, const SDL_WindowEvent *event)
 			SDLPUI_EVENT_TRACER("window", new_w,
 				fill_window_name(new_w, name, sizeof(name)),
 				"mouse entered");
-			if (a->w_mouse && a->w_mouse->index != new_w->index
-					&& a->w_mouse->d_mouse) {
-				if (a->w_mouse->d_mouse->ftb->handle_window_loses_mouse) {
-					(*a->w_mouse->d_mouse->ftb->handle_window_loses_mouse)(
-						a->w_mouse->d_mouse,
-						a->w_mouse);
-				}
-				a->w_mouse->d_mouse = NULL;
+			if (a->w_mouse && a->w_mouse->index != new_w->index) {
+				sdlpui_begin_focus_transaction();
+				sdlpui_window_loses_focus(
+					SDLPUI_ACTION_HINT_MOUSE);
+				sdlpui_end_focus_transaction();
 			}
 			a->w_mouse = new_w;
 			break;
@@ -3714,28 +3730,24 @@ static void handle_window_focus(struct my_app *a, const SDL_WindowEvent *event)
 			SDLPUI_EVENT_TRACER("window", a->w_mouse,
 				fill_window_name(a->w_mouse, name,
 				sizeof(name)), "mouse left");
-			if (a->w_mouse && a->w_mouse->d_mouse) {
-				if (a->w_mouse->d_mouse->ftb->handle_window_loses_mouse) {
-					(*a->w_mouse->d_mouse->ftb->handle_window_loses_mouse)(
-						a->w_mouse->d_mouse,
-						a->w_mouse);
-				}
-				a->w_mouse->d_mouse = NULL;
+			if (a->w_mouse) {
+				sdlpui_begin_focus_transaction();
+				sdlpui_window_loses_focus(
+						SDLPUI_ACTION_HINT_MOUSE);
+				sdlpui_end_focus_transaction();
+				a->w_mouse = NULL;
 			}
-			a->w_mouse = NULL;
 			break;
 		case SDL_WINDOWEVENT_FOCUS_GAINED:
 			new_w = get_window_by_id(a, event->windowID);
 			SDLPUI_EVENT_TRACER("window", new_w,
 				fill_window_name(new_w, name, sizeof(name)),
 				"gained key focus");
-			if (a->w_key && a->w_key->index != new_w->index
-					&& a->w_key->d_key) {
-				if (a->w_key->d_key->ftb->handle_window_loses_key) {
-					(*a->w_key->d_key->ftb->handle_window_loses_key)(
-						a->w_key->d_key, a->w_key);
-				}
-				a->w_key->d_key = NULL;
+			if (a->w_key && a->w_key->index != new_w->index) {
+				sdlpui_begin_focus_transaction();
+				sdlpui_window_loses_focus(
+						SDLPUI_ACTION_HINT_KEY);
+				sdlpui_end_focus_transaction();
 			}
 			a->w_key = new_w;
 			break;
@@ -3743,14 +3755,13 @@ static void handle_window_focus(struct my_app *a, const SDL_WindowEvent *event)
 			SDLPUI_EVENT_TRACER("window", a->w_key,
 				fill_window_name(a->w_key, name, sizeof(name)),
 				"lost key focus");
-			if (a->w_key && a->w_key->d_key) {
-				if (a->w_key->d_key->ftb->handle_window_loses_key) {
-					(*a->w_key->d_key->ftb->handle_window_loses_key)(
-						a->w_key->d_key, a->w_key);
-				}
-				a->w_key->d_key = NULL;
+			if (a->w_key) {
+				sdlpui_begin_focus_transaction();
+				sdlpui_window_loses_focus(
+					SDLPUI_ACTION_HINT_KEY);
+				sdlpui_end_focus_transaction();
+				a->w_key = NULL;
 			}
-			a->w_key = NULL;
 			break;
 		default:
 			assert(0);
@@ -3871,7 +3882,7 @@ static void do_sizing(struct sdlpui_window *window, int x, int y)
 				size_state->subwindow->font_height)
 			&& !SDL_RectEquals(&rect, &size_state->subwindow->sizing_rect)) {
 		size_state->subwindow->sizing_rect = rect;
-		window->dirty = true;
+		sdlpui_signal_redraw(window);
 	}
 
 	size_state->originx = x;
@@ -3893,7 +3904,7 @@ static void do_moving(struct sdlpui_window *window, int x, int y)
 	try_snap(window, move_state->subwindow, rect);
 	fit_rect_in_rect_by_xy(rect, &window->inner_rect);
 	if (!SDL_RectEquals(&old_rect, rect)) {
-		window->dirty = true;
+		sdlpui_signal_redraw(window);
 	}
 
 	move_state->originx = x;
@@ -3903,7 +3914,7 @@ static void do_moving(struct sdlpui_window *window, int x, int y)
 static bool handle_mousemotion(struct my_app *a,
 		const SDL_MouseMotionEvent *mouse)
 {
-	struct sdlpui_dialog *d;
+	struct sdlpui_dialog *d_mouse, *d;
 	SDL_Event pendm[4];
 
 	if (!a->w_mouse) {
@@ -3940,19 +3951,24 @@ static bool handle_mousemotion(struct my_app *a,
 		do_sizing(a->w_mouse, mouse->x, mouse->y);
 		return true;
 	}
+
+	sdlpui_begin_focus_transaction();
+
 	/* Have a menu or dialog handle the event if appropriate. */
-	if (a->w_mouse->d_mouse
-			&& a->w_mouse->d_mouse->ftb->handle_mousemove
-			&& (*a->w_mouse->d_mouse->ftb->handle_mousemove)(
-				a->w_mouse->d_mouse, a->w_mouse, mouse)) {
+	d_mouse = sdlpui_get_dialog_with_focus(SDLPUI_ACTION_HINT_MOUSE);
+	if (d_mouse && d_mouse->ftb->handle_mousemove
+			&& (*d_mouse->ftb->handle_mousemove)(d_mouse,
+			a->w_mouse, mouse)) {
+		sdlpui_end_focus_transaction();
 		return true;
 	}
 
 	/*
-	 * Ignore motion events while a mouse button is pressed (at
-	 * least up to the point that the mouse leaves the window).
+	 * Ignore motion events if mouse or key focus (since key focus follows
+	 * the mouse) is locked.
 	 */
-	if (mouse->state != 0) {
+	if (sdlpui_is_focus_locked(SDLPUI_ACTION_HINT_KEY_OR_MOUSE)) {
+		sdlpui_end_focus_transaction();
 		return true;
 	}
 
@@ -3968,57 +3984,42 @@ static bool handle_mousemotion(struct my_app *a,
 			break;
 		}
 		d = tgt->next;
-		if (sdlpui_is_in_dialog(tgt, mouse->x, mouse->y)
-				&& tgt->ftb->find_control_containing) {
-			int comp_ind;
-			struct sdlpui_control *c =
-				(*tgt->ftb->find_control_containing)(
-				tgt, a->w_mouse, mouse->x, mouse->y,
-				&comp_ind);
+		if (sdlpui_is_in_dialog(tgt, mouse->x, mouse->y)) {
+			if (d_mouse && d_mouse->id != tgt->id) {
+				struct sdlpui_control *c;
+				int comp_ind;
 
-			if (!a->w_mouse->d_mouse
-					|| a->w_mouse->d_mouse->id != tgt->id) {
-				struct sdlpui_dialog *old_d =
-					a->w_mouse->d_mouse;
-
-				if (old_d && old_d->ftb->handle_loses_mouse) {
-					(*old_d->ftb->handle_loses_mouse)(
-						old_d, a->w_mouse, c, tgt);
+				if (tgt->ftb->find_control_containing) {
+					c = (*tgt->ftb->find_control_containing)(
+						tgt, a->w_mouse, mouse->x,
+						mouse->y, &comp_ind);
+				} else {
+					c = NULL;
+					comp_ind = 0;
 				}
-				a->w_mouse->d_mouse = tgt;
+				(*d_mouse->ftb->handle_loses_mouse)(
+					d_mouse, a->w_mouse, c, comp_ind, tgt);
 			}
-			/* Have key focus follow mouse. */
+			/*
+			 * Have key focus follow mouse.  Determine if this is
+			 * dead code.  If it is not, does it need to call
+			 * SDL_RaiseWindow() or SDL_SetWindowInputFocus()?
+			 */
 			if (!a->w_key || a->w_key->index != a->w_mouse->index) {
-				if (a->w_key && a->w_key->d_key
-						&& a->w_key->d_key->ftb->handle_loses_key) {
-					(*a->w_key->d_key->ftb->handle_loses_key)(
-						a->w_key->d_key, a->w_key, c,
-						tgt);
-				}
-				if (a->w_key) {
-					a->w_key->d_key = NULL;
-				}
-				SDL_assert(!a->w_key
-					|| !a->w_key->d_mouse);
 				a->w_key = a->w_mouse;
-			} else if (a->w_key->d_key
-					&& a->w_key->d_key->id != tgt->id) {
-				if (a->w_key->d_key->ftb->handle_loses_key) {
-					(*a->w_key->d_key->ftb->handle_loses_key)(
-						a->w_key->d_key, a->w_key,
-						c, tgt);
-				}
 			}
-			a->w_mouse->d_key = tgt;
-			if (a->w_mouse->d_mouse
-					&& a->w_mouse->d_mouse->ftb->handle_mousemove
-					&& (*a->w_mouse->d_mouse->ftb->handle_mousemove)(
-					a->w_mouse->d_mouse, a->w_mouse, mouse)) {
+
+			if (tgt->ftb->handle_mousemove
+					&& (*tgt->ftb->handle_mousemove)(
+					tgt, a->w_mouse, mouse)) {
+				sdlpui_end_focus_transaction();
 				return true;
 			}
 			break;
 		}
 	}
+
+	sdlpui_end_focus_transaction();
 
 	return false;
 }
@@ -4060,6 +4061,7 @@ static bool handle_mousebutton(struct my_app *a,
 		const SDL_MouseButtonEvent *mouse)
 {
 	struct subwindow *subwindow;
+	struct sdlpui_dialog *d_mouse;
 	int button, col, row;
 	uint8_t mods;
 	term *old;
@@ -4086,30 +4088,32 @@ static bool handle_mousebutton(struct my_app *a,
 		return true;
 	}
 
+	sdlpui_begin_focus_transaction();
+
 	/* Have a menu or dialog handle the event if appropriate. */
 	touched = false;
-	if (a->w_mouse->d_mouse) {
+	d_mouse = sdlpui_get_dialog_with_focus(SDLPUI_ACTION_HINT_MOUSE);
+	if (d_mouse) {
 		/*
-		 * Press events outside of the dialog will act as if the dialog 
-		 * lost mouse focus to another unknown dialog.  Do not do the
-		 * same for release events in case the press happens in a
-		 * dialog, followed by mouse motion, and then the release
-		 * happens outside the dialog.
+		 * Press events outside of the dialog will act as if the
+		 * dialog lost mouse focus to another unknown dialog.
 		 */
 		if (mouse->state == SDL_PRESSED && !sdlpui_is_in_dialog(
-				a->w_mouse->d_mouse, mouse->x, mouse->y)) {
-			if (a->w_mouse->d_mouse->ftb->handle_loses_mouse) {
-				(*a->w_mouse->d_mouse->ftb->handle_loses_mouse)(
-					a->w_mouse->d_mouse, a->w_mouse,
-					NULL, NULL);
+				d_mouse, mouse->x, mouse->y)) {
+			if (d_mouse->ftb->handle_loses_mouse) {
+				(*d_mouse->ftb->handle_loses_mouse)(
+					d_mouse, a->w_mouse, NULL, 0, NULL);
 			}
 			touched = true;
-		} else if (a->w_mouse->d_mouse->ftb->handle_mouseclick
-				&& (*a->w_mouse->d_mouse->ftb->handle_mouseclick)(
-				a->w_mouse->d_mouse, a->w_mouse, mouse)) {
+		} else if (d_mouse->ftb->handle_mouseclick
+				&& (*d_mouse->ftb->handle_mouseclick)(
+				d_mouse, a->w_mouse, mouse)) {
+			sdlpui_end_focus_transaction();
 			return true;
 		}
 	}
+
+	sdlpui_end_focus_transaction();
 
 	/* If requested, start moving/sizing on a press. */
 	if (mouse->state != SDL_RELEASED
@@ -4131,7 +4135,7 @@ static bool handle_mousebutton(struct my_app *a,
 
 	/* Otherwise only react to the button press and not the release. */
 	if (mouse->state == SDL_RELEASED) {
-		return touched;
+		return false;
 	}
 
 	subwindow = get_subwindow_by_xy(a->w_mouse, mouse->x, mouse->y);
@@ -4188,11 +4192,21 @@ static bool handle_mousewheel(struct my_app *a,
 		const SDL_MouseWheelEvent *wheel)
 {
 	/* Have a menu or dialog handle the event if appropriate. */
-	if (a->w_mouse && a->w_mouse->d_mouse
-			&& a->w_mouse->d_mouse->ftb->handle_mousewheel
-			&& (*a->w_mouse->d_mouse->ftb->handle_mousewheel)(
-				a->w_mouse->d_mouse, a->w_mouse, wheel)) {
-		return true;
+	if (a->w_mouse) {
+		struct sdlpui_dialog *d_mouse;
+
+		sdlpui_begin_focus_transaction();
+
+		d_mouse =
+			sdlpui_get_dialog_with_focus(SDLPUI_ACTION_HINT_MOUSE);
+		if (d_mouse && d_mouse->ftb->handle_mousewheel
+				&& (*d_mouse->ftb->handle_mousewheel)(d_mouse,
+				a->w_mouse, wheel)) {
+			sdlpui_end_focus_transaction();
+			return true;
+		}
+
+		sdlpui_end_focus_transaction();
 	}
 
 	/* Otherwise, nothing is done. */
@@ -4308,42 +4322,41 @@ static bool trigger_menu_shortcut(struct my_app *a, keycode_t ch, uint8_t mods)
 				&& a->menu_shortcuts[i].type == EVT_KBRD
 				&& a->menu_shortcuts[i].code == ch
 				&& a->menu_shortcuts[i].mods == mods) {
-			if (!a->w_key || a->w_key->index !=
-					a->windows[i].index) {
-				struct sdlpui_window *old_w = a->w_key;
-				struct sdlpui_dialog *old_d = a->w_key->d_key;
+			struct sdlpui_dialog *d_key;
 
-				SDL_assert(!a->windows[i].d_key);
-				SDL_assert(a->windows[i].status_bar->ftb->goto_first_control);
-				(a->windows[i].status_bar->ftb->goto_first_control)(
-					a->windows[i].status_bar, a->windows + i
-				);
-				if (old_w && old_d
-						&& old_d->ftb->handle_loses_key) {
-					(*old_d->ftb->handle_loses_key)(
-						old_d, old_w,
-						a->windows[i].status_bar->c_key,
-						a->windows[i].status_bar);
-				}
-				if (old_w) {
-					old_w->d_key = NULL;
-				}
-			} else if (!a->w_key->d_key ||
-					a->w_key->d_key->id
+			sdlpui_begin_focus_transaction();
+
+			d_key = sdlpui_get_dialog_with_focus(SDLPUI_ACTION_HINT_KEY);
+			if (!a->w_key || a->w_key->index
+					!= a->windows[i].index || !d_key
+					|| d_key->id
 					!= a->windows[i].status_bar->id) {
-				struct sdlpui_dialog *old_d = a->w_key->d_key;
+				/*
+				 * Necessary so SDL recognizes that this
+				 * window is the one with focus.  Unfortunately,
+				 * it does not appear to be sufficient:  on
+				 * Debian 13 with xfce as the desktop, need to
+				 * press the shortcut twice to fully bring up
+				 * the menu in a window that does not currently
+				 * have focus (the first press of the shortcut
+				 * does bring up the menu, but it is
+				 * immediately dismissed because a
+				 * SDL_WINDOWEVENT_FOCUS_LOST event directed
+				 * at its window causes it to pop down).  Some
+				 * quick attempts at resolving that (processing
+				 * all pending events in the queue after raising
+				 * the window and warping the mouse pointer to
+				 * the window after raising it) did not appear
+				 * to help.
+				 */
+				SDL_RaiseWindow(a->windows[i].window);
 
 				SDL_assert(a->windows[i].status_bar->ftb->goto_first_control);
-				(a->windows[i].status_bar->ftb->goto_first_control)(
+				(void)(a->windows[i].status_bar->ftb->goto_first_control)(
 					a->windows[i].status_bar, a->windows + i
 				);
-				if (old_d && old_d->ftb->handle_loses_key) {
-					(*old_d->ftb->handle_loses_key)(
-						old_d, a->windows + i,
-						a->windows[i].status_bar->c_key,
-						a->windows[i].status_bar);
-				}
 			}
+			sdlpui_end_focus_transaction();
 			return true;
 		}
 		++i;
@@ -4529,10 +4542,20 @@ static bool handle_key(struct my_app *a, const SDL_KeyboardEvent *key)
 	keycode_t ch;
 
 	/* Have a menu or dialog handle the event if appropriate. */
-	if (a->w_key && a->w_key->d_key && a->w_key->d_key->ftb->handle_key
-			&& (*a->w_key->d_key->ftb->handle_key)(a->w_key->d_key,
+	if (a->w_key) {
+		struct sdlpui_dialog *d_key;
+
+		sdlpui_begin_focus_transaction();
+
+		d_key = sdlpui_get_dialog_with_focus(SDLPUI_ACTION_HINT_KEY);
+		if (d_key && d_key->ftb->handle_key
+				&& (*d_key->ftb->handle_key)(d_key,
 				a->w_key, key)) {
-		return true;
+			sdlpui_end_focus_transaction();
+			return true;
+		}
+
+		sdlpui_end_focus_transaction();
 	}
 
 	/*
@@ -4603,10 +4626,20 @@ static bool handle_text_input(struct my_app *a, const SDL_TextInputEvent *input)
 	uint8_t mods;
 
 	/* Have a menu or dialog handle the event if appropriate. */
-	if (a->w_key && a->w_key->d_key && a->w_key->d_key->ftb->handle_textin
-			&& (*a->w_key->d_key->ftb->handle_textin)(
-				a->w_key->d_key, a->w_key, input)) {
-		return true;
+	if (a->w_key) {
+		struct sdlpui_dialog *d_key;
+
+		sdlpui_begin_focus_transaction();
+
+		d_key = sdlpui_get_dialog_with_focus(SDLPUI_ACTION_HINT_KEY);
+		if (d_key && d_key->ftb->handle_textin
+				&& (*d_key->ftb->handle_textin)(d_key,
+				a->w_key, input)) {
+			sdlpui_end_focus_transaction();
+			return true;
+		}
+
+		sdlpui_end_focus_transaction();
 	}
 
 	textinput_event_to_angband_key(input, a->kp_as_mod, &ch, &mods);
@@ -4624,10 +4657,20 @@ static bool handle_text_editing(struct my_app *a,
 		const SDL_TextEditingEvent *edit)
 {
 	/* Have a menu or dialog handle the event if appropriate. */
-	if (a->w_key && a->w_key->d_key && a->w_key->d_key->ftb->handle_textedit
-			&& (*a->w_key->d_key->ftb->handle_textedit)(
-				a->w_key->d_key, a->w_key, edit)) {
-		return true;
+	if (a->w_key) {
+		struct sdlpui_dialog *d_key;
+
+		sdlpui_begin_focus_transaction();
+
+		d_key = sdlpui_get_dialog_with_focus(SDLPUI_ACTION_HINT_KEY);
+		if (d_key && d_key->ftb->handle_textedit
+				&& (*d_key->ftb->handle_textedit)(d_key,
+				a->w_key, edit)) {
+			sdlpui_end_focus_transaction();
+			return true;
+		}
+
+		sdlpui_end_focus_transaction();
 	}
 
 	/* Not passed on to the game's core. */
@@ -4814,7 +4857,7 @@ static errr term_xtra_clear(void)
 	render_fill_rect(subwindow->window,
 			subwindow->texture, &subwindow->inner_rect, &subwindow->color);
 
-	subwindow->window->dirty = true;
+	sdlpui_signal_redraw(subwindow->window);
 
 	return 0;
 }
@@ -4824,8 +4867,12 @@ static errr term_xtra_fresh(void)
 	struct subwindow *subwindow = Term->data;
 	assert(subwindow != NULL);
 
-	if (!subwindow->window->d_mouse && !subwindow->window->d_key) {
+	sdlpui_begin_focus_transaction();
+	if (!sdlpui_any_dialog_with_focus()) {
+		sdlpui_end_focus_transaction();
 		try_redraw_window(subwindow->window);
+	} else {
+		sdlpui_end_focus_transaction();
 	}
 
 	return 0;
@@ -4908,7 +4955,7 @@ static errr term_curs_hook(int col, int row)
 
 	render_cursor(subwindow, col, row, false);
 
-	subwindow->window->dirty = true;
+	sdlpui_signal_redraw(subwindow->window);
 
 	return 0;
 }
@@ -4920,7 +4967,7 @@ static errr term_bigcurs_hook(int col, int row)
 
 	render_cursor(subwindow, col, row, true);
 
-	subwindow->window->dirty = true;
+	sdlpui_signal_redraw(subwindow->window);
 
 	return 0;
 }
@@ -4939,7 +4986,7 @@ static errr term_wipe_hook(int col, int row, int n)
 
 	render_fill_rect(subwindow->window, subwindow->texture, &rect, &subwindow->color);
 
-	subwindow->window->dirty = true;
+	sdlpui_signal_redraw(subwindow->window);
 
 	return 0;
 }
@@ -4987,7 +5034,7 @@ static errr term_text_hook(int col, int row, int n, int a, const wchar_t *s)
 		rect.x += subwindow->font_width;
 	}
 
-	subwindow->window->dirty = true;
+	sdlpui_signal_redraw(subwindow->window);
 
 	return 0;
 }
@@ -5029,7 +5076,7 @@ static errr term_pict_hook(int col, int row, int n,
 		render_tile_font_scaled(subwindow, col + i, row, ap[i], cp[i], false, dhrclip);
 	}
 
-	subwindow->window->dirty = true;
+	sdlpui_signal_redraw(subwindow->window);
 
 	return 0;
 }
@@ -5988,13 +6035,15 @@ static struct subwindow *get_subwindow_by_xy(
 }
 
 static void handle_button_open_subwindow(struct sdlpui_control *ctrl,
-		struct sdlpui_dialog *dlg, struct sdlpui_window *window)
+		struct sdlpui_dialog *dlg, struct sdlpui_window *window,
+		enum sdlpui_action_hint hint)
 {
 	int tag;
 	unsigned int index;
 	struct subwindow *subwindow;
 	int minw, minh;
 
+	(void)hint;
 	assert(ctrl->ftb->get_tag);
 	tag = (*ctrl->ftb->get_tag)(ctrl);
 	assert(tag >= 0);
@@ -6438,11 +6487,12 @@ static void wipe_window(struct sdlpui_window *window, int display)
 	window->graphics.texture = NULL;
 	window->graphics.id = GRAPHICS_NONE;
 
-	window->dirty = true;
 	window->withdrawn_fullscreen = false;
 
 	window->config = NULL;
 	window->inited = true;
+
+	sdlpui_signal_redraw(window);
 }
 
 static void dump_subwindow(const struct subwindow *subwindow, ang_file *config)
@@ -6565,8 +6615,7 @@ static void detach_subwindow_from_window(struct sdlpui_window *window,
 		mb = (struct sdlpui_menu_button*)sm->controls[cidx].priv;
 		assert(mb->subtype_code == SDLPUI_MB_TOGGLE);
 		mb->v.toggled = SDL_FALSE;
-		window->status_bar->dirty = SDL_TRUE;
-		window->dirty = true;
+		sdlpui_dialog_mark_for_redraw(window->status_bar, window);
 	}
 }
 
@@ -7023,8 +7072,6 @@ static void free_window(struct sdlpui_window *window)
 		sdlpui_popdown_dialog(window->d_head, window, SDL_FALSE);
 	}
 	window->d_tail = NULL;
-	window->d_mouse = NULL;
-	window->d_key = NULL;
 	window->status_bar = NULL;
 	window->move_button = NULL;
 	window->size_button = NULL;

--- a/src/sdl2/pui-ctrl.c
+++ b/src/sdl2/pui-ctrl.c
@@ -19,6 +19,7 @@
 
 #include "pui-ctrl.h"
 #include "pui-dlg.h"
+#include "pui-foc.h"
 #include "pui-misc.h"
 
 
@@ -56,20 +57,6 @@ static void render_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
 static void respond_default_pb(struct sdlpui_control *c,
 		struct sdlpui_dialog *d, struct sdlpui_window *w,
 		enum sdlpui_action_hint hint);
-static void gain_key_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, int comp_ind);
-static void lose_key_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, struct sdlpui_control *new_c,
-		struct sdlpui_dialog *new_d);
-static void gain_mouse_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, int comp_ind);
-static void lose_mouse_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, struct sdlpui_control *new_c,
-		struct sdlpui_dialog *new_d);
-static void arm_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, enum sdlpui_action_hint hint);
-static void disarm_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, enum sdlpui_action_hint hint);
 static int get_pb_interactable_component(struct sdlpui_control *c,
 		SDL_bool first);
 static void resize_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
@@ -102,25 +89,17 @@ static void render_mb(struct sdlpui_control *c,
 static void respond_default_mb(struct sdlpui_control *c,
 		struct sdlpui_dialog *d, struct sdlpui_window *w,
 		enum sdlpui_action_hint hint);
-static void gain_key_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, int comp_ind);
-static void lose_key_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, struct sdlpui_control *new_c,
-		struct sdlpui_dialog *new_d);
-static void gain_mouse_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, int comp_ind);
-static void lose_mouse_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, struct sdlpui_control *new_c,
-		struct sdlpui_dialog *new_d);
+static void gain_focus_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, enum sdlpui_action_hint ah,
+		int comp_ind);
+static void lose_focus_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, enum sdlpui_action_hint ah,
+		struct sdlpui_control *new_c, struct sdlpui_dialog *new_d);
 static void lose_child_mb(struct sdlpui_control *c,
 		struct sdlpui_dialog *child);
-static void arm_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, enum sdlpui_action_hint hint);
-static void disarm_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, enum sdlpui_action_hint hint);
 static int get_mb_interactable_component(struct sdlpui_control *c,
 		SDL_bool first);
-static SDL_bool step_within_mb(struct sdlpui_control *c, SDL_bool forward);
+static int step_within_mb(struct sdlpui_control *c, SDL_bool forward);
 static int get_mb_interactable_component_at(struct sdlpui_control *c, Sint32 x,
 		Sint32 y);
 static void resize_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
@@ -160,10 +139,6 @@ static const struct sdlpui_control_funcs image_funcs = {
 	NULL,
 	NULL,
 	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
 	resize_image,
 	query_image_natural_size,
 	NULL,
@@ -185,10 +160,6 @@ static const struct sdlpui_control_funcs label_funcs = {
 	get_label_caption,
 	change_label_caption,
 	render_label,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
 	NULL,
 	NULL,
 	NULL,
@@ -218,13 +189,9 @@ const struct sdlpui_control_funcs push_button_funcs = {
 	change_pb_caption,
 	render_pb,
 	respond_default_pb,
-	gain_key_pb,
-	lose_key_pb,
-	gain_mouse_pb,
-	lose_mouse_pb,
 	NULL,
-	arm_pb,
-	disarm_pb,
+	NULL,
+	NULL,
 	get_pb_interactable_component,
 	NULL,
 	NULL,
@@ -250,13 +217,9 @@ static const struct sdlpui_control_funcs menu_button_funcs = {
 	change_mb_caption,
 	render_mb,
 	respond_default_mb,
-	gain_key_mb,
-	lose_key_mb,
-	gain_mouse_mb,
-	lose_mouse_mb,
+	gain_focus_mb,
+	lose_focus_mb,
 	lose_child_mb,
-	arm_mb,
-	disarm_mb,
 	get_mb_interactable_component,
 	step_within_mb,
 	get_mb_interactable_component_at,
@@ -452,8 +415,7 @@ static void change_label_caption(struct sdlpui_control *c,
 	SDL_free(lp->caption);
 	lp->caption = caption_copy;
 	resize_label(c, d, w, c->rect.w, c->rect.h);
-	d->dirty = SDL_TRUE;
-	sdlpui_signal_redraw(w);
+	sdlpui_dialog_mark_for_redraw(d, w);
 }
 
 
@@ -602,8 +564,7 @@ static void change_pb_caption(struct sdlpui_control *c,
 	SDL_free(pbp->caption);
 	pbp->caption = caption_copy;
 	resize_pb(c, d, w, c->rect.w, c->rect.h);
-	d->dirty = SDL_TRUE;
-	sdlpui_signal_redraw(w);
+	sdlpui_dialog_mark_for_redraw(d, w);
 }
 
 
@@ -615,6 +576,7 @@ static void render_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
 		SDLPUI_COLOR_COUNTERSINK);
 	TTF_Font *font = sdlpui_get_ttf(w);
 	struct sdlpui_push_button *pbp;
+	struct sdlpui_control_feedback cf;
 	SDL_Rect dst_r;
 
 	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
@@ -623,10 +585,7 @@ static void render_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
 		(*c->ftb->get_caption)(c), c->rect, pbp->caption_rect,
 		d->texture);
 
-	/*
-	 * Always draw a border.  There's one pixel between these to leave
-	 * space for indicating whether it's armed or not.
-	 */
+	/* Always draw a border. */
 	SDL_SetRenderDrawColor(r, countersink_color->r, countersink_color->g,
 		countersink_color->b, countersink_color->a);
 	dst_r = c->rect;
@@ -638,42 +597,54 @@ static void render_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
 		dst_r.y += d->rect.y;
 	}
 	SDL_RenderDrawRect(r, &dst_r);
-	dst_r.x += 2;
-	dst_r.y += 2;
-	dst_r.w -= 4;
-	dst_r.h -= 4;
-	SDL_SetRenderDrawColor(r, fg->r, fg->g, fg->b, fg->a);
-	SDL_RenderDrawRect(r, &dst_r);
+	++dst_r.x;
+	++dst_r.y;
+	dst_r.w -= 2;
+	dst_r.h -= 2;
 
-	if (pbp->has_key || pbp->has_mouse) {
+	sdlpui_begin_focus_transaction();
+	if (sdlpui_query_feedback(c, &cf)) {
 		/* Strengthen the inner border to signal that it has focus. */
-		++dst_r.x;
-		++dst_r.y;
-		dst_r.w -= 2;
-		dst_r.h -= 2;
-		SDL_RenderDrawRect(r, &dst_r);
-	}
+		const SDL_Color *fc;
+		SDL_bool is_fg;
 
-	if (!pbp->armed) {
-		/*
-		 * Button is not depressed.  Highlight left and top edges
-		 * as if there's lighting from the upper left since it
-		 * protrudes above the surface.
-		 */
-		SDL_Point points[3];
-
-		points[0].x = c->rect.x + 1;
-		points[0].y = c->rect.y + c->rect.h - 2;
-		if (!d->texture) {
-			points[0].x += d->rect.x;
-			points[0].y += d->rect.y;
+		sdlpui_end_focus_transaction();
+		if (cf.mf_mouse == SDLPUI_FEEDBACK_UNAVAIL
+				|| cf.mf_key == SDLPUI_FEEDBACK_UNAVAIL
+				|| (cf.mf_mouse == SDLPUI_FEEDBACK_NONE
+				&& cf.cf_mouse == SDLPUI_FEEDBACK_UNAVAIL)
+				|| (cf.mf_key == SDLPUI_FEEDBACK_NONE
+				&& cf.cf_key == SDLPUI_FEEDBACK_UNAVAIL)) {
+			fc = sdlpui_get_color(w, SDLPUI_COLOR_ACTION_UNAVAIL);
+			is_fg = SDL_FALSE;
+		} else if (cf.mf_mouse == SDLPUI_FEEDBACK_ACTION
+				|| cf.mf_key == SDLPUI_FEEDBACK_ACTION
+				|| (cf.mf_mouse == SDLPUI_FEEDBACK_NONE
+				&& cf.cf_mouse == SDLPUI_FEEDBACK_ACTION)
+				|| (cf.mf_key == SDLPUI_FEEDBACK_NONE
+				&& cf.cf_key == SDLPUI_FEEDBACK_ACTION)) {
+			fc = sdlpui_get_color(w, SDLPUI_COLOR_ACTION_FEEDBACK);
+			is_fg = SDL_FALSE;
+		} else {
+			fc = fg;
+			is_fg = SDL_TRUE;
 		}
-		points[1].x = points[0].x;
-		points[1].y = points[0].y - c->rect.h + 3;
-		points[2].x = points[0].x + c->rect.w - 3;
-		points[2].y = points[1].y;
-		SDL_RenderDrawLines(r, points, 3);
+
+		SDL_SetRenderDrawColor(r, fc->r, fc->g, fc->b, fc->a);
+		SDL_RenderDrawRect(r, &dst_r);
+		if (!is_fg) {
+			SDL_SetRenderDrawColor(r, fg->r, fg->g, fg->b, fg->a);
+		}
+	} else {
+		sdlpui_end_focus_transaction();
+		SDL_SetRenderDrawColor(r, fg->r, fg->g, fg->b, fg->a);
 	}
+	/* Draw the inner border */
+	++dst_r.x;
+	++dst_r.y;
+	dst_r.w -= 2;
+	dst_r.h -= 2;
+	SDL_RenderDrawRect(r, &dst_r);
 
 	if (pbp->caption_rect.h > 0 && pbp->caption_rect.w > 0) {
 		dst_r = pbp->caption_rect;
@@ -695,10 +666,10 @@ static void render_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
 			dst_r.x += d->rect.x;
 			dst_r.y += d->rect.y;
 		}
-		dst_r.x += 2;
-		dst_r.y += 2;
-		dst_r.w -= 4;
-		dst_r.h -= 4;
+		++dst_r.x;
+		++dst_r.y;
+		dst_r.w -= 2;
+		dst_r.h -= 2;
 		sdlpui_stipple_rect(r, stipple, &dst_r);
 	}
 }
@@ -715,115 +686,17 @@ static void respond_default_pb(struct sdlpui_control *c,
 	if (!pbp->disabled && pbp->callback) {
 		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
 			(*c->ftb->get_caption)(c), "default action invoked");
-		(pbp->callback)(c, d, w);
+		sdlpui_begin_focus_transaction();
+		sdlpui_trigger_momentary_feedback(hint, SDL_TRUE);
+		sdlpui_end_focus_transaction();
+		sdlpui_dialog_mark_for_redraw(d, w);
+		(pbp->callback)(c, d, w, hint);
 	} else {
 		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
 			(*c->ftb->get_caption)(c),
 			(pbp->disabled)
 			? ((pbp->callback) ? "default action suppressed; disable yes, callback available" : "default action suppressed; disable yes, callback unavailable")
 			: ((pbp->callback) ? "default action suppressed; disable no, callback available" : "default action suppressed; disable no, callback unavailable"));
-	}
-}
-
-
-static void gain_key_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, int comp_ind)
-{
-	struct sdlpui_push_button *pbp;
-
-	SDL_assert(comp_ind == 0 || comp_ind == -1);
-	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
-	pbp = c->priv;
-	if (!pbp->has_key) {
-		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
-			(*c->ftb->get_caption)(c), "gains key focus");
-		pbp->has_key = SDL_TRUE;
-		d->dirty = SDL_TRUE;
-		sdlpui_signal_redraw(w);
-	}
-}
-
-
-static void lose_key_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, struct sdlpui_control *new_c,
-		struct sdlpui_dialog *new_d)
-{
-	struct sdlpui_push_button *pbp;
-
-	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
-	pbp = c->priv;
-	if (pbp->has_key) {
-		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
-			(*c->ftb->get_caption)(c), "loses key focus");
-		pbp->has_key = SDL_FALSE;
-		d->dirty = SDL_TRUE;
-		sdlpui_signal_redraw(w);
-	}
-}
-
-
-static void gain_mouse_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, int comp_ind)
-{
-	struct sdlpui_push_button *pbp;
-
-	SDL_assert(comp_ind == 0 || comp_ind == -1);
-	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
-	pbp = c->priv;
-	if (!pbp->has_mouse) {
-		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
-			(*c->ftb->get_caption)(c), "gains mouse focus");
-		pbp->has_mouse = SDL_TRUE;
-		d->dirty = SDL_TRUE;
-		sdlpui_signal_redraw(w);
-	}
-}
-
-
-static void lose_mouse_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, struct sdlpui_control *new_c,
-		struct sdlpui_dialog *new_d)
-{
-	struct sdlpui_push_button *pbp;
-
-	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
-	pbp = c->priv;
-	if (pbp->has_mouse) {
-		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
-			(*c->ftb->get_caption)(c), "loses mouse focus");
-		pbp->has_mouse = SDL_FALSE;
-		d->dirty = SDL_TRUE;
-		sdlpui_signal_redraw(w);
-	}
-}
-
-
-static void arm_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, enum sdlpui_action_hint hint)
-{
-	struct sdlpui_push_button *pbp;
-
-	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
-	pbp = c->priv;
-	if (!pbp->armed) {
-		pbp->armed = SDL_TRUE;
-		d->dirty = SDL_TRUE;
-		sdlpui_signal_redraw(w);
-	}
-}
-
-
-static void disarm_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, enum sdlpui_action_hint hint)
-{
-	struct sdlpui_push_button *pbp;
-
-	SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
-	pbp = c->priv;
-	if (pbp->armed) {
-		pbp->armed = SDL_FALSE;
-		d->dirty = SDL_TRUE;
-		sdlpui_signal_redraw(w);
 	}
 }
 
@@ -930,8 +803,7 @@ static SDL_bool set_pb_disabled(struct sdlpui_control *c,
 	old_value = pbp->disabled;
 	if (!old_value != !disabled) {
 		pbp->disabled = (disabled) ? SDL_TRUE : SDL_FALSE;
-		d->dirty = SDL_TRUE;
-		sdlpui_signal_redraw(w);
+		sdlpui_dialog_mark_for_redraw(d, w);
 	}
 	return old_value;
 }
@@ -1023,13 +895,6 @@ static SDL_bool handle_mb_mousemove(struct sdlpui_control *c,
 		struct sdlpui_dialog *d, struct sdlpui_window *w,
 		const struct SDL_MouseMotionEvent *e)
 {
-	/*
-	 * Ignore moution events while a mouse button is pressed (at least up
-	 * to the point that the mouse leaves the window).
-	 */
-	if (e->state != 0) {
-		return SDL_TRUE;
-	}
 	if (sdlpui_is_in_control(c, d, e->x, e->y)) {
 		/*
 		 * ranged_int buttons care whether the mouse is in the left or
@@ -1041,51 +906,37 @@ static SDL_bool handle_mb_mousemove(struct sdlpui_control *c,
 		SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
 		mbp = c->priv;
 		if (mbp->subtype_code == SDLPUI_MB_RANGED_INT) {
-			int old = mbp->has_mouse;
+			sdlpui_begin_focus_transaction();
+			if (!sdlpui_is_focus_locked(
+					SDLPUI_ACTION_HINT_KEY_OR_MOUSE)) {
+				int new_ci, old_ci = sdlpui_control_has_focus(c,
+					SDLPUI_ACTION_HINT_MOUSE);
 
-			if (e->x <= d->rect.x + c->rect.x + c->rect.w / 2) {
-				mbp->has_mouse = (mbp->v.ranged_int.curr
-					> mbp->v.ranged_int.min) ? 1 : 0;
-			} else {
-				mbp->has_mouse = (mbp->v.ranged_int.curr
-					< mbp->v.ranged_int.max) ? 2 : 0;
-			}
-			if (old != mbp->has_mouse) {
-				if (!mbp->has_mouse) {
-					SDLPUI_EVENT_TRACER(
-						(*c->ftb->get_type_name)(c),
-						c, (*c->ftb->get_caption)(c),
-						"loses mouse focus");
-					d->c_mouse = NULL;
-				} else if (!old) {
-					SDLPUI_EVENT_TRACER(
-						(*c->ftb->get_type_name)(c),
-						c, (*c->ftb->get_caption)(c),
-						"gains mouse focus");
-					d->c_mouse = c;
+				if (e->x <= d->rect.x + c->rect.x
+						+ c->rect.w / 2) {
+					new_ci = (mbp->v.ranged_int.curr
+						> mbp->v.ranged_int.min)
+						? 1 : 0;
+				} else {
+					new_ci = (mbp->v.ranged_int.curr
+						< mbp->v.ranged_int.max)
+						? 2 : 0;
 				}
-				/* Have keyboard focus follow the mouse. */
-				if (mbp->has_key != mbp->has_mouse) {
-					if (!mbp->has_mouse) {
-						SDLPUI_EVENT_TRACER(
-							(*c->ftb->get_type_name)(c),
-							c,
-							(*c->ftb->get_caption)(c),
-							"loses key focus");
-						d->c_key = NULL;
-					} else if (!mbp->has_key) {
-						SDLPUI_EVENT_TRACER(
-							(*c->ftb->get_type_name)(c),
-							c,
-							(*c->ftb->get_caption)(c),
-							"gains key focus");
-						d->c_key = c;
+				if (old_ci != new_ci) {
+					if (!new_ci) {
+						(void)sdlpui_change_focus(NULL,
+							0, d, w,
+							SDLPUI_ACTION_HINT_MOUSE,
+							SDL_FALSE);
+					} else {
+						(void)sdlpui_change_focus(c,
+							new_ci - 1, d, w,
+							SDLPUI_ACTION_HINT_MOUSE,
+							SDL_FALSE);
 					}
-					mbp->has_key = mbp->has_mouse;
 				}
-				d->dirty = SDL_TRUE;
-				sdlpui_signal_redraw(w);
 			}
+			sdlpui_end_focus_transaction();
 		}
 		return SDL_TRUE;
 	}
@@ -1103,6 +954,20 @@ static SDL_bool handle_mb_mousewheel(struct sdlpui_control *c,
 {
 	struct sdlpui_menu_button *mbp;
 	Sint32 change, result;
+	int comp_ind;
+
+	sdlpui_begin_focus_transaction();
+	comp_ind = sdlpui_control_has_focus(c, SDLPUI_ACTION_HINT_MOUSE);
+	if (!comp_ind) {
+		/*
+		 * The control does not have focus so let the dialog handle
+		 * the event.
+		 */
+		sdlpui_end_focus_transaction();
+		return SDL_FALSE;
+	}
+
+	sdlpui_end_focus_transaction();
 
 	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
 	mbp = c->priv;
@@ -1126,7 +991,7 @@ static SDL_bool handle_mb_mousewheel(struct sdlpui_control *c,
 	 * Also flip if the left side of the control has focus (so the default
 	 * direction of changes is negative).
 	 */
-	if (mbp->has_mouse == 1) {
+	if (comp_ind == 1) {
 		change *= -1;
 	}
 	result = mbp->v.ranged_int.curr + change;
@@ -1145,10 +1010,9 @@ static SDL_bool handle_mb_mousewheel(struct sdlpui_control *c,
 		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
 			(*c->ftb->get_caption)(c),
 			"value changed by mouse wheel");
-		d->dirty = SDL_TRUE;
-		sdlpui_signal_redraw(w);
+		sdlpui_dialog_mark_for_redraw(d, w);
 		if (mbp->callback) {
-			(*mbp->callback)(c, d, w);
+			(*mbp->callback)(c, d, w, SDLPUI_ACTION_HINT_MOUSE);
 		}
 	} else {
 		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
@@ -1211,7 +1075,6 @@ static const char *get_mb_caption(const struct sdlpui_control *c)
 		}
 		(void)SDL_snprintf(mbp->v.ranged_int.expanded_caption,
 			ecap_sz, mbp->caption, mbp->v.ranged_int.curr);
-
 	}
 	return mbp->v.ranged_int.expanded_caption;
 }
@@ -1239,8 +1102,7 @@ static void change_mb_caption(struct sdlpui_control *c,
 		mbp->v.ranged_int.expanded_caption = NULL;
 	}
 	resize_mb(c, d, w, c->rect.w, c->rect.h);
-	d->dirty = SDL_TRUE;
-	sdlpui_signal_redraw(w);
+	sdlpui_dialog_mark_for_redraw(d, w);
 }
 
 
@@ -1251,6 +1113,7 @@ static void render_mb(struct sdlpui_control *c,
 	const SDL_Color *fg = sdlpui_get_color(w, SDLPUI_COLOR_MENU_FG);
 	TTF_Font *font = sdlpui_get_ttf(w);
 	struct sdlpui_menu_button *mbp;
+	struct sdlpui_control_feedback cf;
 	struct SDL_Rect dst_r;
 
 	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
@@ -1259,7 +1122,262 @@ static void render_mb(struct sdlpui_control *c,
 		(*c->ftb->get_caption)(c), c->rect, mbp->caption_rect,
 		d->texture);
 
-	SDL_SetRenderDrawColor(r, fg->r, fg->g, fg->b, fg->a);
+	sdlpui_begin_focus_transaction();
+	if (sdlpui_query_feedback(c, &cf)) {
+		/* Put a border on it to signal that it has focus. */
+		SDL_bool last_fg;
+
+		sdlpui_end_focus_transaction();
+		if (mbp->subtype_code != SDLPUI_MB_RANGED_INT) {
+			const SDL_Color *fc;
+
+			if (cf.mf_mouse == SDLPUI_FEEDBACK_UNAVAIL
+					|| cf.mf_key == SDLPUI_FEEDBACK_UNAVAIL
+					|| (cf.mf_mouse == SDLPUI_FEEDBACK_NONE
+					&& cf.cf_mouse == SDLPUI_FEEDBACK_UNAVAIL)
+					|| (cf.mf_key == SDLPUI_FEEDBACK_NONE
+					&& cf.cf_key == SDLPUI_FEEDBACK_UNAVAIL)) {
+				fc = sdlpui_get_color(w,
+					SDLPUI_COLOR_ACTION_UNAVAIL);
+				last_fg = SDL_FALSE;
+			} else if (cf.mf_mouse == SDLPUI_FEEDBACK_ACTION
+					|| cf.mf_key == SDLPUI_FEEDBACK_ACTION
+					|| (cf.mf_mouse == SDLPUI_FEEDBACK_NONE
+					&& cf.cf_mouse == SDLPUI_FEEDBACK_ACTION)
+					|| (cf.mf_key == SDLPUI_FEEDBACK_NONE
+					&& cf.cf_key == SDLPUI_FEEDBACK_ACTION)) {
+				fc = sdlpui_get_color(w,
+					SDLPUI_COLOR_ACTION_FEEDBACK);
+				last_fg = SDL_FALSE;
+			} else {
+				fc = fg;
+				last_fg = SDL_TRUE;
+			}
+			SDL_SetRenderDrawColor(r, fc->r, fc->g, fc->b, fc->a);
+
+			dst_r = c->rect;
+			if (!d->texture) {
+				/*
+				 * Rendering directly to the window's buffer
+				 * so use its coordinates.
+				 */
+				dst_r.x += d->rect.x;
+				dst_r.y += d->rect.y;
+			}
+			++dst_r.x;
+			++dst_r.y;
+			dst_r.w -= 2;
+			dst_r.h -= 2;
+			SDL_RenderDrawRect(r, &dst_r);
+		} else if (cf.key_focus && cf.mouse_focus
+				&& cf.key_focus != cf.mouse_focus) {
+			/*
+			 * Both sides have focus.  Take care if the color of
+			 * each side's indicator is different.
+			 */
+			if (cf.mf_mouse == cf.mf_key
+					&& (cf.mf_mouse != SDLPUI_FEEDBACK_NONE
+					|| cf.cf_mouse == cf.cf_key)) {
+				const SDL_Color *fc;
+
+				if (cf.mf_mouse == SDLPUI_FEEDBACK_UNAVAIL
+						|| (cf.mf_mouse
+						== SDLPUI_FEEDBACK_NONE
+						&& cf.cf_mouse
+						== SDLPUI_FEEDBACK_UNAVAIL)) {
+					fc = sdlpui_get_color(w,
+						SDLPUI_COLOR_ACTION_UNAVAIL);
+					last_fg = SDL_FALSE;
+				} else if (cf.mf_mouse == SDLPUI_FEEDBACK_ACTION
+						|| (cf.mf_mouse
+						== SDLPUI_FEEDBACK_NONE
+						&& cf.cf_mouse
+						== SDLPUI_FEEDBACK_ACTION)) {
+					fc = sdlpui_get_color(w,
+						SDLPUI_COLOR_ACTION_FEEDBACK);
+					last_fg = SDL_FALSE;
+				} else {
+					fc = fg;
+					last_fg = SDL_TRUE;
+				}
+				SDL_SetRenderDrawColor(r, fc->r, fc->g, fc->b,
+					fc->a);
+
+				dst_r = c->rect;
+				if (!d->texture) {
+					/*
+					 * Rendering directly to the window's
+					 * buffer so use its coordinates.
+					 */
+					dst_r.x += d->rect.x;
+					dst_r.y += d->rect.y;
+				}
+				++dst_r.x;
+				++dst_r.y;
+				dst_r.w -= 2;
+				dst_r.h -= 2;
+				SDL_RenderDrawRect(r, &dst_r);
+			} else {
+				const SDL_Color *leftc, *rightc;
+				SDL_Point points[4];
+				SDL_bool left_fg, right_fg;
+
+				/*
+				 * For now, assume the left side has mouse
+				 * focus and the right side has key focus.
+				 * Swap later if necessary.
+				 */
+				if (cf.mf_mouse == SDLPUI_FEEDBACK_UNAVAIL
+						|| (cf.mf_mouse ==
+						SDLPUI_FEEDBACK_NONE
+						&& cf.cf_mouse ==
+						SDLPUI_FEEDBACK_UNAVAIL)) {
+					leftc = sdlpui_get_color(w,
+						SDLPUI_COLOR_ACTION_UNAVAIL);
+					left_fg = SDL_FALSE;
+				} else if (cf.mf_mouse == SDLPUI_FEEDBACK_ACTION
+						|| (cf.mf_mouse ==
+						SDLPUI_FEEDBACK_NONE
+						&& cf.cf_mouse ==
+						SDLPUI_FEEDBACK_ACTION)) {
+					leftc = sdlpui_get_color(w,
+						SDLPUI_COLOR_ACTION_FEEDBACK);
+					left_fg = SDL_FALSE;
+				} else {
+					leftc = fg;
+					left_fg = SDL_TRUE;
+				}
+				if (cf.mf_key == SDLPUI_FEEDBACK_UNAVAIL
+						|| (cf.mf_key ==
+						SDLPUI_FEEDBACK_NONE
+						&& cf.cf_key ==
+						SDLPUI_FEEDBACK_UNAVAIL)) {
+					rightc = sdlpui_get_color(w,
+						SDLPUI_COLOR_ACTION_UNAVAIL);
+					right_fg = SDL_FALSE;
+				} else if (cf.mf_key == SDLPUI_FEEDBACK_ACTION
+						|| (cf.mf_key ==
+						SDLPUI_FEEDBACK_NONE
+						&& cf.cf_key ==
+						SDLPUI_FEEDBACK_ACTION)) {
+					rightc = sdlpui_get_color(w,
+						SDLPUI_COLOR_ACTION_FEEDBACK);
+					right_fg = SDL_FALSE;
+				} else {
+					rightc = fg;
+					right_fg = SDL_TRUE;
+				}
+				if (cf.key_focus == 1) {
+					const SDL_Color *tmp = leftc;
+
+					leftc = rightc;
+					rightc = tmp;
+					last_fg = left_fg;
+				} else {
+					last_fg = right_fg;
+				}
+
+				points[0].x = c->rect.x + c->rect.w / 2;
+				points[0].y = c->rect.y + 1;
+				if (!d->texture) {
+					points[0].x += d->rect.x;
+					points[0].y += d->rect.y;
+				}
+				points[1].x = points[0].x - (c->rect.w - 2) / 2;
+				points[1].y = points[0].y;
+				points[2].x = points[1].x;
+				points[2].y = points[1].y + c->rect.h - 3;
+				points[3].x = points[0].x;
+				points[3].y = points[2].y;
+				SDL_SetRenderDrawColor(r, leftc->r, leftc->g,
+					leftc->b, leftc->a);
+				SDL_RenderDrawLines(r, points, 4);
+				points[0].x = c->rect.x + c->rect.w / 2 + 1;
+				points[0].y = c->rect.y + 1;
+				if (!d->texture) {
+					points[0].x += d->rect.x;
+					points[0].y += d->rect.y;
+				}
+				points[1].x = points[0].x +
+					(c->rect.w - 5) / 2;
+				points[1].y = points[0].y;
+				points[2].x = points[1].x;
+				points[2].y = points[1].y + c->rect.h - 3;
+				points[3].x = points[0].x;
+				points[3].y = points[2].y;
+				SDL_SetRenderDrawColor(r, rightc->r, rightc->g,
+					rightc->b, rightc->a);
+				SDL_RenderDrawLines(r, points, 4);
+			}
+		} else {
+			/*
+			 * Only the left or right side has focus.  Do not draw
+			 * the line that would split the button in two.
+			 */
+			const SDL_Color *fc;
+			SDL_Point points[4];
+
+			if (cf.mf_mouse == SDLPUI_FEEDBACK_UNAVAIL
+					|| cf.mf_key == SDLPUI_FEEDBACK_UNAVAIL
+					|| (cf.mf_mouse == SDLPUI_FEEDBACK_NONE
+					&& cf.cf_mouse
+					== SDLPUI_FEEDBACK_UNAVAIL)
+					|| (cf.mf_key == SDLPUI_FEEDBACK_NONE
+					&& cf.cf_key
+					== SDLPUI_FEEDBACK_UNAVAIL)) {
+				fc = sdlpui_get_color(w,
+					SDLPUI_COLOR_ACTION_UNAVAIL);
+				last_fg = SDL_FALSE;
+			} else if (cf.mf_mouse == SDLPUI_FEEDBACK_ACTION
+					|| cf.mf_key == SDLPUI_FEEDBACK_ACTION
+					|| (cf.mf_mouse == SDLPUI_FEEDBACK_NONE
+					&& cf.cf_mouse
+					== SDLPUI_FEEDBACK_ACTION)
+					|| (cf.mf_key == SDLPUI_FEEDBACK_NONE
+					&& cf.cf_key
+					== SDLPUI_FEEDBACK_ACTION)) {
+				fc = sdlpui_get_color(w,
+					SDLPUI_COLOR_ACTION_FEEDBACK);
+				last_fg = SDL_FALSE;
+			} else {
+				fc = fg;
+				last_fg = SDL_TRUE;
+			}
+			SDL_SetRenderDrawColor(r, fc->r, fc->g, fc->b, fc->a);
+
+			if (cf.key_focus == 1 || cf.mouse_focus == 1) {
+				points[0].x = c->rect.x + c->rect.w / 2;
+				points[0].y = c->rect.y + 1;
+				if (!d->texture) {
+					points[0].x += d->rect.x;
+					points[0].y += d->rect.y;
+				}
+				points[1].x = points[0].x - c->rect.w / 2 + 1;
+				points[1].y = points[0].y;
+			} else {
+				points[0].x = c->rect.x + c->rect.w / 2 + 1;
+				points[0].y = c->rect.y + 1;
+				if (!d->texture) {
+					points[0].x += d->rect.x;
+					points[0].y += d->rect.y;
+				}
+				points[1].x = points[0].x +
+					(c->rect.w - 5) / 2;
+				points[1].y = points[0].y;
+			}
+			points[2].x = points[1].x;
+			points[2].y = points[1].y + c->rect.h - 3;
+			points[3].x = points[0].x;
+			points[3].y = points[2].y;
+			SDL_RenderDrawLines(r, points, 4);
+		}
+		if (!last_fg) {
+			SDL_SetRenderDrawColor(r, fg->r, fg->g, fg->b, fg->a);
+		}
+	} else {
+		sdlpui_end_focus_transaction();
+		SDL_SetRenderDrawColor(r, fg->r, fg->g, fg->b, fg->a);
+	}
 
 	if (mbp->caption_rect.h > 0 && mbp->caption_rect.w > 0) {
 		dst_r = mbp->caption_rect;
@@ -1306,112 +1424,6 @@ static void render_mb(struct sdlpui_control *c,
 		}
 	}
 
-	if (mbp->has_key || mbp->has_mouse) {
-		/*
-		 * Put a border on it to signal that it has focus.  The border
-		 * leaves space for the highlighting that happens if armed.
-		 */
-		if (mbp->subtype_code != SDLPUI_MB_RANGED_INT
-				|| (mbp->has_key && mbp->has_mouse
-				&& mbp->has_key != mbp->has_mouse)) {
-			dst_r = c->rect;
-			if (!d->texture) {
-				/*
-				 * Rendering directly to the window's buffer
-				 * so use its coordinates.
-				 */
-				dst_r.x += d->rect.x;
-				dst_r.y += d->rect.y;
-			}
-			--dst_r.w;
-			--dst_r.h;
-			SDL_RenderDrawRect(r, &dst_r);
-		} else {
-			/*
-			 * Only the left or right side has focus.  Don't draw
-			 * the line that would split the button in two.
-			 */
-			SDL_Point points[4];
-
-			if (mbp->has_key == 1 || mbp->has_mouse == 1) {
-				points[0].x = c->rect.x + c->rect.w / 2;
-				points[0].y = c->rect.y;
-				if (!d->texture) {
-					points[0].x += d->rect.x;
-					points[0].y += d->rect.y;
-				}
-				points[1].x = points[0].x - c->rect.w / 2;
-				points[1].y = points[0].y;
-			} else {
-				points[0].x = c->rect.x + c->rect.w / 2 + 1;
-				points[0].y = c->rect.y;
-				if (!d->texture) {
-					points[0].x += d->rect.x;
-					points[0].y += d->rect.y;
-				}
-				points[1].x = points[0].x +
-					(c->rect.w + 1) / 2 - 2;
-				points[1].y = points[0].y;
-			}
-			points[2].x = points[1].x;
-			points[2].y = points[1].y + c->rect.h - 1;
-			points[3].x = points[0].x;
-			points[3].y = points[2].y;
-			SDL_RenderDrawLines(r, points, 4);
-		}
-	}
-
-	if (mbp->armed) {
-		/*
-		 * Button is depressed.  Was flat with the surface; now
-		 * highlight right and bottom edges as if there's lighting from
-		 * the upper left.
-		 */
-		SDL_Point points[3];
-		int npt;
-
-		if (mbp->subtype_code != SDLPUI_MB_RANGED_INT
-				|| mbp->armed == 3) {
-			points[0].x = c->rect.x;
-			points[0].y = c->rect.y + c->rect.h - 1;
-			if (!d->texture) {
-				points[0].x += d->rect.x;
-				points[0].y += d->rect.y;
-			}
-			points[1].x = points[0].x + c->rect.w - 1;
-			points[1].y = points[0].y;
-			points[2].x = points[1].x;
-			points[2].y = points[1].y - c->rect.h + 1;
-			npt = 3;
-		} else if (mbp->armed == 1) {
-			/* Only the left side is depressed. */
-			points[0].x = c->rect.x;
-			points[0].y = c->rect.y + c->rect.h - 1;
-			if (!d->texture) {
-				points[0].x += d->rect.x;
-				points[0].y += d->rect.y;
-			}
-			points[1].x = points[0].x + c->rect.w / 2;
-			points[1].y = points[0].y;
-			npt = 2;
-		} else {
-			SDL_assert(mbp->armed == 2);
-			/* Only the right side is depressed. */
-			points[0].x = c->rect.x + c->rect.w / 2 + 1;
-			points[0].y = c->rect.y + c->rect.h - 1;
-			if (!d->texture) {
-				points[0].x += d->rect.x;
-				points[0].y += d->rect.y;
-			}
-			points[1].x = points[0].x + (c->rect.w + 1) / 2 - 2;
-			points[1].y = points[0].y;
-			points[2].x = points[1].x;
-			points[2].y = points[1].y - c->rect.h + 1;
-			npt = 3;
-		}
-		SDL_RenderDrawLines(r, points, npt);
-	}
-
 	if (mbp->disabled) {
 		struct sdlpui_stipple *stipple = sdlpui_get_stipple(w);
 
@@ -1430,7 +1442,8 @@ static void respond_default_mb(struct sdlpui_control *c,
 		enum sdlpui_action_hint hint)
 {
 	struct sdlpui_menu_button *mbp;
-	int inci, newi;
+	int has_key, has_mouse, inci, newi;
+	SDL_bool child_already;
 
 	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
 	mbp = c->priv;
@@ -1440,6 +1453,14 @@ static void respond_default_mb(struct sdlpui_control *c,
 	}
 
 	switch (mbp->subtype_code) {
+	case SDLPUI_MB_NONE:
+		sdlpui_begin_focus_transaction();
+		sdlpui_trigger_momentary_feedback(hint,
+			(mbp->callback) ? SDL_TRUE : SDL_FALSE);
+		sdlpui_end_focus_transaction();
+		sdlpui_dialog_mark_for_redraw(d, w);
+		break;
+
 	case SDLPUI_MB_SUBMENU:
 		if (!mbp->v.submenu.child) {
 			struct sdlpui_dialog *other_child =
@@ -1450,44 +1471,84 @@ static void respond_default_mb(struct sdlpui_control *c,
 					SDL_FALSE);
 			}
 			help_mb_popup_submenu(c, d, w);
+			child_already = SDL_FALSE;
 		} else {
 			SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
 				(*c->ftb->get_caption)(c),
 				"child menu already displayed");
+			child_already = SDL_TRUE;
 		}
-		/* Give the first button in the child menu keyboard focus. */
-		if (mbp->v.submenu.child->ftb->goto_first_control) {
-			(*mbp->v.submenu.child->ftb->goto_first_control)(
-				mbp->v.submenu.child, w);
+		/*
+		 * Give the first button in the child menu keyboard focus.  If
+		 * the menu was already displayed and key focus does not
+		 * change, provide visual feedback.
+		 */
+		if (child_already) {
+			struct sdlpui_control *old_key, *new_key;
+
+			sdlpui_begin_focus_transaction();
+			old_key = sdlpui_get_control_with_focus(
+				SDLPUI_ACTION_HINT_KEY);
+			if (mbp->v.submenu.child->ftb->goto_first_control) {
+				new_key = (*mbp->v.submenu.child->ftb->goto_first_control)(mbp->v.submenu.child, w);
+			} else {
+				new_key = old_key;
+			}
+			if ((!old_key && !new_key) || (old_key && new_key
+					&& old_key->id == new_key->id)) {
+				sdlpui_trigger_momentary_feedback(hint,
+					SDL_FALSE);
+				sdlpui_dialog_mark_for_redraw(d, w);
+			}
+			sdlpui_end_focus_transaction();
+		} else {
+			if (mbp->v.submenu.child->ftb->goto_first_control) {
+				(void)(*mbp->v.submenu.child->ftb->goto_first_control)(
+					mbp->v.submenu.child, w);
+			}
 		}
 		break;
 
 	case SDLPUI_MB_RANGED_INT:
-		if (hint == SDLPUI_ACTION_HINT_KEY
-				|| mbp->has_key == mbp->has_mouse) {
-			inci = (mbp->has_key == 1) ?
-				-1 : ((mbp->has_key == 2) ? 1 : 0);
-		} else if (hint == SDLPUI_ACTION_HINT_MOUSE
-				|| mbp->has_key == 0) {
-			inci = (mbp->has_mouse == 1) ?
-				-1 : ((mbp->has_mouse == 2) ? 1 : 0);
-		} else if (mbp->has_mouse == 0) {
-			inci = (mbp->has_key == 1) ?
-				-1 : ((mbp->has_key == 2) ? 1 : 0);
+		sdlpui_begin_focus_transaction();
+		has_key = sdlpui_control_has_focus(c, SDLPUI_ACTION_HINT_KEY);
+		has_mouse = sdlpui_control_has_focus(c,
+			SDLPUI_ACTION_HINT_MOUSE);
+		if (hint == SDLPUI_ACTION_HINT_KEY || has_key == has_mouse) {
+			inci = (has_key == 1) ? -1 : ((has_key == 2) ? 1 : 0);
+		} else if (hint == SDLPUI_ACTION_HINT_MOUSE || has_key == 0) {
+			inci = (has_mouse == 1)
+				? -1 : ((has_mouse == 2) ? 1 : 0);
+		} else if (has_mouse == 0) {
+			inci = (has_key == 1) ? -1 : 1;
 		} else {
 			/* It's not clear what should be done, so do nothing. */
 			inci = 0;
 		}
-		newi = mbp->v.ranged_int.curr + inci;
-		if (newi < mbp->v.ranged_int.min) {
-			newi = mbp->v.ranged_int.min;
-		} else if (newi > mbp->v.ranged_int.max) {
-			newi = mbp->v.ranged_int.max;
+		if (inci > 0) {
+			if (mbp->v.ranged_int.curr > mbp->v.ranged_int.max
+					- inci) {
+				newi = mbp->v.ranged_int.max;
+			} else {
+				newi = mbp->v.ranged_int.curr + inci;
+			}
+		} else if (inci < 0) {
+			if (mbp->v.ranged_int.curr < mbp->v.ranged_int.min
+					- inci) {
+				newi = mbp->v.ranged_int.min;
+			} else {
+				newi = mbp->v.ranged_int.curr + inci;
+			}
+		} else {
+			newi = mbp->v.ranged_int.curr;
 		}
 		if (newi == mbp->v.ranged_int.curr) {
 			SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
 				(*c->ftb->get_caption)(c),
 				"left unchanged by default response");
+			sdlpui_trigger_momentary_feedback(hint, SDL_FALSE);
+			sdlpui_end_focus_transaction();
+			sdlpui_dialog_mark_for_redraw(d, w);
 			return;
 		}
 		if (mbp->v.ranged_int.expanded_caption) {
@@ -1499,8 +1560,8 @@ static void respond_default_mb(struct sdlpui_control *c,
 		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
 			(*c->ftb->get_caption)(c),
 			"changed by default response");
-		d->dirty = SDL_TRUE;
-		sdlpui_signal_redraw(w);
+		sdlpui_end_focus_transaction();
+		sdlpui_dialog_mark_for_redraw(d, w);
 		break;
 
 	case SDLPUI_MB_TOGGLE:
@@ -1508,8 +1569,7 @@ static void respond_default_mb(struct sdlpui_control *c,
 			(*c->ftb->get_caption)(c),
 			"changed by default response");
 		mbp->v.toggled = !mbp->v.toggled;
-		d->dirty = SDL_TRUE;
-		sdlpui_signal_redraw(w);
+		sdlpui_dialog_mark_for_redraw(d, w);
 		break;
 
 	default:
@@ -1517,136 +1577,66 @@ static void respond_default_mb(struct sdlpui_control *c,
 	}
 
 	if (mbp->callback) {
-		(*mbp->callback)(c, d, w);
+		(*mbp->callback)(c, d, w, hint);
 	}
 }
 
 
-static void gain_key_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, int comp_ind)
+static void gain_focus_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, enum sdlpui_action_hint ah,
+		int comp_ind)
 {
 	struct sdlpui_menu_button *mbp;
-	int old;
 
 	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
 	mbp = c->priv;
 
-	SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
-		(*c->ftb->get_caption)(c), "gains key focus");
-	old = mbp->has_key;
-	if (mbp->subtype_code == SDLPUI_MB_RANGED_INT) {
-		if (comp_ind < 0) {
-			comp_ind += 2;
-		}
-		SDL_assert(comp_ind == 0 || comp_ind == 1);
-		mbp->has_key = comp_ind + 1;
-	} else if (mbp->subtype_code == SDLPUI_MB_INDICATOR) {
-		SDL_assert(0);
-	} else {
-		SDL_assert(comp_ind == 0 || comp_ind == -1);
-		mbp->has_key = 1;
-	}
-	if (old != mbp->has_key) {
-		d->dirty = SDL_TRUE;
-		sdlpui_signal_redraw(w);
-	}
 	if (mbp->subtype_code == SDLPUI_MB_SUBMENU && !mbp->v.submenu.child) {
 		help_mb_popup_submenu(c, d, w);
 	}
 }
 
 
-static void lose_key_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, struct sdlpui_control *new_c,
-		struct sdlpui_dialog *new_d)
+static void lose_focus_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, enum sdlpui_action_hint ah,
+		struct sdlpui_control *new_c, struct sdlpui_dialog *new_d)
 {
 	struct sdlpui_menu_button *mbp;
 
 	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
 	mbp = c->priv;
 
-	if (mbp->has_key) {
-		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
-			(*c->ftb->get_caption)(c), "loses key focus");
-		mbp->has_key = 0;
-		d->dirty = SDL_TRUE;
-		sdlpui_signal_redraw(w);
-	}
 	/*
-	 * Pop down the child dialog if what is gaining focus is not a
-	 * descendant of it.
+	 * Pop down the child dialog if what is gaining focus is not that dialog
+	 * or a descendant of it and if this control does not retain some
+	 * focus.
 	 */
-	if (mbp->subtype_code == SDLPUI_MB_SUBMENU && mbp->v.submenu.child
-			&& (!new_d || !sdlpui_is_descendant_dialog(d, new_d))) {
-		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
-			(*c->ftb->get_caption)(c), "popping down submenu");
-		sdlpui_popdown_dialog(mbp->v.submenu.child, w, SDL_FALSE);
-		mbp->v.submenu.child = NULL;
-	}
-}
+	if (mbp->subtype_code == SDLPUI_MB_SUBMENU && mbp->v.submenu.child) {
+		SDL_bool retains_focus;
 
+		sdlpui_begin_focus_transaction();
 
-static void gain_mouse_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, int comp_ind)
-{
-	struct sdlpui_menu_button *mbp;
-	int old;
-
-	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
-	mbp = c->priv;
-
-	SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
-		(*c->ftb->get_caption)(c), "gains mouse focus");
-	old = mbp->has_mouse;
-	if (mbp->subtype_code == SDLPUI_MB_RANGED_INT) {
-		if (comp_ind < 0) {
-			comp_ind += 2;
+		if (ah == SDLPUI_ACTION_HINT_KEY) {
+			retains_focus = (sdlpui_control_has_focus(c,
+				SDLPUI_ACTION_HINT_MOUSE) != 0);
+		} else {
+			retains_focus = (sdlpui_control_has_focus(c,
+				SDLPUI_ACTION_HINT_KEY) != 0);
 		}
-		SDL_assert(comp_ind == 0 || comp_ind == 1);
-		mbp->has_mouse = comp_ind + 1;
-	} else if (mbp->subtype_code == SDLPUI_MB_INDICATOR) {
-		SDL_assert(0);
-	} else {
-		SDL_assert(comp_ind == 0 || comp_ind == -1);
-		mbp->has_mouse = 1;
-	}
-	if (old != mbp->has_mouse) {
-		d->dirty = SDL_TRUE;
-		sdlpui_signal_redraw(w);
-	}
-	if (mbp->subtype_code == SDLPUI_MB_SUBMENU && !mbp->v.submenu.child) {
-		help_mb_popup_submenu(c, d, w);
-	}
-}
+		if (!retains_focus && (!new_d || (new_d->id
+				!= mbp->v.submenu.child->id
+				&& !sdlpui_is_descendant_dialog(
+				mbp->v.submenu.child, new_d)))) {
+			SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
+				(c->ftb->get_caption)
+				? (*c->ftb->get_caption)(c) : "(none)",
+				"popping down submenu");
+			sdlpui_popdown_dialog(mbp->v.submenu.child,
+				w, SDL_FALSE);
+			mbp->v.submenu.child = NULL;
+		}
 
-
-static void lose_mouse_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, struct sdlpui_control *new_c,
-		struct sdlpui_dialog *new_d)
-
-{
-	struct sdlpui_menu_button *mbp;
-
-	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
-	mbp = c->priv;
-
-	if (mbp->has_mouse) {
-		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
-			(*c->ftb->get_caption)(c), "loses mouse focus");
-		mbp->has_mouse = 0;
-		d->dirty = SDL_TRUE;
-		sdlpui_signal_redraw(w);
-	}
-	/*
-	 * Pop down the child dialog if what is gaining focus is not a
-	 * descendant of it.
-	 */
-	if (mbp->subtype_code == SDLPUI_MB_SUBMENU && mbp->v.submenu.child
-			&& (!new_d || !sdlpui_is_descendant_dialog(d, new_d))) {
-		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
-			(*c->ftb->get_caption)(c), "popping down submenu");
-		sdlpui_popdown_dialog(mbp->v.submenu.child, w, SDL_FALSE);
-		mbp->v.submenu.child = NULL;
+		sdlpui_end_focus_transaction();
 	}
 }
 
@@ -1662,66 +1652,6 @@ static void lose_child_mb(struct sdlpui_control *c, struct sdlpui_dialog *child)
 	if (mbp->v.submenu.child) {
 		SDL_assert(mbp->v.submenu.child == child);
 		mbp->v.submenu.child = NULL;
-	}
-}
-
-
-static void arm_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, enum sdlpui_action_hint hint)
-{
-	struct sdlpui_menu_button *mbp;
-	int old;
-
-	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
-	mbp = c->priv;
-
-	SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
-		(*c->ftb->get_caption)(c), "arming");
-	old = mbp->armed;
-	if (mbp->subtype_code != SDLPUI_MB_RANGED_INT) {
-		mbp->armed = 1;
-	} else {
-		if (hint == SDLPUI_ACTION_HINT_KEY
-				|| hint == SDLPUI_ACTION_HINT_NONE) {
-			mbp->armed |= mbp->has_key;
-		}
-		if (hint == SDLPUI_ACTION_HINT_MOUSE
-				|| hint == SDLPUI_ACTION_HINT_NONE) {
-			mbp->armed |= mbp->has_mouse;
-		}
-	}
-	if (old != mbp->armed) {
-		d->dirty = SDL_TRUE;
-		sdlpui_signal_redraw(w);
-	}
-}
-
-
-static void disarm_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, enum sdlpui_action_hint hint)
-{
-	struct sdlpui_menu_button *mbp;
-	int old;
-
-	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
-	mbp = c->priv;
-
-	SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
-		(*c->ftb->get_caption)(c), "disarming");
-	old = mbp->armed;
-	if (mbp->subtype_code != SDLPUI_MB_RANGED_INT
-			|| hint == SDLPUI_ACTION_HINT_NONE) {
-		mbp->armed = 0;
-	} else {
-		if (hint == SDLPUI_ACTION_HINT_KEY) {
-			mbp->armed &= ~mbp->has_key;
-		} else if (hint == SDLPUI_ACTION_HINT_MOUSE) {
-			mbp->armed &= ~mbp->has_mouse;
-		}
-	}
-	if (old != mbp->armed) {
-		d->dirty = SDL_TRUE;
-		sdlpui_signal_redraw(w);
 	}
 }
 
@@ -1757,30 +1687,35 @@ static int get_mb_interactable_component(struct sdlpui_control *c,
 }
 
 
-static SDL_bool step_within_mb(struct sdlpui_control *c, SDL_bool forward)
+static int step_within_mb(struct sdlpui_control *c, SDL_bool forward)
 {
 	struct sdlpui_menu_button *mbp;
+	int result = 0;
 
 	SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
 	mbp = c->priv;
 
-	SDL_assert(mbp->has_key);
 	if (mbp->subtype_code == SDLPUI_MB_RANGED_INT) {
+		int has_key;
+
+		sdlpui_begin_focus_transaction();
+
+		has_key = sdlpui_control_has_focus(c, SDLPUI_ACTION_HINT_KEY);
 		if (forward) {
-			if (mbp->has_key == 1 && mbp->v.ranged_int.curr
+			if (has_key == 1 && mbp->v.ranged_int.curr
 					< mbp->v.ranged_int.max) {
-				mbp->has_key = 2;
-				return SDL_TRUE;
+				result = 2;
 			}
 		} else {
-			if (mbp->has_key == 2 && mbp->v.ranged_int.curr
+			if (has_key == 2 && mbp->v.ranged_int.curr
 					> mbp->v.ranged_int.min) {
-				mbp->has_key = 1;
-				return SDL_TRUE;
+				result = 1;
 			}
 		}
+
+		sdlpui_end_focus_transaction();
 	}
-	return SDL_FALSE;
+	return result;
 }
 
 
@@ -1974,8 +1909,7 @@ static SDL_bool set_mb_disabled(struct sdlpui_control *c,
 	old_value = mbp->disabled;
 	if (!old_value != !disabled) {
 		mbp->disabled = (disabled) ? SDL_TRUE : SDL_FALSE;
-		d->dirty = SDL_TRUE;
-		sdlpui_signal_redraw(w);
+		sdlpui_dialog_mark_for_redraw(d, w);
 	}
 	return old_value;
 }
@@ -2139,39 +2073,23 @@ SDL_bool sdlpui_control_handle_key(struct sdlpui_control *c,
 		struct sdlpui_dialog *d, struct sdlpui_window *w,
 		const struct SDL_KeyboardEvent *e)
 {
-	if (e->keysym.sym == SDLK_RETURN) {
+	if (e->keysym.sym == SDLK_RETURN && e->state == SDL_PRESSED) {
 		SDL_Keymod mods = sdlpui_get_interesting_keymods();
 
-		if (e->state == SDL_PRESSED) {
-			if (mods == KMOD_NONE && c->ftb->arm) {
-				(*c->ftb->arm)(c, d, w, SDLPUI_ACTION_HINT_KEY);
-			}
-		} else {
-			/*
-			 * Always disarm, regardless of the modifier state,
-			 * in case a modifier key was pressed between
-			 * depressing and releasing the key.
-			 */
-			if (c->ftb->disarm) {
-				(*c->ftb->disarm)(c, d, w,
+		if (mods == KMOD_NONE) {
+			if (c->ftb->respond_default) {
+				SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c),
+					c,
+					(c->ftb->get_caption)
+					? (*c->ftb->get_caption)(c) : "(none)",
+					"invoking default reponse");
+				(*c->ftb->respond_default)(c, d, w,
 					SDLPUI_ACTION_HINT_KEY);
-			}
-			if (mods == KMOD_NONE) {
-				if (c->ftb->respond_default) {
-					SDLPUI_EVENT_TRACER(
-						(*c->ftb->get_type_name)(c), c,
-						(c->ftb->get_caption)
-						? (*c->ftb->get_caption)(c)
-						: "(none)",
-						"invoking default reponse");
-					(*c->ftb->respond_default)(c, d, w,
-						SDLPUI_ACTION_HINT_KEY);
-				} else if (d->ftb->respond_default) {
-					SDLPUI_EVENT_TRACER("dialog", d,
-						"(not extracted)",
-						"invoking default reponse");
-					(*d->ftb->respond_default)(d, w);
-				}
+			} else if (d->ftb->respond_default) {
+				SDLPUI_EVENT_TRACER("dialog", d,
+					"(not extracted)",
+					"invoking default reponse");
+				(*d->ftb->respond_default)(d, w);
 			}
 		}
 		return SDL_TRUE;
@@ -2199,27 +2117,13 @@ SDL_bool sdlpui_control_handle_mouseclick(struct sdlpui_control *c,
 		struct sdlpui_dialog *d, struct sdlpui_window *w,
 		const struct SDL_MouseButtonEvent *e)
 {
-	if (e->button == SDL_BUTTON_LEFT) {
-		if (e->state == SDL_PRESSED) {
-			if (c->ftb->arm) {
-				(*c->ftb->arm)(c, d, w,
-					 SDLPUI_ACTION_HINT_MOUSE);
-			}
-		} else {
-			if (c->ftb->disarm) {
-				(*c->ftb->disarm)(c, d, w,
-					SDLPUI_ACTION_HINT_MOUSE);
-			}
-			if (c->ftb->respond_default) {
-				SDLPUI_EVENT_TRACER(
-					(*c->ftb->get_type_name)(c), c,
-					(c->ftb->get_caption)
-					? (*c->ftb->get_caption)(c) : "(none)",
-					"invoking default response");
-				(*c->ftb->respond_default)(c, d, w,
-					SDLPUI_ACTION_HINT_MOUSE);
-			}
-		}
+	if (e->button == SDL_BUTTON_LEFT && e->state == SDL_PRESSED
+			&& c->ftb->respond_default) {
+		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
+			(c->ftb->get_caption)
+			? (*c->ftb->get_caption)(c) : "(none)",
+			"invoking default response");
+		(*c->ftb->respond_default)(c, d, w, SDLPUI_ACTION_HINT_MOUSE);
 	}
 	/* Swallow the event, even if nothing was done. */
 	return SDL_TRUE;
@@ -2243,12 +2147,8 @@ SDL_bool sdlpui_control_handle_mousemove(struct sdlpui_control *c,
 		struct sdlpui_dialog *d, struct sdlpui_window *w,
 		const struct SDL_MouseMotionEvent *e)
 {
-	/*
-	 * Ignore motion events while a mouse button is pressed (at least
-	 * up to the point that the mouse leaves the window).  If the mouse
-	 * is moving within the control, it also does nothing.
-	 */
-	if (e->state != 0 || sdlpui_is_in_control(c, d, e->x, e->y)) {
+	/* If the mouse is moving within the control, it does nothing. */
+	if (sdlpui_is_in_control(c, d, e->x, e->y)) {
 		return SDL_TRUE;
 	}
 	/*
@@ -2266,10 +2166,14 @@ SDL_bool sdlpui_control_handle_mousemove(struct sdlpui_control *c,
  * \param c is the control which was activated.
  * \param d is the dialog containing the control.
  * \param w is the window containing the dialog.
+ * \param hint specifies the type of input that triggered the action.  It is
+ * ignored in this function.
  */
 void sdlpui_invoke_dialog_default_action(struct sdlpui_control *c,
-		struct sdlpui_dialog *d, struct sdlpui_window *w)
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		enum sdlpui_action_hint hint)
 {
+	(void)hint;
 	if (d->ftb->respond_default) {
 		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c), c,
 			(c->ftb->get_caption) ? (*c->ftb->get_caption)(c)
@@ -2396,7 +2300,7 @@ void sdlpui_create_label(struct sdlpui_control *c, const char *caption,
  * independent of the lifetime of the control.
  * \param halign specifies how the label should be horizontally aligned within
  * the control's bounds if the control is wider than the label.
- * \param callback is the function to invoke when the button is released.  It
+ * \param callback is the function to invoke when the button is pressed.  It
  * may be NULL.
  * \param tag is a value the application can use as it wishes to have buttons
  * with the same callback act differently.
@@ -2412,7 +2316,8 @@ void sdlpui_create_label(struct sdlpui_control *c, const char *caption,
 void sdlpui_create_push_button(struct sdlpui_control *c, const char *caption,
 		enum sdlpui_hor_align halign, void (*callback)(
 		struct sdlpui_control*, struct sdlpui_dialog*,
-		struct sdlpui_window*), int tag, SDL_bool disabled)
+		struct sdlpui_window*, enum sdlpui_action_hint), int tag,
+		SDL_bool disabled)
 {
 	Uint32 id = sdlpui_reserve_id();
 	struct sdlpui_push_button *pbp;
@@ -2442,9 +2347,6 @@ void sdlpui_create_push_button(struct sdlpui_control *c, const char *caption,
 	pbp->halign = halign;
 	pbp->tag = tag;
 	pbp->disabled = (disabled) ? SDL_TRUE : SDL_FALSE;
-	pbp->has_key = SDL_FALSE;
-	pbp->has_mouse = SDL_FALSE;
-	pbp->armed = SDL_FALSE;
 	c->ftb = &push_button_funcs;
 	c->priv = pbp;
 	c->id = id;
@@ -2461,7 +2363,7 @@ void sdlpui_create_push_button(struct sdlpui_control *c, const char *caption,
  * independent of the lifetime of the control.
  * \param halign specifies how the label should be horizontally aligned within
  * the control's bounds if the control is wider than the label.
- * \param callback is the function to invoke when the button is released.  It
+ * \param callback is the function to invoke when the button is pressed.  It
  * may be NULL.
  * \param tag is a value the application can use as it wishes to have buttons
  * with the same callback act differently.
@@ -2477,7 +2379,8 @@ void sdlpui_create_push_button(struct sdlpui_control *c, const char *caption,
 void sdlpui_create_menu_button(struct sdlpui_control *c, const char *caption,
 		enum sdlpui_hor_align halign, void (*callback)(
 		struct sdlpui_control*, struct sdlpui_dialog*,
-		struct sdlpui_window *w), int tag, SDL_bool disabled)
+		struct sdlpui_window *w, enum sdlpui_action_hint), int tag,
+		SDL_bool disabled)
 {
 	Uint32 id = sdlpui_reserve_id();
 	struct sdlpui_menu_button *mbp;
@@ -2506,9 +2409,6 @@ void sdlpui_create_menu_button(struct sdlpui_control *c, const char *caption,
 	mbp->callback = callback;
 	mbp->halign = halign;
 	mbp->tag = tag;
-	mbp->has_key = 0;
-	mbp->has_mouse = 0;
-	mbp->armed = 0;
 	mbp->disabled = (disabled) ? SDL_TRUE : SDL_FALSE;
 	mbp->subtype_code = SDLPUI_MB_NONE;
 	c->ftb = &menu_button_funcs;
@@ -2566,9 +2466,6 @@ void sdlpui_create_menu_indicator(struct sdlpui_control *c, const char *caption,
 	mbp->callback = NULL;
 	mbp->halign = halign;
 	mbp->tag = tag;
-	mbp->has_key = 0;
-	mbp->has_mouse = 0;
-	mbp->armed = 0;
 	mbp->disabled = SDL_FALSE;
 	mbp->subtype_code = SDLPUI_MB_INDICATOR;
 	mbp->v.toggled = (curr_value) ? SDL_TRUE : SDL_FALSE;
@@ -2611,8 +2508,8 @@ void sdlpui_create_menu_indicator(struct sdlpui_control *c, const char *caption,
 void sdlpui_create_menu_ranged_int(struct sdlpui_control *c,
 		const char *caption, enum sdlpui_hor_align halign,
 		void (*callback)(struct sdlpui_control*, struct sdlpui_dialog*,
-		struct sdlpui_window*), int tag, SDL_bool disabled,
-		int curr_value, int min_value, int max_value)
+		struct sdlpui_window*, enum sdlpui_action_hint), int tag,
+		SDL_bool disabled, int curr_value, int min_value, int max_value)
 {
 	Uint32 id = sdlpui_reserve_id();
 	struct sdlpui_menu_button *mbp;
@@ -2641,9 +2538,6 @@ void sdlpui_create_menu_ranged_int(struct sdlpui_control *c,
 	mbp->callback = callback;
 	mbp->halign = halign;
 	mbp->tag = tag;
-	mbp->has_key = 0;
-	mbp->has_mouse = 0;
-	mbp->armed = 0;
 	mbp->disabled = (disabled) ? SDL_TRUE : SDL_FALSE;
 	mbp->subtype_code = SDLPUI_MB_RANGED_INT;
 	mbp->v.ranged_int.expanded_caption = NULL;
@@ -2668,7 +2562,7 @@ void sdlpui_create_menu_ranged_int(struct sdlpui_control *c,
  * independent of the lifetime of the control.
  * \param halign specifies how the label should be horizontally aligned within
  * the control's bounds if the control is wider than the label.
- * \param callback is the function to invoke when the button is released.  It
+ * \param callback is the function to invoke when the button is pressed.  It
  * may be NULL.
  * \param tag is a value the application can use as it wishes to have buttons
  * with the same callback act differently.
@@ -2685,8 +2579,8 @@ void sdlpui_create_menu_ranged_int(struct sdlpui_control *c,
 void sdlpui_create_menu_toggle(struct sdlpui_control *c, const char *caption,
 		enum sdlpui_hor_align halign, void (*callback)(
 		struct sdlpui_control*, struct sdlpui_dialog*,
-		struct sdlpui_window*), int tag, SDL_bool disabled,
-		SDL_bool curr_value)
+		struct sdlpui_window*, enum sdlpui_action_hint hint), int tag,
+		SDL_bool disabled, SDL_bool curr_value)
 {
 	Uint32 id = sdlpui_reserve_id();
 	struct sdlpui_menu_button *mbp;
@@ -2715,9 +2609,6 @@ void sdlpui_create_menu_toggle(struct sdlpui_control *c, const char *caption,
 	mbp->callback = callback;
 	mbp->halign = halign;
 	mbp->tag = tag;
-	mbp->has_key = 0;
-	mbp->has_mouse = 0;
-	mbp->armed = 0;
 	mbp->disabled = (disabled) ? SDL_TRUE : SDL_FALSE;
 	mbp->subtype_code = SDLPUI_MB_TOGGLE;
 	mbp->v.toggled = (curr_value) ? SDL_TRUE : SDL_FALSE;
@@ -2792,9 +2683,6 @@ void sdlpui_create_submenu_button(struct sdlpui_control *c, const char *caption,
 	mbp->callback = NULL;
 	mbp->halign = halign;
 	mbp->tag = tag;
-	mbp->has_key = 0;
-	mbp->has_mouse = 0;
-	mbp->armed = 0;
 	mbp->disabled = (disabled) ? SDL_TRUE : SDL_FALSE;
 	mbp->subtype_code = SDLPUI_MB_SUBMENU;
 	mbp->v.submenu.creator = creator;

--- a/src/sdl2/pui-ctrl.h
+++ b/src/sdl2/pui-ctrl.h
@@ -14,9 +14,10 @@ struct sdlpui_window;
 
 /**
  * Default width for empty space around labels, push buttons, and menu buttons
- * Two is smallest useful value (one pixel to indicate focus; another to
- * indicate arming).  Larger than that will leave some blank space between
- * the caption for a control and what's drawn to indicate focus or arming.
+ * Two is the smallest useful value (one pixel of empty space and one pixel to
+ * indicate focus and feedback about starting or continuing an action).
+ * Larger than that will leave some blank space between the caption for a
+ * control and what is drawn to indicate focus or feedback.
  */
 #define SDLPUI_DEFAULT_CTRL_BORDER 3
 
@@ -51,7 +52,9 @@ enum sdlpui_menu_button_type {
 enum sdlpui_action_hint {
 	SDLPUI_ACTION_HINT_NONE,
 	SDLPUI_ACTION_HINT_KEY,
-	SDLPUI_ACTION_HINT_MOUSE
+	SDLPUI_ACTION_HINT_MOUSE,
+	SDLPUI_ACTION_HINT_KEY_OR_MOUSE,
+	SDLPUI_ACTION_HINT_KEY_AND_MOUSE
 };
 
 /** How to horizontally align something (usually a label) in a larger box. */
@@ -180,44 +183,47 @@ struct sdlpui_control_funcs {
 		struct sdlpui_dialog *d, struct sdlpui_window *w,
 		enum sdlpui_action_hint hint);
 	/**
-	 * Signal that the given control has gained keyboard focus and
-	 * perhaps should change its appearance when rendered.  comp_ind is
-	 * only relevant for compound controls and is the index of the component
-	 * that should receive focus.  Negative indices are relative to the
-	 * number of controls in the compound control so -1 is the "last"
-	 * control.  Can be NULL.
+	 * Signal that the given control has gained focus or already has focus
+	 * but the component with focus has changed.  ah specifies the type of
+	 * focus:  SDLPUI_ACTION_HINT_KEY for keyboard focus or
+	 * SDLPUI_ACTION_HINT_MOUSE_FOCUS for mouse focus.  comp_ind is only
+	 * relevant for compound controls and is the zero-based index of the
+	 * component that should receive focus.  Can be NULL:  the control
+	 * either does not accept focus (get_interactable_component is NULL
+	 * or always returns zero and get_interactable_component_at is NULL
+	 * or always returns zero) or does not need to do anything beyond
+	 * what is done by the functions in pui-foc.h.  The caller will signal
+	 * that the containing dialog and window need redrawing so this hook
+	 * does not need to do that.  When called, the state returned by the
+	 * routines in pui-foc.h refers to the state after the change of
+	 * focus.  This hook should be treated as for the private use of the
+	 * routines in pui-foc.h:  all others should use those routines to
+	 * manage where focus is routed.
 	 */
-	void (*gain_key)(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, int comp_ind);
+	void (*gain_focus)(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, enum sdlpui_action_hint ah,
+		int comp_ind);
 	/**
-	 * Signal that the given control has lost keyboard focus.  Can be NULL.
-	 * new_c is the control gaining key focus; it will be NULL if no
-	 * control is taking focus or new_d is NULL.
-	 * new_d is the dialog gaining key focus; it will be NULL if no
-	 * dialog is taking focus or the dialog is unknown (in another
-	 * window).
+	 * Signal that the given control has lost focus.  ah specifies the type
+	 * of focus:  SDLPUI_ACTION_HINT_KEY for keyboard focus or
+	 * SDLPUI_ACTION_HINT_MOUSE_FOCUS for mouse focus.  new_c is the
+	 * control gaining key focus; it will be NULL if no control is taking
+	 * focus or new_d is NULL.  new_d is the dialog gaining key focus; it
+	 * will be NULL if no dialog is taking focus or the dialog is unknown
+	 * (in another window).  Can be NULL:  the control either does not
+	 * accept focus (get_interactable_component is NULL or always returns
+	 * zero and get_interactable_component_at is NULL or always returns
+	 * zero) or does not need to do anything beyond what is done by the
+	 * functions in pui-foc.h.  The caller will signal that the containing
+	 * dialog and window need redrawing so this hook does not need to do
+	 * that.  When called, the state returned by the routines in pui-foc.h
+	 * refers to the state after the change of focus.  This hook should be
+	 * treated as for the private use of the routines in pui-foc.h:  all
+	 * others should use those routines to manage where focus is routed.
 	 */
-	void (*lose_key)(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, struct sdlpui_control *new_c,
-		struct sdlpui_dialog *new_d);
-	/**
-	 * Signal that the given control has gained mouse focus and
-	 * perhaps should change its appearance when rendered.  comp_ind
-	 * has the same meaning as for gain_key above.  Can be NULL.
-	 */
-	void (*gain_mouse)(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, int comp_ind);
-	/**
-	 * Signal that the given control has lost mouse focus.  Can be NULL.
-	 * new_c is the control gaining mouse focus; it will be NULL if no
-	 * control is taking focus or new_d is NULL.
-	 * new_d is the dialog gaining mouse focus; it will be NULL if no
-	 * dialog is taking focus or the dialog is unknown (in another
-	 * window).
-	 */
-	void (*lose_mouse)(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, struct sdlpui_control *new_c,
-		struct sdlpui_dialog *new_d);
+	void (*lose_focus)(struct sdlpui_control *c, struct sdlpui_dialog *d,
+		struct sdlpui_window *w, enum sdlpui_action_hint ah,
+		struct sdlpui_control *new_c, struct sdlpui_dialog *new_d);
 	/**
 	 * Signal that the child dialog for a control has been removed.  Can
 	 * be NULL if the control does not create a dialog, set the created
@@ -227,18 +233,6 @@ struct sdlpui_control_funcs {
 	void (*lose_child)(struct sdlpui_control *c,
 		struct sdlpui_dialog *child);
 	/**
-	 * Signal that the control has become armed (i.e. key or mouse button
-	 * depressed while the control has focus).  Can be NULL.
-	 */
-	void (*arm)(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, enum sdlpui_action_hint hint);
-	/**
-	 * Signal that the control has become disarmed (i.e. key or mouse button
-	 * released while the control has focus).  Can be NULL.
-	 */
-	void (*disarm)(struct sdlpui_control *c, struct sdlpui_dialog *d,
-		struct sdlpui_window *w, enum sdlpui_action_hint hint);
-	/**
 	 * For simple controls, either returns zero (the control does not
 	 * accept focus) or one (it does).  For compound controls it returns:
 	 *     a) Zero if none of the components accepts focus.
@@ -246,21 +240,22 @@ struct sdlpui_control_funcs {
 	 *        the first component that can accept focus.
 	 *     c) If first is SDL_FALSE, returns the one-based index of the last
 	 *        component that can accept focus.
-	 * May be NULL:  callers will then assume the control can't accept
+	 * May be NULL:  callers will then assume the control cannot accept
 	 * focus.
 	 */
 	int (*get_interactable_component)(struct sdlpui_control *c,
 		SDL_bool first);
 	/**
-	 * Step (forward if forward is not SDL_FALSE; backward otherwise;
-	 * never wrap around) between the interactable components within the
-	 * given control, assumed to already have key focus, and transfer the
-	 * key focus to the result of the step.  Return SDL_FALSE if stepping
-	 * was not possible; otherwise return SDL_TRUE.  May be NULL:  callers
-	 * will then assume that any attempt to step within the control will
-	 * be ineffective.
+	 * Return the one-based index of the next (if forward is true) or
+	 * previous (if forward is false) component to receive focus.  The
+	 * current component with focus can be retrieved with
+	 * sdlpui_control_has_focus().  Return zero if there is not a component
+	 * that can receive focus for the step specified by forward.  Do not
+	 * wrap around when considering which component should receive focus.
+	 * May be NULL:  callers will then assume that any attempt to step
+	 * within the control will be ineffective.
 	 */
-	SDL_bool (*step_within)(struct sdlpui_control *c, SDL_bool forward);
+	int (*step_within)(struct sdlpui_control *c, SDL_bool forward);
 	/**
 	 * For a simple control, either returns zero (the control does not
 	 * accept focus or contain the given coordinates, relative to the
@@ -371,23 +366,13 @@ struct sdlpui_menu_button {
 	char *caption;
 	/** Invoked by the menu button's respond_default handler. */
 	void (*callback)(struct sdlpui_control*, struct sdlpui_dialog*,
-		struct sdlpui_window *w);
+		struct sdlpui_window *w, enum sdlpui_action_hint hint);
 	enum sdlpui_hor_align halign;
 	/**
 	 * This is a hook for the application to differentiate buttons with
 	 * the same contents for callback, subtype_code, and v.
 	 */
 	int tag;
-	int has_key;	/**< 0 = no key focus, 1 = key focus (for ranged_int
-				button, left side has focus), 2 = key focus
-				for right side of ranged_int button */
-	int has_mouse;	/**< 0 = no mouse focus, 1 = mouse focus (for ranged_int
-				button, left side has focus), 2 = mouse focus
-				for right side of ranged_int button */
-	int armed;	/**< 0 = not depressed, 1 = button depressed (for
-				ranged_int button, left side depressed), 2 =
-				ranged_int button right side depressed,
-				3 = ranged_int button both sides depressed */
 	SDL_bool disabled;
 			/**< if not SDL_FALSE, no response to events and
 				different look */
@@ -422,7 +407,7 @@ struct sdlpui_push_button {
 	char *caption;
 	/** Invoked by the push button's respond_default handler. */
 	void (*callback)(struct sdlpui_control*, struct sdlpui_dialog*,
-		struct sdlpui_window*);
+		struct sdlpui_window*, enum sdlpui_action_hint hint);
 	enum sdlpui_hor_align halign;
 	/**
 	 * This is a hook for the application to differentiate push buttons
@@ -431,9 +416,6 @@ struct sdlpui_push_button {
 	int tag;
 	SDL_bool disabled;	/**< if not SDL_FALSE, no response to events and
 					different look */
-	SDL_bool has_key;	/**< if not SDL_FALSE, has key focus */
-	SDL_bool has_mouse;	/**< if not SDL_FALSE, has mouse focus */
-	SDL_bool armed;		/**< if not SDL_FALSE, button is depressed */
 };
 
 
@@ -460,7 +442,8 @@ SDL_bool sdlpui_control_handle_mousemove(struct sdlpui_control *c,
 
 /* Standard callbacks for button controls */
 void sdlpui_invoke_dialog_default_action(struct sdlpui_control *c,
-		struct sdlpui_dialog *d, struct sdlpui_window *w);
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		enum sdlpui_action_hint hint);
 
 /* Constructors for controls in generic dialogs */
 void sdlpui_create_image(struct sdlpui_control *c, SDL_Texture *image,
@@ -471,25 +454,28 @@ void sdlpui_create_label(struct sdlpui_control *c, const char *caption,
 void sdlpui_create_push_button(struct sdlpui_control *c, const char *caption,
 		enum sdlpui_hor_align halign, void (*callback)(
 		struct sdlpui_control*, struct sdlpui_dialog*,
-		struct sdlpui_window*), int tag, SDL_bool disabled);
+		struct sdlpui_window*, enum sdlpui_action_hint), int tag,
+		SDL_bool disabled);
 
 /* Constructors for controls in menus */
 void sdlpui_create_menu_button(struct sdlpui_control *c, const char *caption,
 		enum sdlpui_hor_align halign, void (*callback)(
 		struct sdlpui_control*, struct sdlpui_dialog*,
-		struct sdlpui_window*), int tag, SDL_bool disabled);
+		struct sdlpui_window*, enum sdlpui_action_hint), int tag,
+		SDL_bool disabled);
 void sdlpui_create_menu_indicator(struct sdlpui_control *c, const char *caption,
 		enum sdlpui_hor_align halign, int tag, SDL_bool curr_value);
 void sdlpui_create_menu_ranged_int(struct sdlpui_control *c,
 		const char *caption, enum sdlpui_hor_align halign,
 		void (*callback)(struct sdlpui_control*, struct sdlpui_dialog*,
-		struct sdlpui_window*), int tag, SDL_bool disabled,
+		struct sdlpui_window*, enum sdlpui_action_hint), int tag,
+		SDL_bool disabled,
 		int curr_value, int min_value, int max_value);
 void sdlpui_create_menu_toggle(struct sdlpui_control *c, const char *caption,
 		enum sdlpui_hor_align halign, void (*callback)(
 		struct sdlpui_control*, struct sdlpui_dialog*,
-		struct sdlpui_window*), int tag, SDL_bool disabled,
-		SDL_bool curr_value);
+		struct sdlpui_window*, enum sdlpui_action_hint), int tag,
+		SDL_bool disabled, SDL_bool curr_value);
 void sdlpui_create_submenu_button(struct sdlpui_control *c, const char *caption,
 		enum sdlpui_hor_align halign, struct sdlpui_dialog *(*creator)(
 		struct sdlpui_control*, struct sdlpui_dialog*, struct

--- a/src/sdl2/pui-dlg.c
+++ b/src/sdl2/pui-dlg.c
@@ -18,18 +18,17 @@
  */
 
 #include "pui-dlg.h"
+#include "pui-foc.h"
 #include "pui-misc.h"
 #include "pui-win.h"
 #include <limits.h> /* INT_MAX */
 
 static SDL_bool handle_simple_menu_key(struct sdlpui_dialog *d,
 		struct sdlpui_window *w, const struct SDL_KeyboardEvent *e);
-static SDL_bool handle_simple_menu_textin(struct sdlpui_dialog *d,
-		struct sdlpui_window *w, const struct SDL_TextInputEvent *e);
 static void render_simple_menu(struct sdlpui_dialog *d,
 		struct sdlpui_window *w);
-static void goto_simple_menu_first_control(struct sdlpui_dialog *d,
-		struct sdlpui_window *w);
+static struct sdlpui_control* goto_simple_menu_first_control(
+		struct sdlpui_dialog *d, struct sdlpui_window *w);
 static void step_simple_menu_control(struct sdlpui_dialog *d,
 		struct sdlpui_window *w, struct sdlpui_control *c,
 		SDL_bool forward);
@@ -53,8 +52,8 @@ static void cleanup_simple_menu(struct sdlpui_dialog *d);
 
 static void render_simple_info(struct sdlpui_dialog *d,
 		struct sdlpui_window *w);
-static void goto_simple_info_first_control(struct sdlpui_dialog *d,
-		struct sdlpui_window *w);
+static struct sdlpui_control* goto_simple_info_first_control(
+		struct sdlpui_dialog *d, struct sdlpui_window *w);
 static struct sdlpui_control *find_simple_info_control_containing(
 		struct sdlpui_dialog *d, struct sdlpui_window *w,
 		Sint32 x, Sint32 y, int *comp_ind);
@@ -70,7 +69,7 @@ Uint32 SDLPUI_DIALOG_SIMPLE_INFO = 0;
 
 static const struct sdlpui_dialog_funcs simple_menu_funcs = {
 	handle_simple_menu_key,
-	handle_simple_menu_textin,
+	sdlpui_dialog_handle_textin,
 	sdlpui_dialog_handle_textedit,
 	sdlpui_dialog_handle_mouseclick,
 	sdlpui_dialog_handle_mousemove,
@@ -133,42 +132,47 @@ static SDL_bool handle_simple_menu_key(struct sdlpui_dialog *d,
 {
 	/*
 	 * Swap which keys do what depending on the orientation of the menu.
-	 * fwd_alt1, fwd_alt2, fwd_alt3 are for the keys corresponding to
-	 * the in-game east (for vertical menus) or south (for horizontal
-	 * menus) motion commands from either keyset.
+	 * Allow motion commands from either keyset.
 	 */
 	struct k_dirsyms {
-		SDL_Keycode fwd, fwd_alt1, fwd_alt2, fwd_alt3, bck, nxt, prv;
+		SDL_Keycode fwd[4], bck[4], nxt[4], prv[4];
 	};
 	static const struct k_dirsyms vsyms = {
-		SDLK_RIGHT,
-		SDLK_6,
-		SDLK_KP_6,
-		SDLK_l,
-		SDLK_LEFT,
-		SDLK_DOWN,
-		SDLK_UP
+		/* East descends into the menu hierarchy. */
+		{ SDLK_RIGHT, SDLK_6, SDLK_KP_6, SDLK_l },
+		/* West backs out. */
+		{ SDLK_LEFT, SDLK_4, SDLK_KP_4, SDLK_h },
+		/* South goes to the next item in this menu. */
+		{ SDLK_DOWN, SDLK_2, SDLK_KP_2, SDLK_j },
+		/* North goes to the previous item in this menu. */
+		{ SDLK_UP, SDLK_8, SDLK_KP_8, SDLK_k },
 	};
 	static const struct k_dirsyms hsyms = {
-		SDLK_DOWN,
-		SDLK_2,
-		SDLK_KP_2,
-		SDLK_j,
-		SDLK_UP,
-		SDLK_RIGHT,
-		SDLK_LEFT
+		/* South descends. */
+		{ SDLK_DOWN, SDLK_2, SDLK_KP_2, SDLK_j },
+		/* North backs out. */
+		{ SDLK_UP, SDLK_8, SDLK_KP_8, SDLK_k },
+		/* East goes to the next item in this menu. */
+		{ SDLK_RIGHT, SDLK_6, SDLK_KP_6, SDLK_l },
+		/* West goes to the previous item in this menu. */
+		{ SDLK_LEFT, SDLK_4, SDLK_KP_4, SDLK_h },
 	};
 	const struct k_dirsyms *csyms;
+	struct sdlpui_control *c;
+	struct sdlpui_simple_menu *p;
+	SDL_Keymod mods;
+
+	sdlpui_begin_focus_transaction();
+
 	/*
 	 * Most of the additional event handling is as a proxy for the menu's
 	 * control with keyboard focus so remember what that is.
 	 */
-	struct sdlpui_control *c = d->c_key;
-	struct sdlpui_simple_menu *p;
-	SDL_Keymod mods;
+	c = sdlpui_get_control_with_focus(SDLPUI_ACTION_HINT_KEY);
 
 	/* Relay to the control with focus.  if it handles it we're done. */
 	if (c && c->ftb->handle_key && (*c->ftb->handle_key)(c, d, w, e)) {
+		sdlpui_end_focus_transaction();
 		return SDL_TRUE;
 	}
 
@@ -177,240 +181,106 @@ static SDL_bool handle_simple_menu_key(struct sdlpui_dialog *d,
 	csyms = (p->vertical) ? &vsyms : &hsyms;
 
 	mods = sdlpui_get_interesting_keymods();
-	if (e->keysym.sym == csyms->fwd) {
-		/*
-		 * Invoke the default action for a menu entry which will
-		 * descend deeper into the menu hierarchy if that entry leads
-		 * to a submenu.  If there's no entry with keyboard focus,
-		 * give focus to the first active entry.
-		 */
-		if (c) {
-			if (e->state == SDL_PRESSED) {
-				if (mods == KMOD_NONE) {
-					(*c->ftb->arm)(c, d, w,
-						SDLPUI_ACTION_HINT_KEY);
-				}
-			} else {
+	if (e->state == SDL_PRESSED) {
+		if (mods == KMOD_NONE) {
+			if (e->keysym.sym == csyms->fwd[0]
+					|| e->keysym.sym == csyms->fwd[1]
+					|| e->keysym.sym == csyms->fwd[2]
+					|| e->keysym.sym == csyms->fwd[3]) {
 				/*
-				 * Always disarm, regardless of the modifier
-				 * state, in case the modifier keys changed
-				 * between the press and release.
+				 * Invoke the default action for a menu entry.
+				 * That will descend deeper into the menu
+				 * hierarchy if that entry leads to a submenu.
+				 * If there is no entry with keyboard focus,
+				 * give focus to the first active entry.
 				 */
-				if (c->ftb->disarm) {
-					(*c->ftb->disarm)(c, d, w,
-						SDLPUI_ACTION_HINT_KEY);
+				if (c) {
+					if (c->ftb->respond_default) {
+						SDLPUI_EVENT_TRACER(
+							(*c->ftb->get_type_name)(c),
+							c,
+							(c->ftb->get_caption)
+							? (*c->ftb->get_caption)(c)
+							: "(none)",
+							"invoking default response");
+						(*c->ftb->respond_default)(c,
+							d, w,
+							SDLPUI_ACTION_HINT_KEY);
+					}
+				} else if (!sdlpui_is_focus_locked(SDLPUI_ACTION_HINT_KEY)
+						&& d->ftb->goto_first_control) {
+					(void)(*d->ftb->goto_first_control)(d, w);
 				}
-				if (mods == KMOD_NONE
-						&& c->ftb->respond_default) {
-					SDLPUI_EVENT_TRACER(
-						(*c->ftb->get_type_name)(c), c,
-						(c->ftb->get_caption)
-						? (*c->ftb->get_caption)(c)
-						: "(none)",
-						"invoking default response");
-					(*c->ftb->respond_default)(c, d, w,
-						SDLPUI_ACTION_HINT_KEY);
-				}
-			}
-		} else if (e->state == SDL_RELEASED
-				&& d->ftb->goto_first_control) {
-			(*d->ftb->goto_first_control)(d, w);
-		}
-		return SDL_TRUE;
-	}
-
-	if (e->keysym.sym == csyms->fwd_alt1 || e->keysym.sym == csyms->fwd_alt2
-			|| e->keysym.sym == csyms->fwd_alt3) {
-		/*
-		 * Like fwd, but as these symbols also trigger the text input
-		 * handler, just handle arming and disarming of the menu
-		 * button here.
-		 */
-		if (c) {
-			if (e->state == SDL_PRESSED) {
-				if (mods == KMOD_NONE && c->ftb->arm) {
-					(*c->ftb->arm)(c, d, w,
-						SDLPUI_ACTION_HINT_KEY);
-				}
-			} else {
+				sdlpui_end_focus_transaction();
+				return SDL_TRUE;
+			} else if (e->keysym.sym == csyms->bck[0]
+					|| e->keysym.sym == csyms->bck[1]
+					|| e->keysym.sym == csyms->bck[2]
+					|| e->keysym.sym == csyms->bck[3]) {
 				/*
-				 * Always disarm, regardless of the modifier
-				 * state, in case the modifier keys changed
-				 * between the press and release.
+				 * Back out to the previous level of the menu
+				 * hierarchy, if any.
 				 */
-				if (c->ftb->disarm) {
-					(*c->ftb->disarm)(c, d, w,
-						SDLPUI_ACTION_HINT_KEY);
+				sdlpui_dialog_give_key_focus_to_parent(d, w);
+				sdlpui_end_focus_transaction();
+				return SDL_TRUE;
+			} else if (e->keysym.sym == csyms->nxt[0]
+					|| e->keysym.sym == csyms->nxt[1]
+					|| e->keysym.sym == csyms->nxt[2]
+					|| e->keysym.sym == csyms->nxt[3]) {
+				/*
+				 * Go to the next active button in the menu or
+				 * wrap around to the first active button in
+				 * the menu if already at the end.  If the
+				 * menu does not already have key focus, give
+				 * it key focus and go to the first active
+				 * button.
+				 */
+				if (!sdlpui_is_focus_locked(SDLPUI_ACTION_HINT_KEY)) {
+					if (c) {
+						if (d->ftb->step_control) {
+							(*d->ftb->step_control)(
+								d, w, c,
+								SDL_TRUE);
+						}
+					} else if (d->ftb->goto_first_control) {
+						(void)(*d->ftb->goto_first_control)(d, w);
+					}
 				}
+				sdlpui_end_focus_transaction();
+				return SDL_TRUE;
+			} else if (e->keysym.sym == csyms->prv[0]
+					|| e->keysym.sym == csyms->prv[1]
+					|| e->keysym.sym == csyms->prv[2]
+					|| e->keysym.sym == csyms->prv[3]) {
+				/*
+				 * Go to the previous active button in the
+				 * menu or wrap around to the first active
+				 * button in the menu if already at the end.
+				 * If the menu does not already have key focus,
+				 * give it key focus and go to the first
+				 * active button.
+				 */
+				if (!sdlpui_is_focus_locked(SDLPUI_ACTION_HINT_KEY)) {
+					if (c) {
+						if (d->ftb->step_control) {
+							(*d->ftb->step_control)(
+								d, w, c,
+								SDL_FALSE);
+						}
+					} else if (d->ftb->goto_first_control) {
+						(void)(*d->ftb->goto_first_control)(d, w);
+					}
+				}
+				sdlpui_end_focus_transaction();
+				return SDL_TRUE;
 			}
 		}
-		return SDL_TRUE;
 	}
 
-	if (e->keysym.sym == csyms->bck) {
-		/*
-		 * Back out to the previous level of the menu hierarchy, if any.
-		 */
-		if (e->state == SDL_RELEASED && mods == KMOD_NONE) {
-			sdlpui_dialog_give_key_focus_to_parent(d, w);
-		}
-		return SDL_TRUE;
-	}
-
-	if (e->keysym.sym == csyms->nxt) {
-		/*
-		 * Go to the next active button in the menu or wrap around to
-		 * the first active button in the menu if already at the end.
-		 * If the menu does not already have key focus, give it key
-		 * focus and go to the first active button.
-		 */
-		if (e->state == SDL_RELEASED && mods == KMOD_NONE) {
-			if (c) {
-				if (d->ftb->step_control) {
-					(*d->ftb->step_control)(d, w, c,
-						SDL_TRUE);
-				}
-			} else if (d->ftb->goto_first_control) {
-				(*d->ftb->goto_first_control)(d, w);
-			}
-		}
-		return SDL_TRUE;
-	}
-
-	if (e->keysym.sym == csyms->prv) {
-		/*
-		 * Go to the previous active button in the menu or wrap around
-		 * to the first active button in the menu if already at the end.
-		 * If the menu does not already have key focus, give it key
-		 * focus and go to the first active button.
-		 */
-		if (e->state == SDL_RELEASED && mods == KMOD_NONE) {
-			if (c) {
-				if (d->ftb->step_control) {
-					(*d->ftb->step_control)(d, w, c,
-						SDL_FALSE);
-				}
-			} else if (d->ftb->goto_first_control) {
-				(*d->ftb->goto_first_control)(d, w);
-			}
-		}
-		return SDL_TRUE;
-	}
+	sdlpui_end_focus_transaction();
 
 	return sdlpui_dialog_handle_key(d, w, e);
-}
-
-
-static SDL_bool handle_simple_menu_textin(struct sdlpui_dialog *d,
-		struct sdlpui_window *w, const struct SDL_TextInputEvent *e)
-{
-	/*
-	 * Swap which keys do what depending on the orientation of the menu.
-	 * All correspond to in-game motion commands from either keyset.
-	 */
-	struct ti_dirsyms {
-		uint32_t fwd_alt1, fwd_alt2, bck_alt1, bck_alt2, nxt_alt1,
-			nxt_alt2, prv_alt1, prv_alt2;
-	};
-	static const struct ti_dirsyms vsyms = {
-		/* East descends into the menu hierarchy. */
-		'6', 'l',
-		/* West backs out. */
-		'4', 'h',
-		/* South goes to the next item in this menu. */
-		'2', 'j',
-		/* North goes to the previous item in this menu. */
-		'8', 'k'
-	};
-	static const struct ti_dirsyms hsyms = {
-		/* South descends. */
-		'2', 'j',
-		/* North backs out. */
-		'8', 'k',
-		/* East goes to the next item in this menu. */
-		'6', 'l',
-		/* West goes to the previous item in this menu. */
-		'4', 'h'
-	};
-	const struct ti_dirsyms *csyms;
-	/*
-	 * Most of the additional event handling is as a proxy for the menu's
-	 * control with keyboard focus so remember what that is.
-	 */
-	struct sdlpui_control *c = d->c_key;
-	struct sdlpui_simple_menu *p;
-	uint32_t ch = sdlpui_utf8_to_codepoint(e->text);
-
-	SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
-	p = d->priv;
-	csyms = (p->vertical) ? &vsyms : &hsyms;
-
-	if (ch == csyms->fwd_alt1 || ch == csyms->fwd_alt2) {
-		/*
-		 * Invoke the default action on the menu entry which will
-		 * descend deeper into the menu hierarchy if the entry leads
-		 * to a submenu.  If there's no menu entry with keyboard focus,
-		 * give keyboard focus to the first active entry.
-		 */
-		if (c) {
-			if (c->ftb->respond_default) {
-				SDLPUI_EVENT_TRACER(
-					(*c->ftb->get_type_name)(c), c,
-					(c->ftb->get_caption)
-					? (*c->ftb->get_caption)(c) : "(none)",
-					"invoking default response");
-				(*c->ftb->respond_default)(c, d, w,
-					SDLPUI_ACTION_HINT_KEY);
-			}
-		} else if (d->ftb->goto_first_control) {
-			(*d->ftb->goto_first_control)(d, w);
-		}
-		return SDL_TRUE;
-	}
-
-	if (ch == csyms->bck_alt1 || ch == csyms->bck_alt2) {
-		/*
-		 * Back out to the previous level of the menu hierarchy, if any.
-		 */
-		sdlpui_dialog_give_key_focus_to_parent(d, w);
-		return SDL_TRUE;
-	}
-
-	if (ch == csyms->nxt_alt1 || ch == csyms->nxt_alt2) {
-		/*
-		 * Go to the next active button in the menu or wrap around to
-		 * the first active button in the menu if already at the end.
-		 * If the menu does not already have key focus, give it key
-		 * focus and go to the first active button.
-		 */
-		if (c) {
-			if (d->ftb->step_control) {
-				(*d->ftb->step_control)(d, w, c, SDL_TRUE);
-			}
-		} else if (d->ftb->goto_first_control) {
-			(*d->ftb->goto_first_control)(d, w);
-		}
-		return SDL_TRUE;
-	}
-
-	if (ch == csyms->prv_alt1 || ch == csyms->prv_alt2) {
-		/*
-		 * Got to the previous active button in the menu or wrap around
-		 * to the last active button in the menu if already at the
-		 * beginning.  If the menu does not already have key focus,
-		 * give it key focus and go to the first active button.
-		 */
-		if (c) {
-			if (d->ftb->step_control) {
-				(*d->ftb->step_control)(d, w, c, SDL_FALSE);
-			}
-		} else if (d->ftb->goto_first_control) {
-			(*d->ftb->goto_first_control)(d, w);
-		}
-		return SDL_TRUE;
-	}
-
-	return sdlpui_dialog_handle_textin(d, w, e);
 }
 
 
@@ -453,12 +323,11 @@ static void render_simple_menu(struct sdlpui_dialog *d, struct sdlpui_window *w)
 			color->a);
 		SDL_RenderDrawRect(r, &dst_r);
 	}
-	d->dirty = SDL_FALSE;
 }
 
 
-static void goto_simple_menu_first_control(struct sdlpui_dialog *d,
-		struct sdlpui_window *w)
+static struct sdlpui_control* goto_simple_menu_first_control(
+		struct sdlpui_dialog *d, struct sdlpui_window *w)
 {
 	struct sdlpui_simple_menu *p;
 	int i = 0;
@@ -470,35 +339,25 @@ static void goto_simple_menu_first_control(struct sdlpui_dialog *d,
 		int comp_ind;
 
 		if (i >= p->n_vis) {
-			/* There's no members that can take focus. */
-			SDLPUI_EVENT_TRACER("dialog", d, "(not extracted)",
-				"gains key focus");
-			if (d->c_key && d->c_key->ftb->lose_key) {
-				(*d->c_key->ftb->lose_key)(d->c_key, d, w,
-					NULL, d);
-			}
-			d->c_key = NULL;
-			/* Anyways, still give the dialog key focus. */
-			sdlpui_dialog_gain_key_focus(w, d);
-			return;
+			/*
+			 * There are no members that can take focus.  Still
+			 * give focus to the dialog.
+			 */
+			sdlpui_begin_focus_transaction();
+			(void)sdlpui_change_focus(NULL, 0, d, w,
+				SDLPUI_ACTION_HINT_KEY, SDL_FALSE);
+			sdlpui_end_focus_transaction();
+			return NULL;
 		}
 		comp_ind = (p->v_ctrls[i]->ftb->get_interactable_component) ?
 			(p->v_ctrls[i]->ftb->get_interactable_component)(
 				p->v_ctrls[i], SDL_TRUE) : 0;
 		if (comp_ind) {
-			SDLPUI_EVENT_TRACER("dialog", d, "(not extracted)",
-				"gains key focus");
-			if (d->c_key && d->c_key->id != p->v_ctrls[i]->id
-					&& d->c_key->ftb->lose_key) {
-				(*d->c_key->ftb->lose_key)(d->c_key, d, w,
-					p->v_ctrls[i], d);
-			}
-			SDL_assert(p->v_ctrls[i]->ftb->gain_key);
-			(*p->v_ctrls[i]->ftb->gain_key)(
-				p->v_ctrls[i], d, w, comp_ind - 1);
-			d->c_key = p->v_ctrls[i];
-			sdlpui_dialog_gain_key_focus(w, d);
-			return;
+			sdlpui_begin_focus_transaction();
+			(void)sdlpui_change_focus(p->v_ctrls[i], comp_ind - 1,
+				d, w, SDLPUI_ACTION_HINT_KEY, SDL_FALSE);
+			sdlpui_end_focus_transaction();
+			return p->v_ctrls[i];
 		}
 		++i;
 	}
@@ -510,14 +369,18 @@ static void step_simple_menu_control(struct sdlpui_dialog *d,
 		SDL_bool forward)
 {
 	struct sdlpui_simple_menu *p;
-	int istart, itry;
+	int comp_ind, istart, itry;
 
 	SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
 	p = d->priv;
 
-	if (c->ftb->step_within && (*c->ftb->step_within)(c, forward)) {
-		d->dirty = SDL_TRUE;
-		sdlpui_signal_redraw(w);
+	comp_ind = (c->ftb->step_within)
+		? (*c->ftb->step_within)(c, forward) : 0;
+	if (comp_ind) {
+		sdlpui_begin_focus_transaction();
+		(void)sdlpui_change_focus(c, comp_ind - 1, d, w,
+				SDLPUI_ACTION_HINT_KEY, SDL_FALSE);
+		sdlpui_end_focus_transaction();
 		return;
 	}
 
@@ -538,8 +401,6 @@ static void step_simple_menu_control(struct sdlpui_dialog *d,
 	}
 	itry = istart;
 	while (1) {
-		int comp_ind;
-
 		if (forward) {
 			++itry;
 			if (itry == p->n_vis) {
@@ -551,28 +412,26 @@ static void step_simple_menu_control(struct sdlpui_dialog *d,
 				itry = p->n_vis - 1;
 			}
 		}
-		if (itry == istart) {
-			/*
-			 * Wrapped around without finding another control that
-			 * can accept focus.
-			 */
-			SDL_assert(d->c_key && d->c_key->id == c->id);
-			break;
-		}
 		comp_ind = (p->v_ctrls[itry]->ftb->get_interactable_component) ?
 			(*p->v_ctrls[itry]->ftb->get_interactable_component)(
 				p->v_ctrls[itry], forward) : 0;
 		if (comp_ind) {
-			if (d->c_key && d->c_key->id != p->v_ctrls[itry]->id
-					&& d->c_key->ftb->lose_key) {
-				(*d->c_key->ftb->lose_key)(d->c_key, d, w,
-					p->v_ctrls[itry], d);
-			}
-			if (p->v_ctrls[itry]->ftb->gain_key) {
-				(*p->v_ctrls[itry]->ftb->gain_key)(
-					p->v_ctrls[itry], d, w, comp_ind - 1);
-			}
-			d->c_key = p->v_ctrls[itry];
+			sdlpui_begin_focus_transaction();
+			(void)sdlpui_change_focus(p->v_ctrls[itry],
+				comp_ind - 1, d, w, SDLPUI_ACTION_HINT_KEY,
+				SDL_FALSE);
+			sdlpui_end_focus_transaction();
+			break;
+		}
+		if (itry == istart) {
+			/*
+			 * Wrapped around without finding a control that can
+			 * accept focus.
+			 */
+			sdlpui_begin_focus_transaction();
+			(void)sdlpui_change_focus(NULL, 0, d, w,
+				SDLPUI_ACTION_HINT_KEY, SDL_FALSE);
+			sdlpui_end_focus_transaction();
 			break;
 		}
 	}
@@ -1062,23 +921,21 @@ static void render_simple_info(struct sdlpui_dialog *d,
 	dst_r.w -= 2;
 	dst_r.h -= 2;
 	SDL_RenderDrawRect(r, &dst_r);
-	d->dirty = SDL_FALSE;
 }
 
 
-static void goto_simple_info_first_control(struct sdlpui_dialog *d,
-		struct sdlpui_window *w)
+static struct sdlpui_control* goto_simple_info_first_control(
+		struct sdlpui_dialog *d, struct sdlpui_window *w)
 {
 	struct sdlpui_simple_info *id;
 
 	SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_INFO && d->priv);
 	id = d->priv;
-
-	SDL_assert(id->button.ftb->gain_key);
-	(*id->button.ftb->gain_key)(&id->button, d, w, 0);
-	SDL_assert(!d->c_key || d->c_key->id == id->button.id);
-	d->c_key = &id->button;
-	sdlpui_dialog_gain_key_focus(w, d);
+	sdlpui_begin_focus_transaction();
+	(void)sdlpui_change_focus(&id->button, 0, d, w, SDLPUI_ACTION_HINT_KEY,
+		SDL_FALSE);
+	sdlpui_end_focus_transaction();
+	return &id->button;
 }
 
 
@@ -1210,6 +1067,16 @@ static void cleanup_simple_info(struct sdlpui_dialog *d)
 
 
 /**
+ * Return SDL_TRUE and reset the redraw flag if the given dialog should be
+ * redrawn.  Otherwise, return SDL_FALSE.
+ */
+SDL_bool sdlpui_dialog_should_redraw(struct sdlpui_dialog *d)
+{
+	return SDL_AtomicCAS(&d->dirty, SDL_TRUE, SDL_FALSE);
+}
+
+
+/**
  * Determine if a given coordinate, relative to the window, is in a dialog.
  *
  * \param d is the dialog of interest.
@@ -1259,6 +1126,18 @@ SDL_bool sdlpui_is_descendant_dialog(struct sdlpui_dialog *ancestor,
 	}
 }
 
+
+/**
+ * Mark that the given dialog should be redrawn.
+ */
+void sdlpui_dialog_mark_for_redraw(struct sdlpui_dialog *d,
+		struct sdlpui_window *w)
+{
+	(void)SDL_AtomicSet(&d->dirty, SDL_TRUE);
+	sdlpui_signal_redraw(w);
+}
+
+
 /**
  * Pop up a dialog.
  *
@@ -1271,14 +1150,16 @@ void sdlpui_popup_dialog(struct sdlpui_dialog *d, struct sdlpui_window *w,
 		SDL_bool give_key_focus)
 {
 	/* Assume it may have been obscured and needs to be redrawn. */
-	d->dirty = SDL_TRUE;
-	sdlpui_signal_redraw(w);
+	sdlpui_dialog_mark_for_redraw(d, w);
 	if (d->pop_callback) {
 		(*d->pop_callback)(d, w, SDL_TRUE);
 	}
 	sdlpui_dialog_push_to_top(w, d);
 	if (give_key_focus) {
-		sdlpui_dialog_gain_key_focus(w, d);
+		sdlpui_begin_focus_transaction();
+		(void)sdlpui_change_focus(NULL, 0, d, w, SDLPUI_ACTION_HINT_KEY,
+			SDL_FALSE);
+		sdlpui_end_focus_transaction();
 	}
 }
 
@@ -1308,37 +1189,43 @@ void sdlpui_popdown_dialog(struct sdlpui_dialog *d, struct sdlpui_window *w,
 	}
 
 	while (1) {
-		struct sdlpui_dialog *parent = sdlpui_get_dialog_parent(d);
-		struct sdlpui_control *parent_ctrl =
+		struct sdlpui_dialog *parent_d = sdlpui_get_dialog_parent(d);
+		struct sdlpui_control *parent_c =
 			sdlpui_get_dialog_parent_ctrl(d);
 
 		if (d->pop_callback) {
 			(*d->pop_callback)(d, w, SDL_FALSE);
 		}
-		sdlpui_dialog_pop(w, d);
-		if (parent_ctrl && parent_ctrl->ftb->lose_child) {
-			(*parent_ctrl->ftb->lose_child)(parent_ctrl, d);
+		sdlpui_begin_focus_transaction();
+		if (sdlpui_dialog_has_focus(d, SDLPUI_ACTION_HINT_MOUSE)) {
+			(void)sdlpui_change_focus(NULL, 0, NULL, w,
+				SDLPUI_ACTION_HINT_MOUSE, SDL_TRUE);
+		} else if (sdlpui_dialog_has_focus(d, SDLPUI_ACTION_HINT_KEY)) {
+			(void)sdlpui_change_focus(NULL, 0, NULL, w,
+				SDLPUI_ACTION_HINT_KEY, SDL_TRUE);
 		}
-		if (parent) {
-			SDL_assert(parent->ftb->set_child);
-			(*parent->ftb->set_child)(parent, NULL);
+		sdlpui_end_focus_transaction();
+		sdlpui_dialog_pop(w, d);
+		if (parent_c && parent_c->ftb->lose_child) {
+			(*parent_c->ftb->lose_child)(parent_c, d);
+		}
+		if (parent_d) {
+			SDL_assert(parent_d->ftb->set_child);
+			(*parent_d->ftb->set_child)(parent_d, NULL);
 
 			/*
 			 * If the parent control has key focus but not mouse
 			 * focus, lose that focus when the child is lost.
 			 */
-			if (parent_ctrl && parent->c_key
-					&& parent->c_key->id == parent_ctrl->id
-					&& (!parent->c_mouse
-					|| parent->c_mouse->id
-					!= parent_ctrl->id)) {
-				if (parent_ctrl->ftb->lose_key) {
-					(*parent_ctrl->ftb->lose_key)(
-						parent_ctrl, parent, w,
-						NULL, NULL);
-				}
-				parent->c_key = NULL;
+			sdlpui_begin_focus_transaction();
+			if (parent_c && sdlpui_control_has_focus(parent_c,
+					SDLPUI_ACTION_HINT_KEY)
+					&& !sdlpui_control_has_focus(
+					parent_c, SDLPUI_ACTION_HINT_MOUSE)) {
+				(void)sdlpui_change_focus(NULL, 0, parent_d, w,
+					SDLPUI_ACTION_HINT_KEY, SDL_FALSE);
 			}
+			sdlpui_end_focus_transaction();
 		}
 		if (d->ftb->cleanup) {
 			(*d->ftb->cleanup)(d);
@@ -1346,13 +1233,13 @@ void sdlpui_popdown_dialog(struct sdlpui_dialog *d, struct sdlpui_window *w,
 		sdlpui_unregister_dialog(d);
 		SDL_free(d);
 
-		if ((parent && parent->pinned)
-				|| (!parent && !stopping_point)
-				|| (parent && stopping_point
-				&& parent->id == stopping_point->id)) {
+		if ((parent_d && parent_d->pinned)
+				|| (!parent_d && !stopping_point)
+				|| (parent_d && stopping_point
+				&& parent_d->id == stopping_point->id)) {
 			break;
 		}
-		d = parent;
+		d = parent_d;
 	}
 }
 
@@ -1364,33 +1251,29 @@ void sdlpui_popdown_dialog(struct sdlpui_dialog *d, struct sdlpui_window *w,
  *
  * \param d is the dialog that's ceding focus.
  * \param w is the window containing the dialog.
+ *
+ * Does nothing if keyboard focus is currently locked.
  */
 void sdlpui_dialog_give_key_focus_to_parent(struct sdlpui_dialog *d,
 		struct sdlpui_window *w)
 {
-	struct sdlpui_dialog *parent = sdlpui_get_dialog_parent(d);
+	struct sdlpui_dialog *parent_d;
+	struct sdlpui_control *parent_c;
 
-	if (parent) {
-		if (d->c_key && d->c_key->ftb->lose_key) {
-			(*d->c_key->ftb->lose_key)(d->c_key, d, w, NULL,
-				parent);
-		}
-		d->c_key = NULL;
-		SDLPUI_EVENT_TRACER("dialog", d,
-			"(not extracted)", "yields key focus");
-		sdlpui_dialog_yield_key_focus(w, d);
-		SDLPUI_EVENT_TRACER("dialog", parent,
-			"(not extracted)", "gains key focus");
-		sdlpui_dialog_gain_key_focus(w, parent);
-	} else {
-		SDLPUI_EVENT_TRACER("dialog", d,
-			"(not extracted)", "yields key focus");
-		sdlpui_dialog_yield_key_focus(w, d);
-		if (!d->pinned) {
-			SDLPUI_EVENT_TRACER("dialog", d,
-				"(not extracted)", "popping down");
-			sdlpui_popdown_dialog(d, w, SDL_FALSE);
-		}
+	sdlpui_begin_focus_transaction();
+	if (sdlpui_is_focus_locked(SDLPUI_ACTION_HINT_KEY)) {
+		sdlpui_end_focus_transaction();
+		return;
+	}
+	parent_d = sdlpui_get_dialog_parent(d);
+	parent_c = sdlpui_get_dialog_parent_ctrl(d);
+	(void)sdlpui_change_focus(parent_c, 0, parent_d, w,
+		SDLPUI_ACTION_HINT_KEY, SDL_FALSE);
+	sdlpui_end_focus_transaction();
+	if (!parent_d && !d->pinned) {
+		SDLPUI_EVENT_TRACER("dialog", d, "(not extracted)",
+			"popping down");
+		sdlpui_popdown_dialog(d, w, SDL_FALSE);
 	}
 }
 
@@ -1446,38 +1329,58 @@ struct sdlpui_control *sdlpui_get_dialog_parent_ctrl(struct sdlpui_dialog *d)
 SDL_bool sdlpui_dialog_handle_key(struct sdlpui_dialog *d,
 		struct sdlpui_window *w, const struct SDL_KeyboardEvent *e)
 {
+	struct sdlpui_control *c_key;
 	SDL_Keymod mods;
+	SDL_bool handled;
+
+	sdlpui_begin_focus_transaction();
 
 	/* Relay to the control with focus.  If it handles it, we are done. */
-	if (d->c_key && d->c_key->ftb->handle_key
-			&& (*d->c_key->ftb->handle_key)(d->c_key, d, w, e)) {
+	c_key = sdlpui_get_control_with_focus(SDLPUI_ACTION_HINT_KEY);
+	if (c_key && c_key->ftb->handle_key
+			&& (*c_key->ftb->handle_key)(c_key, d, w, e)) {
+		sdlpui_end_focus_transaction();
 		return SDL_TRUE;
 	}
 
 	mods = sdlpui_get_interesting_keymods();
+	handled = SDL_FALSE;
 	switch (e->keysym.sym) {
 	case SDLK_ESCAPE:
-		if (e->state == SDL_RELEASED && mods == KMOD_NONE) {
-			while (1) {
-				struct sdlpui_dialog *child =
-					sdlpui_get_dialog_child(d);
+		if (e->state == SDL_PRESSED && mods == KMOD_NONE
+				&& !sdlpui_is_focus_locked(SDLPUI_ACTION_HINT_KEY)) {
+			SDL_bool mouse_locked;
 
+			handled = SDL_TRUE;
+			mouse_locked = sdlpui_is_focus_locked(SDLPUI_ACTION_HINT_MOUSE);
+			while (1) {
+				struct sdlpui_dialog *child;
+
+				if (mouse_locked
+						&& sdlpui_dialog_has_focus(d,
+						SDLPUI_ACTION_HINT_MOUSE)) {
+					break;
+				}
+				child = sdlpui_get_dialog_child(d);
 				if (!child) {
+					if (!d->pinned) {
+						SDLPUI_EVENT_TRACER("dialog", d,
+							"(not extracted)",
+							"popping down");
+						sdlpui_popdown_dialog(d, w,
+							SDL_TRUE);
+					}
 					break;
 				}
 				d = child;
-			}
-			if (!d->pinned) {
-				SDLPUI_EVENT_TRACER("dialog", d,
-					"(not extracted)", "popping down");
-				sdlpui_popdown_dialog(d, w, SDL_TRUE);
 			}
 		}
 		break;
 
 	case SDLK_RETURN:
-		if (e->state == SDL_RELEASED && mods == KMOD_NONE
+		if (e->state == SDL_PRESSED && mods == KMOD_NONE
 				&& d->ftb->respond_default) {
+			handled = SDL_TRUE;
 			SDLPUI_EVENT_TRACER("dialog", d, "(not extracted)",
 				"invoking default response");
 			(*d->ftb->respond_default)(d, w);
@@ -1485,23 +1388,26 @@ SDL_bool sdlpui_dialog_handle_key(struct sdlpui_dialog *d,
 		break;
 
 	case SDLK_TAB:
-		if (e->state == SDL_RELEASED
+		if (e->state == SDL_PRESSED
 				&& (mods & ~(KMOD_SHIFT | KMOD_CTRL))
-				== KMOD_NONE) {
-			if (!d->c_key) {
+				== KMOD_NONE
+				&& !sdlpui_is_focus_locked(SDLPUI_ACTION_HINT_KEY)) {
+			handled = SDL_TRUE;
+			if (!c_key) {
 				if (d->ftb->goto_first_control) {
-					(*d->ftb->goto_first_control)(d, w);
+					(void)(*d->ftb->goto_first_control)(d, w);
 				}
 			} else if (d->ftb->step_control) {
-				(*d->ftb->step_control)(d, w, d->c_key,
+				(*d->ftb->step_control)(d, w, c_key,
 					(mods & (KMOD_SHIFT)) == 0);
 			}
 		}
 		break;
 	}
 
-	/* Swallow the event, even if nothing was done. */
-	return SDL_TRUE;
+	sdlpui_end_focus_transaction();
+
+	return handled;
 }
 
 
@@ -1517,11 +1423,19 @@ SDL_bool sdlpui_dialog_handle_key(struct sdlpui_dialog *d,
 SDL_bool sdlpui_dialog_handle_textin(struct sdlpui_dialog *d,
 		struct sdlpui_window *w, const struct SDL_TextInputEvent *e)
 {
+	struct sdlpui_control *c_key;
+
+	sdlpui_begin_focus_transaction();
+
 	/* Relay to the control with focus.  If it handles it, we are done. */
-	if (d->c_key && d->c_key->ftb->handle_textin
-			&& (*d->c_key->ftb->handle_textin)(d->c_key, d, w, e)) {
+	c_key = sdlpui_get_control_with_focus(SDLPUI_ACTION_HINT_KEY);
+	if (c_key && c_key->ftb->handle_textin
+			&& (*c_key->ftb->handle_textin)(c_key, d, w, e)) {
+		sdlpui_end_focus_transaction();
 		return SDL_TRUE;
 	}
+
+	sdlpui_end_focus_transaction();
 
 	/* Do nothing and swallow the event. */
 	return SDL_TRUE;
@@ -1540,12 +1454,19 @@ SDL_bool sdlpui_dialog_handle_textin(struct sdlpui_dialog *d,
 SDL_bool sdlpui_dialog_handle_textedit(struct sdlpui_dialog *d,
 		struct sdlpui_window *w, const struct SDL_TextEditingEvent *e)
 {
+	struct sdlpui_control *c_key;
+
+	sdlpui_begin_focus_transaction();
+
 	/* Relay to the control with focus.  If it handles it, we are done. */
-	if (d->c_key && d->c_key->ftb->handle_textedit
-			&& (*d->c_key->ftb->handle_textedit)(
-				d->c_key, d, w, e)) {
+	c_key = sdlpui_get_control_with_focus(SDLPUI_ACTION_HINT_KEY);
+	if (c_key && c_key->ftb->handle_textedit
+			&& (*c_key->ftb->handle_textedit)(c_key, d, w, e)) {
+		sdlpui_end_focus_transaction();
 		return SDL_TRUE;
 	}
+
+	sdlpui_end_focus_transaction();
 
 	/* Do nothing and swallow the event. */
 	return SDL_TRUE;
@@ -1564,12 +1485,20 @@ SDL_bool sdlpui_dialog_handle_textedit(struct sdlpui_dialog *d,
 SDL_bool sdlpui_dialog_handle_mouseclick(struct sdlpui_dialog *d,
 		struct sdlpui_window *w, const struct SDL_MouseButtonEvent *e)
 {
+	struct sdlpui_control *c_mouse;
+
+	sdlpui_begin_focus_transaction();
+
 	/* Relay to the control with focus.  If it handles it, we are done. */
-	if (d->c_mouse && d->c_mouse->ftb->handle_mouseclick
-			&& (*d->c_mouse->ftb->handle_mouseclick)(
-				d->c_mouse, d, w, e)) {
+	c_mouse = sdlpui_get_control_with_focus(SDLPUI_ACTION_HINT_MOUSE);
+	if (c_mouse && c_mouse->ftb->handle_mouseclick
+			&& (*c_mouse->ftb->handle_mouseclick)(
+				c_mouse, d, w, e)) {
+		sdlpui_end_focus_transaction();
 		return SDL_TRUE;
 	}
+
+	sdlpui_end_focus_transaction();
 
 	/* Do nothing and swallow the event. */
 	return SDL_TRUE;
@@ -1588,78 +1517,41 @@ SDL_bool sdlpui_dialog_handle_mouseclick(struct sdlpui_dialog *d,
 SDL_bool sdlpui_dialog_handle_mousemove(struct sdlpui_dialog *d,
 		struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e)
 {
-	struct sdlpui_control *c_mouse = d->c_mouse, *c;
+	struct sdlpui_control *c, *c_mouse;
 	int comp_ind;
 
+	sdlpui_begin_focus_transaction();
+
 	/* Relay to the control with focus.  If it handles it, we are done. */
+	c_mouse = sdlpui_get_control_with_focus(SDLPUI_ACTION_HINT_MOUSE);
 	if (c_mouse && c_mouse->ftb->handle_mousemove
 			&& (*c_mouse->ftb->handle_mousemove)(
 				c_mouse, d, w, e)) {
+		sdlpui_end_focus_transaction();
+		return SDL_TRUE;
+	}
+
+	/* If not allowed to change focus, swallow the event. */
+	if (sdlpui_is_focus_locked(SDLPUI_ACTION_HINT_KEY_OR_MOUSE)) {
+		sdlpui_end_focus_transaction();
 		return SDL_TRUE;
 	}
 
 	/*
-	 * Ignore motion events while a mouse button is pressed (at least up
-	 * to the point that the mouse leaves the window).
-	 */
-	if (e->state != 0) {
-		return SDL_TRUE;
-	}
-
-	/*
-	 * Otherwise, see if the mouse has entered another control in the
-	 * dialog.  If it has, give focus to that control.
+	 * See if the mouse has entered another control in the dialog.  If it
+	 * has, give focus to that control.
 	 */
 	c = (d->ftb->find_control_containing) ?
 		(*d->ftb->find_control_containing)(d, w, e->x, e->y, &comp_ind) :
 		NULL;
-	if (c) {
-		if (c_mouse && c_mouse->ftb->lose_mouse) {
-			(*c_mouse->ftb->lose_mouse)(c_mouse, d, w, c, d);
-		}
-		if (c->ftb->gain_mouse) {
-			(*c->ftb->gain_mouse)(c, d, w, comp_ind);
-		}
-		d->c_mouse = c;
-
-		/* Have keyboard focus follow the mouse. */
-		if (!d->c_key || d->c_key->id != c->id) {
-			if (d->c_key && d->c_key->ftb->lose_key) {
-				(*d->c_key->ftb->lose_key)(d->c_key, d, w, c,
-					d);
-			}
-			if (c && c->ftb->gain_key) {
-				(c->ftb->gain_key)(c, d, w, comp_ind);
-			}
-			d->c_key = c;
-		}
-	}
 	if (c || sdlpui_is_in_dialog(d, e->x, e->y)) {
-		if (!c) {
-			if (c_mouse) {
-				if (c_mouse->ftb->lose_mouse) {
-					(*c_mouse->ftb->lose_mouse)(
-						c_mouse, d, w, NULL, d);
-				}
-				d->c_mouse = NULL;
-			}
-			/* Have keyboard focus follow the mouse. */
-			if (d->c_key) {
-				if (d->c_key->ftb->lose_key) {
-					(*d->c_key->ftb->lose_key)(
-						d->c_key, d, w, NULL, d);
-				}
-				d->c_key = NULL;
-			}
-		}
-		SDLPUI_EVENT_TRACER("dialog", d, "(not extracted)",
-			"gains mouse focus");
-		SDLPUI_EVENT_TRACER("dialog", d, "(not extracted)",
-			"gains key focus");
-		sdlpui_dialog_gain_mouse_focus(w, d);
-		sdlpui_dialog_gain_key_focus(w, d);
+		(void)sdlpui_change_focus(c, comp_ind, d, w,
+			SDLPUI_ACTION_HINT_MOUSE, SDL_FALSE);
+		sdlpui_end_focus_transaction();
 		return SDL_TRUE;
 	}
+
+	sdlpui_end_focus_transaction();
 
 	/*
 	 * Let the window handle the mouse motion.  For now keep focus though
@@ -1681,12 +1573,20 @@ SDL_bool sdlpui_dialog_handle_mousemove(struct sdlpui_dialog *d,
 SDL_bool sdlpui_dialog_handle_mousewheel(struct sdlpui_dialog *d,
 		struct sdlpui_window *w, const struct SDL_MouseWheelEvent *e)
 {
+	struct sdlpui_control *c_mouse;
+
+	sdlpui_begin_focus_transaction();
+
 	/* Relay to the control with focus.  If it handles it, we're done. */
-	if (d->c_mouse && d->c_mouse->ftb->handle_mousewheel
-			&& (*d->c_mouse->ftb->handle_mousewheel)(
-				d->c_mouse, d, w, e)) {
+	c_mouse = sdlpui_get_control_with_focus(SDLPUI_ACTION_HINT_MOUSE);
+	if (c_mouse && c_mouse->ftb->handle_mousewheel
+			&& (*c_mouse->ftb->handle_mousewheel)(
+				c_mouse, d, w, e)) {
+		sdlpui_end_focus_transaction();
 		return SDL_TRUE;
 	}
+
+	sdlpui_end_focus_transaction();
 
 	/* Do nothing and swallow the event. */
 	return SDL_TRUE;
@@ -1713,41 +1613,15 @@ void sdlpui_dismiss_dialog(struct sdlpui_dialog *d, struct sdlpui_window *w)
  *
  * \param d is the dialog.
  * \param w is the window containing the dialog.
+ *
+ * Called from routines in pui-foc.h so do not need calls to
+ * sdlpui_begin_focus_transaction() and sdlpui_end_focus_transaction().
  */
 void sdlpui_dialog_handle_window_loses_mouse(struct sdlpui_dialog *d,
 		struct sdlpui_window *w)
 {
-	if (d->c_mouse) {
-		if (d->c_mouse->ftb->disarm) {
-			(*d->c_mouse->ftb->disarm)(d->c_mouse, d, w,
-				SDLPUI_ACTION_HINT_NONE);
-		}
-		if (d->c_mouse->ftb->lose_mouse) {
-			(*d->c_mouse->ftb->lose_mouse)(d->c_mouse, d, w, NULL,
-				NULL);
-		}
-		/* Key focus follows mouse. */
-		if (d->c_key && d->c_key->id == d->c_mouse->id
-				&& d->c_mouse->ftb->lose_key) {
-			(*d->c_mouse->ftb->lose_key)(d->c_mouse, d, w, NULL,
-				NULL);
-		}
-	}
-	/* Key focus follows mouse. */
-	if (d->c_key && (!d->c_mouse || d->c_key->id != d->c_mouse->id)) {
-		if (d->c_key->ftb->disarm) {
-			(*d->c_key->ftb->disarm)(d->c_key, d, w,
-				SDLPUI_ACTION_HINT_NONE);
-		}
-		if (d->c_key->ftb->lose_key) {
-			(*d->c_key->ftb->lose_key)(d->c_key, d, w, NULL,
-				NULL);
-		}
-	}
-	d->c_mouse = NULL;
-	d->c_key = NULL;
-	sdlpui_dialog_yield_mouse_focus(w, d);
-	sdlpui_dialog_yield_key_focus(w, d);
+	(void)sdlpui_change_focus(NULL, 0, NULL, w, SDLPUI_ACTION_HINT_MOUSE,
+		SDL_TRUE);
 }
 
 
@@ -1756,6 +1630,9 @@ void sdlpui_dialog_handle_window_loses_mouse(struct sdlpui_dialog *d,
  *
  * \param d is the menu.
  * \param w is the window containing the menu.
+ *
+ * Called from routines in pui-foc.h so do not need calls to
+ * sdlpui_begin_focus_transaction() and sdlpui_end_focus_transaction().
  */
 void sdlpui_menu_handle_window_loses_mouse(struct sdlpui_dialog *d,
 		struct sdlpui_window *w)
@@ -1775,21 +1652,15 @@ void sdlpui_menu_handle_window_loses_mouse(struct sdlpui_dialog *d,
  *
  * \param d is the dialog.
  * \param w is the window containing the dialog or menu.
+ *
+ * Called from routines in pui-foc.h so do not need calls to
+ * sdlpui_begin_focus_transaction() and sdlpui_end_focus_transaction().
  */
 void sdlpui_dialog_handle_window_loses_key(struct sdlpui_dialog *d,
 		struct sdlpui_window *w)
 {
-	if (d->c_key) {
-		if (d->c_key->ftb->disarm) {
-			(*d->c_key->ftb->disarm)(d->c_key, d, w,
-				SDLPUI_ACTION_HINT_KEY);
-		}
-		if (d->c_key->ftb->lose_key) {
-			(*d->c_key->ftb->lose_key)(d->c_key, d, w, NULL, NULL);
-		}
-	}
-	d->c_key = NULL;
-	sdlpui_dialog_yield_key_focus(w, d);
+	(void)sdlpui_change_focus(NULL, 0, NULL, w, SDLPUI_ACTION_HINT_KEY,
+		SDL_TRUE);
 }
 
 
@@ -1798,12 +1669,15 @@ void sdlpui_dialog_handle_window_loses_key(struct sdlpui_dialog *d,
  *
  * \param d is the menu.
  * \param w is the window containing the menu.
+ *
+ * Called from routines in pui-foc.h so do not need calls to
+ * sdlpui_begin_focus_transaction() and sdlpui_end_focus_transaction().
  */
 void sdlpui_menu_handle_window_loses_key(struct sdlpui_dialog *d,
 		struct sdlpui_window *w)
 {
 	/*
-	 * Dimiss all the child dialogs up to the one which has mouse focus
+	 * Dismiss all the child dialogs up to the one which has mouse focus
 	 * or has a parent control with mouse focus.  If the dialog itself
 	 * is not dismissed in that process, treat it like a generic dialog
 	 * when the window loses key focus.
@@ -1819,17 +1693,16 @@ void sdlpui_menu_handle_window_loses_key(struct sdlpui_dialog *d,
 		deepest = child;
 	}
 	while (1) {
-		struct sdlpui_dialog *d_mouse =
-			sdlpui_dialog_with_mouse_focus(w);
-		struct sdlpui_dialog *parent =
+		struct sdlpui_dialog *parent_d =
 			sdlpui_get_dialog_parent(deepest);
-		struct sdlpui_control *parent_ctrl =
+		struct sdlpui_control *parent_c =
 			sdlpui_get_dialog_parent_ctrl(deepest);
 
-		if (deepest->pinned || deepest->c_mouse
-				|| (d_mouse && deepest->id == d_mouse->id)
-				|| (parent && parent->c_mouse && parent_ctrl
-				&& parent->c_mouse->id == parent_ctrl->id)) {
+		if (deepest->pinned || sdlpui_dialog_has_focus(deepest,
+				SDLPUI_ACTION_HINT_MOUSE)
+				|| (parent_d && parent_c
+				&& sdlpui_control_has_focus(parent_c,
+				SDLPUI_ACTION_HINT_MOUSE))) {
 			if (deepest->id == d->id) {
 				sdlpui_dialog_handle_window_loses_key(d, w);
 			}
@@ -1838,10 +1711,10 @@ void sdlpui_menu_handle_window_loses_key(struct sdlpui_dialog *d,
 		SDLPUI_EVENT_TRACER("dialog", deepest, "(not extracted)",
 			"popping down");
 		sdlpui_popdown_dialog(deepest, w, SDL_FALSE);
-		if (!parent) {
+		if (!parent_d) {
 			break;
 		}
-		deepest = parent;
+		deepest = parent_d;
 	}
 }
 
@@ -1852,17 +1725,20 @@ void sdlpui_menu_handle_window_loses_key(struct sdlpui_dialog *d,
  * \param d is the dialog.
  * \param w is the window containing the menu.
  * \param new_c is the control gaining mouse focus.  It may be NULL.
+ * \param new_ind is the zero-based index of the component of new_c gaining
+ * mouse focus.  It is ignored if new_c is NULL.
  * \param new_d is the dialog gaining mouse focus.  It may be NULL.
  */
 void sdlpui_dialog_handle_loses_mouse(struct sdlpui_dialog *d,
 		struct sdlpui_window *w, struct sdlpui_control *new_c,
-		struct sdlpui_dialog *new_d)
+		int new_ind, struct sdlpui_dialog *new_d)
 {
-	/*
-	 * Gets the same treatment as if the mouse left the window containing
-	 * the dialog.
-	 */
-	sdlpui_dialog_handle_window_loses_mouse(d, w);
+	sdlpui_begin_focus_transaction();
+	if (sdlpui_dialog_has_focus(d, SDLPUI_ACTION_HINT_MOUSE)) {
+		(void)sdlpui_change_focus(new_c, new_ind, new_d, w,
+			SDLPUI_ACTION_HINT_MOUSE, SDL_FALSE);
+	}
+	sdlpui_end_focus_transaction();
 }
 
 
@@ -1873,11 +1749,13 @@ void sdlpui_dialog_handle_loses_mouse(struct sdlpui_dialog *d,
  * \param d is the dialog.
  * \param w is the window containing the menu.
  * \param new_c is the control gaining mouse focus.  It may be NULL.
+ * \param new_ind is the zero-based index of the component of new_c gaining
+ * mouse focus.  It is ignored if new_c is NULL.
  * \param new_d is the dialog gaining mouse focus.  It may be NULL.
  */
 void sdlpui_menu_handle_loses_mouse(struct sdlpui_dialog *d,
 		struct sdlpui_window *w, struct sdlpui_control *new_c,
-		struct sdlpui_dialog *new_d)
+		int new_ind, struct sdlpui_dialog *new_d)
 {
 	/*
 	 * The mouse left the menu.  If the mouse is in a descendant, do
@@ -1889,6 +1767,12 @@ void sdlpui_menu_handle_loses_mouse(struct sdlpui_dialog *d,
 	 */
 	SDL_bool pop_parents = SDL_TRUE;
 
+	sdlpui_begin_focus_transaction();
+	if (sdlpui_is_focus_locked(SDLPUI_ACTION_HINT_KEY_OR_MOUSE)) {
+		sdlpui_end_focus_transaction();
+		return;
+	}
+
 	if (new_d && sdlpui_is_descendant_dialog(d, new_d)) {
 		pop_parents = SDL_FALSE;
 	} else if (new_c && new_d) {
@@ -1896,8 +1780,8 @@ void sdlpui_menu_handle_loses_mouse(struct sdlpui_dialog *d,
 		struct sdlpui_control *parent_c =
 			sdlpui_get_dialog_parent_ctrl(d);
 
-		if ((parent_d && new_d->id == parent_d->id)
-				&& (parent_c && new_c->id == parent_c->id)) {
+		if (parent_d && new_d->id == parent_d->id
+				&& parent_c && new_c->id == parent_c->id) {
 			struct sdlpui_dialog *child_d =
 				sdlpui_get_dialog_child(d);
 
@@ -1913,6 +1797,7 @@ void sdlpui_menu_handle_loses_mouse(struct sdlpui_dialog *d,
 	}
 
 	if (pop_parents) {
+		sdlpui_end_focus_transaction();
 		while (1) {
 			struct sdlpui_dialog *parent_d =
 				sdlpui_get_dialog_parent(d);
@@ -1925,67 +1810,14 @@ void sdlpui_menu_handle_loses_mouse(struct sdlpui_dialog *d,
 				sdlpui_popdown_dialog(d, w, SDL_FALSE);
 				break;
 			}
-			if (new_d) {
-				struct sdlpui_control *parent_c =
-					sdlpui_get_dialog_parent_ctrl(d);
-
-				if (new_c && parent_c
-						&& new_d->id == parent_d->id
-						&& new_c->id == parent_c->id) {
-					struct sdlpui_dialog *child_d =
-						sdlpui_get_dialog_child(d);
-
-					SDL_assert(child_d);
-					SDLPUI_EVENT_TRACER("dialog",
-						child_d, "(not extracted)",
-						"popping down");
-					SDL_assert(!child_d->pinned);
-					sdlpui_popdown_dialog(child_d, w,
-						SDL_FALSE);
-					break;
-				} else if (new_d->id == parent_d->id) {
-					SDLPUI_EVENT_TRACER("dialog", d,
-						"(not extracted)",
-						"popping down");
-					sdlpui_popdown_dialog(d, w, SDL_FALSE);
-					break;
-				}
-			}
 			d = parent_d;
 		}
 	} else {
-		if (d->c_mouse) {
-			if (d->c_mouse->ftb->disarm) {
-				(*d->c_mouse->ftb->disarm)(d->c_mouse, d, w,
-					SDLPUI_ACTION_HINT_NONE);
-			}
-			if (d->c_mouse->ftb->lose_mouse) {
-				(*d->c_mouse->ftb->lose_mouse)(d->c_mouse, d,
-					w, new_c, new_d);
-			}
-			/* Key focus follows mouse. */
-			if (d->c_key && d->c_key->id == d->c_mouse->id
-					&& d->c_mouse->ftb->lose_key) {
-				(*d->c_mouse->ftb->lose_key)(d->c_mouse, d,
-					w, new_c, new_d);
-			}
+		if (sdlpui_dialog_has_focus(d, SDLPUI_ACTION_HINT_MOUSE)) {
+			(void)sdlpui_change_focus(new_c, new_ind, new_d, w,
+				SDLPUI_ACTION_HINT_MOUSE, SDL_FALSE);
 		}
-		/* Key focus follows mouse. */
-		if (d->c_key && (!d->c_mouse
-				|| d->c_key->id != d->c_mouse->id)) {
-			if (d->c_key->ftb->disarm) {
-				(*d->c_key->ftb->disarm)(d->c_key, d, w,
-					SDLPUI_ACTION_HINT_NONE);
-			}
-			if (d->c_key->ftb->lose_key) {
-				(*d->c_key->ftb->lose_key)(d->c_key, d,
-					w, new_c, new_d);
-			}
-		}
-		d->c_mouse = NULL;
-		d->c_key = NULL;
-		sdlpui_dialog_yield_mouse_focus(w, d);
-		sdlpui_dialog_yield_key_focus(w, d);
+		sdlpui_end_focus_transaction();
 	}
 }
 
@@ -1996,17 +1828,20 @@ void sdlpui_menu_handle_loses_mouse(struct sdlpui_dialog *d,
  * \param d is the dialog.
  * \param w is the window containing the menu.
  * \param new_c is the control gaining key focus.  It may be NULL.
+ * \param new_ind is the zero-based index of the component of new_c gaining
+ * key focus.  It is ignored if new_c is NULL.
  * \param new_d is the dialog gaining key focus.  It may be NULL.
  */
 void sdlpui_dialog_handle_loses_key(struct sdlpui_dialog *d,
 		struct sdlpui_window *w, struct sdlpui_control *new_c,
-		struct sdlpui_dialog *new_d)
+		int new_ind, struct sdlpui_dialog *new_d)
 {
-	/*
-	 * Gets the same treatment as if the window containing the dialog lost
-	 * key focus.
-	 */
-	sdlpui_dialog_handle_window_loses_key(d, w);
+	sdlpui_begin_focus_transaction();
+	if (sdlpui_dialog_has_focus(d, SDLPUI_ACTION_HINT_KEY)) {
+		(void)sdlpui_change_focus(new_c, new_ind, new_d, w,
+			SDLPUI_ACTION_HINT_KEY, SDL_FALSE);
+	}
+	sdlpui_end_focus_transaction();
 }
 
 
@@ -2017,11 +1852,13 @@ void sdlpui_dialog_handle_loses_key(struct sdlpui_dialog *d,
  * \param d is the menu.
  * \param w is the window containing the menu.
  * \param new_c is the new control with key focus.
+ * \param new_ind is the zero-based index of the component of new_c gaining
+ * key focus.  It is ignored if new_c is NULL.
  * \param new_d is the dialog or menu that contains new_c.
  */
 void sdlpui_menu_handle_loses_key(struct sdlpui_dialog *d,
 		struct sdlpui_window *w, struct sdlpui_control *new_c,
-		struct sdlpui_dialog *new_d)
+		int new_ind, struct sdlpui_dialog *new_d)
 {
 	/*
 	 * The menu lost key focus.  If the dialog receiving focus is a
@@ -2029,7 +1866,7 @@ void sdlpui_menu_handle_loses_key(struct sdlpui_dialog *d,
 	 * control receiving focus is the parent control for this dialog or
 	 * the parent control for this dialog has mouse focus, pop down the
 	 * children of this dialog unless they have mouse focus and update focus
-	 * for this dialog.  Othrwise, descend to the deepest child of
+	 * for this dialog.  Otherwise, descend to the deepest child of
 	 * this dialog and pop down it and all parents up to the first dialog
 	 * that is either pinned, has mouse focus, or has a parent control
 	 * that has mouse focus.  If this dialog is not popped down in that
@@ -2037,6 +1874,11 @@ void sdlpui_menu_handle_loses_key(struct sdlpui_dialog *d,
 	 */
 	SDL_bool pop_parents = SDL_TRUE;
 
+	sdlpui_begin_focus_transaction();
+	if (sdlpui_is_focus_locked(SDLPUI_ACTION_HINT_KEY)) {
+		sdlpui_end_focus_transaction();
+		return;
+	}
 	if (new_d && sdlpui_is_descendant_dialog(d, new_d)) {
 		pop_parents = SDL_FALSE;
 	} else {
@@ -2044,14 +1886,15 @@ void sdlpui_menu_handle_loses_key(struct sdlpui_dialog *d,
 		struct sdlpui_control *parent_c =
 			sdlpui_get_dialog_parent_ctrl(d);
 
-		if (parent_c && parent_d && ((parent_d->c_mouse
-				&& parent_d->c_mouse->id == parent_c->id)
+		if (parent_c && parent_d
+				&& (sdlpui_control_has_focus(parent_c, SDLPUI_ACTION_HINT_MOUSE)
 				|| (new_c && new_d && new_c->id == parent_c->id
 				&& new_d->id == parent_d->id))) {
 			struct sdlpui_dialog *child_d =
 				sdlpui_get_dialog_child(d);
 			struct sdlpui_dialog *mouse_d =
-				sdlpui_dialog_with_mouse_focus(w);
+				sdlpui_get_dialog_with_focus(
+				SDLPUI_ACTION_HINT_MOUSE);
 
 			if (child_d && !child_d->pinned
 					&& (!mouse_d
@@ -2080,20 +1923,16 @@ void sdlpui_menu_handle_loses_key(struct sdlpui_dialog *d,
 			deepest = child;
 		}
 		while (1) {
-			struct sdlpui_dialog *d_mouse =
-				sdlpui_dialog_with_mouse_focus(w);
-			struct sdlpui_dialog *parent =
+			struct sdlpui_dialog *parent_d =
 				sdlpui_get_dialog_parent(deepest);
-			struct sdlpui_control *parent_ctrl =
+			struct sdlpui_control *parent_c =
 				sdlpui_get_dialog_parent_ctrl(deepest);
 
-			if (deepest->pinned || deepest->c_mouse
-					|| (d_mouse
-					&& deepest->id == d_mouse->id)
-					|| (parent && parent->c_mouse
-					&& parent_ctrl
-					&& parent->c_mouse->id
-					== parent_ctrl->id)) {
+			if (deepest->pinned || sdlpui_dialog_has_focus(deepest,
+					SDLPUI_ACTION_HINT_MOUSE)
+					|| (parent_d && parent_c
+					&& sdlpui_control_has_focus(parent_c,
+					SDLPUI_ACTION_HINT_MOUSE))) {
 				if (deepest->id == d->id) {
 					pop_parents = SDL_FALSE;
 				}
@@ -2102,28 +1941,22 @@ void sdlpui_menu_handle_loses_key(struct sdlpui_dialog *d,
 			SDLPUI_EVENT_TRACER("dialog", deepest,
 				"(not extracted)", "popping down");
 			sdlpui_popdown_dialog(deepest, w, SDL_FALSE);
-			if (!parent) {
+			if (!parent_d) {
 				break;
 			}
-			deepest = parent;
+			deepest = parent_d;
 		}
 		if (pop_parents) {
+			sdlpui_end_focus_transaction();
 			return;
 		}
 	}
 
-	if (d->c_key) {
-		if (d->c_key->ftb->disarm) {
-			(*d->c_key->ftb->disarm)(d->c_key, d, w,
-				SDLPUI_ACTION_HINT_NONE);
-		}
-		if (d->c_key->ftb->lose_key) {
-			(*d->c_key->ftb->lose_key)(d->c_key, d, w, new_c,
-				new_d);
-		}
-		d->c_key = NULL;
+	if (sdlpui_dialog_has_focus(d, SDLPUI_ACTION_HINT_KEY)) {
+		(void)sdlpui_change_focus(new_c, new_ind, new_d, w,
+			SDLPUI_ACTION_HINT_KEY, SDL_FALSE);
 	}
-	sdlpui_dialog_yield_key_focus(w, d);
+	sdlpui_end_focus_transaction();
 }
 
 
@@ -2230,14 +2063,12 @@ struct sdlpui_dialog *sdlpui_start_simple_menu(struct sdlpui_dialog *parent,
 	result->next_r = NULL;
 	result->prev_r = NULL;
 	result->texture = NULL;
-	result->c_mouse = NULL;
-	result->c_key = NULL;
 	result->priv = psm;
 	result->id = id;
 	result->type_code = SDLPUI_DIALOG_SIMPLE_MENU;
 	result->tag = tag;
 	result->pinned = SDL_FALSE;
-	result->dirty = SDL_TRUE;
+	result->dirty.value = SDL_TRUE;
 	sdlpui_register_dialog(result);
 
 	return result;
@@ -2402,14 +2233,12 @@ struct sdlpui_dialog *sdlpui_start_simple_info(const char *button_label,
 	result->next_r = NULL;
 	result->prev_r = NULL;
 	result->texture = NULL;
-	result->c_mouse = NULL;
-	result->c_key = NULL;
 	result->priv = psi;
 	result->id = id;
 	result->type_code = SDLPUI_DIALOG_SIMPLE_INFO;
 	result->tag = tag;
 	result->pinned = SDL_FALSE;
-	result->dirty = SDL_TRUE;
+	result->dirty.value = SDL_TRUE;
 	sdlpui_register_dialog(result);
 
 	return result;

--- a/src/sdl2/pui-dlg.h
+++ b/src/sdl2/pui-dlg.h
@@ -90,30 +90,36 @@ struct sdlpui_dialog_funcs {
 	SDL_bool (*handle_mousewheel)(struct sdlpui_dialog *d,
 		struct sdlpui_window *w, const SDL_MouseWheelEvent *e);
 	/**
-	 * Respond to the mouse focus being taken by another dialog.  May be
-	 * NULL.  new_c is the control taking focus, it may be NULL.  new_d
-	 * is the dialog taking focus, it may be NULL.
+	 * Respond to the mouse focus being taken by another dialog.  May not
+	 * be NULL.  new_c is the control taking focus; it may be NULL.  new_ind
+	 * is the zero-based index of the component in new_c taking focus; it
+	 * is ignored if new_c is NULL.  new_d is the dialog taking focus; it
+	 * may be NULL.
 	 */
 	void (*handle_loses_mouse)(struct sdlpui_dialog *d,
 		struct sdlpui_window *w, struct sdlpui_control *new_c,
-		struct sdlpui_dialog *new_d);
+		int new_ind, struct sdlpui_dialog *new_d);
 	/**
-	 * Respond to the key focus being taken by another dialog.  May be NULL.
-	 * new_c is the control taking focus, it may be NULL.  new_d is the
-	 * dialog taking focus; it may be NULL.
+	 * Respond to the key focus being taken by another dialog.  May not be
+	 * NULL.  new_c is the control taking focus; it may be NULL.  new_ind
+	 * is the zero-based index of the component in new_c taking focus; it
+	 * is ignored if new_c is NULL.  new_d is the dialog taking focus; it
+	 * may be NULL.
 	 */
 	void (*handle_loses_key)(struct sdlpui_dialog *d,
 		struct sdlpui_window *w, struct sdlpui_control *new_c,
-		struct sdlpui_dialog *new_d);
+		int new_ind, struct sdlpui_dialog *new_d);
 	/**
 	 * Respond to the mouse leaving the containing window if the dialog
-	 * had mouse focus when that happened.  May be NULL.
+	 * had mouse focus when that happened.  May not be NULL.  Only for
+	 * use by the routines in pui_foc.h.
 	 */
 	void (*handle_window_loses_mouse)(struct sdlpui_dialog *d,
 		struct sdlpui_window *w);
 	/**
 	 * Respond to the containing window losing key focus if the dialog
-	 * had key focus when that happened.  May be NULL.
+	 * had key focus when that happened.  May not be NULL.  Only for
+	 * use by the routines in pui_foc.h.
 	 */
 	void (*handle_window_loses_key)(struct sdlpui_dialog *d,
 		struct sdlpui_window *w);
@@ -127,29 +133,31 @@ struct sdlpui_dialog_funcs {
 		struct sdlpui_window *w);
 	/**
 	 * Go to the dialog's primary (or first) control that can accept
-	 * focus and give it key focus.  May be NULL if there is nothing in the
-	 * dialog that can accept focus.
+	 * focus and give it key focus.  Return a pointer to that control or
+	 * NULL if there is no such control.  May be NULL if there is nothing
+	 * in the dialog that can accept focus.
 	 */
-	void (*goto_first_control)(struct sdlpui_dialog *d,
+	struct sdlpui_control* (*goto_first_control)(struct sdlpui_dialog *d,
 		struct sdlpui_window *w);
 	/**
 	 * If forward is not SDL_FALSE, go to the dialog's next (with wrap
 	 * around) control after c that can accept focus.  If forward is
 	 * SDL_FALSE, go to the dialog's previous (with wrap around) control
 	 * before c that can accept focus.  May be NULL if the dialog never
-	 * accepts focus (goto_first_control is NULL or never changes d->c_key
-	 * from NULL and find_control_containing is NULL or always returns
-	 * NULL) or if it only has one, simple, control that can accept focus.
+	 * accepts focus (goto_first_control is NULL or never switches focus
+	 * to a control in the dialog) and find_control_containing is NULL
+	 * or always returns NULL) or if it only has one, simple, control
+	 * that can accept focus.
 	 */
 	void (*step_control)(struct sdlpui_dialog *d, struct sdlpui_window *w,
 		struct sdlpui_control *c, SDL_bool forward);
 	/**
 	 * Find the dialog's control that's willing to accept focus and
-	 * contains the given coordinate, relative to the window.  For simple
-	 * controls, set *comp_ind to zero.  For compound controls, set
-	 * *comp_ind to the index of the control, in the compound control, that
-	 * accepts focus and holds the coordinate.  May be NULL:  then mouse
-	 * motion will never cause the dialog to accept focus.
+	 * contains the given coordinate, relative to the window.  If no
+	 * control is found or the control is simple, set *comp_ind to zero.
+	 * If the control is compound, set *comp_ind to the zero-based index
+	 * of the component in the control that accepts focus.  May be NULL:
+	 * then mouse motion will never cause the dialog to accept focus.
 	 */
 	struct sdlpui_control *(*find_control_containing)(
 		struct sdlpui_dialog *d, struct sdlpui_window *w, Sint32 x,
@@ -237,12 +245,6 @@ struct sdlpui_dialog {
 	 * directly render to the window's backing buffer.
 	 */
 	SDL_Texture *texture;
-	/**
-	 * These point to the control which should receive mouse or keyboard
-	 * events, respectively.  If NULL, events will be directed to the
-	 * dialog itself.
-	 */
-	struct sdlpui_control *c_mouse, *c_key;
 	/** Holds menu/dialog-specific data. */
 	void *priv;
 	/**
@@ -267,11 +269,12 @@ struct sdlpui_dialog {
 	 */
 	SDL_bool pinned;
 	/**
-	 * If not SDL_FALSE, the dialog/menu's texture or visible state is
-	 * out-of-date with respect to the state of the dialog/menu and should
-	 * be rerendered.
+	 * Access with sdlpui_dialog_mark_for_redraw() or
+	 * sdlpui_dialog_should_redraw().  If its value is equal to SDL_TRUE,
+	 * what is shown on the screen or stored in the dialog's texture is
+	 * out of date with the dialog's current state.
 	 */
-	SDL_bool dirty;
+	SDL_atomic_t dirty;
 };
 
 
@@ -321,9 +324,12 @@ struct sdlpui_simple_info {
 };
 
 
+SDL_bool sdlpui_dialog_should_redraw(struct sdlpui_dialog *d);
 SDL_bool sdlpui_is_in_dialog(const struct sdlpui_dialog *d, Sint32 x, Sint32 y);
 SDL_bool sdlpui_is_descendant_dialog(struct sdlpui_dialog *ancestor,
 		const struct sdlpui_dialog *other);
+void sdlpui_dialog_mark_for_redraw(struct sdlpui_dialog *d,
+		struct sdlpui_window *w);
 void sdlpui_popup_dialog(struct sdlpui_dialog *d, struct sdlpui_window *w,
 		SDL_bool give_key_focus);
 void sdlpui_popdown_dialog(struct sdlpui_dialog *d, struct sdlpui_window *w,
@@ -358,16 +364,16 @@ void sdlpui_menu_handle_window_loses_key(struct sdlpui_dialog *d,
 		struct sdlpui_window *w);
 void sdlpui_dialog_handle_loses_mouse(struct sdlpui_dialog *d,
 		struct sdlpui_window *w, struct sdlpui_control *new_c,
-		struct sdlpui_dialog *new_d);
+		int new_ind, struct sdlpui_dialog *new_d);
 void sdlpui_menu_handle_loses_mouse(struct sdlpui_dialog *d,
 		struct sdlpui_window *w, struct sdlpui_control *new_c,
-		struct sdlpui_dialog *new_d);
+		int new_ind, struct sdlpui_dialog *new_d);
 void sdlpui_dialog_handle_loses_key(struct sdlpui_dialog *d,
 		struct sdlpui_window *w, struct sdlpui_control *new_c,
-		struct sdlpui_dialog *new_d);
+		int new_ind, struct sdlpui_dialog *new_d);
 void sdlpui_menu_handle_loses_key(struct sdlpui_dialog *d,
 		struct sdlpui_window *w, struct sdlpui_control *new_c,
-		struct sdlpui_dialog *new_d);
+		int new_ind, struct sdlpui_dialog *new_d);
 
 /* Construct a simple menu */
 struct sdlpui_dialog *sdlpui_start_simple_menu(struct sdlpui_dialog *parent,

--- a/src/sdl2/pui-foc.c
+++ b/src/sdl2/pui-foc.c
@@ -1,0 +1,1106 @@
+/**
+ * \file sdl2/pui-foc.c
+ * \brief Define the interface for working with a control that has focus
+ * and the visual feedback that control provides.
+ *
+ * Copyright (c) 2026 Eric Branlund
+ *
+ * This work is free software; you can redistribute it and/or modify it
+ * under the terms of either:
+ *
+ * a) the GNU General Public License as published by the Free Software
+ *    Foundation, version 2, or
+ *
+ * b) the "Angband licence":
+ *    This software may be copied and distributed for educational, research,
+ *    and not for profit purposes provided that this copyright and statement
+ *    are included in all such copies.  Other copyrights may also apply.
+ */
+
+#include "pui-foc.h"
+#include "pui-focp.h"
+#include "pui-dlg.h"
+#include "pui-misc.h"
+#include "pui-win.h"
+#include <errno.h>	/* errno, ERANGE */
+#include <limits.h>	/* UINT_MAX */
+
+
+struct sdlpui_focus_state {
+	/** Point to the control with focus; may be NULL */
+	struct sdlpui_control *c;
+	/**
+	 * Point to the dialog with focus; may be NULL but must point to the
+	 * dialog containing c if c is not NULL
+	 */
+	struct sdlpui_dialog *d;
+	/**
+	 * Point to the window containing c and d; may be NULL if c and d
+	 * are NULL
+	 */
+	struct sdlpui_window *w;
+	/**
+	 * Installed timer to handle changes when momentary feedback lapses
+	 * or zero if there is no timer active
+	 */
+	SDL_TimerID momentary_timer;
+	/**
+	 * If not equal to SDLPUI_FEEDBACK_NONE, momentary_lapses is valid:
+	 * in that case, the focus indicator should be altered if
+	 * !SDL_TICKS_PASSED(SDL_GetTicks(), momentary_lapses); otherwise,
+	 * the focus indicator does not have to be changed to provide feedback
+	 * about non-repeated actions
+	 */
+	enum sdlpui_feedback momentary;
+	/**
+	 * Value of the ticks counter when the current momentary feedback
+	 * lapses; only useful if momentary is not SDLPUI_FEEDBACK_NONE
+	 */
+	Uint32 momentary_lapses;
+	/**
+	 * Number of continued actions in progress whose last repetition was
+	 * successful
+	 */
+	unsigned int continued;
+	/**
+	 * Number of continued actions in progress whose last repetition was
+	 * not successful
+	 */
+	unsigned int continued_unavail;
+	/** Zero-based index of component in control that has focus */
+	int comp_ind;
+	/**
+	 * Whether or not events, like mouse motion or a Tab key press, can
+	 * move focus from the control that has it
+	 */
+	SDL_bool focus_locked;
+};
+
+
+static struct sdlpui_focus_state key_focus = {
+	NULL, NULL, NULL, 0, SDLPUI_FEEDBACK_NONE, 0, 0, 0, 0, SDL_FALSE
+};
+
+static struct sdlpui_focus_state mouse_focus = {
+	NULL, NULL, NULL, 0, SDLPUI_FEEDBACK_NONE, 0, 0, 0, 0, SDL_FALSE
+};
+
+static SDL_mutex *lock = NULL;
+static Uint32 momentary_default_duration = SDLPUI_MOMENTARY_DEFAULT;
+static Uint32 momentary_duration = SDLPUI_MOMENTARY_DEFAULT;
+
+
+/**
+ * Respond to the lapsing of momentary feedback.
+ */
+static Uint32 handle_momentary_feedback_timer(Uint32 interval, void *param)
+{
+	struct sdlpui_focus_state *state = param;
+
+	sdlpui_begin_focus_transaction();
+	SDLPUI_EVENT_TRACER((state->c)
+		? (*state->c->ftb->get_type_name)(state->c) : "none",
+		state->c, (state->c && state->c->ftb->get_caption)
+		? (*state->c->ftb->get_caption)(state->c) : "(none)",
+		"momentary feedback timer lapses");
+	state->momentary_timer = 0;
+	state->momentary = SDLPUI_FEEDBACK_NONE;
+	state->momentary_lapses = 0;
+	if (state->d && state->w) {
+		SDL_Event dummy;
+
+		sdlpui_dialog_mark_for_redraw(state->d, state->w);
+		/* Send a fake event so the main thread will wake and redraw. */
+		SDL_zero(dummy);
+		dummy.type = SDL_USEREVENT;
+		dummy.user.code = 0;
+		dummy.user.data1 = NULL;
+		dummy.user.data2 = NULL;
+		SDL_PushEvent(&dummy);
+	}
+	sdlpui_end_focus_transaction();
+
+	/* This is a one-shot action and does not repeat. */
+	return 0;
+}
+
+
+/**
+ * Acquire access to the focus and feedback state and prevent other
+ * threads from accessing that state.
+ */
+void sdlpui_begin_focus_transaction(void)
+{
+	if (!lock || SDL_LockMutex(lock)) {
+		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+			"sdlpui_begin_focus_transaction() could not lock the "
+			"mutex");
+		sdlpui_force_quit();
+	}
+}
+
+
+/**
+ * Release access to the focus and feedback state and allow other threads
+ * to access that state.
+ */
+void sdlpui_end_focus_transaction(void)
+{
+	if (!lock || SDL_UnlockMutex(lock)) {
+		SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION,
+			"sdlpui_end_focus_transaction() could not unlock the "
+			"mutex");
+		sdlpui_force_quit();
+	}
+}
+
+/**
+ * Handle a window losing focus.
+ *
+ * \param ah is SDLPUI_ACTION_HINT_KEY if the window lost key focus or
+ * SDLPUI_ACTION_HINT_MOUSE if the window lost mouse focus.
+ */
+void sdlpui_window_loses_focus(enum sdlpui_action_hint ah)
+{
+	switch (ah) {
+	case SDLPUI_ACTION_HINT_KEY:
+		if (key_focus.d) {
+			(*key_focus.d->ftb->handle_window_loses_key)(
+				key_focus.d, key_focus.w);
+		}
+		break;
+
+	case SDLPUI_ACTION_HINT_MOUSE:
+		if (mouse_focus.d) {
+			(*mouse_focus.d->ftb->handle_window_loses_mouse)(
+				mouse_focus.d, mouse_focus.w);
+		}
+		break;
+
+	default:
+		/* Do nothing. */
+		break;
+	}
+}
+
+/**
+ * Update which control or dialog has focus.
+ *
+ * \param c points to the control that now has the focus indicated by ah.  May
+ * be NULL if no control has that type of focus.
+ * \param comp_ind is the zero-based index of the element in c that has the
+ * focus indicated by ah.  If c is a simple control (it does not have multiple
+ * components that can accept focus), use zero for comp_ind.  The value of
+ * comp_ind is not used when c is NULL.
+ * \param d points to the dialog that now has the focus indicated by ah.  That
+ * must be the dialog that contains c if c is not NULL.  May be NULL if c is
+ * NULL and no dialog has that type of focus.
+ * \param w points to the window that contains c and d.  If c and d are NULL,
+ * it must point to the window that had focus.
+ * \param ah is SDLPUI_ACTION_HINT_KEY if the caller is interested in changing
+ * key focus or SDLPUI_ACTION_HINT_MOUSE if the caller is interested in changing
+ * mouse focus.
+ * \param force will, if true, clear a focus lock that is present and would
+ * prevent the focus change from taking effect.  If force is false and a focus
+ * lock is present that would prevent the change, the focus change will not
+ * occur.
+ * \return SDL_TRUE if the focus was changed.  Otherwise, return SDL_FALSE.
+ *
+ * By policy, any change to mouse focus also changes key focus:
+ * "focus follows the mouse".  Also by policy, a change to focus clears any
+ * visual feedback about an action that was triggered or repeating.
+ */
+SDL_bool sdlpui_change_focus(struct sdlpui_control *c, int comp_ind,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		enum sdlpui_action_hint ah, SDL_bool force)
+{
+	struct sdlpui_control *kc = NULL, *mc = NULL;
+	struct sdlpui_dialog *kd = NULL, *md = NULL;
+	struct sdlpui_window *kw = NULL, *mw = NULL;
+	SDL_bool key_changed = SDL_FALSE, key_only_ind = SDL_FALSE;
+	SDL_bool mouse_changed = SDL_FALSE, mouse_only_ind = SDL_FALSE;
+	SDL_bool result = SDL_FALSE;
+
+	SDL_assert(w);
+
+	switch (ah) {
+	case SDLPUI_ACTION_HINT_KEY:
+		if (c && key_focus.c && key_focus.c->id == c->id) {
+			if (comp_ind != key_focus.comp_ind) {
+				key_changed = SDL_TRUE;
+				key_only_ind = SDL_TRUE;
+			}
+		} else if (c || key_focus.c || ((key_focus.d && d
+				&& key_focus.d->id != d->id)
+				|| (!key_focus.d && d)
+				|| (key_focus.d && !d))) {
+			key_changed = SDL_TRUE;
+		}
+		break;
+
+	case SDLPUI_ACTION_HINT_MOUSE:
+		if (c && mouse_focus.c && mouse_focus.c->id == c->id) {
+			if (comp_ind != mouse_focus.comp_ind) {
+				mouse_changed = SDL_TRUE;
+				mouse_only_ind = SDL_TRUE;
+			}
+			/* Focus follows the mouse. */
+			if (!key_focus.c || key_focus.c->id != c->id) {
+				key_changed = SDL_TRUE;
+			} else if (comp_ind != key_focus.comp_ind) {
+				key_changed = SDL_TRUE;
+				key_only_ind = SDL_TRUE;
+			}
+		} else if (c || mouse_focus.c || ((mouse_focus.d && d &&
+				mouse_focus.d->id != d->id)
+				|| (!mouse_focus.d && d)
+				|| (mouse_focus.d && !d))) {
+			mouse_changed = SDL_TRUE;
+			/* Focus follows the mouse. */
+			if (c && key_focus.c && key_focus.c->id == c->id) {
+				if (comp_ind != key_focus.comp_ind) {
+					key_changed = SDL_TRUE;
+					key_only_ind = SDL_TRUE;
+				}
+			} else if (c || key_focus.c || ((key_focus.d && d
+					&& key_focus.d->id != d->id)
+					|| (!key_focus.d && d)
+					|| (key_focus.d && !d))) {
+				key_changed = SDL_TRUE;
+			}
+		}
+		break;
+
+	default:
+		/* Do nothing. */
+		break;
+	}
+
+	if (key_changed && key_focus.focus_locked) {
+		if (force) {
+#ifdef SDLPUI_TRACE_EVENTS
+			SDL_LogVerbose(SDL_LOG_CATEGORY_APPLICATION,
+				"key focus lock forcibly unlocked; key focus "
+				"is currently with control, %s (%s), and is "
+				"moving to the control, %s (%s)\n",
+				(key_focus.c) ?
+				(*key_focus.c->ftb->get_type_name)(key_focus.c)
+				: "none",
+				(key_focus.c && key_focus.c->ftb->get_caption)
+				? (*key_focus.c->ftb->get_caption)(key_focus.c)
+				: "none", (c) ? (*c->ftb->get_type_name)(c)
+				: "none", (c && c->ftb->get_caption)
+				? (*c->ftb->get_caption)(c) : "none");
+#endif
+			key_focus.focus_locked = SDL_FALSE;
+		} else {
+#ifdef SDLPUI_TRACE_EVENTS
+			SDL_LogVerbose(SDL_LOG_CATEGORY_APPLICATION,
+				"key focus lock prevents focus change; key "
+				"focus is currently with control, %s (%s), and "
+				"would have moved to the control, %s (%s)\n",
+				(key_focus.c) ?
+				(*key_focus.c->ftb->get_type_name)(key_focus.c)
+				: "none",
+				(key_focus.c && key_focus.c->ftb->get_caption)
+				? (*key_focus.c->ftb->get_caption)(key_focus.c)
+				: "none", (c) ? (*c->ftb->get_type_name)(c)
+				: "none", (c && c->ftb->get_caption)
+				? (*c->ftb->get_caption)(c) : "none");
+#endif
+			key_changed = SDL_FALSE;
+		}
+	}
+	if (mouse_changed && mouse_focus.focus_locked) {
+		if (force) {
+#ifdef SDLPUI_TRACE_EVENTS
+			SDL_LogVerbose(SDL_LOG_CATEGORY_APPLICATION,
+				"mouse focus lock forcibly unlocked; mouse "
+				"focus is currently with control, %s (%s), "
+				"and is moving to the control, %s (%s)\n",
+				(mouse_focus.c) ?
+				(*mouse_focus.c->ftb->get_type_name)(mouse_focus.c)
+				: "none", (mouse_focus.c
+				&& mouse_focus.c->ftb->get_caption)
+				? (*mouse_focus.c->ftb->get_caption)(mouse_focus.c)
+				: "none", (c) ? (*c->ftb->get_type_name)(c)
+				: "none", (c && c->ftb->get_caption)
+				? (*c->ftb->get_caption)(c) : "none");
+#endif
+			mouse_focus.focus_locked = SDL_FALSE;
+		} else {
+#ifdef SDLPUI_TRACE_EVENTS
+			SDL_LogVerbose(SDL_LOG_CATEGORY_APPLICATION,
+				"mouse focus lock prevents focus change; "
+				"mouse focus is currently with control, %s "
+				"(%s), and would have moved to the control, "
+				"%s (%s)\n", (mouse_focus.c) ?
+				(*mouse_focus.c->ftb->get_type_name)(mouse_focus.c)
+				: "none", (mouse_focus.c
+				&& mouse_focus.c->ftb->get_caption)
+				? (*mouse_focus.c->ftb->get_caption)(mouse_focus.c)
+				: "none", (c) ? (*c->ftb->get_type_name)(c)
+				: "none", (c && c->ftb->get_caption)
+				? (*c->ftb->get_caption)(c) : "none");
+#endif
+			mouse_changed = SDL_FALSE;
+		}
+	}
+	if (key_changed) {
+		result = SDL_TRUE;
+		kc = key_focus.c;
+		kd = key_focus.d;
+		kw = key_focus.w;
+		key_focus.c = c;
+		key_focus.d = d;
+		key_focus.w = (c || d) ? w : NULL;
+		if (key_focus.momentary_timer) {
+			SDLPUI_EVENT_TRACER((key_focus.c)
+				? (*key_focus.c->ftb->get_type_name)(
+				key_focus.c) : "none", key_focus.c, (key_focus.c
+				&& key_focus.c->ftb->get_caption)
+				? (*key_focus.c->ftb->get_caption)(key_focus.c)
+				: "(none)", "prior momentary feedback "
+				"timer canceled");
+			(void)SDL_RemoveTimer(key_focus.momentary_timer);
+			key_focus.momentary_timer = 0;
+		}
+		key_focus.continued = 0;
+		key_focus.continued_unavail = 0;
+		key_focus.momentary = SDLPUI_FEEDBACK_NONE;
+		key_focus.comp_ind = (c) ? comp_ind : 0;
+		if (!key_only_ind && kc) {
+			SDL_assert(kd && kw);
+			SDLPUI_EVENT_TRACER((*kc->ftb->get_type_name)(kc), kc,
+				(kc->ftb->get_caption)
+				? (*kc->ftb->get_caption)(kc) : "(none)",
+				"loses key focus");
+			sdlpui_dialog_mark_for_redraw(kd, kw);
+			if (kc->ftb->lose_focus) {
+				(*kc->ftb->lose_focus)(kc, kd, kw,
+					SDLPUI_ACTION_HINT_KEY, c, d);
+			}
+		}
+	}
+	if (mouse_changed) {
+		result = SDL_TRUE;
+		mc = mouse_focus.c;
+		md = mouse_focus.d;
+		mw = mouse_focus.w;
+		mouse_focus.c = c;
+		mouse_focus.d = d;
+		mouse_focus.w = (c || d) ? w : NULL;
+		if (mouse_focus.momentary_timer) {
+			SDLPUI_EVENT_TRACER((mouse_focus.c)
+				? (*mouse_focus.c->ftb->get_type_name)(
+				mouse_focus.c) : "none", mouse_focus.c,
+				(mouse_focus.c
+				&& mouse_focus.c->ftb->get_caption)
+				? (*mouse_focus.c->ftb->get_caption)(
+				mouse_focus.c) : "(none)", "prior momentary "
+				"feedback timer canceled");
+			(void)SDL_RemoveTimer(mouse_focus.momentary_timer);
+			mouse_focus.momentary_timer = 0;
+		}
+		mouse_focus.continued = 0;
+		mouse_focus.continued_unavail = 0;
+		mouse_focus.momentary = SDLPUI_FEEDBACK_NONE;
+		mouse_focus.comp_ind = (c) ? comp_ind : 0;
+	}
+	if (mouse_changed && !mouse_only_ind && mc) {
+		SDL_assert(md && mw);
+		SDLPUI_EVENT_TRACER((*mc->ftb->get_type_name)(mc), mc,
+			(mc->ftb->get_caption) ? (*mc->ftb->get_caption)(mc)
+			: "(none)", "loses mouse focus");
+		sdlpui_dialog_mark_for_redraw(md, mw);
+		if (mc->ftb->lose_focus) {
+			(*mc->ftb->lose_focus)(mc, md, mw,
+				SDLPUI_ACTION_HINT_MOUSE, c, d);
+		}
+	}
+	if (key_changed && c) {
+		SDL_assert(d);
+		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c),
+			c, (c->ftb->get_caption)
+			? (*c->ftb->get_caption)(c) : "(none)",
+			(key_only_ind) ? "changes component with key focus"
+			: "gains key focus");
+		sdlpui_dialog_mark_for_redraw(d, w);
+		if (c->ftb->gain_focus) {
+			(*c->ftb->gain_focus)(c, d, w,
+				SDLPUI_ACTION_HINT_KEY, comp_ind);
+		}
+	}
+	if (mouse_changed && c) {
+		SDL_assert(d);
+		SDLPUI_EVENT_TRACER((*c->ftb->get_type_name)(c),
+			c, (c->ftb->get_caption)
+			? (*c->ftb->get_caption)(c) : "(none)",
+			(mouse_only_ind) ? "changes component with mouse focus"
+			: "gains mouse focus");
+		sdlpui_dialog_mark_for_redraw(d, w);
+		if (c->ftb->gain_focus) {
+			(*c->ftb->gain_focus)(c, d, w,
+				SDLPUI_ACTION_HINT_MOUSE, comp_ind);
+		}
+	}
+	return result;
+}
+
+
+/**
+ * Return a pointer to control that has the specified focus.
+ *
+ * \param ah is SDLPUI_ACTION_HINT_KEY if the caller is interested in the
+ * control that has key focus or SDLPUI_ACTION_HINT_MOUSE if the caller is
+ * interested in the control that has mouse focus.
+ * \return a pointer to the control with the type of focus specified by ah
+ * or NULL if no control has that focus.
+ */
+struct sdlpui_control *sdlpui_get_control_with_focus(
+		enum sdlpui_action_hint ah)
+{
+	struct sdlpui_control *result;
+
+	switch (ah) {
+	case SDLPUI_ACTION_HINT_KEY:
+		result = key_focus.c;
+		break;
+
+	case SDLPUI_ACTION_HINT_MOUSE:
+		result = mouse_focus.c;
+		break;
+
+	default:
+		result = NULL;
+		break;
+	}
+
+	return result;
+}
+
+
+/**
+ * Return a pointer to dialog that has the specified focus.
+ *
+ * \param ah is SDLPUI_ACTION_HINT_KEY if the caller is interested in the
+ * dialog that has key focus or SDLPUI_ACTION_HINT_MOUSE if the caller is
+ * interested in the dialog that has mouse focus.
+ * \return a pointer to the dialog with the type of focus specified by ah
+ * or NULL if no dialog has that focus.
+ */
+struct sdlpui_dialog *sdlpui_get_dialog_with_focus(
+		enum sdlpui_action_hint ah)
+{
+	struct sdlpui_dialog *result;
+
+	switch (ah) {
+	case SDLPUI_ACTION_HINT_KEY:
+		result = key_focus.d;
+		break;
+
+	case SDLPUI_ACTION_HINT_MOUSE:
+		result = mouse_focus.d;
+		break;
+
+	default:
+		result = NULL;
+		break;
+	}
+
+	return result;
+}
+
+
+/**
+ * Return whether the given control has focus.
+ *
+ * \param c is the control of interest.
+ * \param ah is SDLPUI_ACTION_HINT_KEY if the caller is interested in whether
+ * c has key focus or SDLPUI_ACTION_HINT_MOUSE if the caller is interested
+ * in whether c has mouse focus.
+ * \return the one-base index of the control's component has the type of focus
+ * indicated by ah.  Otherwise, return zero.
+ */
+int sdlpui_control_has_focus(const struct sdlpui_control *c,
+		enum sdlpui_action_hint ah)
+{
+	const struct sdlpui_focus_state *state;
+
+	switch (ah) {
+	case SDLPUI_ACTION_HINT_KEY:
+		state = &key_focus;
+		break;
+
+	case SDLPUI_ACTION_HINT_MOUSE:
+		state = &mouse_focus;
+		break;
+
+	default:
+		return 0;
+	}
+
+	return (c && state->c && c->id == state->c->id)
+		? state->comp_ind + 1 : 0;
+}
+
+
+/**
+ * Return whether the given dialog has focus.
+ *
+ * \param d is the dialog of interest.
+ * \param ah is SDLPUI_ACTION_HINT_KEY if the caller is interested in whether
+ * d has key focus or SDLPUI_ACTION_HINT_MOUSE if the caller is interested
+ * in whether d has mouse focus.
+ * \return SDL_TRUE if the dialog has the type of focus indicated by ah.
+ * Otherwise, return SDL_FALSE.
+ */
+SDL_bool sdlpui_dialog_has_focus(const struct sdlpui_dialog *d,
+		enum sdlpui_action_hint ah)
+{
+	const struct sdlpui_focus_state *state;
+
+	switch (ah) {
+	case SDLPUI_ACTION_HINT_KEY:
+		state = &key_focus;
+		break;
+
+	case SDLPUI_ACTION_HINT_MOUSE:
+		state = &mouse_focus;
+		break;
+
+	default:
+		return SDL_FALSE;
+	}
+
+	return (d && state->d && d->id == state->d->id) ? SDL_TRUE : SDL_FALSE;
+}
+
+
+/**
+ * Return whether any dialog has focus.
+ */
+SDL_bool sdlpui_any_dialog_with_focus(void)
+{
+	return (key_focus.d || mouse_focus.d) ? SDL_TRUE : SDL_FALSE;
+}
+
+
+/**
+ * Gather what kinds of visual feedback the given control should provide.
+ *
+ * \param c points to the control of interest.
+ * \param cf points to where the results should be stored.
+ * \return SDL_TRUE if the control has key or mouse focus.  Otherwise, return
+ * SDL_FALSE.
+ */
+SDL_bool sdlpui_query_feedback(const struct sdlpui_control *c,
+		struct sdlpui_control_feedback *cf)
+{
+	SDL_bool result = SDL_FALSE;
+
+	cf->key_focus = 0;
+	cf->mouse_focus = 0;
+	cf->mf_mouse = SDLPUI_FEEDBACK_NONE;
+	cf->cf_mouse = SDLPUI_FEEDBACK_NONE;
+	cf->mf_key = SDLPUI_FEEDBACK_NONE;
+	cf->cf_key = SDLPUI_FEEDBACK_NONE;
+
+	if (mouse_focus.c && mouse_focus.c->id == c->id) {
+		result = SDL_TRUE;
+		cf->mouse_focus = 1 + mouse_focus.comp_ind;
+		if (mouse_focus.momentary != SDLPUI_FEEDBACK_NONE
+				&& !SDL_TICKS_PASSED(SDL_GetTicks(),
+				mouse_focus.momentary_lapses)) {
+			cf->mf_mouse = mouse_focus.momentary;
+		}
+		if (mouse_focus.continued_unavail) {
+			cf->cf_mouse = SDLPUI_FEEDBACK_UNAVAIL;
+		} else if (mouse_focus.continued) {
+			cf->cf_mouse = SDLPUI_FEEDBACK_ACTION;
+		}
+	}
+	if (key_focus.c && key_focus.c->id == c->id) {
+		result = SDL_TRUE;
+		cf->key_focus = 1 + key_focus.comp_ind;
+		if (key_focus.momentary != SDLPUI_FEEDBACK_NONE
+				&& !SDL_TICKS_PASSED(SDL_GetTicks(),
+				key_focus.momentary_lapses)) {
+			cf->mf_key = key_focus.momentary;
+		}
+		if (key_focus.continued_unavail) {
+			cf->cf_key = SDLPUI_FEEDBACK_UNAVAIL;
+		} else if (key_focus.continued) {
+			cf->cf_key = SDLPUI_FEEDBACK_ACTION;
+		}
+	}
+	return result;
+}
+
+
+/**
+ * Signal that the control with focus is starting an action that does not
+ * repeat.
+ *
+ * \param ah specifies what type of focus is of interest:
+ * SDLPUI_ACTION_HINT_KEY for the control with key focus or
+ * SDLPUI_ACTION_HINT_MOUSE for the control with mouse focus.
+ * \param avail, if true, specifies that the action is possible.  If false,
+ * the action does nothing.
+ */
+void sdlpui_trigger_momentary_feedback(enum sdlpui_action_hint ah,
+		SDL_bool avail)
+{
+	struct sdlpui_focus_state *state;
+
+	switch (ah) {
+	case SDLPUI_ACTION_HINT_KEY:
+		state = &key_focus;
+		break;
+
+	case SDLPUI_ACTION_HINT_MOUSE:
+		state = &mouse_focus;
+		break;
+
+	default:
+		return;
+	}
+
+	if (state->c) {
+		if (state->momentary_timer) {
+			SDLPUI_EVENT_TRACER((*state->c->ftb->get_type_name)(
+				state->c), state->c,
+				(state->c->ftb->get_caption)
+				? (state->c->ftb->get_caption)(state->c)
+				: "(none)", "prior momentary feedback timer "
+				"canceled");
+			(void)SDL_RemoveTimer(state->momentary_timer);
+		}
+		SDLPUI_EVENT_TRACER((*state->c->ftb->get_type_name)(
+			state->c), state->c, (state->c->ftb->get_caption)
+			? (state->c->ftb->get_caption)(state->c) : "(none)",
+			"adding momentary feedback");
+		state->momentary_timer = SDL_AddTimer(momentary_duration,
+			handle_momentary_feedback_timer, state);
+		if (state->momentary_timer) {
+			SDL_assert(momentary_duration
+				!= SDLPUI_MOMENTARY_DEFAULT);
+			state->momentary_lapses = SDL_GetTicks()
+				+ momentary_duration;
+			state->momentary = (avail) ? SDLPUI_FEEDBACK_ACTION
+				: SDLPUI_FEEDBACK_UNAVAIL;
+		} else {
+			state->momentary = SDLPUI_FEEDBACK_NONE;
+			SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+				"SDL_AddTimer() failed while adding visual "
+				"feedback for control with focus: %s",
+				SDL_GetError());
+		}
+	} else {
+		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+			"sdl_trigger_momentary_feedback() called without "
+			"a control having focus");
+	}
+}
+
+
+/**
+ * Signal that the control with focus is starting an action that automatically
+ * repeats.
+ *
+ * \param ah specifies what type of focus is of interest:
+ * SDLPUI_ACTION_HINT_KEY for the control with key focus or
+ * SDLPUI_ACTION_HINT_MOUSE for the control with mouse focus.
+ * \param avail, if true, specifies that the initial repetition of the action
+ * is possible.  If false, the initial repetition of the action does nothing.
+ */
+void sdlpui_start_continued_feedback(enum sdlpui_action_hint ah, SDL_bool avail)
+{
+	struct sdlpui_focus_state *state;
+
+	switch (ah) {
+	case SDLPUI_ACTION_HINT_KEY:
+		state = &key_focus;
+		break;
+
+	case SDLPUI_ACTION_HINT_MOUSE:
+		state = &mouse_focus;
+		break;
+
+	default:
+		return;
+	}
+
+	if (state->c) {
+		if (avail) {
+			if (state->continued < UINT_MAX) {
+				++state->continued;
+			} else {
+				SDL_assert(0);
+			}
+		} else {
+			if (state->continued_unavail < UINT_MAX) {
+				++state->continued_unavail;
+			} else {
+				SDL_assert(0);
+			}
+		}
+	} else {
+		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+			"sdl_start_continued_feedback() called without "
+			"a control having focus");
+	}
+}
+
+
+/**
+ * Signal that a repeating action tied to the control with focus is changing
+ * its effect.
+ *
+ * \param ah specifies what type of focus is of interest:
+ * SDLPUI_ACTION_HINT_KEY for the control with key focus or
+ * SDLPUI_ACTION_HINT_MOUSE for the control with mouse focus.
+ * \param now_avail, if true, specifies that the last repetition of the action
+ * did something, but the next repetition will not do anything.  If false, the
+ * last repetition of the action did nothing, but the next repetition will do
+ * something.
+ */
+void sdlpui_switch_continued_feedback(enum sdlpui_action_hint ah,
+		SDL_bool now_avail)
+{
+	struct sdlpui_focus_state *state;
+
+	switch (ah) {
+	case SDLPUI_ACTION_HINT_KEY:
+		state = &key_focus;
+		break;
+
+	case SDLPUI_ACTION_HINT_MOUSE:
+		state = &mouse_focus;
+		break;
+
+	default:
+		return;
+	}
+
+	if (state->c) {
+		if (now_avail) {
+			if (state->continued_unavail && state->continued
+					< UINT_MAX) {
+				--state->continued_unavail;
+				++state->continued;
+			} else {
+				SDL_assert(0);
+			}
+		} else {
+			if (state->continued && state->continued_unavail
+					< UINT_MAX) {
+				--state->continued;
+				++state->continued_unavail;
+			} else {
+				SDL_assert(0);
+			}
+		}
+	} else {
+		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+			"sdl_switch_continued_feedback() called without "
+			"a control having focus");
+	}
+}
+
+
+/**
+ * Signal that the control with focus is stopping an action that automatically
+ * repeats.
+ *
+ * \param ah specifies what type of focus is of interest:
+ * SDLPUI_ACTION_HINT_KEY for the control with key focus or
+ * SDLPUI_ACTION_HINT_MOUSE for the control with mouse focus.
+ * \param avail, if true, specifies that the last repetition of the action
+ * was possible.  If false, the last repetition of the action did nothing.
+ */
+void sdlpui_stop_continued_feedback(enum sdlpui_action_hint ah, SDL_bool avail)
+{
+	struct sdlpui_focus_state *state;
+
+	switch (ah) {
+	case SDLPUI_ACTION_HINT_KEY:
+		state = &key_focus;
+		break;
+
+	case SDLPUI_ACTION_HINT_MOUSE:
+		state = &mouse_focus;
+		break;
+
+	default:
+		return;
+	}
+
+	if (state->c) {
+		if (avail) {
+			if (state->continued) {
+				--state->continued;
+			} else {
+				SDL_assert(0);
+			}
+		} else {
+			if (state->continued_unavail) {
+				--state->continued_unavail;
+			} else {
+				SDL_assert(0);
+			}
+		}
+	} else {
+		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+			"sdl_stop_continued_feedback() called without "
+			"a control having focus");
+	}
+}
+
+
+/**
+ * Return whether normal focus changes are temporarily disabled.
+ *
+ * \param ah specifies what type of focus is of interest:
+ * SDLPUI_ACTION_HINT_KEY for key focus, SDLPUI_ACTION_HINT_MOUSE for mouse
+ * focus, SDLPUI_ACTION_HINT_KEY_OR_MOUSE for whether focus changes are
+ * temporarily disabled for key or mouse, or SDLPUI_ACTION_HINT_KEY_AND_MOUSE
+ * for whether focus changes are temporarily disabled for key and mouse.
+ * \return SDL_TRUE if normal focus changes are disabled for the focus specified
+ * by ah.  Otherwise, return SDL_FALSE.
+ */
+SDL_bool sdlpui_is_focus_locked(enum sdlpui_action_hint ah)
+{
+	SDL_bool result;
+
+	switch (ah) {
+	case SDLPUI_ACTION_HINT_KEY:
+		result = key_focus.focus_locked;
+		break;
+
+	case SDLPUI_ACTION_HINT_MOUSE:
+		result = mouse_focus.focus_locked;
+		break;
+
+	case SDLPUI_ACTION_HINT_KEY_OR_MOUSE:
+		result = key_focus.focus_locked || mouse_focus.focus_locked;
+		break;
+
+	case SDLPUI_ACTION_HINT_KEY_AND_MOUSE:
+		result = key_focus.focus_locked && mouse_focus.focus_locked;
+		break;
+
+	default:
+		result = SDL_FALSE;
+		break;
+	}
+
+	return result;
+}
+
+
+/**
+ * Temporarily disable normal focus changes.
+ *
+ * \param ah specifies what type of focus is of interest:
+ * SDLPUI_ACTION_HINT_KEY for key focus, SDLPUI_ACTION_HINT_MOUSE for mouse
+ * focus, or SDLPUI_ACTION_HINT_KEY_AND_MOUSE for both key and mouse focus.
+ *
+ * Focus changes should not be disabled in most circumstances.  One exception
+ * is for a control that allows dragging with the mouse.  In that case,
+ * definitely do not want the focus to change for small excursions of the
+ * mouse from the bounds of the control (and if allowing small excursions, it
+ * is easiest to allow any excursions up to the point that the mouse pointer
+ * leaves the window).  For consistency, also lock key focus during the drag.
+ * So, at the start of the drag, the control would call
+ * sdlpui_lock_focus(SDLPUI_ACTION_HINT_KEY_AND_MOUSE) and then would call
+ * sdlpui_unlock_focus(SDLPUI_ACTION_HINT_KEY_AND_MOUSE) at the end of the drag.
+ *
+ * Some events, like the mouse pointer leaving the window, will always change
+ * focus regardless of whether focus has been locked.
+ */
+void sdlpui_lock_focus(enum sdlpui_action_hint ah)
+{
+	switch (ah) {
+	case SDLPUI_ACTION_HINT_KEY:
+		key_focus.focus_locked = SDL_TRUE;
+		break;
+
+	case SDLPUI_ACTION_HINT_MOUSE:
+		mouse_focus.focus_locked = SDL_TRUE;
+		break;
+
+	case SDLPUI_ACTION_HINT_KEY_AND_MOUSE:
+		key_focus.focus_locked = SDL_TRUE;
+		mouse_focus.focus_locked = SDL_TRUE;
+		break;
+
+	default:
+		/* Do nothing. */
+		break;
+	}
+}
+
+
+/**
+ * Reenable normal focus changes.
+ *
+ * \param ah specifies what type of focus is of interest:
+ * SDLPUI_ACTION_HINT_KEY for key focus or SDLPUI_ACTION_HINT_MOUSE for mouse
+ * focus, or SDLPUI_ACTION_HINT_KEY_AND_MOUSE for both key and mouse focus.
+ */
+void sdlpui_unlock_focus(enum sdlpui_action_hint ah)
+{
+	switch (ah) {
+	case SDLPUI_ACTION_HINT_KEY:
+		key_focus.focus_locked = SDL_FALSE;
+		break;
+
+	case SDLPUI_ACTION_HINT_MOUSE:
+		mouse_focus.focus_locked = SDL_FALSE;
+		break;
+
+	case SDLPUI_ACTION_HINT_KEY_AND_MOUSE:
+		key_focus.focus_locked = SDL_FALSE;
+		mouse_focus.focus_locked = SDL_FALSE;
+		break;
+
+	default:
+		/* Do nothing. */
+		break;
+	}
+}
+
+
+/**
+ * Set the duration for momentary activation feedback and return the previous
+ * value.
+ *
+ * \param newv is the new duration, in milliseconds.  Two values have
+ * special meanings.  SDLPUI_MOMENTARY_DEFAULT sets the value to what it was
+ * when the first successful call to sdlpui_init() returned.
+ * SDLPUI_MOMENTARY_UNCHANGED leaves the value at its prior value.
+ * \return the previous value for momentary activation feedback duration, in
+ * milliseconds.
+ *
+ * The default value is derived from the environment variable,
+ * SDLPUI_MOMENTARY_DEFAULT, if that variable is set and is a positive decimal
+ * integer value that can fit in a Uint32.
+ */
+Uint32 sdlpui_set_momentary_feedback_duration(Uint32 newv)
+{
+	Uint32 prev;
+
+	if (momentary_duration == SDLPUI_MOMENTARY_DEFAULT) {
+		if (momentary_default_duration == SDLPUI_MOMENTARY_DEFAULT) {
+			char *ev = SDL_getenv("SDLPUI_MOMENTARY_DEFAULT");
+
+			if (ev) {
+				char *ep;
+				unsigned long uv;
+				SDL_bool valid = SDL_TRUE;
+
+				errno = 0;
+				uv = SDL_strtoul(ev, &ep, 10);
+				valid = *ev && !*ep && uv > 0;
+
+#if 4294967295 < ULONG_MAX
+				if (uv >= SDL_MAX_UINT32) {
+					valid = SDL_FALSE;
+				}
+#else
+				if (uv == ULONG_MAX
+						&& errno == ERANGE) {
+					valid = SDL_FALSE;
+				}
+#endif
+				momentary_default_duration =
+					(valid) ? (Uint32)uv : 100;
+			} else {
+				momentary_default_duration = 100;
+			}
+		}
+		momentary_duration = momentary_default_duration;
+	}
+
+	prev = momentary_duration;
+	if (newv != SDLPUI_MOMENTARY_UNCHANGED) {
+		momentary_duration = (newv == SDLPUI_MOMENTARY_DEFAULT)
+			? momentary_default_duration : newv;
+	}
+
+	return prev;
+}
+
+
+/**
+ * This is a private interface for sdlpui_init() or test cases to initialize
+ * static variables in sdlpui-foc.c.
+ *
+ * \return zero if successful.  Otherwise, return a non-zero value.
+ *
+ * Can safely be called multiple times without an intervening sdlpui_foc_quit().
+ * For multithreaded applications, race conditions are possible if
+ * sdlpui_foc_init() can be called while a call to sdlpui_foc_init() or
+ * sdlpui_foc_quit() is in progress.  Those applications should be structured
+ * to avoid that possibility.
+ */
+int sdlpui_foc_init(void)
+{
+	if (!lock) {
+		lock = SDL_CreateMutex();
+		if (!lock) {
+			SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+				"sdlpui_foc_init() could not create a "
+				"mutex: %s", SDL_GetError());
+			return 1;
+		}
+		sdlpui_begin_focus_transaction();
+		(void)sdlpui_set_momentary_feedback_duration(
+			SDLPUI_MOMENTARY_DEFAULT);
+		sdlpui_end_focus_transaction();
+	}
+
+	return 0;
+}
+
+
+/**
+ * This is a private interface for sdlpui_quit() or test cases to release
+ * resources allocated in sdlpui_foc_init().
+ *
+ * Can safely be called multiple times without an intervening call to
+ * sdlpui_foc_init().  Once called, the only routines that from sdlpui-foc.h
+ * that are useful are sdlpui_foc_init() and sdlpui_foc_quit().  For
+ * multithreaded applications, race conditions are possible if
+ * sdlpui_foc_quit() can be called while another call to a routine in
+ * sdlpui-foc.c is in progress.  Those applications should be structured to
+ * avoid that possibility.
+ */
+void sdlpui_foc_quit(void)
+{
+	if (lock) {
+		SDL_mutex *l = lock;
+
+		if (SDL_LockMutex(l)) {
+			SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION,
+				"sdlpui_foc_quit() could not lock the mutex");
+			sdlpui_force_quit();
+		}
+		SDL_zero(key_focus);
+		key_focus.c = NULL;
+		key_focus.d = NULL;
+		key_focus.w = NULL;
+		SDL_zero(mouse_focus);
+		mouse_focus.c = NULL;
+		mouse_focus.d = NULL;
+		mouse_focus.w = NULL;
+		lock = NULL;
+		if (SDL_UnlockMutex(l)) {
+			SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION,
+				"sdlpui_foc_quit() could not unlock the mutex");
+			sdlpui_force_quit();
+		}
+		SDL_DestroyMutex(l);
+	}
+}

--- a/src/sdl2/pui-foc.h
+++ b/src/sdl2/pui-foc.h
@@ -1,0 +1,214 @@
+/**
+ * \file sdl2/pui-foc.h
+ * \brief Declare the interface for working with a control that has focus
+ * and the visual feedback that control provides.
+ *
+ * The policy is:
+ *     A control and dialog or a dialog can be marked for key focus.
+ *     The control, if any, will have first priority for handling a
+ *     SDL_KeyboardEvent, SDL_TextInputEvent, or SDL_TextEditEvent.  The dialog
+ *     will have the next highest priority for handling such an event.
+ *
+ *     A control and dialog or a dialog can be marked for mouse focus.
+ *     The control, if any, will have first priority for handling a
+ *     SDL_MouseButtonEvent, SDL_MouseMotionEvent, or SDL_MouseWheelEvent.
+ *     The dialog will have the next highest priority for handling such an
+ *     event.
+ *
+ *     The key focus can be different than the mouse focus, but a change
+ *     to which control has mouse focus (because of a SDL_MouseMotionEvent,
+ *     for instance) will change which change the key focus to match the
+ *     mouse focus.  The user will be able to navigate between controls
+ *     with the keyboard, but something that changes the mouse focus will
+ *     snap the key focus to the same control and dialog or same dialog.
+ *
+ *     An event which moves focus between controls or between members of a
+ *     compound control does not require any other visual feedback besides
+ *     the changes to the focus indicators.
+ *
+ *     If an event triggers a non-repeating action from a control with focus,
+ *     the control momentarily changes the color (to either
+ *     SDLPUI_COLOR_MENU_ACTION_FEEDBACK is in a menu or
+ *     SDLPUI_COLOR_ACTION_FEEDBACK if it is not in a menu) for what it
+ *     draws to indicate that it has focus.  If the visual appearance of a
+ *     control already changes at the start of an action, then the control can
+ *     omit momentarily changing the color of the focus indicator.  If focus
+ *     moves away from the control while it is momentarily displaying the
+ *     altered focus indicator, the indicator is cleared, as it would be if
+ *     the control had not initiated an action before the change to focus.
+ *     For example, a push button changes the color of its focus rectangle
+ *     briefly when it receives a left mouse button press event and starts the
+ *     action bound to the button.  A toggle button changes its appearance
+ *     upon receipt of a similar event so the action, toggling the state
+ *     associated with the button, does not trigger a change to the focus
+ *     indicator.
+ *
+ *     If the control with focus repeats an action as long as a key or mouse
+ *     button remains pressed, the control changes the color of its focus
+ *     indicator (the altered color is the same as above) upon receipt of the
+ *     press event and retains that color change until the receipt of the
+ *     release event.  If the control loses focus before receipt of the
+ *     release event, it clears the focus indicator and stops the repeated
+ *     action.  If the press continues but the repeated action no longer has
+ *     an effect, change the color displayed for the focus indicator to
+ *     SDLPUI_COLOR_MENU_ACTION_UNAVAIL if the control is in a menu or
+ *     SDLPUI_COLOR_ACTION_UNAVAIL if it is not in a menu.
+ *
+ *     If a non-disabled control with focus receives an event that would
+ *     trigger an action but, in the current circumstances, that action is
+ *     not possible, the control momentarily changes the color (to
+ *     SDLPUI_COLOR_MENU_ACTION_UNAVAIL if the control is in a menu or
+ *     SDLPUI_COLOR_ACTION_UNAVAIL if it is not in a menu) for what it draws
+ *     to indicate that it has focus.  For an example, a scrolled list that
+ *     normally responds to a press of the Home key by changing the display
+ *     to show the start of the list would briefly change the color of its
+ *     focus indicator to SDLPUI_COLOR_ACTION_UNAVAIL if the Home key is
+ *     pressed when the scrolled list is already displaying the start of the
+ *     list.
+ *
+ *     If an element within a control with focus is being dragged, change
+ *     the color of the focus indicator to SDLPUI_COLOR_MENU_ACTION_DRAG if
+ *     the control is in a menu or SDLPUI_COLOR_ACTION_DRAG if the control
+ *     is not in a menu.
+ *
+ *     If momentary changes to the focus indicator overlap, the most recent
+ *     supersedes any earlier ones.
+ *
+ *     If a control allows for more than one type of action, the changes to
+ *     the focus indicator for a repeated action continue until all of the
+ *     repeated actions complete.  If the feedback for multiple actions
+ *     mandates different colors for the focus indicator, the control could
+ *     draw alternating segments of the indicator in the different colors.
+ *     If it chooses not to do that and only displays the focus indicator in
+ *     one color, the color for any momentary feedback should supersede the
+ *     color for feedback related to continued actions and feedback for an
+ *     unavailable repeated action should supersede feedback about available
+ *     repeated actions.
+ *
+ * Issues:
+ *     The extra use of color decreases usability in environments where
+ *     there is a limited gamut of colors, either by choice or by necessity,
+ *     and gets away from the spirit of https://github.com/angband/angband/commit/d6886368017822967efa5911a64b8819502fd7e4 .
+ *     Could use alternate line styles instead of color:  do that all the
+ *     time or only in certain conditions like if a command line argument
+ *     or an environment variable is set?
+ *
+ *     Currently does nothing to assist a control that wants to use the
+ *     respond_default callback (and let the dialog handle the key and
+ *     button events) and also wants to have the action fire repeatedly
+ *     while a key or button remains pressed.
+ *
+ *     Currently does nothing to assist a control with implementing drags.
+ *
+ *     If compatibility with SDL versions prior to 2.0.18 is no longer
+ *     necessary, can change internal details about tick handling,
+ *     Uint32, SDL_GetTicks(), and SDL_TICKS_PASSED, to instead use
+ *     Uint64, SDL_GetTicks64(), and direct comparison of tick values.
+ */
+
+#ifndef INCLUDED_SDL2_SDLPUI_FOCUS_H
+#define INCLUDED_SDL2_SDLPUI_FOCUS_H
+
+#include "pui-ctrl.h"
+
+struct sdlpui_dialog;
+struct sdlpui_window;
+
+/**
+ * Set out possible types of visual feedback that a control with focus
+ * can provide.
+ */
+enum sdlpui_feedback {
+	/**
+	 * No recent attempt to start an action, no ongoing actions, and
+	 * no ongoing drag
+	 */
+	SDLPUI_FEEDBACK_NONE = 0,
+	/**
+	 * Recent successful attempt to start an action or an ongoing repeating
+	 * action whose last repetition was successful
+	 */
+	SDLPUI_FEEDBACK_ACTION,
+	/**
+	 * Recent attempt to start an action but that action was not available
+	 * in those circumstances or an ongoing repeating action whose last
+	 * repetition did not do anything because of the circumstances at the
+	 * time
+	 */
+	SDLPUI_FEEDBACK_UNAVAIL,
+	/** An element of the control with focus is being dragged */
+	SDLPUI_FEEDBACK_DRAGGING,
+};
+
+/**
+ * Hold the results gathered by sdlpui_query_feedback.
+ */
+struct sdlpui_control_feedback {
+	/**
+	 * Hold the one-based index of the component with mouse focus.
+	 * If zero, no component has mouse focus.
+	 */
+	int mouse_focus;
+	/**
+	 * Hold the one-based index of the component with key focus.
+	 * If zero, no component has key focus.
+	 */
+	int key_focus;
+	/** Specify the type of momentary feedback for latest mouse input. */
+	enum sdlpui_feedback mf_mouse;
+	/** Specify the type of continued feedback for mouse input. */
+	enum sdlpui_feedback cf_mouse;
+	/** Specify the type of momentary feedback for latest key input. */
+	enum sdlpui_feedback mf_key;
+	/** Specify the type of continued feedback for key input. */
+	enum sdlpui_feedback cf_key;
+};
+
+/**
+ * Special value for sdlpui_set_momentary_feedback_duration():  restore the
+ * value to what it was when the first successful call to sdlpui_init()
+ * returned
+ */
+#define SDLPUI_MOMENTARY_DEFAULT (0)
+
+/**
+ * Special value for sdlpui_set_momentary_feedback_duration():  leave the
+ * current value unchanged
+ */
+#define SDLPUI_MOMENTARY_UNCHANGED (SDL_MAX_UINT32)
+
+
+void sdlpui_begin_focus_transaction(void);
+void sdlpui_end_focus_transaction(void);
+
+void sdlpui_window_loses_focus(enum sdlpui_action_hint ah);
+SDL_bool sdlpui_change_focus(struct sdlpui_control *c, int comp_ind,
+		struct sdlpui_dialog *d, struct sdlpui_window *w,
+		enum sdlpui_action_hint ah, SDL_bool force);
+struct sdlpui_control *sdlpui_get_control_with_focus(
+		enum sdlpui_action_hint ah);
+struct sdlpui_dialog *sdlpui_get_dialog_with_focus(
+		enum sdlpui_action_hint ah);
+int sdlpui_control_has_focus(const struct sdlpui_control *c,
+		enum sdlpui_action_hint ah);
+SDL_bool sdlpui_dialog_has_focus(const struct sdlpui_dialog *d,
+		enum sdlpui_action_hint ah);
+SDL_bool sdlpui_any_dialog_with_focus(void);
+
+SDL_bool sdlpui_query_feedback(const struct sdlpui_control *c,
+		struct sdlpui_control_feedback *cf);
+void sdlpui_trigger_momentary_feedback(enum sdlpui_action_hint ah,
+		SDL_bool avail);
+void sdlpui_start_continued_feedback(enum sdlpui_action_hint ah,
+		SDL_bool avail);
+void sdlpui_switch_continued_feedback(enum sdlpui_action_hint ah,
+		SDL_bool now_avail);
+void sdlpui_stop_continued_feedback(enum sdlpui_action_hint ah, SDL_bool avail);
+
+SDL_bool sdlpui_is_focus_locked(enum sdlpui_action_hint ah);
+void sdlpui_lock_focus(enum sdlpui_action_hint ah);
+void sdlpui_unlock_focus(enum sdlpui_action_hint ah);
+
+Uint32 sdlpui_set_momentary_feedback_duration(Uint32 newv);
+
+#endif /* INCLUDED_SDL2_SDLPUI_FOCUS_H */

--- a/src/sdl2/pui-focp.h
+++ b/src/sdl2/pui-focp.h
@@ -1,0 +1,14 @@
+/**
+ * \file sdl2/pui-focp.h
+ * \brief Declare private interfaces, used internally in sdlpui-misc.c or by
+ * test cases, for initializing and cleaning up for the routines in
+ * sdlpui-foc.c.
+ */
+
+#ifndef INCLUDED_SDL2_SDLPUI_FOCUSP_H
+#define INCLUDED_SDL2_SDLPUI_FOCUSP_H
+
+int sdlpui_foc_init(void);
+void sdlpui_foc_quit(void);
+
+#endif /* INCLUDED_SDL2_SDLPUI_FOCUSP_H */

--- a/src/sdl2/pui-misc.c
+++ b/src/sdl2/pui-misc.c
@@ -19,6 +19,7 @@
 #include "pui-misc.h"
 #include "pui-ctrl.h"
 #include "pui-dlg.h"
+#include "pui-focp.h"
 
 
 struct sdlpui_code {
@@ -46,9 +47,10 @@ static struct sdlpui_id_registry my_ids = { NULL, NULL, 0 };
  * Initialize the resources needed by the sdlpui_*() calls.
  *
  * Can safely be called multiple times without an intervening sdlpui_quit().
- * For multithreaded applications, a race condition condition is possible
- * if sdlpui_init() can be called while a call to sdlpui_quit() is in progress.
- * Those applications should be structured to avoid that possibility.
+ * For multithreaded applications, race conditions are possible if
+ * sdlpui_init() can be called while a call to sdlpui_init() or sdlpui_quit()
+ * is in progress.  Those applications should be structured to avoid that
+ * possibility.
  */
 int sdlpui_init(void)
 {
@@ -102,24 +104,28 @@ int sdlpui_init(void)
 		}
 	}
 
-	return 0;
+	return sdlpui_foc_init();
 }
 
 
 /**
  * Release the resources allocated by sdlpui_init().
  *
- * Can safey be called multiple times without an intervening call to.
+ * Can safey be called multiple times without an intervening call to
  * sdlpui_init().  Once called, the only sdlpui_*() calls that can be safely
  * used are sdlpui_init() and sdlpui_quit().  For multithreaded applications,
- * race conditions are possible if sdlpui_init() or sdlpui_quit() can be
- * called while a call to sdlpui_quit() is in progress.  Those applications
- * should be structured to avoid that possibility.
+ * race conditions are possible if sdlpui_quit() can be called while a call
+ * to sdlpui_init(), sdlpui_register_code(), or the routines in sdlpui-foc.h
+ * is in progress.  Those applications should be structured to avoid that
+ * possibility.
  */
 void sdlpui_quit(void)
 {
-	SDL_mutex *lock = my_codes.lock;
+	SDL_mutex *lock;
 
+	sdlpui_foc_quit();
+
+	lock = my_codes.lock;
 	if (lock) {
 		if (!SDL_LockMutex(lock)) {
 			struct sdlpui_code *entries = my_codes.entries;

--- a/src/sdl2/pui-win.h
+++ b/src/sdl2/pui-win.h
@@ -85,6 +85,36 @@ struct sdlpui_stipple *sdlpui_get_stipple(struct sdlpui_window *w);
 						in dialogs and inner boundary
 						for dialogs that are not
 						menus */
+#define SDLPUI_COLOR_MENU_ACTION_FEEDBACK (7)
+					/* color for a menu control's focus
+						indicator if a repeating
+						action is in progress or,
+						briefly, after initiating a
+						non-repeating action */
+#define SDLPUI_COLOR_MENU_ACTION_UNAVAIL (8)
+					/* color for a menu control's focus
+						indicator if an ineffective
+						repeating action is in progress
+						or, briefly, after trying to
+						initiate a an action that is
+						not possible in the current
+						circumstances */
+#define SDLPUI_COLOR_MENU_ACTION_DRAG (9)
+					/* color for a menu control's focus
+						indicator if the element with
+						focus is being dragged */
+#define SDLPUI_COLOR_ACTION_FEEDBACK (10)
+					/* like SDLPUI_COLOR_MENU_ACTION_FEEDBACK
+						but for a control that is
+						in a normal dialog */
+#define SDLPUI_COLOR_ACTION_UNAVAIL (11)
+					/* like SDLPUI_COLOR_MENU_ACTION_UNAVAIL
+						but for a control that is
+						in a normal dialog */
+#define SDLPUI_COLOR_ACTION_DRAG (12)
+					/* like SDLPUI_COLOR_MENU_ACTION_DRAG
+						but for a control that is
+						in a normal dialog */
 
 /**
  * Retrieve a reference to the color to use for a specific role when
@@ -99,7 +129,9 @@ const SDL_Color *sdlpui_get_color(struct sdlpui_window *w, int role);
 
 /**
  * Signal that the window needs to be redrawn to reflect the state of the
- * dialogs and menus.
+ * dialogs and menus.  This can be invoked from a separate thread (namely
+ * one handling timer callbacks), so synchronizing access from multiple
+ * threads is necessary.
  */
 void sdlpui_signal_redraw(struct sdlpui_window *w);
 
@@ -126,61 +158,6 @@ void sdlpui_dialog_push_to_top(struct sdlpui_window *w,
  * them and signalling that a redraw is necessary for the window.
  */
 void sdlpui_dialog_pop(struct sdlpui_window *w, struct sdlpui_dialog *d);
-
-/**
- * Tell the given window that the given dialog wants to take keyboard focus
- * and receive all keyboard, text input, or text editing events in the window
- * until it yields keyboard focus.
- *
- * \param w is the window containing the dialog.
- * \param d is the dialog that wants to gain focus.
- */
-void sdlpui_dialog_gain_key_focus(struct sdlpui_window *w,
-		struct sdlpui_dialog *d);
-
-/**
- * Tell the given window that the given dialog wants to give up keyboard focus
- * and not be sent keyboard, text input, or text editing events until it
- * reacquires keyboard focus.
- *
- * \param w is the window containing the dialog.
- * \param d is the dialog that is yielding focus.
- */
-void sdlpui_dialog_yield_key_focus(struct sdlpui_window *w,
-		struct sdlpui_dialog *d);
-
-/**
- * Tell the given window that the given dialog wants to take mouse focus and
- * receive all mouse button, mouse wheel, and mouse motion events in the window
- * until it yields mouse focus.
- *
- * \param w is the window containing the dialog.
- * \param d is the dialog that wants to gain focus.
- */
-void sdlpui_dialog_gain_mouse_focus(struct sdlpui_window *w,
-		struct sdlpui_dialog *d);
-
-/**
- * Tell the given window that the given dialog wants to give up mouse focus
- * and not be sent mouse button or mouse wheel events until it reacquires
- * mouse focus.  Mouse motion events may be sent to a dialog without focus to
- * see if that event would cause it to reacquire focus.
- *
- * \param w is the window containing the dialog.
- * \param d is the dialog that is yielding focus.
- */
-void sdlpui_dialog_yield_mouse_focus(struct sdlpui_window *w,
-		struct sdlpui_dialog *d);
-
-/**
- * Get the dialog with key focus, if any.
- */
-struct sdlpui_dialog *sdlpui_dialog_with_key_focus(struct sdlpui_window *w);
-
-/**
- * Get the dialog with mouse focus, if any.
- */
-struct sdlpui_dialog *sdlpui_dialog_with_mouse_focus(struct sdlpui_window *w);
 
 /**
  * Quit the application.  Expected to not return.


### PR DESCRIPTION
Implement policies for focus and visual feedback that will better handle more complex controls like scrolled lists.  Comments at the start of sdl2/pui-foc.h describe the policies.

One intended user-visible change is that actions in the front-end's menus or dialogs are triggered by a mouse or key press rather than the release.  The other is that arming, a change to shading for buttons between a press and release, has been replaced by changing the color of the focus indicator when an action is initiated if there is no other change to the visual appearance.

The changes have the side effect of avoiding assertion failures in the keyboard shortcuts to bring up the menus, at least on Debian 13 with xfce as the desktop.

The interface between main-sdl2.c and the menus changes in several ways.  main-sdl2.c now has to initialize SDL's timer subsystem.  Since sdlpui_signal_redraw() may be invoked by a timer callback, its implementation will have to be thread-safe.  The functions, sdlpui_dialog_gain_key_focus(), sdlpui_dialog_yield_key_focus(), sdlpui_dialog_gain_mouse_focus(), sdlpui_dialog_yield_mouse_focus(), sdlpui_dialog_with_key_focus(), and sdlpui_dialog_with_mouse_focus(), are removed and replaced with interfaces declared in sdl2/pui-foc.h.  There are additional palette entries that the menus will request by sdlpui_get_color().

The programming interface for dialogs and menus, struct sdlpui_dialog and its related function table, struct sdlpui_dialog_funcs, has changed.  The handle_loses_mouse and handle_loses_key entries in the function table must not be NULL and use new prototypes.  The handle_window_loses_mouse and handle_window_loses_key entries in the function table must not be NULL.  The goto_first_control entry in the function table is now expected to return a pointer to the control gaining focus.  The c_mouse and c_key members for struct sdlpui_dialog are removed.  The dirty member for struct sdlpui_dialog is now an SDL_atomic_t and, except for initialization, it should not be directly accessed:  use the functions sdlpui_dialog_should_redraw() and sdlpui_dialog_mark_for_redraw() instead.

The programming interface for individual controls, sdlpui_control and its related function table, struct sdlpui_control_funcs, has changed.  The gain_key and gain_mouse entries in the function table are removed and replaced with gain_focus.  The lose_key and lose_mouse entries in the function table are removed and replaced with lose_focus.  The arm and disarm entries in the function table are removed.  The step_within entry in the function table is expected to return the one-based index of the component gaining focus.

The structures for menu buttons, struct sdlpui_menu_button, and push buttons in dialogs, struct sdlpui_push_button, have an additional argument to the callback member which indicates the nature of the event triggering the callback.  The has_key, has_mouse, and armed members are removed.