### PR TITLE
For efficiency, use Term_queue_chars() in display_area()

### DIFF
--- a/src/ui-output.c
+++ b/src/ui-output.c
@@ -104,16 +104,25 @@ static void display_area(const wchar_t *text, const uint8_t *attrs,
 		size_t n_lines,
 		region area, size_t line_from)
 {
-	size_t i, j;
+	size_t i;
 
 	n_lines = MIN(n_lines, (size_t) area.page_rows);
 
 	for (i = 0; i < n_lines; i++) {
+		size_t st = line_starts[line_from + i];
+		size_t ll = line_lengths[line_from + i];
+		size_t j0, j1;
+
 		Term_erase(area.col, area.row + i, area.width);
-		for (j = 0; j < line_lengths[line_from + i]; j++) {
-			Term_putch(area.col + j, area.row + i,
-					attrs[line_starts[line_from + i] + j],
-					text[line_starts[line_from + i] + j]);
+		for (j0 = 0; j0 < ll; j0 = j1) {
+			uint8_t a = attrs[st + j0];
+
+			j1 = j0 + 1;
+			while (j1 < ll && attrs[st + j1] == a) {
+				++j1;
+			}
+			Term_queue_chars(area.col + j0, area.row + i,
+				(int)(j1 - j0), a, text + st + j0);
 		}
 	}
 }


### PR DESCRIPTION
With a 10 minute run of the borg under Xcode's CPU Profiler instrument, here are the cycle counts reported before and after the change for updating the object list subwindow from redraw_stuff() calls inlined into run_game_loop():

|Function                  | Cycles without change | Cycles with change |
|--------------------------|-----------------------|--------------------|
|all functions             | 592.83G               | 615.23G            |
|play_game                 | 589.44G               | 326.56G            |
|run_game_loop             | 185.22G               | 193.13G            |
|redraw_stuff              |   3.50G               |   3.60G            |
|event_signal              |   3.01G               |   3.07G            |
|game_event_dispatch       |   3.01G               |   3.07G            |
|update_itemlist_subwindow |   2.23G               |   2.29G            |
|object_list_show_subwindow|   2.04G               |   2.07G            |
|textui_textblock_place    | 273.20M               | 152.42M            |
|display_area              | 217.19M               | 102.01M            |
|textblock_calculate_lines |  49.00M               |  50.00M            |

The fraction of the textui_textblock_place()'s cycles spent in display_area() decreases from 79.5% to 66.9% with the change and the fraction of update_itemlist_subwindow()'s cycles spent in display_area(), decreases from 9.7% to 4.5%.