### PR TITLE
Simplify map_info a little

### DIFF
--- a/src/cave-map.c
+++ b/src/cave-map.c
@@ -82,6 +82,7 @@
 void map_info(struct loc grid, struct grid_data *g)
 {
 	struct object *obj;
+	int16_t m_idx;
 
 	assert(grid.x < cave->width);
 	assert(grid.y < cave->height);
@@ -94,19 +95,31 @@ void map_info(struct loc grid, struct grid_data *g)
 	g->unseen_object = false;
 	g->unseen_money = false;
 
-	/* Use real feature (remove later) */
-	g->f_idx = square(cave, grid)->feat;
+	g->hallucinate = player->timed[TMD_IMAGE] ? true : false;
+
+	/* Use known feature */
+	g->f_idx = square(player->cave, grid)->feat;
 	if (f_info[g->f_idx].mimic)
 		g->f_idx = (uint32_t) (f_info[g->f_idx].mimic - f_info);
 
-	g->in_view = (square_isseen(cave, grid)) ? true : false;
-	g->is_player = (square(cave, grid)->mon < 0) ? true : false;
-	g->m_idx = (g->is_player) ? 0 : square(cave, grid)->mon;
-	g->hallucinate = player->timed[TMD_IMAGE] ? true : false;
+	/* Monsters and player */
+	m_idx = square(cave, grid)->mon;
+	if (m_idx > 0) {
+		/* If the monster isn't "visible", make sure we don't list it.*/
+		struct monster *mon = cave_monster(cave, m_idx);
 
-	if (g->in_view) {
+		g->m_idx = (monster_is_visible(mon)) ? m_idx : 0;
+		g->is_player = false;
+	} else {
+		g->m_idx = 0;
+		g->is_player = (m_idx < 0);
+	}
+
+	/* Visiblity and lighting */
+	if (square_isseen(cave, grid)) {
 		bool lit = square_islit(cave, grid);
 
+		g->in_view = true;
 		if (sqinfo_has(square(cave, grid)->info, SQUARE_CLOSE_PLAYER)) {
 			if (player_has(player, PF_UNLIGHT) &&
 					player->state.cur_light <= 1) {
@@ -122,16 +135,9 @@ void map_info(struct loc grid, struct grid_data *g)
 
 		/* Remember seen feature */
 		square_memorize(cave, grid);
-	} else if (!square_isknown(cave, grid)) {
-		g->f_idx = FEAT_NONE;
-	} else if (square_isglow(cave, grid)) {
-		g->lighting = LIGHTING_LIT;
+	} else {
+		g->in_view = false;
 	}
-
-	/* Use known feature */
-	g->f_idx = square(player->cave, grid)->feat;
-	if (f_info[g->f_idx].mimic)
-		g->f_idx = (uint32_t) (f_info[g->f_idx].mimic - f_info);
 
 	/* There is a known trap in this square */
 	if (square_trap(player->cave, grid) && square_isknown(cave, grid)) {
@@ -169,13 +175,6 @@ void map_info(struct loc grid, struct grid_data *g)
 		}
 	}
 
-	/* Monsters */
-	if (g->m_idx > 0) {
-		/* If the monster isn't "visible", make sure we don't list it.*/
-		struct monster *mon = cave_monster(cave, g->m_idx);
-		if (!monster_is_visible(mon)) g->m_idx = 0;
-	}
-
 	/* Rare random hallucination on non-outer walls */
 	if (g->hallucinate && g->m_idx == 0 && g->first_kind == 0) {
 		if (one_in_(128) && (int) g->f_idx != FEAT_PERM)
@@ -187,10 +186,9 @@ void map_info(struct loc grid, struct grid_data *g)
 			g->hallucinate = false;
 	}
 
-	assert((int) g->f_idx < FEAT_MAX);
-	if (!g->hallucinate)
-		assert((int)g->m_idx < cave->mon_max);
-	/* All other g fields are 'flags', mostly booleans. */
+	assert((int)g->f_idx < FEAT_MAX);
+	assert(g->lighting >= 0 && g->lighting < LIGHTING_MAX);
+	assert(g->hallucinate || (int)g->m_idx < cave->mon_max);
 }
 
 


### PR DESCRIPTION
Remove some assignments that do not change a value or are overwritten later without using the earlier value.  Combine some branches.  In a 10 minute run with the borg before the change, the fraction of time in do_cmd_fire()'s cmd_get_item() spent in event_signal_point() is 43.6%.  After the change, it is a bit less, 41.9%.